### PR TITLE
feat: v1 UI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,9 @@
       "Bash(uv tool run:*)",
       "Bash(git ls-remote:*)",
       "Bash(./scripts/test:*)",
-      "Bash(make:*)"
+      "Bash(make:*)",
+      "Bash(uv run ruff format:*)",
+      "Bash(uv run ruff:*)"
     ]
   },
   "hooks": {

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 lint:
 	./scripts/lint
 
-quality: lint
+quality: lint api-gen
 	cd frontend && pnpm check
 	@echo "All quality checks passed!"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "djlint>=1.36.4",
     "pytest>=8.3",
     "pytest-django>=4.9",
     "ruff>=0.8",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -35,6 +35,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "djlint" },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "ruff" },
@@ -52,9 +53,22 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "djlint", specifier = ">=1.36.4" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-django", specifier = ">=4.9" },
     { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -64,6 +78,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cssbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "jsbeautifier" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/01/fdf41c1e5f93d359681976ba10410a04b299d248e28ecce1d4e88588dde4/cssbeautifier-1.15.4.tar.gz", hash = "sha256:9bb08dc3f64c101a01677f128acf01905914cf406baf87434dcde05b74c0acf5", size = 25376, upload-time = "2025-02-27T17:53:51.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/51/ef6c5628e46092f0a54c7cee69acc827adc6b6aab57b55d344fefbdf28f1/cssbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:78c84d5e5378df7d08622bbd0477a1abdbd209680e95480bf22f12d5701efc98", size = 123667, upload-time = "2025-02-27T17:53:43.594Z" },
 ]
 
 [[package]]
@@ -106,6 +134,35 @@ wheels = [
 ]
 
 [[package]]
+name = "djlint"
+version = "1.36.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama" },
+    { name = "cssbeautifier" },
+    { name = "jsbeautifier" },
+    { name = "json5" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/ecf5be9f5c59a0c53bcaa29671742c5e269cc7d0e2622e3f65f41df251bf/djlint-1.36.4.tar.gz", hash = "sha256:17254f218b46fe5a714b224c85074c099bcb74e3b2e1f15c2ddc2cf415a408a1", size = 47849, upload-time = "2024-12-24T13:06:36.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/67/f7aeea9be6fb3bd984487af8d0d80225a0b1e5f6f7126e3332d349fb13fe/djlint-1.36.4-py3-none-any.whl", hash = "sha256:e9699b8ac3057a6ed04fb90835b89bee954ed1959c01541ce4f8f729c938afdd", size = 52290, upload-time = "2024-12-24T13:06:33.76Z" },
+]
+
+[[package]]
+name = "editorconfig"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
+]
+
+[[package]]
 name = "gunicorn"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -127,12 +184,43 @@ wheels = [
 ]
 
 [[package]]
+name = "jsbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
+]
+
+[[package]]
+name = "json5"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/e8/a3f261a66e4663f22700bc8a17c08cb83e91fbf086726e7a228398968981/json5-0.13.0.tar.gz", hash = "sha256:b1edf8d487721c0bf64d83c28e91280781f6e21f4a797d3261c7c828d4c165bf", size = 52441, upload-time = "2026-01-01T19:42:14.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/9e/038522f50ceb7e74f1f991bf1b699f24b0c2bbe7c390dd36ad69f4582258/json5-0.13.0-py3-none-any.whl", hash = "sha256:9a08e1dd65f6a4d4c6fa82d216cf2477349ec2346a38fd70cc11d2557499fbcc", size = 36163, upload-time = "2026-01-01T19:42:13.962Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -271,6 +359,72 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.1.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/86/07d5056945f9ec4590b518171c4254a5925832eb727b56d3c38a7476f316/regex-2026.1.15.tar.gz", hash = "sha256:164759aa25575cbc0651bef59a0b18353e54300d79ace8084c818ad8ac72b7d5", size = 414811, upload-time = "2026-01-14T23:18:02.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/0a/47fa888ec7cbbc7d62c5f2a6a888878e76169170ead271a35239edd8f0e8/regex-2026.1.15-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:d920392a6b1f353f4aa54328c867fec3320fa50657e25f64abf17af054fc97ac", size = 489170, upload-time = "2026-01-14T23:16:19.835Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c4/d000e9b7296c15737c9301708e9e7fbdea009f8e93541b6b43bdb8219646/regex-2026.1.15-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:b5a28980a926fa810dbbed059547b02783952e2efd9c636412345232ddb87ff6", size = 291146, upload-time = "2026-01-14T23:16:21.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b6/921cc61982e538682bdf3bdf5b2c6ab6b34368da1f8e98a6c1ddc503c9cf/regex-2026.1.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:621f73a07595d83f28952d7bd1e91e9d1ed7625fb7af0064d3516674ec93a2a2", size = 288986, upload-time = "2026-01-14T23:16:23.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/33/eb7383dde0bbc93f4fb9d03453aab97e18ad4024ac7e26cef8d1f0a2cff0/regex-2026.1.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d7d92495f47567a9b1669c51fc8d6d809821849063d168121ef801bbc213846", size = 799098, upload-time = "2026-01-14T23:16:25.088Z" },
+    { url = "https://files.pythonhosted.org/packages/27/56/b664dccae898fc8d8b4c23accd853f723bde0f026c747b6f6262b688029c/regex-2026.1.15-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8dd16fba2758db7a3780a051f245539c4451ca20910f5a5e6ea1c08d06d4a76b", size = 864980, upload-time = "2026-01-14T23:16:27.297Z" },
+    { url = "https://files.pythonhosted.org/packages/16/40/0999e064a170eddd237bae9ccfcd8f28b3aa98a38bf727a086425542a4fc/regex-2026.1.15-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1e1808471fbe44c1a63e5f577a1d5f02fe5d66031dcbdf12f093ffc1305a858e", size = 911607, upload-time = "2026-01-14T23:16:29.235Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/c77f644b68ab054e5a674fb4da40ff7bffb2c88df58afa82dbf86573092d/regex-2026.1.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0751a26ad39d4f2ade8fe16c59b2bf5cb19eb3d2cd543e709e583d559bd9efde", size = 803358, upload-time = "2026-01-14T23:16:31.369Z" },
+    { url = "https://files.pythonhosted.org/packages/27/31/d4292ea8566eaa551fafc07797961c5963cf5235c797cc2ae19b85dfd04d/regex-2026.1.15-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0c7684c7f9ca241344ff95a1de964f257a5251968484270e91c25a755532c5", size = 775833, upload-time = "2026-01-14T23:16:33.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b2/cff3bf2fea4133aa6fb0d1e370b37544d18c8350a2fa118c7e11d1db0e14/regex-2026.1.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:74f45d170a21df41508cb67165456538425185baaf686281fa210d7e729abc34", size = 788045, upload-time = "2026-01-14T23:16:35.005Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/99/2cb9b69045372ec877b6f5124bda4eb4253bc58b8fe5848c973f752bc52c/regex-2026.1.15-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f1862739a1ffb50615c0fde6bae6569b5efbe08d98e59ce009f68a336f64da75", size = 859374, upload-time = "2026-01-14T23:16:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/09/16/710b0a5abe8e077b1729a562d2f297224ad079f3a66dce46844c193416c8/regex-2026.1.15-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:453078802f1b9e2b7303fb79222c054cb18e76f7bdc220f7530fdc85d319f99e", size = 763940, upload-time = "2026-01-14T23:16:38.685Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/7585c8e744e40eb3d32f119191969b91de04c073fca98ec14299041f6e7e/regex-2026.1.15-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:a30a68e89e5a218b8b23a52292924c1f4b245cb0c68d1cce9aec9bbda6e2c160", size = 850112, upload-time = "2026-01-14T23:16:40.646Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d6/43e1dd85df86c49a347aa57c1f69d12c652c7b60e37ec162e3096194a278/regex-2026.1.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9479cae874c81bf610d72b85bb681a94c95722c127b55445285fb0e2c82db8e1", size = 789586, upload-time = "2026-01-14T23:16:42.799Z" },
+    { url = "https://files.pythonhosted.org/packages/93/38/77142422f631e013f316aaae83234c629555729a9fbc952b8a63ac91462a/regex-2026.1.15-cp314-cp314-win32.whl", hash = "sha256:d639a750223132afbfb8f429c60d9d318aeba03281a5f1ab49f877456448dcf1", size = 271691, upload-time = "2026-01-14T23:16:44.671Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a9/ab16b4649524ca9e05213c1cdbb7faa85cc2aa90a0230d2f796cbaf22736/regex-2026.1.15-cp314-cp314-win_amd64.whl", hash = "sha256:4161d87f85fa831e31469bfd82c186923070fc970b9de75339b68f0c75b51903", size = 280422, upload-time = "2026-01-14T23:16:46.607Z" },
+    { url = "https://files.pythonhosted.org/packages/be/2a/20fd057bf3521cb4791f69f869635f73e0aaf2b9ad2d260f728144f9047c/regex-2026.1.15-cp314-cp314-win_arm64.whl", hash = "sha256:91c5036ebb62663a6b3999bdd2e559fd8456d17e2b485bf509784cd31a8b1705", size = 273467, upload-time = "2026-01-14T23:16:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/77/0b1e81857060b92b9cad239104c46507dd481b3ff1fa79f8e7f865aae38a/regex-2026.1.15-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ee6854c9000a10938c79238de2379bea30c82e4925a371711af45387df35cab8", size = 492073, upload-time = "2026-01-14T23:16:51.154Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f3/f8302b0c208b22c1e4f423147e1913fd475ddd6230565b299925353de644/regex-2026.1.15-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c2b80399a422348ce5de4fe40c418d6299a0fa2803dd61dc0b1a2f28e280fcf", size = 292757, upload-time = "2026-01-14T23:16:53.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f0/ef55de2460f3b4a6da9d9e7daacd0cb79d4ef75c64a2af316e68447f0df0/regex-2026.1.15-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:dca3582bca82596609959ac39e12b7dad98385b4fefccb1151b937383cec547d", size = 291122, upload-time = "2026-01-14T23:16:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/55/bb8ccbacabbc3a11d863ee62a9f18b160a83084ea95cdfc5d207bfc3dd75/regex-2026.1.15-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef71d476caa6692eea743ae5ea23cde3260677f70122c4d258ca952e5c2d4e84", size = 807761, upload-time = "2026-01-14T23:16:57.251Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/84/f75d937f17f81e55679a0509e86176e29caa7298c38bd1db7ce9c0bf6075/regex-2026.1.15-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c243da3436354f4af6c3058a3f81a97d47ea52c9bd874b52fd30274853a1d5df", size = 873538, upload-time = "2026-01-14T23:16:59.349Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d9/0da86327df70349aa8d86390da91171bd3ca4f0e7c1d1d453a9c10344da3/regex-2026.1.15-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8355ad842a7c7e9e5e55653eade3b7d1885ba86f124dd8ab1f722f9be6627434", size = 915066, upload-time = "2026-01-14T23:17:01.607Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5e/f660fb23fc77baa2a61aa1f1fe3a4eea2bbb8a286ddec148030672e18834/regex-2026.1.15-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f192a831d9575271a22d804ff1a5355355723f94f31d9eef25f0d45a152fdc1a", size = 812938, upload-time = "2026-01-14T23:17:04.366Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/a47a29bfecebbbfd1e5cd3f26b28020a97e4820f1c5148e66e3b7d4b4992/regex-2026.1.15-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:166551807ec20d47ceaeec380081f843e88c8949780cd42c40f18d16168bed10", size = 781314, upload-time = "2026-01-14T23:17:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ec/7ec2bbfd4c3f4e494a24dec4c6943a668e2030426b1b8b949a6462d2c17b/regex-2026.1.15-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f9ca1cbdc0fbfe5e6e6f8221ef2309988db5bcede52443aeaee9a4ad555e0dac", size = 795652, upload-time = "2026-01-14T23:17:08.521Z" },
+    { url = "https://files.pythonhosted.org/packages/46/79/a5d8651ae131fe27d7c521ad300aa7f1c7be1dbeee4d446498af5411b8a9/regex-2026.1.15-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b30bcbd1e1221783c721483953d9e4f3ab9c5d165aa709693d3f3946747b1aea", size = 868550, upload-time = "2026-01-14T23:17:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b7/25635d2809664b79f183070786a5552dd4e627e5aedb0065f4e3cf8ee37d/regex-2026.1.15-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2a8d7b50c34578d0d3bf7ad58cde9652b7d683691876f83aedc002862a35dc5e", size = 769981, upload-time = "2026-01-14T23:17:12.871Z" },
+    { url = "https://files.pythonhosted.org/packages/16/8b/fc3fcbb2393dcfa4a6c5ffad92dc498e842df4581ea9d14309fcd3c55fb9/regex-2026.1.15-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9d787e3310c6a6425eb346be4ff2ccf6eece63017916fd77fe8328c57be83521", size = 854780, upload-time = "2026-01-14T23:17:14.837Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/38/dde117c76c624713c8a2842530be9c93ca8b606c0f6102d86e8cd1ce8bea/regex-2026.1.15-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:619843841e220adca114118533a574a9cd183ed8a28b85627d2844c500a2b0db", size = 799778, upload-time = "2026-01-14T23:17:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/0d/3a6cfa9ae99606afb612d8fb7a66b245a9d5ff0f29bb347c8a30b6ad561b/regex-2026.1.15-cp314-cp314t-win32.whl", hash = "sha256:e90b8db97f6f2c97eb045b51a6b2c5ed69cedd8392459e0642d4199b94fabd7e", size = 274667, upload-time = "2026-01-14T23:17:19.301Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b2/297293bb0742fd06b8d8e2572db41a855cdf1cae0bf009b1cb74fe07e196/regex-2026.1.15-cp314-cp314t-win_amd64.whl", hash = "sha256:5ef19071f4ac9f0834793af85bd04a920b4407715624e40cb7a0631a11137cdf", size = 284386, upload-time = "2026-01-14T23:17:21.231Z" },
+    { url = "https://files.pythonhosted.org/packages/95/e4/a3b9480c78cf8ee86626cb06f8d931d74d775897d44201ccb813097ae697/regex-2026.1.15-cp314-cp314t-win_arm64.whl", hash = "sha256:ca89c5e596fc05b015f27561b3793dc2fa0917ea0d7507eebb448efd35274a70", size = 274837, upload-time = "2026-01-14T23:17:23.146Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -296,12 +450,33 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]

--- a/docs/plans/DataModel.md
+++ b/docs/plans/DataModel.md
@@ -1,0 +1,191 @@
+# Pinball Database — Data Model + Admin + API
+
+## Context
+
+Building an interactive pinball database for The Flip museum. Data is coming from many sources, including:
+
+- **Existing online pinball databases**: OPDB, possibly IPDB, and possibly Pinside
+- **Editorial contributions from The Flip** (books, research, curatorial notes)
+- **Crowdsourcing** (think wikipedia for pinball)
+
+## Data Model Architecture
+
+Two-layer model inspired by CRDTs.
+
+- **Layer 1** is a stream of per-field **claims** from multiple sources.
+- **Layer 2** is a **resolved Model** table — a materialized view derived by merging claims with priority-based conflict resolution. The Flip adjudicates conflicts and adds original research with per-fact citations.
+
+## Models (`backend/apps/machines/models.py`)
+
+### Source
+
+Represents a data origin (a database, a book, The Flip's editorial team, etc.).
+
+| Field         | Type                                 | Notes                                                           |
+| ------------- | ------------------------------------ | --------------------------------------------------------------- |
+| `name`        | CharField(200), unique               | e.g., "IPDB", "Pinball Compendium Vol. 3", "The Flip Editorial" |
+| `slug`        | SlugField(200), unique               | Auto-generated                                                  |
+| `source_type` | CharField choices                    | `database`, `book`, `editorial`, `other`                        |
+| `priority`    | PositiveSmallIntegerField, default=0 | Higher wins conflicts. Editorial sources get highest.           |
+| `url`         | URLField, blank                      | e.g., `https://ipdb.org`                                        |
+| `description` | TextField, blank                     |                                                                 |
+
+### Claim
+
+A single fact asserted by a single source about a single model. This is the core of the provenance system — the "stream of changes."
+
+| Field        | Type                        | Notes                                                   |
+| ------------ | --------------------------- | ------------------------------------------------------- |
+| `model`      | FK → PinballModel, CASCADE  | The model this claim is about                           |
+| `source`     | FK → Source, PROTECT        | Where this fact came from                               |
+| `field_name` | CharField(100)              | Column name on PinballModel or key for `extra_data`     |
+| `value`      | JSONField                   | The asserted value (string, number, bool, etc.)         |
+| `citation`   | TextField, blank            | "Pinball Compendium Vol. 3, p.47" or IPDB URL           |
+| `is_active`  | BooleanField, default=True  | False when superseded by a newer claim from same source |
+| `created_at` | DateTimeField, auto_now_add | When this claim was recorded                            |
+
+Indexes: `(model, field_name)`, `(source, model)`, `(field_name, is_active)`.
+
+Unique constraint: `(model, source, field_name, is_active)` filtered to `is_active=True` — at most one active claim per source per field per model. (Use `UniqueConstraint` with `condition`.)
+
+When a source re-asserts a field, the old claim is marked `is_active=False` and a new one is created. This preserves full history.
+
+**Enforced via `ClaimManager.assert_claim(model, source, field_name, value, citation="")`**: A transactional manager method that deactivates the existing active claim (if any) and creates the new one atomically. All write paths must go through this method — no direct `Claim.objects.create()` for production code.
+
+### Manufacturer (brand-level grouping)
+
+User-facing brand. Corporate incarnations are tracked separately in ManufacturerEntity. For example, "Gottlieb" is one Manufacturer with four ManufacturerEntity records spanning different ownership eras.
+
+| Field                  | Type                                   | Notes                                                            |
+| ---------------------- | -------------------------------------- | ---------------------------------------------------------------- |
+| `name`                 | CharField(200), unique                 | Brand name                                                       |
+| `slug`                 | SlugField(200), unique                 | Auto-generated                                                   |
+| `trade_name`           | CharField(200), blank                  | Brand name if different (e.g., "Bally" for Midway Manufacturing) |
+| `opdb_manufacturer_id` | PositiveIntegerField, unique, nullable | OPDB's manufacturer_id for cross-referencing                     |
+
+### ManufacturerEntity (corporate incarnation)
+
+IPDB tracks corporate entities rather than brands — e.g., four separate entries for Gottlieb across its ownership eras. Each entity maps to one brand-level Manufacturer and carries the IPDB cross-reference ID.
+
+| Field                  | Type                                   | Notes                                              |
+| ---------------------- | -------------------------------------- | -------------------------------------------------- |
+| `manufacturer`         | FK → Manufacturer, CASCADE             | Parent brand                                       |
+| `name`                 | CharField(300)                         | Full corporate name, e.g., "D. Gottlieb & Company" |
+| `ipdb_manufacturer_id` | PositiveIntegerField, unique, nullable | IPDB's ManufacturerId for cross-referencing        |
+| `years_active`         | CharField(50), blank                   | Operating period, e.g., "1931-1977"                |
+
+### PinballModel (the pinball title/design — the resolved/materialized view)
+
+These fields are **derived** from resolving claims. The resolution logic picks the winning claim per field (highest priority source, most recent if tied).
+
+| Field                 | Type                                   | Notes                                                   |
+| --------------------- | -------------------------------------- | ------------------------------------------------------- |
+| `name`                | CharField(300)                         | NOT unique (e.g., multiple "Star Trek")                 |
+| `slug`                | SlugField(300), unique                 | Disambiguated: `star-trek-bally-1979`                   |
+| `ipdb_id`             | PositiveIntegerField, unique, nullable | IPDB cross-reference                                    |
+| `opdb_id`             | CharField(50), unique, nullable        | OPDB cross-reference (hierarchical ID)                  |
+| `pinside_id`          | PositiveIntegerField, unique, nullable | Pinside cross-reference                                 |
+| `manufacturer`        | FK → Manufacturer, nullable            | Browse by manufacturer                                  |
+| `year`                | PositiveSmallIntegerField, nullable    | Filter by decade                                        |
+| `month`               | PositiveSmallIntegerField, nullable    |                                                         |
+| `machine_type`        | CharField choices (PM/EM/SS)           | Filter                                                  |
+| `display_type`        | CharField choices, blank               | Score reels, alpha-numeric, DMD, LCD, etc.              |
+| `player_count`        | PositiveSmallIntegerField, nullable    |                                                         |
+| `theme`               | CharField(300), blank                  |                                                         |
+| `production_quantity` | CharField(100), blank                  | Often approximate                                       |
+| `mpu`                 | CharField(200), blank                  | Electronic system                                       |
+| `flipper_count`       | PositiveSmallIntegerField, nullable    |                                                         |
+| `ipdb_rating`         | DecimalField(4,2), nullable            |                                                         |
+| `pinside_rating`      | DecimalField(4,2), nullable            |                                                         |
+| `educational_text`    | TextField, blank                       | Museum content                                          |
+| `sources_notes`       | TextField, blank                       | Editorial                                               |
+| `extra_data`          | JSONField, default=dict                | Resolved catch-all for fields without dedicated columns |
+| `created_at`          | DateTimeField, auto_now_add            |                                                         |
+| `updated_at`          | DateTimeField, auto_now                |                                                         |
+
+Indexes: `(manufacturer, year)`, `(machine_type, year)`, `(display_type)`.
+
+**`extra_data`** (renamed from `ipdb_data`): Holds resolved values for fields that don't have dedicated columns — model_number, abbreviations, playfield features, toys, marketing slogans, weight, msrp, factory address, etc. Any `field_name` in a Claim that doesn't match a column on PinballModel gets resolved into this JSON.
+
+### Person
+
+| Field  | Type                   | Notes                                 |
+| ------ | ---------------------- | ------------------------------------- |
+| `name` | CharField(200)         | Display name (e.g., "Pat Lawlor")     |
+| `slug` | SlugField(200), unique | For URLs: `/people/pat-lawlor`        |
+| `bio`  | TextField, blank       | Biographical text (editorial content) |
+
+### DesignCredit
+
+| Field    | Type                       | Notes                                                                     |
+| -------- | -------------------------- | ------------------------------------------------------------------------- |
+| `model`  | FK → PinballModel, CASCADE |                                                                           |
+| `person` | FK → Person, CASCADE       |                                                                           |
+| `role`   | CharField choices          | concept, design, art, mechanics, music, sound, software, animation, other |
+
+Unique together: `(model, person, role)`.
+
+The importer splits IPDB's comma-separated credit strings (e.g., `"Larry DeMar, Pat Lawlor"`) into individual Person records via `get_or_create`.
+
+## Resolution logic (`backend/apps/machines/resolve.py`)
+
+A `resolve_model(model)` function that:
+
+1. Fetches all active claims for the model, ordered by `field_name`, `-source__priority`, `-created_at`
+2. For each field, picks the winning claim (first in that ordering)
+3. Maps winning values to PinballModel columns (with type coercion) or `extra_data` keys
+4. For `manufacturer` (FK): IPDB sources look up via `ManufacturerEntity.ipdb_manufacturer_id` → parent `Manufacturer`; OPDB sources match on `Manufacturer.opdb_manufacturer_id` directly. Falls back to normalized name lookup. Uses `get_or_create` only after ID-based matching fails.
+5. Saves the resolved PinballModel
+
+Also a `resolve_all()` for batch re-resolution after a scrape.
+
+The resolution logic is tested independently in `test_resolve.py`: set up claims from multiple sources with different priorities, verify the resolved PinballModel has the right values.
+
+## Django Admin (`backend/apps/machines/admin.py`)
+
+- **SourceAdmin**: list_display (name, source_type, priority), list_filter (source_type)
+- **ClaimAdmin**: list_display (model, field_name, value_truncated, source, is_active, created_at), list_filter (source, is_active, field_name), search (model\_\_name, field_name), readonly created_at. Override `save_model()` to route through `ClaimManager.assert_claim()` so admin creates respect the superseding invariant.
+- **ManufacturerAdmin**: list_display (name, trade_name, opdb_manufacturer_id, entity_count), search, prepopulated slug, ManufacturerEntityInline (TabularInline, extra=1)
+- **PersonAdmin**: list_display (name, credit_count), search (name), prepopulated slug
+- **PinballModelAdmin**: list_display (name, manufacturer, year, machine_type, ipdb_id), list_filter (machine_type, display_type, manufacturer), search (name, ipdb_id, manufacturer\_\_name), fieldsets grouping identity/specs/cross-references/ratings/museum content/extra data (collapsed), DesignCreditInline + ClaimInline (readonly, collapsed — shows provenance per model)
+- **DesignCreditInline**: TabularInline on PinballModel, extra=1
+- **ClaimInline**: TabularInline on PinballModel, readonly, collapsed, shows active claims with source and citation
+
+## API (`backend/apps/machines/api.py`)
+
+Wire separate routers into `backend/config/api.py`:
+
+```python
+from apps.machines.api import models_router, manufacturers_router, people_router, sources_router
+api.add_router("/models/", models_router)
+api.add_router("/manufacturers/", manufacturers_router)
+api.add_router("/people/", people_router)
+api.add_router("/sources/", sources_router)
+```
+
+Define explicit Ninja `Schema` classes for all request/response payloads (not `ModelSchema` — we want control over what's exposed). Key schemas: `PinballModelListSchema` (slim, for list view), `PinballModelDetailSchema` (full, with credits + provenance + extra_data), `ManufacturerSchema`, `PersonSchema`, `ClaimSchema`.
+
+### Endpoints
+
+**`GET /api/models/`** — Paginated list with filters:
+
+- `?search=` — searches name, manufacturer name, and theme via `Q(name__icontains=...) | Q(manufacturer__name__icontains=...) | Q(theme__icontains=...)`. For extra_data: use `Cast(extra_data, TextField())` + `icontains` (works on both SQLite and PostgreSQL). Defined as explicit Ninja `FilterSchema` or manual Q-building, not admin-style search.
+- `?manufacturer=` — manufacturer slug
+- `?type=SS` — machine_type
+- `?display=DMD` — display_type
+- `?year_min=` / `?year_max=` — year range
+- `?person=` — filter by person slug (via DesignCredit)
+- `?ordering=` — name, -name, year, -year, -ipdb_rating, -pinside_rating
+- `?page=` / `?page_size=` — pagination (default 25)
+
+**`GET /api/models/{slug}/`** — Full detail including credits, extra_data, and provenance (active claims grouped by field with source + citation).
+
+**`GET /api/manufacturers/`** — List with model counts.
+
+**`GET /api/manufacturers/{slug}/`** — Detail with model list.
+
+**`GET /api/people/`** — List with credit counts.
+
+**`GET /api/people/{slug}/`** — Person detail with bio + all credited models grouped by role.
+
+**`GET /api/sources/`** — List of all sources.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.15.0",
 		"globals": "^17.3.0",
+		"openapi-typescript": "^7.13.0",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.4.1",
 		"svelte": "^5.51.3",
@@ -31,11 +32,15 @@
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.56.0",
 		"vite": "^7.3.1",
-		"vitest": "^4.0.18",
-		"openapi-typescript": "^7.13.0"
+		"vitest": "^4.0.18"
 	},
 	"dependencies": {
-		"openapi-fetch": "^0.17.0"
+		"@fortawesome/fontawesome-svg-core": "^7.2.0",
+		"@fortawesome/free-regular-svg-icons": "^7.2.0",
+		"@fortawesome/free-solid-svg-icons": "^7.2.0",
+		"open-props": "^1.7.23",
+		"openapi-fetch": "^0.17.0",
+		"postcss-jit-props": "^1.0.16"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,9 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@fortawesome/fontawesome-svg-core':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@fortawesome/free-regular-svg-icons':
+        specifier: ^7.2.0
+        version: 7.2.0
+      '@fortawesome/free-solid-svg-icons':
+        specifier: ^7.2.0
+        version: 7.2.0
+      open-props:
+        specifier: ^1.7.23
+        version: 1.7.23
       openapi-fetch:
         specifier: ^0.17.0
         version: 0.17.0
+      postcss-jit-props:
+        specifier: ^1.0.16
+        version: 1.0.16(postcss@8.5.6)
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
@@ -259,6 +274,22 @@ packages:
   '@eslint/plugin-kit@0.6.0':
     resolution: {integrity: sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@fortawesome/fontawesome-common-types@7.2.0':
+    resolution: {integrity: sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    resolution: {integrity: sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/free-regular-svg-icons@7.2.0':
+    resolution: {integrity: sha512-iycmlN51EULlQ4D/UU9WZnHiN0CvjJ2TuuCrAh+1MVdzD+4ViKYH2deNAll4XAAYlZa8WAefHR5taSK8hYmSMw==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/free-solid-svg-icons@7.2.0':
+    resolution: {integrity: sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==}
+    engines: {node: '>=6'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -851,6 +882,12 @@ packages:
     resolution: {integrity: sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==}
     engines: {node: '>=18'}
 
+  globalyzer@0.1.0:
+    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
+
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -974,6 +1011,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  open-props@1.7.23:
+    resolution: {integrity: sha512-+xyrJmxV9QUBFbSwPROYhOg/FLXry+uuPr4R+B5EaE4556Oc18/8ZC/fL5A+/lbRSwNvA0Alh+C0KpyFWLmLZg==}
+
   openapi-fetch@0.17.0:
     resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
 
@@ -1023,6 +1063,12 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  postcss-jit-props@1.0.16:
+    resolution: {integrity: sha512-EXHA65umJ3+BiMnd6kOCargYe+QXS72hGrkW9nqaCdt6aeOp4fT3Nme6qn6yIDBmzv19mx3zeVU0PdiqJBCwoA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.2.8
 
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -1149,6 +1195,9 @@ packages:
   svelte@5.51.3:
     resolution: {integrity: sha512-3+ni7BMjiEQeMCa1fDQzHy2ESAebgQDVOTuE4jlj2/QOAB2grRta8ew80p95miWE+ZmimpL7B3t9SSO4rv0aqQ==}
     engines: {node: '>=18'}
+
+  tiny-glob@0.2.9:
+    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1432,6 +1481,20 @@ snapshots:
     dependencies:
       '@eslint/core': 1.1.0
       levn: 0.4.1
+
+  '@fortawesome/fontawesome-common-types@7.2.0': {}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/free-regular-svg-icons@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
+  '@fortawesome/free-solid-svg-icons@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -2021,6 +2084,10 @@ snapshots:
 
   globals@17.3.0: {}
 
+  globalyzer@0.1.0: {}
+
+  globrex@0.1.2: {}
+
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
@@ -2117,6 +2184,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  open-props@1.7.23: {}
+
   openapi-fetch@0.17.0:
     dependencies:
       openapi-typescript-helpers: 0.1.0
@@ -2167,6 +2236,11 @@ snapshots:
   picomatch@4.0.3: {}
 
   pluralize@8.0.0: {}
+
+  postcss-jit-props@1.0.16(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      tiny-glob: 0.2.9
 
   postcss-load-config@3.1.4(postcss@8.5.6):
     dependencies:
@@ -2311,6 +2385,11 @@ snapshots:
       locate-character: 3.0.0
       magic-string: 0.30.21
       zimmerframe: 1.1.4
+
+  tiny-glob@0.2.9:
+    dependencies:
+      globalyzer: 0.1.0
+      globrex: 0.1.2
 
   tinybench@2.9.0: {}
 

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+import postcssJitProps from 'postcss-jit-props';
+import OpenProps from 'open-props';
+
+export default {
+	plugins: [postcssJitProps(OpenProps)]
+};

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,0 +1,119 @@
+/* ========================================
+   GLOBAL STYLES
+   Open Props (JIT) + custom semantic tokens
+   ======================================== */
+
+/* Open Props normalize — sets sensible defaults on base elements,
+   provides adaptive --surface-* and --text-* tokens */
+@import 'open-props/normalize';
+
+/* ========================================
+   TYPOGRAPHY
+   ======================================== */
+:root {
+	--font-body: 'Lora', serif;
+	--font-mono: var(--font-mono, monospace);
+}
+
+html {
+	font-family: var(--font-body);
+}
+
+/* ========================================
+   SEMANTIC COLOR TOKENS — Light Theme
+   Warm off-white palette (from flipfix)
+   ======================================== */
+:root {
+	/* Surfaces */
+	--color-background: #fbf7f0;
+	--color-surface: #ffffff;
+	--color-border: #d1d5db;
+	--color-border-soft: #e7e5e4;
+
+	/* Text */
+	--color-text-primary: #333333;
+	--color-text-muted: #6b7280;
+
+	/* Accent */
+	--color-accent: #0078d4;
+	--color-accent-hover: #026ec1;
+
+	/* Semantic */
+	--color-success: #16a34a;
+	--color-error: #dc2626;
+	--color-warning: #b45309;
+	--color-link: #2563eb;
+
+	/* Inputs */
+	--color-input-bg: #ffffff;
+	--color-input-border: #d1d5db;
+	--color-input-focus: #0078d4;
+	--color-input-focus-ring: rgba(59, 130, 246, 0.15);
+}
+
+/* ========================================
+   SEMANTIC COLOR TOKENS — Dark Theme
+   Based on VS Code's "Dark Modern" (exact values)
+   Source: https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_modern.json
+   ======================================== */
+@media (prefers-color-scheme: dark) {
+	:root {
+		/* Surfaces */
+		--color-background: #1f1f1f;
+		--color-surface: #252525;
+		--color-border: #616161;
+		--color-border-soft: #2b2b2b;
+
+		/* Text */
+		--color-text-primary: #cccccc;
+		--color-text-muted: #9ca3af;
+
+		/* Accent */
+		--color-accent: #0078d4;
+		--color-accent-hover: #026ec1;
+
+		/* Semantic */
+		--color-success: #2ea043;
+		--color-error: #f85149;
+		--color-warning: #fbbf24;
+		--color-link: #4daafc;
+
+		/* Inputs */
+		--color-input-bg: #2b2b2b;
+		--color-input-border: #404040;
+		--color-input-focus: #0078d4;
+		--color-input-focus-ring: rgba(0, 120, 212, 0.25);
+	}
+}
+
+/* ========================================
+   BASE OVERRIDES
+   Override Open Props normalize with our tokens
+   ======================================== */
+html {
+	background-color: var(--color-background);
+	color: var(--color-text-primary);
+}
+
+a {
+	color: var(--color-link);
+}
+
+a:hover {
+	color: var(--color-accent-hover);
+}
+
+/* ========================================
+   UTILITY
+   ======================================== */
+.visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -4,6 +4,12 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&display=swap"
+			rel="stylesheet"
+		/>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -7,7 +7,6 @@ function getCsrfToken(): string | undefined {
 }
 
 const client = createClient<paths>({
-	baseUrl: '/api',
 	headers: {
 		'Content-Type': 'application/json'
 	}

--- a/frontend/src/lib/api/pagination.ts
+++ b/frontend/src/lib/api/pagination.ts
@@ -1,0 +1,9 @@
+/**
+ * Page sizes matching the backend Django Ninja pagination config.
+ * See backend/apps/machines/api.py @paginate decorators.
+ */
+export const PAGE_SIZES = {
+	models: 25,
+	manufacturers: 50,
+	people: 50
+} as const;

--- a/frontend/src/lib/components/FaIcon.svelte
+++ b/frontend/src/lib/components/FaIcon.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+
+	interface Props {
+		icon: IconDefinition;
+		class?: string;
+	}
+
+	let { icon, class: className = '' }: Props = $props();
+
+	let path = $derived(() => {
+		const d = icon.icon[4];
+		return Array.isArray(d) ? d[0] : d;
+	});
+</script>
+
+<svg
+	viewBox="0 0 {icon.icon[0]} {icon.icon[1]}"
+	fill="currentColor"
+	class={className}
+	aria-hidden="true"
+>
+	<path d={path()} />
+</svg>

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+	import { faBars, faXmark } from '@fortawesome/free-solid-svg-icons';
+	import FaIcon from './FaIcon.svelte';
+
+	let mobileNavOpen = $state(false);
+
+	const navItems = [
+		{ href: '/models' as const, label: 'Models' },
+		{ href: '/manufacturers' as const, label: 'Manufacturers' },
+		{ href: '/people' as const, label: 'People' },
+		{ href: '/sources' as const, label: 'Sources' }
+	];
+
+	function isActive(href: string) {
+		return page.url.pathname.startsWith(href);
+	}
+
+	let toggleIcon = $derived(mobileNavOpen ? faXmark : faBars);
+</script>
+
+<header class="site-header">
+	<div class="header-inner">
+		<a href={resolve('/')} class="site-title">The Flip Pinball DB</a>
+
+		<button
+			class="mobile-toggle"
+			onclick={() => (mobileNavOpen = !mobileNavOpen)}
+			aria-label="Toggle navigation"
+			aria-expanded={mobileNavOpen}
+		>
+			<FaIcon icon={toggleIcon} class="icon" />
+		</button>
+
+		<nav class="site-nav" class:open={mobileNavOpen}>
+			{#each navItems as { href, label } (href)}
+				<a
+					href={resolve(href)}
+					class="nav-link"
+					class:active={isActive(href)}
+					onclick={() => (mobileNavOpen = false)}
+				>
+					{label}
+				</a>
+			{/each}
+		</nav>
+	</div>
+</header>
+
+<style>
+	.site-header {
+		background-color: var(--color-surface);
+		border-bottom: 1px solid var(--color-border-soft);
+		position: sticky;
+		top: 0;
+		z-index: 100;
+	}
+
+	.header-inner {
+		max-width: 72rem;
+		margin: 0 auto;
+		padding: var(--size-3) var(--size-5);
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.site-title {
+		font-size: var(--font-size-4);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		text-decoration: none;
+	}
+
+	.site-title:hover {
+		color: var(--color-accent);
+	}
+
+	.site-nav {
+		display: flex;
+		gap: var(--size-5);
+	}
+
+	.nav-link {
+		color: var(--color-text-muted);
+		text-decoration: none;
+		font-size: var(--font-size-2);
+		font-weight: 500;
+		padding: var(--size-1) 0;
+		border-bottom: 2px solid transparent;
+		transition:
+			color 0.15s var(--ease-2),
+			border-color 0.15s var(--ease-2);
+	}
+
+	.nav-link:hover {
+		color: var(--color-text-primary);
+	}
+
+	.nav-link.active {
+		color: var(--color-accent);
+		border-bottom-color: var(--color-accent);
+	}
+
+	.mobile-toggle {
+		display: none;
+		background: none;
+		border: none;
+		color: var(--color-text-primary);
+		cursor: pointer;
+		padding: var(--size-1);
+	}
+
+	:global(.mobile-toggle .icon) {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
+
+	@media (max-width: 640px) {
+		.mobile-toggle {
+			display: block;
+		}
+
+		.site-nav {
+			display: none;
+			flex-direction: column;
+			position: absolute;
+			top: 100%;
+			left: 0;
+			right: 0;
+			background-color: var(--color-surface);
+			border-bottom: 1px solid var(--color-border-soft);
+			padding: var(--size-3) var(--size-5);
+			gap: var(--size-2);
+		}
+
+		.site-nav.open {
+			display: flex;
+		}
+	}
+</style>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,5 +1,20 @@
 <script>
+	import '../app.css';
+	import Nav from '$lib/components/Nav.svelte';
+
 	let { children } = $props();
 </script>
 
-{@render children()}
+<Nav />
+
+<main class="page-content">
+	{@render children()}
+</main>
+
+<style>
+	.page-content {
+		max-width: 72rem;
+		margin: 0 auto;
+		padding: var(--size-6) var(--size-5);
+	}
+</style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,6 +1,21 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 	import FaIcon from '$lib/components/FaIcon.svelte';
+
+	let searchValue = $state('');
+
+	function handleSearch(e: SubmitEvent) {
+		e.preventDefault();
+		const q = searchValue.trim();
+		const target = new URL(resolve('/models'), window.location.origin);
+		if (q) {
+			target.searchParams.set('search', q);
+		}
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() used in URL construction above
+		goto(target);
+	}
 </script>
 
 <svelte:head>
@@ -11,10 +26,15 @@
 	<h1>Every pinball machine ever made.</h1>
 	<p class="subtitle">Search thousands of machines by name, manufacturer, designer, or year.</p>
 
-	<div class="search-box">
+	<form class="search-box" onsubmit={handleSearch}>
 		<FaIcon icon={faMagnifyingGlass} class="search-icon" />
-		<input type="search" placeholder="Search machines..." aria-label="Search machines" />
-	</div>
+		<input
+			type="search"
+			placeholder="Search machines..."
+			aria-label="Search machines"
+			bind:value={searchValue}
+		/>
+	</form>
 </section>
 
 <style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,11 +1,80 @@
-<script>
-	import { resolve } from '$app/paths';
+<script lang="ts">
+	import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+	import FaIcon from '$lib/components/FaIcon.svelte';
 </script>
 
 <svelte:head>
-	<title>Home</title>
+	<title>The Flip Pinball DB — Every pinball machine ever made</title>
 </svelte:head>
 
-<h1>Welcome</h1>
-<p>Public landing page (prerendered).</p>
-<p><a href={resolve('/dashboard')}>Go to dashboard</a></p>
+<section class="hero">
+	<h1>Every pinball machine ever made.</h1>
+	<p class="subtitle">Search thousands of machines by name, manufacturer, designer, or year.</p>
+
+	<div class="search-box">
+		<FaIcon icon={faMagnifyingGlass} class="search-icon" />
+		<input type="search" placeholder="Search machines..." aria-label="Search machines" />
+	</div>
+</section>
+
+<style>
+	.hero {
+		text-align: center;
+		padding: var(--size-10) 0 var(--size-8);
+	}
+
+	h1 {
+		font-size: var(--font-size-7);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+		line-height: var(--font-lineheight-1);
+	}
+
+	.subtitle {
+		font-size: var(--font-size-3);
+		color: var(--color-text-muted);
+		margin-bottom: var(--size-8);
+	}
+
+	.search-box {
+		position: relative;
+		max-width: 36rem;
+		margin: 0 auto;
+	}
+
+	:global(.search-icon) {
+		position: absolute;
+		left: var(--size-4);
+		top: 50%;
+		transform: translateY(-50%);
+		width: 1rem;
+		height: 1rem;
+		color: var(--color-text-muted);
+		pointer-events: none;
+	}
+
+	input[type='search'] {
+		width: 100%;
+		padding: var(--size-3) var(--size-4) var(--size-3) var(--size-9);
+		font-size: var(--font-size-2);
+		font-family: var(--font-body);
+		background-color: var(--color-input-bg);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-input-border);
+		border-radius: var(--radius-3);
+		transition:
+			border-color 0.15s var(--ease-2),
+			box-shadow 0.15s var(--ease-2);
+	}
+
+	input[type='search']:focus {
+		outline: none;
+		border-color: var(--color-input-focus);
+		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
+	}
+
+	input[type='search']::placeholder {
+		color: var(--color-text-muted);
+	}
+</style>

--- a/frontend/src/routes/manufacturers/+page.svelte
+++ b/frontend/src/routes/manufacturers/+page.svelte
@@ -1,9 +1,70 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+	import { PAGE_SIZES } from '$lib/api/pagination';
+
+	let { data } = $props();
+
+	function gotoPage(p: number) {
+		const url = new URL(page.url);
+		if (p > 1) {
+			url.searchParams.set('page', String(p));
+		} else {
+			url.searchParams.delete('page');
+		}
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
+		goto(url);
+	}
+
+	let currentPage = $derived(Number(page.url.searchParams.get('page') ?? '1'));
+	let totalPages = $derived(Math.ceil(data.result.count / PAGE_SIZES.manufacturers));
+</script>
+
 <svelte:head>
 	<title>Manufacturers — The Flip Pinball DB</title>
 </svelte:head>
 
 <h1>Manufacturers</h1>
-<p class="description">Browse pinball manufacturers.</p>
+
+{#if data.result.items.length === 0}
+	<p class="empty">No manufacturers found.</p>
+{:else}
+	<p class="count">{data.result.count} manufacturer{data.result.count === 1 ? '' : 's'}</p>
+
+	<div class="table-wrap">
+		<table>
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Trade Name</th>
+					<th class="num">Models</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each data.result.items as mfr (mfr.slug)}
+					<tr>
+						<td><a href={resolve(`/manufacturers/${mfr.slug}`)}>{mfr.name}</a></td>
+						<td>{mfr.trade_name || '—'}</td>
+						<td class="num">{mfr.model_count}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+
+	{#if totalPages > 1}
+		<nav class="pagination" aria-label="Pagination">
+			<button onclick={() => gotoPage(currentPage - 1)} disabled={currentPage <= 1}>
+				Previous
+			</button>
+			<span class="page-info">Page {currentPage} of {totalPages}</span>
+			<button onclick={() => gotoPage(currentPage + 1)} disabled={currentPage >= totalPages}>
+				Next
+			</button>
+		</nav>
+	{/if}
+{/if}
 
 <style>
 	h1 {
@@ -13,8 +74,93 @@
 		margin-bottom: var(--size-3);
 	}
 
-	.description {
+	.count {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-1);
+		margin-bottom: var(--size-3);
+	}
+
+	.empty {
 		color: var(--color-text-muted);
 		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	th {
+		text-align: left;
+		font-size: var(--font-size-0);
+		font-weight: 600;
+		color: var(--color-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 2px solid var(--color-border);
+	}
+
+	td {
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 1px solid var(--color-border-soft);
+		font-size: var(--font-size-1);
+		color: var(--color-text-primary);
+	}
+
+	.num {
+		text-align: right;
+	}
+
+	a {
+		color: var(--color-link);
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+
+	.pagination {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--size-4);
+		padding: var(--size-5) 0;
+	}
+
+	.page-info {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+	}
+
+	button {
+		padding: var(--size-2) var(--size-4);
+		font-size: var(--font-size-1);
+		font-family: var(--font-body);
+		background-color: var(--color-surface);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		cursor: pointer;
+		transition:
+			background-color 0.15s var(--ease-2),
+			border-color 0.15s var(--ease-2);
+	}
+
+	button:hover:not(:disabled) {
+		border-color: var(--color-accent);
+		color: var(--color-accent);
+	}
+
+	button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
 	}
 </style>

--- a/frontend/src/routes/manufacturers/+page.svelte
+++ b/frontend/src/routes/manufacturers/+page.svelte
@@ -1,11 +1,9 @@
 <svelte:head>
-	<title>Dashboard — Pinball DB</title>
+	<title>Manufacturers — The Flip Pinball DB</title>
 </svelte:head>
 
-<h1>Dashboard</h1>
-<p class="description">
-	This page is client-side rendered. Auth gating is UX-only — the backend enforces access control.
-</p>
+<h1>Manufacturers</h1>
+<p class="description">Browse pinball manufacturers.</p>
 
 <style>
 	h1 {

--- a/frontend/src/routes/manufacturers/+page.ts
+++ b/frontend/src/routes/manufacturers/+page.ts
@@ -1,0 +1,18 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async ({ url }) => {
+	const page = url.searchParams.has('page') ? Number(url.searchParams.get('page')) : undefined;
+
+	const { data } = await client.GET('/api/manufacturers/', {
+		params: { query: { page } }
+	});
+
+	if (!data) error(500, 'Failed to load manufacturers');
+
+	return { result: data };
+};

--- a/frontend/src/routes/manufacturers/[slug]/+page.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+page.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	let { data } = $props();
+	let mfr = $derived(data.manufacturer);
+</script>
+
+<svelte:head>
+	<title>{mfr.name} — The Flip Pinball DB</title>
+</svelte:head>
+
+<article>
+	<header>
+		<h1>{mfr.name}</h1>
+		{#if mfr.trade_name && mfr.trade_name !== mfr.name}
+			<p class="trade-name">Trade name: {mfr.trade_name}</p>
+		{/if}
+	</header>
+
+	{#if mfr.models.length === 0}
+		<p class="empty">No models listed for this manufacturer.</p>
+	{:else}
+		<section>
+			<h2>Models ({mfr.models.length})</h2>
+			<div class="table-wrap">
+				<table>
+					<thead>
+						<tr>
+							<th>Name</th>
+							<th>Year</th>
+							<th>Type</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each mfr.models as model (model.slug)}
+							<tr>
+								<td><a href={resolve(`/models/${model.slug}`)}>{model.name}</a></td>
+								<td>{model.year ?? '—'}</td>
+								<td>{model.machine_type}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</section>
+	{/if}
+
+	{#if mfr.ipdb_manufacturer_id}
+		<footer class="external-ids">
+			<a
+				href="https://www.ipdb.org/search.pl?any=&searchtype=advanced&mfgid={mfr.ipdb_manufacturer_id}"
+				target="_blank"
+				rel="noopener"
+			>
+				IPDB
+			</a>
+		</footer>
+	{/if}
+</article>
+
+<style>
+	article {
+		max-width: 48rem;
+	}
+
+	header {
+		margin-bottom: var(--size-6);
+	}
+
+	h1 {
+		font-size: var(--font-size-7);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-2);
+	}
+
+	.trade-name {
+		font-size: var(--font-size-2);
+		color: var(--color-text-muted);
+	}
+
+	h2 {
+		font-size: var(--font-size-3);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	.empty {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	th {
+		text-align: left;
+		font-size: var(--font-size-0);
+		font-weight: 600;
+		color: var(--color-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 2px solid var(--color-border);
+	}
+
+	td {
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 1px solid var(--color-border-soft);
+		font-size: var(--font-size-1);
+		color: var(--color-text-primary);
+	}
+
+	a {
+		color: var(--color-link);
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+
+	.external-ids {
+		display: flex;
+		gap: var(--size-4);
+		padding-top: var(--size-4);
+		margin-top: var(--size-6);
+		border-top: 1px solid var(--color-border-soft);
+	}
+</style>

--- a/frontend/src/routes/manufacturers/[slug]/+page.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+page.svelte
@@ -3,6 +3,10 @@
 
 	let { data } = $props();
 	let mfr = $derived(data.manufacturer);
+	let ipdbId = $derived(
+		mfr.entities.find((e: { ipdb_manufacturer_id?: number | null }) => e.ipdb_manufacturer_id)
+			?.ipdb_manufacturer_id
+	);
 </script>
 
 <svelte:head>
@@ -45,10 +49,10 @@
 		</section>
 	{/if}
 
-	{#if mfr.ipdb_manufacturer_id}
+	{#if ipdbId}
 		<footer class="external-ids">
 			<a
-				href="https://www.ipdb.org/search.pl?any=&searchtype=advanced&mfgid={mfr.ipdb_manufacturer_id}"
+				href="https://www.ipdb.org/search.pl?any=&searchtype=advanced&mfgid={ipdbId}"
 				target="_blank"
 				rel="noopener"
 			>

--- a/frontend/src/routes/manufacturers/[slug]/+page.ts
+++ b/frontend/src/routes/manufacturers/[slug]/+page.ts
@@ -1,0 +1,19 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async ({ params }) => {
+	const { data, response } = await client.GET('/api/manufacturers/{slug}', {
+		params: { path: { slug: params.slug } }
+	});
+
+	if (!data) {
+		if (response?.status === 404) error(404, 'Manufacturer not found');
+		error(500, 'Failed to load manufacturer');
+	}
+
+	return { manufacturer: data };
+};

--- a/frontend/src/routes/models/+page.svelte
+++ b/frontend/src/routes/models/+page.svelte
@@ -1,11 +1,9 @@
 <svelte:head>
-	<title>Dashboard — Pinball DB</title>
+	<title>Models — The Flip Pinball DB</title>
 </svelte:head>
 
-<h1>Dashboard</h1>
-<p class="description">
-	This page is client-side rendered. Auth gating is UX-only — the backend enforces access control.
-</p>
+<h1>Models</h1>
+<p class="description">Browse every pinball machine ever made.</p>
 
 <style>
 	h1 {

--- a/frontend/src/routes/models/+page.svelte
+++ b/frontend/src/routes/models/+page.svelte
@@ -1,9 +1,113 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+	import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+	import FaIcon from '$lib/components/FaIcon.svelte';
+	import { PAGE_SIZES } from '$lib/api/pagination';
+
+	let { data } = $props();
+
+	let searchValue = $state(page.url.searchParams.get('search') ?? '');
+
+	function handleSearch(e: SubmitEvent) {
+		e.preventDefault();
+		const url = new URL(page.url);
+		if (searchValue.trim()) {
+			url.searchParams.set('search', searchValue.trim());
+		} else {
+			url.searchParams.delete('search');
+		}
+		url.searchParams.delete('page');
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
+		goto(url, { keepFocus: true });
+	}
+
+	function gotoPage(p: number) {
+		const url = new URL(page.url);
+		if (p > 1) {
+			url.searchParams.set('page', String(p));
+		} else {
+			url.searchParams.delete('page');
+		}
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
+		goto(url);
+	}
+
+	let currentPage = $derived(Number(page.url.searchParams.get('page') ?? '1'));
+	let totalPages = $derived(Math.ceil(data.result.count / PAGE_SIZES.models));
+</script>
+
 <svelte:head>
 	<title>Models — The Flip Pinball DB</title>
 </svelte:head>
 
 <h1>Models</h1>
-<p class="description">Browse every pinball machine ever made.</p>
+
+<form class="search-bar" onsubmit={handleSearch}>
+	<div class="search-box">
+		<FaIcon icon={faMagnifyingGlass} class="search-icon" />
+		<input
+			type="search"
+			placeholder="Search models..."
+			aria-label="Search models"
+			bind:value={searchValue}
+		/>
+	</div>
+</form>
+
+{#if data.result.items.length === 0}
+	<p class="empty">No models found.</p>
+{:else}
+	<p class="count">{data.result.count} model{data.result.count === 1 ? '' : 's'}</p>
+
+	<div class="table-wrap">
+		<table>
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Manufacturer</th>
+					<th>Year</th>
+					<th>Type</th>
+					<th class="num">IPDB</th>
+					<th class="num">Pinside</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each data.result.items as model (model.slug)}
+					<tr>
+						<td><a href={resolve(`/models/${model.slug}`)}>{model.name}</a></td>
+						<td>
+							{#if model.manufacturer_slug}
+								<a href={resolve(`/manufacturers/${model.manufacturer_slug}`)}>
+									{model.manufacturer_name}
+								</a>
+							{:else}
+								{model.manufacturer_name ?? '—'}
+							{/if}
+						</td>
+						<td>{model.year ?? '—'}</td>
+						<td>{model.machine_type}</td>
+						<td class="num">{model.ipdb_rating ?? '—'}</td>
+						<td class="num">{model.pinside_rating ?? '—'}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+
+	{#if totalPages > 1}
+		<nav class="pagination" aria-label="Pagination">
+			<button onclick={() => gotoPage(currentPage - 1)} disabled={currentPage <= 1}>
+				Previous
+			</button>
+			<span class="page-info">Page {currentPage} of {totalPages}</span>
+			<button onclick={() => gotoPage(currentPage + 1)} disabled={currentPage >= totalPages}>
+				Next
+			</button>
+		</nav>
+	{/if}
+{/if}
 
 <style>
 	h1 {
@@ -13,8 +117,137 @@
 		margin-bottom: var(--size-3);
 	}
 
-	.description {
+	.search-bar {
+		margin-bottom: var(--size-5);
+	}
+
+	.search-box {
+		position: relative;
+		max-width: 24rem;
+	}
+
+	:global(.search-box .search-icon) {
+		position: absolute;
+		left: var(--size-3);
+		top: 50%;
+		transform: translateY(-50%);
+		width: 0.875rem;
+		height: 0.875rem;
+		color: var(--color-text-muted);
+		pointer-events: none;
+	}
+
+	input[type='search'] {
+		width: 100%;
+		padding: var(--size-2) var(--size-3) var(--size-2) var(--size-8);
+		font-size: var(--font-size-1);
+		font-family: var(--font-body);
+		background-color: var(--color-input-bg);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-input-border);
+		border-radius: var(--radius-2);
+		transition:
+			border-color 0.15s var(--ease-2),
+			box-shadow 0.15s var(--ease-2);
+	}
+
+	input[type='search']:focus {
+		outline: none;
+		border-color: var(--color-input-focus);
+		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
+	}
+
+	input[type='search']::placeholder {
+		color: var(--color-text-muted);
+	}
+
+	.count {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-1);
+		margin-bottom: var(--size-3);
+	}
+
+	.empty {
 		color: var(--color-text-muted);
 		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	th {
+		text-align: left;
+		font-size: var(--font-size-0);
+		font-weight: 600;
+		color: var(--color-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 2px solid var(--color-border);
+	}
+
+	td {
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 1px solid var(--color-border-soft);
+		font-size: var(--font-size-1);
+		color: var(--color-text-primary);
+	}
+
+	.num {
+		text-align: right;
+	}
+
+	a {
+		color: var(--color-link);
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+
+	.pagination {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--size-4);
+		padding: var(--size-5) 0;
+	}
+
+	.page-info {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+	}
+
+	button {
+		padding: var(--size-2) var(--size-4);
+		font-size: var(--font-size-1);
+		font-family: var(--font-body);
+		background-color: var(--color-surface);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		cursor: pointer;
+		transition:
+			background-color 0.15s var(--ease-2),
+			border-color 0.15s var(--ease-2);
+	}
+
+	button:hover:not(:disabled) {
+		border-color: var(--color-accent);
+		color: var(--color-accent);
+	}
+
+	button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
 	}
 </style>

--- a/frontend/src/routes/models/+page.ts
+++ b/frontend/src/routes/models/+page.ts
@@ -1,0 +1,32 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async ({ url }) => {
+	const search = url.searchParams.get('search') ?? undefined;
+	const manufacturer = url.searchParams.get('manufacturer') ?? undefined;
+	const type = url.searchParams.get('type') ?? undefined;
+	const display = url.searchParams.get('display') ?? undefined;
+	const year_min = url.searchParams.has('year_min')
+		? Number(url.searchParams.get('year_min'))
+		: undefined;
+	const year_max = url.searchParams.has('year_max')
+		? Number(url.searchParams.get('year_max'))
+		: undefined;
+	const person = url.searchParams.get('person') ?? undefined;
+	const ordering = url.searchParams.get('ordering') ?? undefined;
+	const page = url.searchParams.has('page') ? Number(url.searchParams.get('page')) : undefined;
+
+	const { data } = await client.GET('/api/models/', {
+		params: {
+			query: { search, manufacturer, type, display, year_min, year_max, person, ordering, page }
+		}
+	});
+
+	if (!data) error(500, 'Failed to load models');
+
+	return { result: data };
+};

--- a/frontend/src/routes/models/[slug]/+page.svelte
+++ b/frontend/src/routes/models/[slug]/+page.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	let { data } = $props();
+	let model = $derived(data.model);
+</script>
+
+<svelte:head>
+	<title>{model.name} — The Flip Pinball DB</title>
+</svelte:head>
+
+<article>
+	<header>
+		<h1>{model.name}</h1>
+		<div class="meta">
+			{#if model.manufacturer_name}
+				<span>
+					<a href={resolve(`/manufacturers/${model.manufacturer_slug}`)}>
+						{model.manufacturer_name}
+					</a>
+				</span>
+			{/if}
+			{#if model.year}
+				<span
+					>{model.year}{#if model.month}/{String(model.month).padStart(2, '0')}{/if}</span
+				>
+			{/if}
+			<span>{model.machine_type}</span>
+			<span>{model.display_type}</span>
+		</div>
+	</header>
+
+	<section class="specs">
+		<h2>Specifications</h2>
+		<dl>
+			{#if model.player_count}
+				<dt>Players</dt>
+				<dd>{model.player_count}</dd>
+			{/if}
+			{#if model.flipper_count}
+				<dt>Flippers</dt>
+				<dd>{model.flipper_count}</dd>
+			{/if}
+			{#if model.production_quantity}
+				<dt>Production</dt>
+				<dd>{model.production_quantity}</dd>
+			{/if}
+			{#if model.mpu}
+				<dt>MPU</dt>
+				<dd>{model.mpu}</dd>
+			{/if}
+			{#if model.theme}
+				<dt>Theme</dt>
+				<dd>{model.theme}</dd>
+			{/if}
+		</dl>
+	</section>
+
+	{#if model.ipdb_rating || model.pinside_rating}
+		<section class="ratings">
+			<h2>Ratings</h2>
+			<div class="rating-cards">
+				{#if model.ipdb_rating}
+					<div class="rating-card">
+						<span class="rating-value">{model.ipdb_rating.toFixed(1)}</span>
+						<span class="rating-label">IPDB</span>
+					</div>
+				{/if}
+				{#if model.pinside_rating}
+					<div class="rating-card">
+						<span class="rating-value">{model.pinside_rating.toFixed(1)}</span>
+						<span class="rating-label">Pinside</span>
+					</div>
+				{/if}
+			</div>
+		</section>
+	{/if}
+
+	{#if model.credits.length > 0}
+		<section class="credits">
+			<h2>Credits</h2>
+			<ul>
+				{#each model.credits as credit (credit.person_slug + credit.role)}
+					<li>
+						<a href={resolve(`/people/${credit.person_slug}`)}>{credit.person_name}</a>
+						<span class="role">{credit.role_display}</span>
+					</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
+
+	{#if model.educational_text}
+		<section class="description">
+			<h2>About</h2>
+			<p>{model.educational_text}</p>
+		</section>
+	{/if}
+
+	{#if Object.keys(model.provenance).length > 0}
+		<section class="provenance">
+			<h2>Data Sources</h2>
+			{#each Object.entries(model.provenance) as [field, claims] (field)}
+				<details>
+					<summary>{field}</summary>
+					<ul>
+						{#each claims as claim (claim.source_slug + claim.created_at)}
+							<li>
+								<strong>{claim.source_name}</strong>: {String(claim.value)}
+								{#if claim.citation}
+									<span class="citation">({claim.citation})</span>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				</details>
+			{/each}
+		</section>
+	{/if}
+
+	<footer class="external-ids">
+		{#if model.ipdb_id}
+			<a href="https://www.ipdb.org/machine.cgi?id={model.ipdb_id}" target="_blank" rel="noopener">
+				IPDB #{model.ipdb_id}
+			</a>
+		{/if}
+		{#if model.opdb_id}
+			<a href="https://opdb.org/machines/{model.opdb_id}" target="_blank" rel="noopener"> OPDB </a>
+		{/if}
+		{#if model.pinside_id}
+			<a
+				href="https://pinside.com/pinball/machine/{model.pinside_id}"
+				target="_blank"
+				rel="noopener"
+			>
+				Pinside
+			</a>
+		{/if}
+	</footer>
+</article>
+
+<style>
+	article {
+		max-width: 48rem;
+	}
+
+	header {
+		margin-bottom: var(--size-6);
+	}
+
+	h1 {
+		font-size: var(--font-size-7);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-2);
+	}
+
+	.meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--size-2);
+		font-size: var(--font-size-2);
+		color: var(--color-text-muted);
+	}
+
+	.meta span:not(:last-child)::after {
+		content: '·';
+		margin-left: var(--size-2);
+	}
+
+	h2 {
+		font-size: var(--font-size-3);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	section {
+		margin-bottom: var(--size-6);
+	}
+
+	dl {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: var(--size-1) var(--size-4);
+	}
+
+	dt {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+		font-weight: 500;
+	}
+
+	dd {
+		font-size: var(--font-size-1);
+		color: var(--color-text-primary);
+	}
+
+	.rating-cards {
+		display: flex;
+		gap: var(--size-4);
+	}
+
+	.rating-card {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: var(--size-3) var(--size-5);
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-2);
+	}
+
+	.rating-value {
+		font-size: var(--font-size-5);
+		font-weight: 700;
+		color: var(--color-accent);
+	}
+
+	.rating-label {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.credits ul {
+		list-style: none;
+		padding: 0;
+	}
+
+	.credits li {
+		display: flex;
+		justify-content: space-between;
+		padding: var(--size-2) 0;
+		border-bottom: 1px solid var(--color-border-soft);
+		font-size: var(--font-size-1);
+	}
+
+	.role {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-0);
+	}
+
+	.description p {
+		font-size: var(--font-size-2);
+		color: var(--color-text-primary);
+		line-height: var(--font-lineheight-3);
+	}
+
+	.provenance details {
+		margin-bottom: var(--size-2);
+	}
+
+	.provenance summary {
+		font-size: var(--font-size-1);
+		font-weight: 500;
+		color: var(--color-text-primary);
+		cursor: pointer;
+		padding: var(--size-1) 0;
+	}
+
+	.provenance ul {
+		list-style: none;
+		padding: 0 0 0 var(--size-4);
+	}
+
+	.provenance li {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+		padding: var(--size-1) 0;
+	}
+
+	.citation {
+		font-style: italic;
+	}
+
+	.external-ids {
+		display: flex;
+		gap: var(--size-4);
+		padding-top: var(--size-4);
+		border-top: 1px solid var(--color-border-soft);
+	}
+
+	a {
+		color: var(--color-link);
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/frontend/src/routes/models/[slug]/+page.ts
+++ b/frontend/src/routes/models/[slug]/+page.ts
@@ -1,0 +1,19 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async ({ params }) => {
+	const { data, response } = await client.GET('/api/models/{slug}', {
+		params: { path: { slug: params.slug } }
+	});
+
+	if (!data) {
+		if (response?.status === 404) error(404, 'Machine not found');
+		error(500, 'Failed to load machine');
+	}
+
+	return { model: data };
+};

--- a/frontend/src/routes/people/+page.svelte
+++ b/frontend/src/routes/people/+page.svelte
@@ -1,11 +1,9 @@
 <svelte:head>
-	<title>Dashboard — Pinball DB</title>
+	<title>People — The Flip Pinball DB</title>
 </svelte:head>
 
-<h1>Dashboard</h1>
-<p class="description">
-	This page is client-side rendered. Auth gating is UX-only — the backend enforces access control.
-</p>
+<h1>People</h1>
+<p class="description">Browse pinball designers, artists, and engineers.</p>
 
 <style>
 	h1 {

--- a/frontend/src/routes/people/+page.svelte
+++ b/frontend/src/routes/people/+page.svelte
@@ -1,9 +1,68 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+	import { PAGE_SIZES } from '$lib/api/pagination';
+
+	let { data } = $props();
+
+	function gotoPage(p: number) {
+		const url = new URL(page.url);
+		if (p > 1) {
+			url.searchParams.set('page', String(p));
+		} else {
+			url.searchParams.delete('page');
+		}
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
+		goto(url);
+	}
+
+	let currentPage = $derived(Number(page.url.searchParams.get('page') ?? '1'));
+	let totalPages = $derived(Math.ceil(data.result.count / PAGE_SIZES.people));
+</script>
+
 <svelte:head>
 	<title>People — The Flip Pinball DB</title>
 </svelte:head>
 
 <h1>People</h1>
-<p class="description">Browse pinball designers, artists, and engineers.</p>
+
+{#if data.result.items.length === 0}
+	<p class="empty">No people found.</p>
+{:else}
+	<p class="count">{data.result.count} {data.result.count === 1 ? 'person' : 'people'}</p>
+
+	<div class="table-wrap">
+		<table>
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th class="num">Credits</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each data.result.items as person (person.slug)}
+					<tr>
+						<td><a href={resolve(`/people/${person.slug}`)}>{person.name}</a></td>
+						<td class="num">{person.credit_count}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+
+	{#if totalPages > 1}
+		<nav class="pagination" aria-label="Pagination">
+			<button onclick={() => gotoPage(currentPage - 1)} disabled={currentPage <= 1}>
+				Previous
+			</button>
+			<span class="page-info">Page {currentPage} of {totalPages}</span>
+			<button onclick={() => gotoPage(currentPage + 1)} disabled={currentPage >= totalPages}>
+				Next
+			</button>
+		</nav>
+	{/if}
+{/if}
 
 <style>
 	h1 {
@@ -13,8 +72,93 @@
 		margin-bottom: var(--size-3);
 	}
 
-	.description {
+	.count {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-1);
+		margin-bottom: var(--size-3);
+	}
+
+	.empty {
 		color: var(--color-text-muted);
 		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	th {
+		text-align: left;
+		font-size: var(--font-size-0);
+		font-weight: 600;
+		color: var(--color-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 2px solid var(--color-border);
+	}
+
+	td {
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 1px solid var(--color-border-soft);
+		font-size: var(--font-size-1);
+		color: var(--color-text-primary);
+	}
+
+	.num {
+		text-align: right;
+	}
+
+	a {
+		color: var(--color-link);
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+
+	.pagination {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--size-4);
+		padding: var(--size-5) 0;
+	}
+
+	.page-info {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+	}
+
+	button {
+		padding: var(--size-2) var(--size-4);
+		font-size: var(--font-size-1);
+		font-family: var(--font-body);
+		background-color: var(--color-surface);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		cursor: pointer;
+		transition:
+			background-color 0.15s var(--ease-2),
+			border-color 0.15s var(--ease-2);
+	}
+
+	button:hover:not(:disabled) {
+		border-color: var(--color-accent);
+		color: var(--color-accent);
+	}
+
+	button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
 	}
 </style>

--- a/frontend/src/routes/people/+page.ts
+++ b/frontend/src/routes/people/+page.ts
@@ -1,0 +1,18 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async ({ url }) => {
+	const page = url.searchParams.has('page') ? Number(url.searchParams.get('page')) : undefined;
+
+	const { data } = await client.GET('/api/people/', {
+		params: { query: { page } }
+	});
+
+	if (!data) error(500, 'Failed to load people');
+
+	return { result: data };
+};

--- a/frontend/src/routes/people/[slug]/+page.svelte
+++ b/frontend/src/routes/people/[slug]/+page.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	let { data } = $props();
+	let person = $derived(data.person);
+</script>
+
+<svelte:head>
+	<title>{person.name} — The Flip Pinball DB</title>
+</svelte:head>
+
+<article>
+	<header>
+		<h1>{person.name}</h1>
+	</header>
+
+	{#if person.bio}
+		<section class="bio">
+			<p>{person.bio}</p>
+		</section>
+	{/if}
+
+	{#if Object.keys(person.credits_by_role).length > 0}
+		{#each Object.entries(person.credits_by_role) as [role, credits] (role)}
+			<section class="role-group">
+				<h2>{role}</h2>
+				<ul>
+					{#each credits as credit (credit.model_slug)}
+						<li>
+							<a href={resolve(`/models/${credit.model_slug}`)}>{credit.model_name}</a>
+							<span class="role-label">{credit.role_display}</span>
+						</li>
+					{/each}
+				</ul>
+			</section>
+		{/each}
+	{:else}
+		<p class="empty">No credits listed.</p>
+	{/if}
+</article>
+
+<style>
+	article {
+		max-width: 48rem;
+	}
+
+	header {
+		margin-bottom: var(--size-6);
+	}
+
+	h1 {
+		font-size: var(--font-size-7);
+		font-weight: 700;
+		color: var(--color-text-primary);
+	}
+
+	.bio p {
+		font-size: var(--font-size-2);
+		color: var(--color-text-primary);
+		line-height: var(--font-lineheight-3);
+		margin-bottom: var(--size-6);
+	}
+
+	h2 {
+		font-size: var(--font-size-3);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	.role-group {
+		margin-bottom: var(--size-6);
+	}
+
+	ul {
+		list-style: none;
+		padding: 0;
+	}
+
+	li {
+		display: flex;
+		justify-content: space-between;
+		padding: var(--size-2) 0;
+		border-bottom: 1px solid var(--color-border-soft);
+		font-size: var(--font-size-1);
+	}
+
+	.role-label {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-0);
+	}
+
+	.empty {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+
+	a {
+		color: var(--color-link);
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/frontend/src/routes/people/[slug]/+page.ts
+++ b/frontend/src/routes/people/[slug]/+page.ts
@@ -1,0 +1,19 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async ({ params }) => {
+	const { data, response } = await client.GET('/api/people/{slug}', {
+		params: { path: { slug: params.slug } }
+	});
+
+	if (!data) {
+		if (response?.status === 404) error(404, 'Person not found');
+		error(500, 'Failed to load person');
+	}
+
+	return { person: data };
+};

--- a/frontend/src/routes/sources/+page.svelte
+++ b/frontend/src/routes/sources/+page.svelte
@@ -1,11 +1,9 @@
 <svelte:head>
-	<title>Dashboard — Pinball DB</title>
+	<title>Sources — The Flip Pinball DB</title>
 </svelte:head>
 
-<h1>Dashboard</h1>
-<p class="description">
-	This page is client-side rendered. Auth gating is UX-only — the backend enforces access control.
-</p>
+<h1>Sources</h1>
+<p class="description">Data sources and provenance.</p>
 
 <style>
 	h1 {

--- a/frontend/src/routes/sources/+page.svelte
+++ b/frontend/src/routes/sources/+page.svelte
@@ -1,20 +1,112 @@
+<script lang="ts">
+	let { data } = $props();
+</script>
+
 <svelte:head>
 	<title>Sources — The Flip Pinball DB</title>
 </svelte:head>
 
 <h1>Sources</h1>
-<p class="description">Data sources and provenance.</p>
+
+{#if data.sources.length === 0}
+	<p class="empty">No sources found.</p>
+{:else}
+	<div class="table-wrap">
+		<table>
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Type</th>
+					<th class="num">Priority</th>
+					<th>URL</th>
+					<th>Description</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each data.sources as source (source.slug)}
+					<tr>
+						<td class="name">{source.name}</td>
+						<td>{source.source_type}</td>
+						<td class="num">{source.priority}</td>
+						<td>
+							{#if source.url}
+								<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external URL -->
+								<a href={source.url} target="_blank" rel="noopener">{source.url}</a>
+							{:else}
+								—
+							{/if}
+						</td>
+						<td class="desc">{source.description || '—'}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+{/if}
 
 <style>
 	h1 {
 		font-size: var(--font-size-6);
 		font-weight: 700;
 		color: var(--color-text-primary);
-		margin-bottom: var(--size-3);
+		margin-bottom: var(--size-5);
 	}
 
-	.description {
+	.empty {
 		color: var(--color-text-muted);
 		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	th {
+		text-align: left;
+		font-size: var(--font-size-0);
+		font-weight: 600;
+		color: var(--color-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 2px solid var(--color-border);
+	}
+
+	td {
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 1px solid var(--color-border-soft);
+		font-size: var(--font-size-1);
+		color: var(--color-text-primary);
+		vertical-align: top;
+	}
+
+	.name {
+		font-weight: 500;
+		white-space: nowrap;
+	}
+
+	.num {
+		text-align: right;
+	}
+
+	.desc {
+		max-width: 20rem;
+	}
+
+	a {
+		color: var(--color-link);
+		text-decoration: none;
+		word-break: break-all;
+	}
+
+	a:hover {
+		text-decoration: underline;
 	}
 </style>

--- a/frontend/src/routes/sources/+page.ts
+++ b/frontend/src/routes/sources/+page.ts
@@ -1,0 +1,14 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async () => {
+	const { data } = await client.GET('/api/sources/');
+
+	if (!data) error(500, 'Failed to load sources');
+
+	return { sources: data };
+};

--- a/scripts/dev
+++ b/scripts/dev
@@ -3,6 +3,9 @@ set -e
 cd "$(dirname "$0")/.."
 trap 'kill 0' EXIT
 
+echo "==> Regenerating API types..."
+make api-gen
+
 ./scripts/dev-backend &
 ./scripts/dev-frontend &
 wait


### PR DESCRIPTION
## Summary
First version with a UI.

- **Design system**: Open Props tokens, Lora font, dark/light theme support, global CSS, Nav component, FaIcon component
- **List pages**: Models (with search), Manufacturers, People (with pagination), Sources — all fetching live data from Django Ninja API
- **Detail pages**: Model, Manufacturer, and Person detail views with 404 handling
- **Landing page**: Search box navigates to `/models?search=`
- **API client fix**: Removed `baseUrl` to avoid double `/api/` prefix (schema paths already include it)
- **Shared pagination constants**: `PAGE_SIZES` mirrors backend config (models: 25, manufacturers/people: 50)

All pages use CSR (`ssr = false`, `prerender = false`) since the API isn't available at build time and the relative baseUrl requires a browser context.

## Test plan

- [ ] `pnpm check` — no type errors
- [ ] `pnpm lint` — no lint errors
- [ ] `pnpm build` — build succeeds (landing page still prerenderable)
- [ ] Start both servers (`make dev`), verify each list page loads data
- [ ] Click through to detail pages for models, manufacturers, and people
- [ ] Use search box on landing page — arrives at models with search results
- [ ] Test pagination on models list
- [ ] Verify empty states (no crashes, shows "no results" message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)