### PR TITLE
chore(ci): parallelize api-types job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
 
   api-types:
     runs-on: ubuntu-latest
-    needs: [backend]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## Summary

- Remove `needs: [backend]` from the `api-types` CI job so all three jobs run in parallel
- The `api-types` job installs and runs the backend independently — it doesn't consume any artifact from the `backend` job

## Test plan

- [ ] All three CI jobs start simultaneously
- [ ] `api-types` job still passes (generates schema and runs `pnpm check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)