### PR TITLE
feat: card grid UI, image coverage, and reusable page components

### DIFF
--- a/backend/apps/machines/api.py
+++ b/backend/apps/machines/api.py
@@ -1,6 +1,6 @@
 """API endpoints for the machines app.
 
-Four routers: models, manufacturers, people, sources.
+Five routers: models, groups, manufacturers, people, sources.
 Wired into the main NinjaAPI instance in config/api.py.
 """
 
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from django.db.models import Count, Q
+from django.db.models import Count, Prefetch, Q
 from django.db.models.functions import Cast
 from django.db.models import TextField
 from django.shortcuts import get_object_or_404
@@ -93,6 +93,12 @@ class DesignCreditSchema(Schema):
     role_display: str
 
 
+class AliasSchema(Schema):
+    name: str
+    slug: str
+    features: list[str] = []
+
+
 class PinballModelListSchema(Schema):
     name: str
     slug: str
@@ -105,6 +111,7 @@ class PinballModelListSchema(Schema):
     ipdb_rating: Optional[float] = None
     pinside_rating: Optional[float] = None
     theme: str
+    thumbnail_url: Optional[str] = None
 
 
 class PinballModelDetailSchema(Schema):
@@ -131,11 +138,77 @@ class PinballModelDetailSchema(Schema):
     extra_data: dict
     credits: list[DesignCreditSchema]
     provenance: dict[str, list[ClaimSchema]]
+    thumbnail_url: Optional[str] = None
+    hero_image_url: Optional[str] = None
+    features: list[str] = []
+    aliases: list[AliasSchema] = []
+    group_name: Optional[str] = None
+    group_slug: Optional[str] = None
+
+
+class GroupMachineSchema(Schema):
+    name: str
+    slug: str
+    year: Optional[int] = None
+    manufacturer_name: Optional[str] = None
+    manufacturer_slug: Optional[str] = None
+    machine_type: str
+    thumbnail_url: Optional[str] = None
+
+
+class GroupListSchema(Schema):
+    name: str
+    slug: str
+    shortname: str
+    machine_count: int = 0
+    thumbnail_url: Optional[str] = None
+
+
+class GroupDetailSchema(Schema):
+    name: str
+    slug: str
+    shortname: str
+    machines: list[GroupMachineSchema]
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _extract_image_urls(extra_data: dict) -> tuple[str | None, str | None]:
+    """Return (thumbnail_url, hero_image_url) from extra_data images claim.
+
+    Picks the primary image, falling back to the first image in the list.
+    For thumbnail: medium → small. For hero: large → medium.
+    """
+    images = extra_data.get("images")
+    if not images or not isinstance(images, list):
+        return None, None
+
+    # Find primary image, fall back to first.
+    img = None
+    for candidate in images:
+        if isinstance(candidate, dict) and candidate.get("primary"):
+            img = candidate
+            break
+    if img is None:
+        img = images[0] if images else None
+    if not isinstance(img, dict):
+        return None, None
+
+    urls = img.get("urls") or {}
+    thumbnail = urls.get("medium") or urls.get("small")
+    hero = urls.get("large") or urls.get("medium")
+    return thumbnail, hero
+
+
+def _extract_features(extra_data: dict) -> list[str]:
+    """Return feature list from extra_data features claim."""
+    features = extra_data.get("features")
+    if not features or not isinstance(features, list):
+        return []
+    return [str(f) for f in features]
 
 
 def _build_model_list_qs(
@@ -150,7 +223,9 @@ def _build_model_list_qs(
 ):
     from .models import PinballModel
 
-    qs = PinballModel.objects.select_related("manufacturer")
+    qs = PinballModel.objects.select_related("manufacturer").filter(
+        alias_of__isnull=True
+    )
 
     if search:
         text_q = (
@@ -194,6 +269,7 @@ def _build_model_list_qs(
 
 
 def _serialize_model_list(pm) -> dict:
+    thumbnail_url, _ = _extract_image_urls(pm.extra_data or {})
     return {
         "name": pm.name,
         "slug": pm.slug,
@@ -208,6 +284,7 @@ def _serialize_model_list(pm) -> dict:
         if pm.pinside_rating is not None
         else None,
         "theme": pm.theme,
+        "thumbnail_url": thumbnail_url,
     }
 
 
@@ -239,6 +316,18 @@ def _serialize_model_detail(pm) -> dict:
             }
         )
 
+    thumbnail_url, hero_image_url = _extract_image_urls(pm.extra_data or {})
+    features = _extract_features(pm.extra_data or {})
+
+    aliases = [
+        {
+            "name": alias.name,
+            "slug": alias.slug,
+            "features": _extract_features(alias.extra_data or {}),
+        }
+        for alias in pm.aliases.all()
+    ]
+
     return {
         "name": pm.name,
         "slug": pm.slug,
@@ -265,6 +354,49 @@ def _serialize_model_detail(pm) -> dict:
         "extra_data": pm.extra_data or {},
         "credits": credits,
         "provenance": provenance,
+        "thumbnail_url": thumbnail_url,
+        "hero_image_url": hero_image_url,
+        "features": features,
+        "aliases": aliases,
+        "group_name": pm.group.name if pm.group else None,
+        "group_slug": pm.group.slug if pm.group else None,
+    }
+
+
+def _serialize_group_list(group) -> dict:
+    thumbnail_url = None
+    machines = list(group.machines.all())
+    if machines:
+        thumbnail_url, _ = _extract_image_urls(machines[0].extra_data or {})
+    return {
+        "name": group.name,
+        "slug": group.slug,
+        "shortname": group.shortname,
+        "machine_count": group.machine_count,
+        "thumbnail_url": thumbnail_url,
+    }
+
+
+def _serialize_group_detail(group) -> dict:
+    machines = []
+    for pm in group.machines.all():
+        thumbnail_url, _ = _extract_image_urls(pm.extra_data or {})
+        machines.append(
+            {
+                "name": pm.name,
+                "slug": pm.slug,
+                "year": pm.year,
+                "manufacturer_name": pm.manufacturer.name if pm.manufacturer else None,
+                "manufacturer_slug": pm.manufacturer.slug if pm.manufacturer else None,
+                "machine_type": pm.machine_type,
+                "thumbnail_url": thumbnail_url,
+            }
+        )
+    return {
+        "name": group.name,
+        "slug": group.slug,
+        "shortname": group.shortname,
+        "machines": machines,
     }
 
 
@@ -306,9 +438,58 @@ def get_model(request, slug: str):
     from .models import PinballModel
 
     pm = get_object_or_404(
-        PinballModel.objects.select_related("manufacturer"), slug=slug
+        PinballModel.objects.select_related("manufacturer", "group").prefetch_related(
+            "aliases"
+        ),
+        slug=slug,
     )
     return _serialize_model_detail(pm)
+
+
+# ---------------------------------------------------------------------------
+# Groups router
+# ---------------------------------------------------------------------------
+
+groups_router = Router(tags=["groups"])
+
+
+@groups_router.get("/", response=list[GroupListSchema])
+@paginate(PageNumberPagination, page_size=25)
+def list_groups(request, search: str = ""):
+    from .models import MachineGroup, PinballModel
+
+    qs = MachineGroup.objects.annotate(
+        machine_count=Count("machines", filter=Q(machines__alias_of__isnull=True))
+    ).prefetch_related(
+        Prefetch(
+            "machines",
+            queryset=PinballModel.objects.filter(alias_of__isnull=True).order_by(
+                "year", "name"
+            ),
+        )
+    )
+    if search:
+        qs = qs.filter(Q(name__icontains=search) | Q(shortname__icontains=search))
+    qs = qs.order_by("name")
+    return [_serialize_group_list(g) for g in qs]
+
+
+@groups_router.get("/{slug}", response=GroupDetailSchema)
+def get_group(request, slug: str):
+    from .models import MachineGroup, PinballModel
+
+    group = get_object_or_404(
+        MachineGroup.objects.prefetch_related(
+            Prefetch(
+                "machines",
+                queryset=PinballModel.objects.filter(
+                    alias_of__isnull=True
+                ).select_related("manufacturer"),
+            )
+        ),
+        slug=slug,
+    )
+    return _serialize_group_detail(group)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -1,6 +1,7 @@
 from ninja import NinjaAPI
 
 from apps.machines.api import (
+    groups_router,
     manufacturers_router,
     models_router,
     people_router,
@@ -19,6 +20,7 @@ def health(request):
 
 
 api.add_router("/models/", models_router)
+api.add_router("/groups/", groups_router)
 api.add_router("/manufacturers/", manufacturers_router)
 api.add_router("/people/", people_router)
 api.add_router("/sources/", sources_router)

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -97,10 +97,12 @@ html {
 
 a {
 	color: var(--color-link);
+	text-decoration: none;
 }
 
 a:hover {
 	color: var(--color-accent-hover);
+	text-decoration: underline;
 }
 
 /* ========================================

--- a/frontend/src/lib/api/pagination.ts
+++ b/frontend/src/lib/api/pagination.ts
@@ -4,6 +4,7 @@
  */
 export const PAGE_SIZES = {
 	models: 25,
+	groups: 25,
 	manufacturers: 50,
 	people: 50
 } as const;

--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		href,
+		title,
+		thumbnailUrl = null,
+		children = undefined
+	}: {
+		href: string;
+		title: string;
+		thumbnailUrl?: string | null;
+		children?: Snippet;
+	} = $props();
+</script>
+
+<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href is pre-resolved by caller -->
+<a {href} class="card">
+	{#if thumbnailUrl}
+		<img src={thumbnailUrl} alt="" class="card-img" loading="lazy" />
+	{:else}
+		<div class="card-img-placeholder"></div>
+	{/if}
+	<div class="card-body">
+		<h3 class="card-title">{title}</h3>
+		{#if children}
+			{@render children()}
+		{/if}
+	</div>
+</a>
+
+<style>
+	.card {
+		display: flex;
+		flex-direction: column;
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-2);
+		overflow: hidden;
+		text-decoration: none;
+		color: inherit;
+		transition:
+			border-color 0.15s var(--ease-2),
+			box-shadow 0.15s var(--ease-2);
+	}
+
+	.card:hover {
+		border-color: var(--color-accent);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+	}
+
+	.card-img {
+		width: 100%;
+		height: 8rem;
+		object-fit: cover;
+	}
+
+	.card-img-placeholder {
+		width: 100%;
+		height: 8rem;
+		background-color: var(--color-border-soft);
+	}
+
+	.card-body {
+		padding: var(--size-3);
+	}
+
+	.card-title {
+		font-size: var(--font-size-2);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-1);
+	}
+</style>

--- a/frontend/src/lib/components/CardGrid.svelte
+++ b/frontend/src/lib/components/CardGrid.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<div class="card-grid">
+	{@render children()}
+</div>
+
+<style>
+	.card-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+		gap: var(--size-4);
+	}
+</style>

--- a/frontend/src/lib/components/DataTable.svelte
+++ b/frontend/src/lib/components/DataTable.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<div class="data-table">
+	{@render children()}
+</div>
+
+<style>
+	.data-table {
+		overflow-x: auto;
+	}
+
+	.data-table :global(table) {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	.data-table :global(th) {
+		text-align: left;
+		font-size: var(--font-size-0);
+		font-weight: 600;
+		color: var(--color-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 2px solid var(--color-border);
+	}
+
+	.data-table :global(td) {
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 1px solid var(--color-border-soft);
+		font-size: var(--font-size-1);
+		color: var(--color-text-primary);
+	}
+
+	.data-table :global(.num) {
+		text-align: right;
+	}
+</style>

--- a/frontend/src/lib/components/DetailPage.svelte
+++ b/frontend/src/lib/components/DetailPage.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		title,
+		subtitle = undefined,
+		children
+	}: {
+		title: string;
+		subtitle?: Snippet;
+		children: Snippet;
+	} = $props();
+</script>
+
+<svelte:head>
+	<title>{title} — The Flip Pinball DB</title>
+</svelte:head>
+
+<article class="detail">
+	<header>
+		<h1>{title}</h1>
+		{#if subtitle}
+			{@render subtitle()}
+		{/if}
+	</header>
+
+	{@render children()}
+</article>
+
+<style>
+	.detail {
+		max-width: 64rem;
+	}
+
+	header {
+		margin-bottom: var(--size-6);
+	}
+
+	h1 {
+		font-size: var(--font-size-7);
+		font-weight: 700;
+		color: var(--color-text-primary);
+	}
+
+	.detail :global(h2) {
+		font-size: var(--font-size-3);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	.detail :global(.empty) {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+</style>

--- a/frontend/src/lib/components/GroupCard.svelte
+++ b/frontend/src/lib/components/GroupCard.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import Card from './Card.svelte';
+
+	let {
+		slug,
+		name,
+		thumbnailUrl = null,
+		shortname = null,
+		machineCount = 0
+	}: {
+		slug: string;
+		name: string;
+		thumbnailUrl?: string | null;
+		shortname?: string | null;
+		machineCount?: number;
+	} = $props();
+</script>
+
+<Card href={resolve(`/groups/${slug}`)} title={name} {thumbnailUrl}>
+	{#if shortname && shortname !== name}
+		<p class="card-shortname">{shortname}</p>
+	{/if}
+	<p class="card-count">{machineCount} machine{machineCount === 1 ? '' : 's'}</p>
+</Card>
+
+<style>
+	.card-shortname {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+		margin-bottom: var(--size-1);
+	}
+
+	.card-count {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+	}
+</style>

--- a/frontend/src/lib/components/ListPage.svelte
+++ b/frontend/src/lib/components/ListPage.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import type { Snippet } from 'svelte';
+	import SearchBar from './SearchBar.svelte';
+	import Pagination from './Pagination.svelte';
+
+	let {
+		title,
+		count,
+		pageSize,
+		entityName,
+		entityNamePlural = `${entityName}s`,
+		search = false,
+		children
+	}: {
+		title: string;
+		count: number;
+		pageSize: number;
+		entityName: string;
+		entityNamePlural?: string;
+		search?: boolean;
+		children: Snippet;
+	} = $props();
+
+	function gotoPage(p: number) {
+		const url = new URL(page.url);
+		if (p > 1) {
+			url.searchParams.set('page', String(p));
+		} else {
+			url.searchParams.delete('page');
+		}
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
+		goto(url);
+	}
+
+	let currentPage = $derived(Number(page.url.searchParams.get('page') ?? '1'));
+	let totalPages = $derived(Math.ceil(count / pageSize));
+</script>
+
+<svelte:head>
+	<title>{title} — The Flip Pinball DB</title>
+</svelte:head>
+
+<h1>{title}</h1>
+
+{#if search}
+	<SearchBar placeholder="Search {entityNamePlural}..." ariaLabel="Search {entityNamePlural}" />
+{/if}
+
+{#if count === 0}
+	<p class="empty">No {entityNamePlural} found.</p>
+{:else}
+	<p class="count">{count} {count === 1 ? entityName : entityNamePlural}</p>
+
+	{@render children()}
+
+	<Pagination {currentPage} {totalPages} onPageChange={gotoPage} />
+{/if}
+
+<style>
+	h1 {
+		font-size: var(--font-size-6);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	.count {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-1);
+		margin-bottom: var(--size-3);
+	}
+
+	.empty {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+</style>

--- a/frontend/src/lib/components/MachineCard.svelte
+++ b/frontend/src/lib/components/MachineCard.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import Card from './Card.svelte';
+
+	let {
+		slug,
+		name,
+		thumbnailUrl = null,
+		manufacturerName = null,
+		year = null,
+		machineType = null,
+		ipdbRating = null,
+		pinsideRating = null
+	}: {
+		slug: string;
+		name: string;
+		thumbnailUrl?: string | null;
+		manufacturerName?: string | null;
+		year?: number | null;
+		machineType?: string | null;
+		ipdbRating?: number | null;
+		pinsideRating?: number | null;
+	} = $props();
+
+	let hasMeta = $derived(!!manufacturerName || !!year || !!machineType);
+	let hasRatings = $derived(!!ipdbRating || !!pinsideRating);
+</script>
+
+<Card href={resolve(`/models/${slug}`)} title={name} {thumbnailUrl}>
+	{#if hasMeta}
+		<div class="card-meta">
+			{#if manufacturerName}
+				<span>{manufacturerName}</span>
+			{/if}
+			{#if year}
+				<span>{year}</span>
+			{/if}
+			{#if machineType}
+				<span>{machineType}</span>
+			{/if}
+		</div>
+	{/if}
+	{#if hasRatings}
+		<div class="card-ratings">
+			{#if ipdbRating}
+				<span>IPDB {ipdbRating}</span>
+			{/if}
+			{#if pinsideRating}
+				<span>Pinside {pinsideRating}</span>
+			{/if}
+		</div>
+	{/if}
+</Card>
+
+<style>
+	.card-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--size-1);
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+	}
+
+	.card-meta span:not(:last-child)::after {
+		content: '·';
+		margin-left: var(--size-1);
+	}
+
+	.card-ratings {
+		display: flex;
+		gap: var(--size-2);
+		margin-top: var(--size-1);
+		font-size: var(--font-size-0);
+		color: var(--color-accent);
+		font-weight: 500;
+	}
+</style>

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -8,6 +8,7 @@
 
 	const navItems = [
 		{ href: '/models' as const, label: 'Models' },
+		{ href: '/groups' as const, label: 'Groups' },
 		{ href: '/manufacturers' as const, label: 'Manufacturers' },
 		{ href: '/people' as const, label: 'People' },
 		{ href: '/sources' as const, label: 'Sources' }

--- a/frontend/src/lib/components/Pagination.svelte
+++ b/frontend/src/lib/components/Pagination.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	let {
+		currentPage,
+		totalPages,
+		onPageChange
+	}: {
+		currentPage: number;
+		totalPages: number;
+		onPageChange: (page: number) => void;
+	} = $props();
+</script>
+
+{#if totalPages > 1}
+	<nav class="pagination" aria-label="Pagination">
+		<button onclick={() => onPageChange(currentPage - 1)} disabled={currentPage <= 1}>
+			Previous
+		</button>
+		<span class="page-info">Page {currentPage} of {totalPages}</span>
+		<button onclick={() => onPageChange(currentPage + 1)} disabled={currentPage >= totalPages}>
+			Next
+		</button>
+	</nav>
+{/if}
+
+<style>
+	.pagination {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--size-4);
+		padding: var(--size-5) 0;
+	}
+
+	.page-info {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+	}
+
+	button {
+		padding: var(--size-2) var(--size-4);
+		font-size: var(--font-size-1);
+		font-family: var(--font-body);
+		background-color: var(--color-surface);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		cursor: pointer;
+		transition:
+			background-color 0.15s var(--ease-2),
+			border-color 0.15s var(--ease-2);
+	}
+
+	button:hover:not(:disabled) {
+		border-color: var(--color-accent);
+		color: var(--color-accent);
+	}
+
+	button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+</style>

--- a/frontend/src/lib/components/SearchBar.svelte
+++ b/frontend/src/lib/components/SearchBar.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+	import FaIcon from './FaIcon.svelte';
+
+	let {
+		placeholder,
+		ariaLabel
+	}: {
+		placeholder: string;
+		ariaLabel: string;
+	} = $props();
+
+	let searchValue = $state(page.url.searchParams.get('search') ?? '');
+
+	function handleSearch(e: SubmitEvent) {
+		e.preventDefault();
+		const url = new URL(page.url);
+		if (searchValue.trim()) {
+			url.searchParams.set('search', searchValue.trim());
+		} else {
+			url.searchParams.delete('search');
+		}
+		url.searchParams.delete('page');
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
+		goto(url, { keepFocus: true });
+	}
+</script>
+
+<form class="search-bar" onsubmit={handleSearch}>
+	<div class="search-box">
+		<FaIcon icon={faMagnifyingGlass} class="search-icon" />
+		<input type="search" {placeholder} aria-label={ariaLabel} bind:value={searchValue} />
+	</div>
+</form>
+
+<style>
+	.search-bar {
+		margin-bottom: var(--size-5);
+	}
+
+	.search-box {
+		position: relative;
+		max-width: 24rem;
+	}
+
+	:global(.search-box .search-icon) {
+		position: absolute;
+		left: var(--size-3);
+		top: 50%;
+		transform: translateY(-50%);
+		width: 0.875rem;
+		height: 0.875rem;
+		color: var(--color-text-muted);
+		pointer-events: none;
+	}
+
+	input[type='search'] {
+		width: 100%;
+		padding: var(--size-2) var(--size-3) var(--size-2) var(--size-8);
+		font-size: var(--font-size-1);
+		font-family: var(--font-body);
+		background-color: var(--color-input-bg);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-input-border);
+		border-radius: var(--radius-2);
+		transition:
+			border-color 0.15s var(--ease-2),
+			box-shadow 0.15s var(--ease-2);
+	}
+
+	input[type='search']:focus {
+		outline: none;
+		border-color: var(--color-input-focus);
+		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
+	}
+
+	input[type='search']::placeholder {
+		color: var(--color-text-muted);
+	}
+</style>

--- a/frontend/src/routes/groups/+page.svelte
+++ b/frontend/src/routes/groups/+page.svelte
@@ -1,0 +1,258 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
+	import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+	import FaIcon from '$lib/components/FaIcon.svelte';
+	import { PAGE_SIZES } from '$lib/api/pagination';
+
+	let { data } = $props();
+
+	let searchValue = $state(page.url.searchParams.get('search') ?? '');
+
+	function handleSearch(e: SubmitEvent) {
+		e.preventDefault();
+		const url = new URL(page.url);
+		if (searchValue.trim()) {
+			url.searchParams.set('search', searchValue.trim());
+		} else {
+			url.searchParams.delete('search');
+		}
+		url.searchParams.delete('page');
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
+		goto(url, { keepFocus: true });
+	}
+
+	function gotoPage(p: number) {
+		const url = new URL(page.url);
+		if (p > 1) {
+			url.searchParams.set('page', String(p));
+		} else {
+			url.searchParams.delete('page');
+		}
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
+		goto(url);
+	}
+
+	let currentPage = $derived(Number(page.url.searchParams.get('page') ?? '1'));
+	let totalPages = $derived(Math.ceil(data.result.count / PAGE_SIZES.groups));
+</script>
+
+<svelte:head>
+	<title>Groups — The Flip Pinball DB</title>
+</svelte:head>
+
+<h1>Groups</h1>
+
+<form class="search-bar" onsubmit={handleSearch}>
+	<div class="search-box">
+		<FaIcon icon={faMagnifyingGlass} class="search-icon" />
+		<input
+			type="search"
+			placeholder="Search groups..."
+			aria-label="Search groups"
+			bind:value={searchValue}
+		/>
+	</div>
+</form>
+
+{#if data.result.items.length === 0}
+	<p class="empty">No groups found.</p>
+{:else}
+	<p class="count">{data.result.count} group{data.result.count === 1 ? '' : 's'}</p>
+
+	<div class="card-grid">
+		{#each data.result.items as group (group.slug)}
+			<a href={resolve(`/groups/${group.slug}`)} class="card">
+				{#if group.thumbnail_url}
+					<img src={group.thumbnail_url} alt="" class="card-img" loading="lazy" />
+				{:else}
+					<div class="card-img-placeholder"></div>
+				{/if}
+				<div class="card-body">
+					<h2 class="card-title">{group.name}</h2>
+					{#if group.shortname && group.shortname !== group.name}
+						<p class="card-shortname">{group.shortname}</p>
+					{/if}
+					<p class="card-count">
+						{group.machine_count} machine{group.machine_count === 1 ? '' : 's'}
+					</p>
+				</div>
+			</a>
+		{/each}
+	</div>
+
+	{#if totalPages > 1}
+		<nav class="pagination" aria-label="Pagination">
+			<button onclick={() => gotoPage(currentPage - 1)} disabled={currentPage <= 1}>
+				Previous
+			</button>
+			<span class="page-info">Page {currentPage} of {totalPages}</span>
+			<button onclick={() => gotoPage(currentPage + 1)} disabled={currentPage >= totalPages}>
+				Next
+			</button>
+		</nav>
+	{/if}
+{/if}
+
+<style>
+	h1 {
+		font-size: var(--font-size-6);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	.search-bar {
+		margin-bottom: var(--size-5);
+	}
+
+	.search-box {
+		position: relative;
+		max-width: 24rem;
+	}
+
+	:global(.search-box .search-icon) {
+		position: absolute;
+		left: var(--size-3);
+		top: 50%;
+		transform: translateY(-50%);
+		width: 0.875rem;
+		height: 0.875rem;
+		color: var(--color-text-muted);
+		pointer-events: none;
+	}
+
+	input[type='search'] {
+		width: 100%;
+		padding: var(--size-2) var(--size-3) var(--size-2) var(--size-8);
+		font-size: var(--font-size-1);
+		font-family: var(--font-body);
+		background-color: var(--color-input-bg);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-input-border);
+		border-radius: var(--radius-2);
+		transition:
+			border-color 0.15s var(--ease-2),
+			box-shadow 0.15s var(--ease-2);
+	}
+
+	input[type='search']:focus {
+		outline: none;
+		border-color: var(--color-input-focus);
+		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
+	}
+
+	input[type='search']::placeholder {
+		color: var(--color-text-muted);
+	}
+
+	.count {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-1);
+		margin-bottom: var(--size-3);
+	}
+
+	.empty {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+
+	.card-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+		gap: var(--size-4);
+	}
+
+	.card {
+		display: flex;
+		flex-direction: column;
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-2);
+		overflow: hidden;
+		text-decoration: none;
+		color: inherit;
+		transition:
+			border-color 0.15s var(--ease-2),
+			box-shadow 0.15s var(--ease-2);
+	}
+
+	.card:hover {
+		border-color: var(--color-accent);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+	}
+
+	.card-img {
+		width: 100%;
+		height: 8rem;
+		object-fit: cover;
+	}
+
+	.card-img-placeholder {
+		width: 100%;
+		height: 8rem;
+		background-color: var(--color-border-soft);
+	}
+
+	.card-body {
+		padding: var(--size-3);
+	}
+
+	.card-title {
+		font-size: var(--font-size-2);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-1);
+	}
+
+	.card-shortname {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+		margin-bottom: var(--size-1);
+	}
+
+	.card-count {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+	}
+
+	.pagination {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--size-4);
+		padding: var(--size-5) 0;
+	}
+
+	.page-info {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+	}
+
+	button {
+		padding: var(--size-2) var(--size-4);
+		font-size: var(--font-size-1);
+		font-family: var(--font-body);
+		background-color: var(--color-surface);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		cursor: pointer;
+		transition:
+			background-color 0.15s var(--ease-2),
+			border-color 0.15s var(--ease-2);
+	}
+
+	button:hover:not(:disabled) {
+		border-color: var(--color-accent);
+		color: var(--color-accent);
+	}
+
+	button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+</style>

--- a/frontend/src/routes/groups/+page.svelte
+++ b/frontend/src/routes/groups/+page.svelte
@@ -1,258 +1,28 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { page } from '$app/state';
-	import { resolve } from '$app/paths';
-	import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
-	import FaIcon from '$lib/components/FaIcon.svelte';
+	import ListPage from '$lib/components/ListPage.svelte';
+	import CardGrid from '$lib/components/CardGrid.svelte';
+	import GroupCard from '$lib/components/GroupCard.svelte';
 	import { PAGE_SIZES } from '$lib/api/pagination';
 
 	let { data } = $props();
-
-	let searchValue = $state(page.url.searchParams.get('search') ?? '');
-
-	function handleSearch(e: SubmitEvent) {
-		e.preventDefault();
-		const url = new URL(page.url);
-		if (searchValue.trim()) {
-			url.searchParams.set('search', searchValue.trim());
-		} else {
-			url.searchParams.delete('search');
-		}
-		url.searchParams.delete('page');
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
-		goto(url, { keepFocus: true });
-	}
-
-	function gotoPage(p: number) {
-		const url = new URL(page.url);
-		if (p > 1) {
-			url.searchParams.set('page', String(p));
-		} else {
-			url.searchParams.delete('page');
-		}
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
-		goto(url);
-	}
-
-	let currentPage = $derived(Number(page.url.searchParams.get('page') ?? '1'));
-	let totalPages = $derived(Math.ceil(data.result.count / PAGE_SIZES.groups));
 </script>
 
-<svelte:head>
-	<title>Groups — The Flip Pinball DB</title>
-</svelte:head>
-
-<h1>Groups</h1>
-
-<form class="search-bar" onsubmit={handleSearch}>
-	<div class="search-box">
-		<FaIcon icon={faMagnifyingGlass} class="search-icon" />
-		<input
-			type="search"
-			placeholder="Search groups..."
-			aria-label="Search groups"
-			bind:value={searchValue}
-		/>
-	</div>
-</form>
-
-{#if data.result.items.length === 0}
-	<p class="empty">No groups found.</p>
-{:else}
-	<p class="count">{data.result.count} group{data.result.count === 1 ? '' : 's'}</p>
-
-	<div class="card-grid">
+<ListPage
+	title="Groups"
+	count={data.result.count}
+	pageSize={PAGE_SIZES.groups}
+	entityName="group"
+	search
+>
+	<CardGrid>
 		{#each data.result.items as group (group.slug)}
-			<a href={resolve(`/groups/${group.slug}`)} class="card">
-				{#if group.thumbnail_url}
-					<img src={group.thumbnail_url} alt="" class="card-img" loading="lazy" />
-				{:else}
-					<div class="card-img-placeholder"></div>
-				{/if}
-				<div class="card-body">
-					<h2 class="card-title">{group.name}</h2>
-					{#if group.shortname && group.shortname !== group.name}
-						<p class="card-shortname">{group.shortname}</p>
-					{/if}
-					<p class="card-count">
-						{group.machine_count} machine{group.machine_count === 1 ? '' : 's'}
-					</p>
-				</div>
-			</a>
+			<GroupCard
+				slug={group.slug}
+				name={group.name}
+				thumbnailUrl={group.thumbnail_url}
+				shortname={group.shortname}
+				machineCount={group.machine_count}
+			/>
 		{/each}
-	</div>
-
-	{#if totalPages > 1}
-		<nav class="pagination" aria-label="Pagination">
-			<button onclick={() => gotoPage(currentPage - 1)} disabled={currentPage <= 1}>
-				Previous
-			</button>
-			<span class="page-info">Page {currentPage} of {totalPages}</span>
-			<button onclick={() => gotoPage(currentPage + 1)} disabled={currentPage >= totalPages}>
-				Next
-			</button>
-		</nav>
-	{/if}
-{/if}
-
-<style>
-	h1 {
-		font-size: var(--font-size-6);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-3);
-	}
-
-	.search-bar {
-		margin-bottom: var(--size-5);
-	}
-
-	.search-box {
-		position: relative;
-		max-width: 24rem;
-	}
-
-	:global(.search-box .search-icon) {
-		position: absolute;
-		left: var(--size-3);
-		top: 50%;
-		transform: translateY(-50%);
-		width: 0.875rem;
-		height: 0.875rem;
-		color: var(--color-text-muted);
-		pointer-events: none;
-	}
-
-	input[type='search'] {
-		width: 100%;
-		padding: var(--size-2) var(--size-3) var(--size-2) var(--size-8);
-		font-size: var(--font-size-1);
-		font-family: var(--font-body);
-		background-color: var(--color-input-bg);
-		color: var(--color-text-primary);
-		border: 1px solid var(--color-input-border);
-		border-radius: var(--radius-2);
-		transition:
-			border-color 0.15s var(--ease-2),
-			box-shadow 0.15s var(--ease-2);
-	}
-
-	input[type='search']:focus {
-		outline: none;
-		border-color: var(--color-input-focus);
-		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
-	}
-
-	input[type='search']::placeholder {
-		color: var(--color-text-muted);
-	}
-
-	.count {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-1);
-		margin-bottom: var(--size-3);
-	}
-
-	.empty {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-2);
-		padding: var(--size-8) 0;
-		text-align: center;
-	}
-
-	.card-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
-		gap: var(--size-4);
-	}
-
-	.card {
-		display: flex;
-		flex-direction: column;
-		background-color: var(--color-surface);
-		border: 1px solid var(--color-border-soft);
-		border-radius: var(--radius-2);
-		overflow: hidden;
-		text-decoration: none;
-		color: inherit;
-		transition:
-			border-color 0.15s var(--ease-2),
-			box-shadow 0.15s var(--ease-2);
-	}
-
-	.card:hover {
-		border-color: var(--color-accent);
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-	}
-
-	.card-img {
-		width: 100%;
-		height: 8rem;
-		object-fit: cover;
-	}
-
-	.card-img-placeholder {
-		width: 100%;
-		height: 8rem;
-		background-color: var(--color-border-soft);
-	}
-
-	.card-body {
-		padding: var(--size-3);
-	}
-
-	.card-title {
-		font-size: var(--font-size-2);
-		font-weight: 600;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-1);
-	}
-
-	.card-shortname {
-		font-size: var(--font-size-0);
-		color: var(--color-text-muted);
-		margin-bottom: var(--size-1);
-	}
-
-	.card-count {
-		font-size: var(--font-size-0);
-		color: var(--color-text-muted);
-	}
-
-	.pagination {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: var(--size-4);
-		padding: var(--size-5) 0;
-	}
-
-	.page-info {
-		font-size: var(--font-size-1);
-		color: var(--color-text-muted);
-	}
-
-	button {
-		padding: var(--size-2) var(--size-4);
-		font-size: var(--font-size-1);
-		font-family: var(--font-body);
-		background-color: var(--color-surface);
-		color: var(--color-text-primary);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		cursor: pointer;
-		transition:
-			background-color 0.15s var(--ease-2),
-			border-color 0.15s var(--ease-2);
-	}
-
-	button:hover:not(:disabled) {
-		border-color: var(--color-accent);
-		color: var(--color-accent);
-	}
-
-	button:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
-	}
-</style>
+	</CardGrid>
+</ListPage>

--- a/frontend/src/routes/groups/+page.ts
+++ b/frontend/src/routes/groups/+page.ts
@@ -1,0 +1,19 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async ({ url }) => {
+	const search = url.searchParams.get('search') ?? undefined;
+	const page = url.searchParams.has('page') ? Number(url.searchParams.get('page')) : undefined;
+
+	const { data } = await client.GET('/api/groups/', {
+		params: { query: { search, page } }
+	});
+
+	if (!data) error(500, 'Failed to load groups');
+
+	return { result: data };
+};

--- a/frontend/src/routes/groups/[slug]/+page.svelte
+++ b/frontend/src/routes/groups/[slug]/+page.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	let { data } = $props();
+	let group = $derived(data.group);
+</script>
+
+<svelte:head>
+	<title>{group.name} — The Flip Pinball DB</title>
+</svelte:head>
+
+<article>
+	<header>
+		<h1>{group.name}</h1>
+		{#if group.shortname && group.shortname !== group.name}
+			<p class="shortname">{group.shortname}</p>
+		{/if}
+	</header>
+
+	{#if group.machines.length === 0}
+		<p class="empty">No machines in this group.</p>
+	{:else}
+		<section>
+			<h2>Machines ({group.machines.length})</h2>
+			<div class="card-grid">
+				{#each group.machines as machine (machine.slug)}
+					<a href={resolve(`/models/${machine.slug}`)} class="card">
+						{#if machine.thumbnail_url}
+							<img src={machine.thumbnail_url} alt="" class="card-img" loading="lazy" />
+						{:else}
+							<div class="card-img-placeholder"></div>
+						{/if}
+						<div class="card-body">
+							<h3 class="card-title">{machine.name}</h3>
+							<div class="card-meta">
+								{#if machine.manufacturer_name}
+									<span>{machine.manufacturer_name}</span>
+								{/if}
+								{#if machine.year}
+									<span>{machine.year}</span>
+								{/if}
+								<span>{machine.machine_type}</span>
+							</div>
+						</div>
+					</a>
+				{/each}
+			</div>
+		</section>
+	{/if}
+</article>
+
+<style>
+	article {
+		max-width: 64rem;
+	}
+
+	header {
+		margin-bottom: var(--size-6);
+	}
+
+	h1 {
+		font-size: var(--font-size-7);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-2);
+	}
+
+	.shortname {
+		font-size: var(--font-size-2);
+		color: var(--color-text-muted);
+	}
+
+	h2 {
+		font-size: var(--font-size-3);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	.empty {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-2);
+		padding: var(--size-8) 0;
+		text-align: center;
+	}
+
+	.card-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+		gap: var(--size-4);
+	}
+
+	.card {
+		display: flex;
+		flex-direction: column;
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-2);
+		overflow: hidden;
+		text-decoration: none;
+		color: inherit;
+		transition:
+			border-color 0.15s var(--ease-2),
+			box-shadow 0.15s var(--ease-2);
+	}
+
+	.card:hover {
+		border-color: var(--color-accent);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+	}
+
+	.card-img {
+		width: 100%;
+		height: 8rem;
+		object-fit: cover;
+	}
+
+	.card-img-placeholder {
+		width: 100%;
+		height: 8rem;
+		background-color: var(--color-border-soft);
+	}
+
+	.card-body {
+		padding: var(--size-3);
+	}
+
+	.card-title {
+		font-size: var(--font-size-2);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-1);
+	}
+
+	.card-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--size-1);
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+	}
+
+	.card-meta span:not(:last-child)::after {
+		content: '·';
+		margin-left: var(--size-1);
+	}
+
+	a {
+		color: var(--color-link);
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/frontend/src/routes/groups/[slug]/+page.svelte
+++ b/frontend/src/routes/groups/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import CardGrid from '$lib/components/CardGrid.svelte';
+	import MachineCard from '$lib/components/MachineCard.svelte';
 
 	let { data } = $props();
 	let group = $derived(data.group);
@@ -22,29 +23,18 @@
 	{:else}
 		<section>
 			<h2>Machines ({group.machines.length})</h2>
-			<div class="card-grid">
+			<CardGrid>
 				{#each group.machines as machine (machine.slug)}
-					<a href={resolve(`/models/${machine.slug}`)} class="card">
-						{#if machine.thumbnail_url}
-							<img src={machine.thumbnail_url} alt="" class="card-img" loading="lazy" />
-						{:else}
-							<div class="card-img-placeholder"></div>
-						{/if}
-						<div class="card-body">
-							<h3 class="card-title">{machine.name}</h3>
-							<div class="card-meta">
-								{#if machine.manufacturer_name}
-									<span>{machine.manufacturer_name}</span>
-								{/if}
-								{#if machine.year}
-									<span>{machine.year}</span>
-								{/if}
-								<span>{machine.machine_type}</span>
-							</div>
-						</div>
-					</a>
+					<MachineCard
+						slug={machine.slug}
+						name={machine.name}
+						thumbnailUrl={machine.thumbnail_url}
+						manufacturerName={machine.manufacturer_name}
+						year={machine.year}
+						machineType={machine.machine_type}
+					/>
 				{/each}
-			</div>
+			</CardGrid>
 		</section>
 	{/if}
 </article>
@@ -82,75 +72,5 @@
 		font-size: var(--font-size-2);
 		padding: var(--size-8) 0;
 		text-align: center;
-	}
-
-	.card-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
-		gap: var(--size-4);
-	}
-
-	.card {
-		display: flex;
-		flex-direction: column;
-		background-color: var(--color-surface);
-		border: 1px solid var(--color-border-soft);
-		border-radius: var(--radius-2);
-		overflow: hidden;
-		text-decoration: none;
-		color: inherit;
-		transition:
-			border-color 0.15s var(--ease-2),
-			box-shadow 0.15s var(--ease-2);
-	}
-
-	.card:hover {
-		border-color: var(--color-accent);
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-	}
-
-	.card-img {
-		width: 100%;
-		height: 8rem;
-		object-fit: cover;
-	}
-
-	.card-img-placeholder {
-		width: 100%;
-		height: 8rem;
-		background-color: var(--color-border-soft);
-	}
-
-	.card-body {
-		padding: var(--size-3);
-	}
-
-	.card-title {
-		font-size: var(--font-size-2);
-		font-weight: 600;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-1);
-	}
-
-	.card-meta {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--size-1);
-		font-size: var(--font-size-0);
-		color: var(--color-text-muted);
-	}
-
-	.card-meta span:not(:last-child)::after {
-		content: '·';
-		margin-left: var(--size-1);
-	}
-
-	a {
-		color: var(--color-link);
-		text-decoration: none;
-	}
-
-	a:hover {
-		text-decoration: underline;
 	}
 </style>

--- a/frontend/src/routes/groups/[slug]/+page.ts
+++ b/frontend/src/routes/groups/[slug]/+page.ts
@@ -1,0 +1,19 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async ({ params }) => {
+	const { data, response } = await client.GET('/api/groups/{slug}', {
+		params: { path: { slug: params.slug } }
+	});
+
+	if (!data) {
+		if (response?.status === 404) error(404, 'Group not found');
+		error(500, 'Failed to load group');
+	}
+
+	return { group: data };
+};

--- a/frontend/src/routes/manufacturers/+page.svelte
+++ b/frontend/src/routes/manufacturers/+page.svelte
@@ -1,38 +1,19 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
+	import ListPage from '$lib/components/ListPage.svelte';
+	import DataTable from '$lib/components/DataTable.svelte';
 	import { PAGE_SIZES } from '$lib/api/pagination';
 
 	let { data } = $props();
-
-	function gotoPage(p: number) {
-		const url = new URL(page.url);
-		if (p > 1) {
-			url.searchParams.set('page', String(p));
-		} else {
-			url.searchParams.delete('page');
-		}
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
-		goto(url);
-	}
-
-	let currentPage = $derived(Number(page.url.searchParams.get('page') ?? '1'));
-	let totalPages = $derived(Math.ceil(data.result.count / PAGE_SIZES.manufacturers));
 </script>
 
-<svelte:head>
-	<title>Manufacturers — The Flip Pinball DB</title>
-</svelte:head>
-
-<h1>Manufacturers</h1>
-
-{#if data.result.items.length === 0}
-	<p class="empty">No manufacturers found.</p>
-{:else}
-	<p class="count">{data.result.count} manufacturer{data.result.count === 1 ? '' : 's'}</p>
-
-	<div class="table-wrap">
+<ListPage
+	title="Manufacturers"
+	count={data.result.count}
+	pageSize={PAGE_SIZES.manufacturers}
+	entityName="manufacturer"
+>
+	<DataTable>
 		<table>
 			<thead>
 				<tr>
@@ -51,116 +32,5 @@
 				{/each}
 			</tbody>
 		</table>
-	</div>
-
-	{#if totalPages > 1}
-		<nav class="pagination" aria-label="Pagination">
-			<button onclick={() => gotoPage(currentPage - 1)} disabled={currentPage <= 1}>
-				Previous
-			</button>
-			<span class="page-info">Page {currentPage} of {totalPages}</span>
-			<button onclick={() => gotoPage(currentPage + 1)} disabled={currentPage >= totalPages}>
-				Next
-			</button>
-		</nav>
-	{/if}
-{/if}
-
-<style>
-	h1 {
-		font-size: var(--font-size-6);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-3);
-	}
-
-	.count {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-1);
-		margin-bottom: var(--size-3);
-	}
-
-	.empty {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-2);
-		padding: var(--size-8) 0;
-		text-align: center;
-	}
-
-	.table-wrap {
-		overflow-x: auto;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-	}
-
-	th {
-		text-align: left;
-		font-size: var(--font-size-0);
-		font-weight: 600;
-		color: var(--color-text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		padding: var(--size-2) var(--size-3);
-		border-bottom: 2px solid var(--color-border);
-	}
-
-	td {
-		padding: var(--size-2) var(--size-3);
-		border-bottom: 1px solid var(--color-border-soft);
-		font-size: var(--font-size-1);
-		color: var(--color-text-primary);
-	}
-
-	.num {
-		text-align: right;
-	}
-
-	a {
-		color: var(--color-link);
-		text-decoration: none;
-	}
-
-	a:hover {
-		text-decoration: underline;
-	}
-
-	.pagination {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: var(--size-4);
-		padding: var(--size-5) 0;
-	}
-
-	.page-info {
-		font-size: var(--font-size-1);
-		color: var(--color-text-muted);
-	}
-
-	button {
-		padding: var(--size-2) var(--size-4);
-		font-size: var(--font-size-1);
-		font-family: var(--font-body);
-		background-color: var(--color-surface);
-		color: var(--color-text-primary);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		cursor: pointer;
-		transition:
-			background-color 0.15s var(--ease-2),
-			border-color 0.15s var(--ease-2);
-	}
-
-	button:hover:not(:disabled) {
-		border-color: var(--color-accent);
-		color: var(--color-accent);
-	}
-
-	button:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
-	}
-</style>
+	</DataTable>
+</ListPage>

--- a/frontend/src/routes/manufacturers/[slug]/+page.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import DetailPage from '$lib/components/DetailPage.svelte';
+	import CardGrid from '$lib/components/CardGrid.svelte';
+	import MachineCard from '$lib/components/MachineCard.svelte';
 
 	let { data } = $props();
 	let mfr = $derived(data.manufacturer);
@@ -9,43 +11,29 @@
 	);
 </script>
 
-<svelte:head>
-	<title>{mfr.name} — The Flip Pinball DB</title>
-</svelte:head>
-
-<article>
-	<header>
-		<h1>{mfr.name}</h1>
+<DetailPage title={mfr.name}>
+	{#snippet subtitle()}
 		{#if mfr.trade_name && mfr.trade_name !== mfr.name}
 			<p class="trade-name">Trade name: {mfr.trade_name}</p>
 		{/if}
-	</header>
+	{/snippet}
 
 	{#if mfr.models.length === 0}
 		<p class="empty">No models listed for this manufacturer.</p>
 	{:else}
 		<section>
 			<h2>Models ({mfr.models.length})</h2>
-			<div class="table-wrap">
-				<table>
-					<thead>
-						<tr>
-							<th>Name</th>
-							<th>Year</th>
-							<th>Type</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each mfr.models as model (model.slug)}
-							<tr>
-								<td><a href={resolve(`/models/${model.slug}`)}>{model.name}</a></td>
-								<td>{model.year ?? '—'}</td>
-								<td>{model.machine_type}</td>
-							</tr>
-						{/each}
-					</tbody>
-				</table>
-			</div>
+			<CardGrid>
+				{#each mfr.models as model (model.slug)}
+					<MachineCard
+						slug={model.slug}
+						name={model.name}
+						thumbnailUrl={model.thumbnail_url}
+						year={model.year}
+						machineType={model.machine_type}
+					/>
+				{/each}
+			</CardGrid>
 		</section>
 	{/if}
 
@@ -60,77 +48,13 @@
 			</a>
 		</footer>
 	{/if}
-</article>
+</DetailPage>
 
 <style>
-	article {
-		max-width: 48rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
-	}
-
 	.trade-name {
 		font-size: var(--font-size-2);
 		color: var(--color-text-muted);
-	}
-
-	h2 {
-		font-size: var(--font-size-3);
-		font-weight: 600;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-3);
-	}
-
-	.empty {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-2);
-		padding: var(--size-8) 0;
-		text-align: center;
-	}
-
-	.table-wrap {
-		overflow-x: auto;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-	}
-
-	th {
-		text-align: left;
-		font-size: var(--font-size-0);
-		font-weight: 600;
-		color: var(--color-text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		padding: var(--size-2) var(--size-3);
-		border-bottom: 2px solid var(--color-border);
-	}
-
-	td {
-		padding: var(--size-2) var(--size-3);
-		border-bottom: 1px solid var(--color-border-soft);
-		font-size: var(--font-size-1);
-		color: var(--color-text-primary);
-	}
-
-	a {
-		color: var(--color-link);
-		text-decoration: none;
-	}
-
-	a:hover {
-		text-decoration: underline;
+		margin-top: var(--size-2);
 	}
 
 	.external-ids {

--- a/frontend/src/routes/models/+page.svelte
+++ b/frontend/src/routes/models/+page.svelte
@@ -65,6 +65,7 @@
 		<table>
 			<thead>
 				<tr>
+					<th class="img-col"></th>
 					<th>Name</th>
 					<th>Manufacturer</th>
 					<th>Year</th>
@@ -76,6 +77,11 @@
 			<tbody>
 				{#each data.result.items as model (model.slug)}
 					<tr>
+						<td class="img-col">
+							{#if model.thumbnail_url}
+								<img src={model.thumbnail_url} alt="" class="thumbnail" loading="lazy" />
+							{/if}
+						</td>
 						<td><a href={resolve(`/models/${model.slug}`)}>{model.name}</a></td>
 						<td>
 							{#if model.manufacturer_slug}
@@ -199,6 +205,18 @@
 		border-bottom: 1px solid var(--color-border-soft);
 		font-size: var(--font-size-1);
 		color: var(--color-text-primary);
+	}
+
+	.img-col {
+		width: 3.5rem;
+		padding: var(--size-1) var(--size-2);
+	}
+
+	.thumbnail {
+		width: 3rem;
+		height: 2.25rem;
+		object-fit: cover;
+		border-radius: var(--radius-1);
 	}
 
 	.num {

--- a/frontend/src/routes/models/+page.svelte
+++ b/frontend/src/routes/models/+page.svelte
@@ -1,271 +1,31 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { page } from '$app/state';
-	import { resolve } from '$app/paths';
-	import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
-	import FaIcon from '$lib/components/FaIcon.svelte';
+	import ListPage from '$lib/components/ListPage.svelte';
+	import CardGrid from '$lib/components/CardGrid.svelte';
+	import MachineCard from '$lib/components/MachineCard.svelte';
 	import { PAGE_SIZES } from '$lib/api/pagination';
 
 	let { data } = $props();
-
-	let searchValue = $state(page.url.searchParams.get('search') ?? '');
-
-	function handleSearch(e: SubmitEvent) {
-		e.preventDefault();
-		const url = new URL(page.url);
-		if (searchValue.trim()) {
-			url.searchParams.set('search', searchValue.trim());
-		} else {
-			url.searchParams.delete('search');
-		}
-		url.searchParams.delete('page');
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
-		goto(url, { keepFocus: true });
-	}
-
-	function gotoPage(p: number) {
-		const url = new URL(page.url);
-		if (p > 1) {
-			url.searchParams.set('page', String(p));
-		} else {
-			url.searchParams.delete('page');
-		}
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
-		goto(url);
-	}
-
-	let currentPage = $derived(Number(page.url.searchParams.get('page') ?? '1'));
-	let totalPages = $derived(Math.ceil(data.result.count / PAGE_SIZES.models));
 </script>
 
-<svelte:head>
-	<title>Models — The Flip Pinball DB</title>
-</svelte:head>
-
-<h1>Models</h1>
-
-<form class="search-bar" onsubmit={handleSearch}>
-	<div class="search-box">
-		<FaIcon icon={faMagnifyingGlass} class="search-icon" />
-		<input
-			type="search"
-			placeholder="Search models..."
-			aria-label="Search models"
-			bind:value={searchValue}
-		/>
-	</div>
-</form>
-
-{#if data.result.items.length === 0}
-	<p class="empty">No models found.</p>
-{:else}
-	<p class="count">{data.result.count} model{data.result.count === 1 ? '' : 's'}</p>
-
-	<div class="table-wrap">
-		<table>
-			<thead>
-				<tr>
-					<th class="img-col"></th>
-					<th>Name</th>
-					<th>Manufacturer</th>
-					<th>Year</th>
-					<th>Type</th>
-					<th class="num">IPDB</th>
-					<th class="num">Pinside</th>
-				</tr>
-			</thead>
-			<tbody>
-				{#each data.result.items as model (model.slug)}
-					<tr>
-						<td class="img-col">
-							{#if model.thumbnail_url}
-								<img src={model.thumbnail_url} alt="" class="thumbnail" loading="lazy" />
-							{/if}
-						</td>
-						<td><a href={resolve(`/models/${model.slug}`)}>{model.name}</a></td>
-						<td>
-							{#if model.manufacturer_slug}
-								<a href={resolve(`/manufacturers/${model.manufacturer_slug}`)}>
-									{model.manufacturer_name}
-								</a>
-							{:else}
-								{model.manufacturer_name ?? '—'}
-							{/if}
-						</td>
-						<td>{model.year ?? '—'}</td>
-						<td>{model.machine_type}</td>
-						<td class="num">{model.ipdb_rating ?? '—'}</td>
-						<td class="num">{model.pinside_rating ?? '—'}</td>
-					</tr>
-				{/each}
-			</tbody>
-		</table>
-	</div>
-
-	{#if totalPages > 1}
-		<nav class="pagination" aria-label="Pagination">
-			<button onclick={() => gotoPage(currentPage - 1)} disabled={currentPage <= 1}>
-				Previous
-			</button>
-			<span class="page-info">Page {currentPage} of {totalPages}</span>
-			<button onclick={() => gotoPage(currentPage + 1)} disabled={currentPage >= totalPages}>
-				Next
-			</button>
-		</nav>
-	{/if}
-{/if}
-
-<style>
-	h1 {
-		font-size: var(--font-size-6);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-3);
-	}
-
-	.search-bar {
-		margin-bottom: var(--size-5);
-	}
-
-	.search-box {
-		position: relative;
-		max-width: 24rem;
-	}
-
-	:global(.search-box .search-icon) {
-		position: absolute;
-		left: var(--size-3);
-		top: 50%;
-		transform: translateY(-50%);
-		width: 0.875rem;
-		height: 0.875rem;
-		color: var(--color-text-muted);
-		pointer-events: none;
-	}
-
-	input[type='search'] {
-		width: 100%;
-		padding: var(--size-2) var(--size-3) var(--size-2) var(--size-8);
-		font-size: var(--font-size-1);
-		font-family: var(--font-body);
-		background-color: var(--color-input-bg);
-		color: var(--color-text-primary);
-		border: 1px solid var(--color-input-border);
-		border-radius: var(--radius-2);
-		transition:
-			border-color 0.15s var(--ease-2),
-			box-shadow 0.15s var(--ease-2);
-	}
-
-	input[type='search']:focus {
-		outline: none;
-		border-color: var(--color-input-focus);
-		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
-	}
-
-	input[type='search']::placeholder {
-		color: var(--color-text-muted);
-	}
-
-	.count {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-1);
-		margin-bottom: var(--size-3);
-	}
-
-	.empty {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-2);
-		padding: var(--size-8) 0;
-		text-align: center;
-	}
-
-	.table-wrap {
-		overflow-x: auto;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-	}
-
-	th {
-		text-align: left;
-		font-size: var(--font-size-0);
-		font-weight: 600;
-		color: var(--color-text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		padding: var(--size-2) var(--size-3);
-		border-bottom: 2px solid var(--color-border);
-	}
-
-	td {
-		padding: var(--size-2) var(--size-3);
-		border-bottom: 1px solid var(--color-border-soft);
-		font-size: var(--font-size-1);
-		color: var(--color-text-primary);
-	}
-
-	.img-col {
-		width: 3.5rem;
-		padding: var(--size-1) var(--size-2);
-	}
-
-	.thumbnail {
-		width: 3rem;
-		height: 2.25rem;
-		object-fit: cover;
-		border-radius: var(--radius-1);
-	}
-
-	.num {
-		text-align: right;
-	}
-
-	a {
-		color: var(--color-link);
-		text-decoration: none;
-	}
-
-	a:hover {
-		text-decoration: underline;
-	}
-
-	.pagination {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: var(--size-4);
-		padding: var(--size-5) 0;
-	}
-
-	.page-info {
-		font-size: var(--font-size-1);
-		color: var(--color-text-muted);
-	}
-
-	button {
-		padding: var(--size-2) var(--size-4);
-		font-size: var(--font-size-1);
-		font-family: var(--font-body);
-		background-color: var(--color-surface);
-		color: var(--color-text-primary);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		cursor: pointer;
-		transition:
-			background-color 0.15s var(--ease-2),
-			border-color 0.15s var(--ease-2);
-	}
-
-	button:hover:not(:disabled) {
-		border-color: var(--color-accent);
-		color: var(--color-accent);
-	}
-
-	button:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
-	}
-</style>
+<ListPage
+	title="Models"
+	count={data.result.count}
+	pageSize={PAGE_SIZES.models}
+	entityName="model"
+	search
+>
+	<CardGrid>
+		{#each data.result.items as model (model.slug)}
+			<MachineCard
+				slug={model.slug}
+				name={model.name}
+				thumbnailUrl={model.thumbnail_url}
+				manufacturerName={model.manufacturer_name}
+				year={model.year}
+				machineType={model.machine_type}
+				ipdbRating={model.ipdb_rating}
+				pinsideRating={model.pinside_rating}
+			/>
+		{/each}
+	</CardGrid>
+</ListPage>

--- a/frontend/src/routes/models/[slug]/+page.svelte
+++ b/frontend/src/routes/models/[slug]/+page.svelte
@@ -362,13 +362,4 @@
 		padding-top: var(--size-4);
 		border-top: 1px solid var(--color-border-soft);
 	}
-
-	a {
-		color: var(--color-link);
-		text-decoration: none;
-	}
-
-	a:hover {
-		text-decoration: underline;
-	}
 </style>

--- a/frontend/src/routes/models/[slug]/+page.svelte
+++ b/frontend/src/routes/models/[slug]/+page.svelte
@@ -10,6 +10,12 @@
 </svelte:head>
 
 <article>
+	{#if model.hero_image_url}
+		<div class="hero-image">
+			<img src={model.hero_image_url} alt="{model.name} backglass" />
+		</div>
+	{/if}
+
 	<header>
 		<h1>{model.name}</h1>
 		<div class="meta">
@@ -27,7 +33,19 @@
 			{/if}
 			<span>{model.machine_type}</span>
 			<span>{model.display_type}</span>
+			{#if model.group_slug}
+				<span>
+					<a href={resolve(`/groups/${model.group_slug}`)}>{model.group_name}</a>
+				</span>
+			{/if}
 		</div>
+		{#if model.features.length > 0}
+			<div class="features">
+				{#each model.features as feature (feature)}
+					<span class="chip">{feature}</span>
+				{/each}
+			</div>
+		{/if}
 	</header>
 
 	<section class="specs">
@@ -55,6 +73,22 @@
 			{/if}
 		</dl>
 	</section>
+
+	{#if model.aliases.length > 0}
+		<section class="variants">
+			<h2>Variants</h2>
+			<ul>
+				{#each model.aliases as alias (alias.slug)}
+					<li>
+						<a href={resolve(`/models/${alias.slug}`)}>{alias.name}</a>
+						{#if alias.features.length > 0}
+							<span class="alias-features">{alias.features.join(', ')}</span>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
 
 	{#if model.ipdb_rating || model.pinside_rating}
 		<section class="ratings">
@@ -144,6 +178,18 @@
 		max-width: 48rem;
 	}
 
+	.hero-image {
+		margin-bottom: var(--size-5);
+	}
+
+	.hero-image img {
+		width: 100%;
+		max-height: 24rem;
+		object-fit: contain;
+		border-radius: var(--radius-2);
+		background-color: var(--color-surface);
+	}
+
 	header {
 		margin-bottom: var(--size-6);
 	}
@@ -166,6 +212,23 @@
 	.meta span:not(:last-child)::after {
 		content: '·';
 		margin-left: var(--size-2);
+	}
+
+	.features {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--size-2);
+		margin-top: var(--size-3);
+	}
+
+	.chip {
+		display: inline-block;
+		padding: var(--size-1) var(--size-3);
+		font-size: var(--font-size-0);
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-round);
+		color: var(--color-text-muted);
 	}
 
 	h2 {
@@ -194,6 +257,24 @@
 	dd {
 		font-size: var(--font-size-1);
 		color: var(--color-text-primary);
+	}
+
+	.variants ul {
+		list-style: none;
+		padding: 0;
+	}
+
+	.variants li {
+		display: flex;
+		justify-content: space-between;
+		padding: var(--size-2) 0;
+		border-bottom: 1px solid var(--color-border-soft);
+		font-size: var(--font-size-1);
+	}
+
+	.alias-features {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-0);
 	}
 
 	.rating-cards {

--- a/frontend/src/routes/people/+page.svelte
+++ b/frontend/src/routes/people/+page.svelte
@@ -1,38 +1,20 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
+	import ListPage from '$lib/components/ListPage.svelte';
+	import DataTable from '$lib/components/DataTable.svelte';
 	import { PAGE_SIZES } from '$lib/api/pagination';
 
 	let { data } = $props();
-
-	function gotoPage(p: number) {
-		const url = new URL(page.url);
-		if (p > 1) {
-			url.searchParams.set('page', String(p));
-		} else {
-			url.searchParams.delete('page');
-		}
-		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param update
-		goto(url);
-	}
-
-	let currentPage = $derived(Number(page.url.searchParams.get('page') ?? '1'));
-	let totalPages = $derived(Math.ceil(data.result.count / PAGE_SIZES.people));
 </script>
 
-<svelte:head>
-	<title>People — The Flip Pinball DB</title>
-</svelte:head>
-
-<h1>People</h1>
-
-{#if data.result.items.length === 0}
-	<p class="empty">No people found.</p>
-{:else}
-	<p class="count">{data.result.count} {data.result.count === 1 ? 'person' : 'people'}</p>
-
-	<div class="table-wrap">
+<ListPage
+	title="People"
+	count={data.result.count}
+	pageSize={PAGE_SIZES.people}
+	entityName="person"
+	entityNamePlural="people"
+>
+	<DataTable>
 		<table>
 			<thead>
 				<tr>
@@ -49,116 +31,5 @@
 				{/each}
 			</tbody>
 		</table>
-	</div>
-
-	{#if totalPages > 1}
-		<nav class="pagination" aria-label="Pagination">
-			<button onclick={() => gotoPage(currentPage - 1)} disabled={currentPage <= 1}>
-				Previous
-			</button>
-			<span class="page-info">Page {currentPage} of {totalPages}</span>
-			<button onclick={() => gotoPage(currentPage + 1)} disabled={currentPage >= totalPages}>
-				Next
-			</button>
-		</nav>
-	{/if}
-{/if}
-
-<style>
-	h1 {
-		font-size: var(--font-size-6);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-3);
-	}
-
-	.count {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-1);
-		margin-bottom: var(--size-3);
-	}
-
-	.empty {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-2);
-		padding: var(--size-8) 0;
-		text-align: center;
-	}
-
-	.table-wrap {
-		overflow-x: auto;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-	}
-
-	th {
-		text-align: left;
-		font-size: var(--font-size-0);
-		font-weight: 600;
-		color: var(--color-text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		padding: var(--size-2) var(--size-3);
-		border-bottom: 2px solid var(--color-border);
-	}
-
-	td {
-		padding: var(--size-2) var(--size-3);
-		border-bottom: 1px solid var(--color-border-soft);
-		font-size: var(--font-size-1);
-		color: var(--color-text-primary);
-	}
-
-	.num {
-		text-align: right;
-	}
-
-	a {
-		color: var(--color-link);
-		text-decoration: none;
-	}
-
-	a:hover {
-		text-decoration: underline;
-	}
-
-	.pagination {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: var(--size-4);
-		padding: var(--size-5) 0;
-	}
-
-	.page-info {
-		font-size: var(--font-size-1);
-		color: var(--color-text-muted);
-	}
-
-	button {
-		padding: var(--size-2) var(--size-4);
-		font-size: var(--font-size-1);
-		font-family: var(--font-body);
-		background-color: var(--color-surface);
-		color: var(--color-text-primary);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		cursor: pointer;
-		transition:
-			background-color 0.15s var(--ease-2),
-			border-color 0.15s var(--ease-2);
-	}
-
-	button:hover:not(:disabled) {
-		border-color: var(--color-accent);
-		color: var(--color-accent);
-	}
-
-	button:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
-	}
-</style>
+	</DataTable>
+</ListPage>

--- a/frontend/src/routes/people/[slug]/+page.svelte
+++ b/frontend/src/routes/people/[slug]/+page.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import DetailPage from '$lib/components/DetailPage.svelte';
+	import CardGrid from '$lib/components/CardGrid.svelte';
+	import MachineCard from '$lib/components/MachineCard.svelte';
 
 	let { data } = $props();
 	let person = $derived(data.person);
 </script>
 
-<svelte:head>
-	<title>{person.name} — The Flip Pinball DB</title>
-</svelte:head>
-
-<article>
-	<header>
-		<h1>{person.name}</h1>
-	</header>
-
+<DetailPage title={person.name}>
 	{#if person.bio}
 		<section class="bio">
 			<p>{person.bio}</p>
@@ -23,37 +17,24 @@
 	{#if Object.keys(person.credits_by_role).length > 0}
 		{#each Object.entries(person.credits_by_role) as [role, credits] (role)}
 			<section class="role-group">
-				<h2>{role}</h2>
-				<ul>
+				<h2>{role} ({credits.length})</h2>
+				<CardGrid>
 					{#each credits as credit (credit.model_slug)}
-						<li>
-							<a href={resolve(`/models/${credit.model_slug}`)}>{credit.model_name}</a>
-							<span class="role-label">{credit.role_display}</span>
-						</li>
+						<MachineCard
+							slug={credit.model_slug}
+							name={credit.model_name}
+							thumbnailUrl={credit.thumbnail_url}
+						/>
 					{/each}
-				</ul>
+				</CardGrid>
 			</section>
 		{/each}
 	{:else}
 		<p class="empty">No credits listed.</p>
 	{/if}
-</article>
+</DetailPage>
 
 <style>
-	article {
-		max-width: 48rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-	}
-
 	.bio p {
 		font-size: var(--font-size-2);
 		color: var(--color-text-primary);
@@ -61,48 +42,7 @@
 		margin-bottom: var(--size-6);
 	}
 
-	h2 {
-		font-size: var(--font-size-3);
-		font-weight: 600;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-3);
-	}
-
 	.role-group {
 		margin-bottom: var(--size-6);
-	}
-
-	ul {
-		list-style: none;
-		padding: 0;
-	}
-
-	li {
-		display: flex;
-		justify-content: space-between;
-		padding: var(--size-2) 0;
-		border-bottom: 1px solid var(--color-border-soft);
-		font-size: var(--font-size-1);
-	}
-
-	.role-label {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-0);
-	}
-
-	.empty {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-2);
-		padding: var(--size-8) 0;
-		text-align: center;
-	}
-
-	a {
-		color: var(--color-link);
-		text-decoration: none;
-	}
-
-	a:hover {
-		text-decoration: underline;
 	}
 </style>

--- a/frontend/src/routes/sources/+page.svelte
+++ b/frontend/src/routes/sources/+page.svelte
@@ -101,12 +101,6 @@
 	}
 
 	a {
-		color: var(--color-link);
-		text-decoration: none;
 		word-break: break-all;
-	}
-
-	a:hover {
-		text-decoration: underline;
 	}
 </style>


### PR DESCRIPTION
## Summary

- **Groups pages**: New list and detail pages with card grid UI, search, and pagination
- **Image coverage**: `_extract_image_urls` falls back to IPDB flat URL list when OPDB images are missing (~29% → ~82% coverage)
- **Card grid UI**: Models, groups, manufacturer detail, and person detail pages now use image card grids instead of tables
- **Reusable components**: Extracted `Card`, `CardGrid`, `MachineCard`, `GroupCard`, `ListPage`, `DetailPage`, `Pagination`, `SearchBar`, and `DataTable` — eliminating ~400 lines of duplicated CSS/markup
- **Default sort**: Models list now defaults to newest-first (`-year`)
- **Global link styles**: Moved repeated `text-decoration` rules to `app.css`

## Component hierarchy

```
ListPage (search?, title, count, pagination)
├── SearchBar (reads/writes URL params)
├── Pagination (prev/next with page callback)
├── CardGrid → Card → MachineCard / GroupCard
└── DataTable (table styling wrapper)

DetailPage (title, subtitle?)
├── h2 / .empty via :global
└── CardGrid → MachineCard (for credits/models)
```

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 152 backend + 1 frontend pass
- [ ] Browse `/models` — search, pagination, card grid
- [ ] Browse `/groups` — search, pagination, card grid
- [ ] Browse `/manufacturers` — table pagination, detail card grid
- [ ] Browse `/people` — table pagination, detail card grids by role

🤖 Generated with [Claude Code](https://claude.com/claude-code)