### PR TITLE
feat: filterable grid for manufacturers and people pages

### DIFF
--- a/frontend/src/lib/api/pagination.ts
+++ b/frontend/src/lib/api/pagination.ts
@@ -1,8 +1,0 @@
-/**
- * Page sizes matching the backend Django Ninja pagination config.
- * See backend/apps/machines/api.py @paginate decorators.
- */
-export const PAGE_SIZES = {
-	manufacturers: 50,
-	people: 50
-} as const;

--- a/frontend/src/lib/components/ManufacturerCard.svelte
+++ b/frontend/src/lib/components/ManufacturerCard.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import Card from './Card.svelte';
+
+	let {
+		slug,
+		name,
+		thumbnailUrl = null,
+		tradeName = null,
+		modelCount = 0
+	}: {
+		slug: string;
+		name: string;
+		thumbnailUrl?: string | null;
+		tradeName?: string | null;
+		modelCount?: number;
+	} = $props();
+</script>
+
+<Card href={resolve(`/manufacturers/${slug}`)} title={name} {thumbnailUrl}>
+	{#if tradeName && tradeName !== name}
+		<p class="card-trade-name">{tradeName}</p>
+	{/if}
+	<p class="card-count">{modelCount} model{modelCount === 1 ? '' : 's'}</p>
+</Card>
+
+<style>
+	.card-trade-name {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+		margin-bottom: var(--size-1);
+	}
+
+	.card-count {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+	}
+</style>

--- a/frontend/src/lib/components/PersonCard.svelte
+++ b/frontend/src/lib/components/PersonCard.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import Card from './Card.svelte';
+
+	let {
+		slug,
+		name,
+		thumbnailUrl = null,
+		creditCount = 0
+	}: {
+		slug: string;
+		name: string;
+		thumbnailUrl?: string | null;
+		creditCount?: number;
+	} = $props();
+</script>
+
+<Card href={resolve(`/people/${slug}`)} title={name} {thumbnailUrl}>
+	<p class="card-count">{creditCount} credit{creditCount === 1 ? '' : 's'}</p>
+</Card>
+
+<style>
+	.card-count {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+	}
+</style>

--- a/frontend/src/routes/manufacturers/+page.svelte
+++ b/frontend/src/routes/manufacturers/+page.svelte
@@ -1,36 +1,27 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
-	import ListPage from '$lib/components/ListPage.svelte';
-	import DataTable from '$lib/components/DataTable.svelte';
-	import { PAGE_SIZES } from '$lib/api/pagination';
+	import FilterableGrid from '$lib/components/FilterableGrid.svelte';
+	import ManufacturerCard from '$lib/components/ManufacturerCard.svelte';
+	import { normalizeText } from '$lib/util';
 
 	let { data } = $props();
 </script>
 
-<ListPage
-	title="Manufacturers"
-	count={data.result.count}
-	pageSize={PAGE_SIZES.manufacturers}
+<FilterableGrid
+	items={data.manufacturers}
+	filterFn={(item, q) =>
+		normalizeText(item.name).includes(q) ||
+		(item.trade_name ? normalizeText(item.trade_name).includes(q) : false)}
+	title="Manufacturers — The Flip Pinball DB"
+	placeholder="Search manufacturers..."
 	entityName="manufacturer"
 >
-	<DataTable>
-		<table>
-			<thead>
-				<tr>
-					<th>Name</th>
-					<th>Trade Name</th>
-					<th class="num">Models</th>
-				</tr>
-			</thead>
-			<tbody>
-				{#each data.result.items as mfr (mfr.slug)}
-					<tr>
-						<td><a href={resolve(`/manufacturers/${mfr.slug}`)}>{mfr.name}</a></td>
-						<td>{mfr.trade_name || '—'}</td>
-						<td class="num">{mfr.model_count}</td>
-					</tr>
-				{/each}
-			</tbody>
-		</table>
-	</DataTable>
-</ListPage>
+	{#snippet children(mfr)}
+		<ManufacturerCard
+			slug={mfr.slug}
+			name={mfr.name}
+			thumbnailUrl={mfr.thumbnail_url}
+			tradeName={mfr.trade_name}
+			modelCount={mfr.model_count}
+		/>
+	{/snippet}
+</FilterableGrid>

--- a/frontend/src/routes/manufacturers/+page.ts
+++ b/frontend/src/routes/manufacturers/+page.ts
@@ -5,14 +5,10 @@ import type { PageLoad } from './$types';
 export const prerender = false;
 export const ssr = false;
 
-export const load: PageLoad = async ({ url }) => {
-	const page = url.searchParams.has('page') ? Number(url.searchParams.get('page')) : undefined;
-
-	const { data } = await client.GET('/api/manufacturers/', {
-		params: { query: { page } }
-	});
+export const load: PageLoad = async () => {
+	const { data } = await client.GET('/api/manufacturers/all/');
 
 	if (!data) error(500, 'Failed to load manufacturers');
 
-	return { result: data };
+	return { manufacturers: data };
 };

--- a/frontend/src/routes/people/+page.svelte
+++ b/frontend/src/routes/people/+page.svelte
@@ -1,35 +1,25 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
-	import ListPage from '$lib/components/ListPage.svelte';
-	import DataTable from '$lib/components/DataTable.svelte';
-	import { PAGE_SIZES } from '$lib/api/pagination';
+	import FilterableGrid from '$lib/components/FilterableGrid.svelte';
+	import PersonCard from '$lib/components/PersonCard.svelte';
+	import { normalizeText } from '$lib/util';
 
 	let { data } = $props();
 </script>
 
-<ListPage
-	title="People"
-	count={data.result.count}
-	pageSize={PAGE_SIZES.people}
+<FilterableGrid
+	items={data.people}
+	filterFn={(item, q) => normalizeText(item.name).includes(q)}
+	title="People — The Flip Pinball DB"
+	placeholder="Search people..."
 	entityName="person"
 	entityNamePlural="people"
 >
-	<DataTable>
-		<table>
-			<thead>
-				<tr>
-					<th>Name</th>
-					<th class="num">Credits</th>
-				</tr>
-			</thead>
-			<tbody>
-				{#each data.result.items as person (person.slug)}
-					<tr>
-						<td><a href={resolve(`/people/${person.slug}`)}>{person.name}</a></td>
-						<td class="num">{person.credit_count}</td>
-					</tr>
-				{/each}
-			</tbody>
-		</table>
-	</DataTable>
-</ListPage>
+	{#snippet children(person)}
+		<PersonCard
+			slug={person.slug}
+			name={person.name}
+			thumbnailUrl={person.thumbnail_url}
+			creditCount={person.credit_count}
+		/>
+	{/snippet}
+</FilterableGrid>

--- a/frontend/src/routes/people/+page.ts
+++ b/frontend/src/routes/people/+page.ts
@@ -5,14 +5,10 @@ import type { PageLoad } from './$types';
 export const prerender = false;
 export const ssr = false;
 
-export const load: PageLoad = async ({ url }) => {
-	const page = url.searchParams.has('page') ? Number(url.searchParams.get('page')) : undefined;
-
-	const { data } = await client.GET('/api/people/', {
-		params: { query: { page } }
-	});
+export const load: PageLoad = async () => {
+	const { data } = await client.GET('/api/people/all/');
 
 	if (!data) error(500, 'Failed to load people');
 
-	return { result: data };
+	return { people: data };
 };


### PR DESCRIPTION
## Summary
- **New unpaginated API endpoints** (`/api/manufacturers/all/`, `/api/people/all/`) with thumbnail URLs derived from each entity's most recent machine
- **Manufacturers page** now shows a card grid with machine thumbnails, sorted by model count (most prolific first). Search filters on name and trade name.
- **People page** same treatment — card grid with thumbnails, sorted by credit count. Search filters on name.
- **New components:** `ManufacturerCard` (shows trade name + model count) and `PersonCard` (shows credit count)
- **Removed** `pagination.ts` — no pages use server-side pagination anymore

## Test plan
- [ ] Manufacturers page shows card grid with images, sorted by model count
- [ ] People page shows card grid with images, sorted by credit count
- [ ] Search filters instantly on both pages (accent-insensitive)
- [ ] Scrolling loads more cards progressively
- [ ] Clicking a card navigates to the detail page
- [ ] `make test` and `make lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)