### PR TITLE
feat: add API docs page with Scalar explorer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,10 +74,16 @@ repos:
         files: ^(CLAUDE|AGENTS)\.md$
         pass_filenames: false
 
-      # Frontend lint
+      # Frontend lint + type check
       - id: frontend-lint
         name: frontend lint
         entry: bash -c 'cd frontend && pnpm lint'
+        language: system
+        files: ^frontend/
+        pass_filenames: false
+      - id: frontend-check
+        name: frontend type check
+        entry: bash -c 'cd frontend && pnpm check'
         language: system
         files: ^frontend/
         pass_filenames: false

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -9,7 +9,8 @@
 	const navItems = [
 		{ href: '/groups' as const, label: 'Groups' },
 		{ href: '/manufacturers' as const, label: 'Manufacturers' },
-		{ href: '/people' as const, label: 'People' }
+		{ href: '/people' as const, label: 'People' },
+		{ href: '/api-docs' as const, label: 'API' }
 	];
 
 	function isActive(href: string) {

--- a/frontend/src/routes/api-docs/+page.svelte
+++ b/frontend/src/routes/api-docs/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 
 	let scalarLoaded = $state(false);
@@ -58,8 +57,9 @@
 	<div class="resource-card">
 		<h3>OpenAPI Spec</h3>
 		<p>
-			<a href={resolve('/api/openapi.json')} target="_blank" rel="noopener"> Download </a> the raw OpenAPI
-			3.1 specification to use with any compatible tooling.
+			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- backend API path, not a SvelteKit route -->
+			<a href="/api/openapi.json" target="_blank" rel="noopener">Download</a> the raw OpenAPI 3.1 specification
+			to use with any compatible tooling.
 		</p>
 	</div>
 

--- a/frontend/src/routes/api-docs/+page.svelte
+++ b/frontend/src/routes/api-docs/+page.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import { onMount } from 'svelte';
+
+	let scalarLoaded = $state(false);
+	let scalarError = $state('');
+
+	const scalarCustomCss = `
+		.scalar-api-reference {
+			--scalar-background-1: var(--color-background);
+			--scalar-background-2: var(--color-surface);
+			--scalar-background-3: var(--color-background);
+			--scalar-color-1: var(--color-text-primary);
+			--scalar-color-2: var(--color-text-muted);
+			--scalar-color-3: var(--color-text-muted);
+			--scalar-color-accent: var(--color-accent);
+			--scalar-font: 'Lora', serif;
+			--scalar-border-color: var(--color-border-soft);
+		}
+	`;
+
+	onMount(() => {
+		const script = document.createElement('script');
+		script.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference';
+		script.onload = () => {
+			// @ts-expect-error — Scalar loaded via CDN
+			Scalar.createApiReference('#scalar-api-reference', {
+				url: '/api/openapi.json',
+				theme: 'none',
+				layout: 'modern',
+				showSidebar: true,
+				hideClientButton: true,
+				customCss: scalarCustomCss
+			});
+			scalarLoaded = true;
+		};
+		script.onerror = () => {
+			scalarError = 'Failed to load API reference. Please try refreshing the page.';
+		};
+		document.head.appendChild(script);
+
+		return () => {
+			script.remove();
+		};
+	});
+</script>
+
+<svelte:head>
+	<title>API — The Flip Pinball DB</title>
+</svelte:head>
+
+<section class="hero">
+	<h1>Open Data API</h1>
+	<p>The Flip Pinball DB is open data. Every bit of data is is available through public APIs.</p>
+</section>
+
+<section class="developer-resources">
+	<div class="resource-card">
+		<h3>OpenAPI Spec</h3>
+		<p>
+			<a href={resolve('/api/openapi.json')} target="_blank" rel="noopener"> Download </a> the raw OpenAPI
+			3.1 specification to use with any compatible tooling.
+		</p>
+	</div>
+
+	<div class="resource-card">
+		<h3>TypeScript Types</h3>
+		<p>Generate fully-typed API bindings in one command:</p>
+		<pre><code>npx openapi-typescript https://flipdb.org/api/openapi.json -o schema.d.ts</code
+			></pre>
+	</div>
+</section>
+
+<section class="api-reference-section">
+	<h2>API Reference</h2>
+	{#if scalarError}
+		<p class="error-message">{scalarError}</p>
+	{:else if !scalarLoaded}
+		<p class="loading-message">Loading API reference…</p>
+	{/if}
+	<div id="scalar-api-reference"></div>
+</section>
+
+<style>
+	.hero {
+		margin-bottom: var(--size-8);
+	}
+
+	.hero h1 {
+		font-size: var(--font-size-7);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	.hero p {
+		font-size: var(--font-size-2);
+		color: var(--color-text-muted);
+		line-height: var(--font-lineheight-3);
+		max-width: 48rem;
+	}
+
+	h2 {
+		font-size: var(--font-size-3);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-4);
+	}
+
+	.api-reference-section {
+		margin-bottom: var(--size-8);
+	}
+
+	.loading-message,
+	.error-message {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+		padding: var(--size-6) 0;
+	}
+
+	.error-message {
+		color: var(--color-error);
+	}
+
+	.developer-resources {
+		margin-bottom: var(--size-8);
+	}
+
+	.resource-card {
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-2);
+		padding: var(--size-4) var(--size-5);
+		margin-bottom: var(--size-4);
+	}
+
+	.resource-card h3 {
+		font-size: var(--font-size-2);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-2);
+	}
+
+	.resource-card p {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+		margin-bottom: var(--size-2);
+		line-height: var(--font-lineheight-3);
+	}
+
+	pre {
+		background-color: var(--color-background);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-2);
+		padding: var(--size-3) var(--size-4);
+		overflow-x: auto;
+		font-size: var(--font-size-0);
+		font-family: var(--font-mono);
+	}
+
+	code {
+		font-family: var(--font-mono);
+	}
+</style>

--- a/frontend/src/routes/api-docs/+page.ts
+++ b/frontend/src/routes/api-docs/+page.ts
@@ -1,0 +1,2 @@
+export const prerender = false;
+export const ssr = false;


### PR DESCRIPTION
## Summary
- Adds `/api-docs` route with "API" nav item
- Hero section communicating the open data philosophy
- Developer resources: OpenAPI spec download link, TypeScript type generation snippet
- Interactive API reference powered by Scalar (loaded via CDN, themed to match the site)
- No backend changes — uses the existing Django Ninja OpenAPI spec at `/api/openapi.json`

## Test plan
- [ ] Visit `/api-docs` and confirm all three sections render
- [ ] Verify Scalar loads and shows endpoints interactively
- [ ] Confirm theming matches site palette (light and dark mode)
- [ ] Click "Download" link for openapi.json
- [ ] Check "API" nav item highlights when on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)