### PR TITLE
feat: add scrape_images management command for demo artwork

### DIFF
--- a/backend/apps/machines/management/commands/scrape_images.py
+++ b/backend/apps/machines/management/commands/scrape_images.py
@@ -1,0 +1,277 @@
+"""Scrape images for pinball machines that don't have artwork.
+
+Quick-and-dirty tool for demo purposes — NOT for production use.
+
+Tries three strategies in order:
+1. Copy from a group sibling (same franchise, different edition)
+2. Scrape IPDB page (for machines with IPDB IDs)
+3. Search Bing Images (fallback for everything else)
+
+Processes in batches with a pause between each for inspection.
+
+Usage:
+    python manage.py scrape_images                    # all machines, batches of 10
+    python manage.py scrape_images --year-min 2024    # only 2024+
+    python manage.py scrape_images --batch-size 5     # smaller batches
+    python manage.py scrape_images --dry-run           # preview without saving
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from html import unescape
+from urllib.parse import quote_plus, urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from django.core.management.base import BaseCommand
+
+from apps.machines.models import Claim, PinballModel, Source
+from apps.machines.resolve import resolve_model
+
+logger = logging.getLogger(__name__)
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+}
+
+# Seconds to wait between network requests (be polite).
+REQUEST_DELAY = 1.5
+
+
+def _has_images(extra_data: dict) -> bool:
+    """Check if extra_data already contains usable image URLs."""
+    if extra_data.get("image_urls"):
+        return True
+    images = extra_data.get("images")
+    if images and isinstance(images, list):
+        return True
+    return False
+
+
+def _try_group_sibling(pm: PinballModel) -> list[str] | None:
+    """Copy image URLs from a sibling in the same group."""
+    if not pm.group:
+        return None
+    for sib in pm.group.machines.exclude(pk=pm.pk):
+        ed = sib.extra_data or {}
+
+        # Try OPDB structured images — extract best URLs.
+        images = ed.get("images")
+        if images and isinstance(images, list):
+            urls = []
+            for img in images:
+                if not isinstance(img, dict):
+                    continue
+                img_urls = img.get("urls", {})
+                url = (
+                    img_urls.get("large")
+                    or img_urls.get("medium")
+                    or img_urls.get("small")
+                )
+                if url:
+                    urls.append(url)
+            if urls:
+                return urls
+
+        # Try IPDB flat URL list.
+        ipdb_urls = ed.get("image_urls")
+        if ipdb_urls and isinstance(ipdb_urls, list):
+            return list(ipdb_urls)
+
+    return None
+
+
+def _try_ipdb_scrape(ipdb_id: int) -> list[str] | None:
+    """Scrape image URLs from an IPDB machine page."""
+    url = f"https://www.ipdb.org/machine.cgi?id={ipdb_id}"
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=15)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        logger.warning("IPDB request failed for id=%s: %s", ipdb_id, e)
+        return None
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    urls = []
+
+    # IPDB thumbnails: /images/{id}/tn_image-{n}.png
+    for img in soup.find_all("img"):
+        src = img.get("src", "")
+        if f"/images/{ipdb_id}/" in src:
+            full_url = urljoin("https://www.ipdb.org/", src)
+            urls.append(full_url)
+
+    return urls if urls else None
+
+
+def _try_bing_images(query: str) -> list[str] | None:
+    """Search Bing Images and return the first few result URLs."""
+    search_url = f"https://www.bing.com/images/search?q={quote_plus(query)}&first=1"
+    try:
+        resp = requests.get(search_url, headers=HEADERS, timeout=15)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        logger.warning("Bing search failed for %r: %s", query, e)
+        return None
+
+    # Bing HTML-encodes quotes in data attributes; decode before parsing.
+    text = unescape(resp.text)
+
+    # Extract original image URLs from 'murl' fields in Bing's JSON metadata.
+    urls = re.findall(r'"murl":"(https?://[^"]+)"', text)
+
+    # Filter for actual image file URLs.
+    image_exts = (".jpg", ".jpeg", ".png", ".webp")
+    good_urls = [u for u in urls if any(u.lower().endswith(ext) for ext in image_exts)]
+
+    # If strict extension filtering is too aggressive, fall back to all murl hits.
+    if not good_urls:
+        good_urls = [u for u in urls if "." in u.split("/")[-1]]
+
+    return good_urls[:3] if good_urls else None
+
+
+class Command(BaseCommand):
+    help = "Scrape images for machines without artwork (demo tool)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=10,
+            help="Number of machines to process per batch (default: 10).",
+        )
+        parser.add_argument(
+            "--year-min",
+            type=int,
+            default=None,
+            help="Only process machines from this year onward.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview what would be scraped without saving.",
+        )
+
+    def handle(self, *args, **options):
+        batch_size = options["batch_size"]
+        year_min = options["year_min"]
+        dry_run = options["dry_run"]
+
+        source, _ = Source.objects.update_or_create(
+            slug="web-scrape",
+            defaults={
+                "name": "Web Scrape",
+                "source_type": "other",
+                "priority": 5,
+                "url": "",
+                "description": "Temporary web-scraped images for demo purposes.",
+            },
+        )
+
+        # Find machines without images, newest first.
+        qs = PinballModel.objects.filter(alias_of__isnull=True).order_by(
+            "-year", "name"
+        )
+        if year_min:
+            qs = qs.filter(year__gte=year_min)
+
+        machines = [pm for pm in qs if not _has_images(pm.extra_data or {})]
+
+        total = len(machines)
+        if total == 0:
+            self.stdout.write(self.style.SUCCESS("All machines already have images!"))
+            return
+
+        total_batches = (total + batch_size - 1) // batch_size
+        self.stdout.write(
+            f"Found {total} machines without images ({total_batches} batches).\n"
+        )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN — nothing will be saved.\n"))
+
+        for i in range(0, total, batch_size):
+            batch = machines[i : i + batch_size]
+            batch_num = i // batch_size + 1
+
+            self.stdout.write(f"--- Batch {batch_num}/{total_batches} ---")
+
+            found_count = 0
+            for pm in batch:
+                strategy, urls = self._find_images(pm)
+
+                if urls:
+                    found_count += 1
+                    if not dry_run:
+                        Claim.objects.assert_claim(
+                            model=pm,
+                            source=source,
+                            field_name="image_urls",
+                            value=urls,
+                        )
+                        resolve_model(pm)
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f"  \u2713 {pm.name} [{pm.year}] \u2014 {strategy} ({len(urls)} URLs)"
+                        )
+                    )
+                    for url in urls[:2]:
+                        self.stdout.write(f"    {url}")
+                    if len(urls) > 2:
+                        self.stdout.write(f"    ... and {len(urls) - 2} more")
+                else:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  \u2717 {pm.name} [{pm.year}] \u2014 no images found"
+                        )
+                    )
+
+            self.stdout.write(
+                f"\n  Batch result: {found_count}/{len(batch)} machines got images."
+            )
+
+            # Pause between batches for inspection.
+            if i + batch_size < total:
+                if not dry_run:
+                    self.stdout.write("\nInspect results at http://localhost:5173")
+                try:
+                    input("Press Enter for next batch (Ctrl+C to stop)... ")
+                except KeyboardInterrupt, EOFError:
+                    self.stdout.write("\n\nStopped.")
+                    return
+
+        action = "would be updated" if dry_run else "updated"
+        self.stdout.write(self.style.SUCCESS(f"\nDone! Machines {action}."))
+
+    def _find_images(self, pm: PinballModel) -> tuple[str | None, list[str] | None]:
+        """Try each strategy in order, return (strategy_name, urls) or (None, None)."""
+
+        # Strategy 1: Group sibling (no network needed).
+        urls = _try_group_sibling(pm)
+        if urls:
+            return "group sibling", urls
+
+        # Strategy 2: IPDB scrape.
+        if pm.ipdb_id:
+            time.sleep(REQUEST_DELAY)
+            urls = _try_ipdb_scrape(pm.ipdb_id)
+            if urls:
+                return "IPDB", urls
+
+        # Strategy 3: Bing Images.
+        time.sleep(REQUEST_DELAY)
+        year_part = f" {pm.year}" if pm.year else ""
+        query = f'"{pm.name}" pinball{year_part}'
+        urls = _try_bing_images(query)
+        if urls:
+            return "Bing Images", urls
+
+        return None, None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,8 +13,10 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "beautifulsoup4>=4.12",
     "djlint>=1.36.4",
     "pytest>=8.3",
     "pytest-django>=4.9",
+    "requests>=2.32",
     "ruff>=0.8",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -35,9 +35,11 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "beautifulsoup4" },
     { name = "djlint" },
     { name = "pytest" },
     { name = "pytest-django" },
+    { name = "requests" },
     { name = "ruff" },
 ]
 
@@ -53,10 +55,59 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "djlint", specifier = ">=1.36.4" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-django", specifier = ">=4.9" },
+    { name = "requests", specifier = ">=2.32" },
     { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
 ]
 
 [[package]]
@@ -172,6 +223,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/13/ef67f59f6a7896fdc2c1d62b5665c5219d6b0a9a1784938eb9a28e55e128/gunicorn-25.1.0.tar.gz", hash = "sha256:1426611d959fa77e7de89f8c0f32eed6aa03ee735f98c01efba3e281b1c47616", size = 594377, upload-time = "2026-02-13T11:09:58.989Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/73/4ad5b1f6a2e21cf1e85afdaad2b7b1a933985e2f5d679147a1953aaa192c/gunicorn-25.1.0-py3-none-any.whl", hash = "sha256:d0b1236ccf27f72cfe14bce7caadf467186f19e865094ca84221424e839b8b8b", size = 197067, upload-time = "2026-02-13T11:09:57.146Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -425,6 +485,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -456,6 +531,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]
@@ -507,6 +591,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `scrape_images` management command to fill in missing machine artwork
- Three strategies tried in order: group siblings, IPDB scrape, Bing Image Search
- Processes in interactive batches (default 10) with pause for inspection between each
- Adds `requests` and `beautifulsoup4` as dev dependencies

## Usage
```bash
python manage.py scrape_images --year-min 2024          # recent machines
python manage.py scrape_images --batch-size 5 --dry-run # preview mode
```

## Test plan
- [x] Dry run verified on 2025+ machines (15/15 found images)
- [x] Live run on 2024+ machines (25/25 filled)
- [x] Live run on 2020+ machines (19/19 filled)
- [x] Manual URL override tested (Pokémon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)