### PR TITLE
fix: use shell form CMD so $PORT expands at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ RUN DJANGO_SETTINGS_MODULE=config.settings \
 EXPOSE 8000
 
 # Default CMD; Railway overrides via startCommand in railway.toml
-CMD ["uv", "run", "gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:${PORT:-8000}", "--workers", "2"]
+CMD uv run gunicorn config.wsgi:application --bind 0.0.0.0:${PORT:-8000} --workers 2


### PR DESCRIPTION
## Summary

Docker JSON array CMD (`CMD ["...", "${PORT:-8000}", "..."]`) doesn't invoke a shell, so `${PORT:-8000}` was passed to gunicorn as a literal string instead of being expanded. Railway auto-injects the `PORT` env var at runtime.

- Changed to shell form `CMD uv run gunicorn ...` which runs via `/bin/sh -c` and expands variables

## Test plan

- [ ] Railway deploy succeeds and health check passes
- [ ] `curl <railway-url>/api/health` returns `{"status": "ok"}`