### PR TITLE
fix: remove startCommand so Dockerfile shell-form CMD runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,5 @@ RUN DJANGO_SETTINGS_MODULE=config.settings \
 
 EXPOSE 8000
 
-# Default CMD; Railway overrides via startCommand in railway.toml
+# Shell form so ${PORT:-8000} is expanded; Railway auto-injects PORT
 CMD uv run gunicorn config.wsgi:application --bind 0.0.0.0:${PORT:-8000} --workers 2

--- a/railway.toml
+++ b/railway.toml
@@ -20,6 +20,6 @@ watchPatterns = [
 
 [deploy]
 preDeployCommand = "uv run python manage.py migrate --noinput"
-startCommand = "uv run gunicorn config.wsgi:application --bind 0.0.0.0:$PORT --workers 2"
+
 healthcheckPath = "/api/health"
 healthcheckTimeout = 10


### PR DESCRIPTION
## Summary

The previous fix (PR #17) changed the Dockerfile CMD to shell form, but Railway's `startCommand` in railway.toml was still overriding it. Railway executes `startCommand` in exec form (no shell), so `$PORT` was passed as a literal string to gunicorn.

- Removed `startCommand` from railway.toml so the Dockerfile's shell-form CMD is used instead

## Test plan

- [ ] Railway deploy succeeds and health check passes
- [ ] `curl <railway-url>/api/health` returns `{"status": "ok"}`