### PR TITLE
fix: bypass uv run at deploy time, use .venv/bin directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ RUN DJANGO_SETTINGS_MODULE=config.settings \
 EXPOSE 8000
 
 # Shell form so ${PORT:-8000} is expanded; Railway auto-injects PORT
-CMD uv run gunicorn config.wsgi:application --bind 0.0.0.0:${PORT:-8000} --workers 2
+CMD .venv/bin/gunicorn config.wsgi:application --bind 0.0.0.0:${PORT:-8000} --workers 2

--- a/railway.toml
+++ b/railway.toml
@@ -19,7 +19,7 @@ watchPatterns = [
 ]
 
 [deploy]
-preDeployCommand = "uv run python manage.py migrate --noinput"
+preDeployCommand = ".venv/bin/python manage.py migrate --noinput"
 
 healthcheckPath = "/api/health"
 healthcheckTimeout = 10


### PR DESCRIPTION
## Summary

`uv run` was hanging during Railway's preDeployCommand with no log output for 3+ minutes. It's likely trying to resolve/install the project at runtime since the Docker build used `--no-install-project`.

- Changed preDeployCommand to use `.venv/bin/python` directly
- Changed Dockerfile CMD to use `.venv/bin/gunicorn` directly
- The venv was already created during Docker build by `uv sync`

## Test plan

- [ ] Railway deploy completes (pre-deploy doesn't hang)
- [ ] Migrations run successfully
- [ ] Health check passes