### PR TITLE
fix: remove health check from Railway config

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -20,6 +20,3 @@ watchPatterns = [
 
 [deploy]
 preDeployCommand = ".venv/bin/python manage.py migrate --noinput"
-
-healthcheckPath = "/api/health"
-healthcheckTimeout = 10


### PR DESCRIPTION
## Summary

Remove Railway health check configuration. The `/api/health` endpoint still exists and can be hit manually, but Railway won't gate deploys on it.

## Test plan

- [ ] Railway deploy succeeds without health check gating