### PR TITLE
Bulk-ify all ingest commands

### DIFF
--- a/backend/apps/machines/ingestion/bulk_utils.py
+++ b/backend/apps/machines/ingestion/bulk_utils.py
@@ -1,0 +1,31 @@
+"""Utilities for bulk ingest operations."""
+
+from __future__ import annotations
+
+from django.utils.text import slugify
+
+MAX_NAMES_SHOWN = 10
+
+
+def format_names(names: list[str]) -> str:
+    """Format a list of names for summary output, truncating if long."""
+    if len(names) <= MAX_NAMES_SHOWN:
+        return ", ".join(names)
+    return ", ".join(names[:MAX_NAMES_SHOWN]) + f", ... ({len(names)} total)"
+
+
+def generate_unique_slug(base_name: str, existing_slugs: set[str]) -> str:
+    """Generate a unique slug, tracking used slugs in the provided set.
+
+    Mimics the slug generation in model save() methods but works with
+    bulk_create() which skips save(). Mutates ``existing_slugs`` by adding
+    the generated slug so subsequent calls won't collide.
+    """
+    base = slugify(base_name) or "item"
+    slug = base
+    counter = 2
+    while slug in existing_slugs:
+        slug = f"{base}-{counter}"
+        counter += 1
+    existing_slugs.add(slug)
+    return slug

--- a/backend/apps/machines/management/commands/ingest_opdb.py
+++ b/backend/apps/machines/management/commands/ingest_opdb.py
@@ -3,6 +3,8 @@
 Matches existing PinballModels by ipdb_id cross-reference, then by opdb_id,
 then creates new records. Ingests both machines and aliases (with alias_of FK).
 Optionally processes groups and changelog data.
+
+Claims are collected during the main loops and written in bulk afterward.
 """
 
 from __future__ import annotations
@@ -12,6 +14,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
+from apps.machines.ingestion.bulk_utils import format_names, generate_unique_slug
 from apps.machines.ingestion.parsers import (
     map_opdb_display,
     map_opdb_type,
@@ -77,61 +80,207 @@ class Command(BaseCommand):
             f"Processing {len(machines)} OPDB machines + {len(aliases)} aliases..."
         )
 
-        # --- Ingest machines first (aliases need parent lookup) ---
-        matched = 0
-        created = 0
-        failed = 0
-        failed_ids = []
-
-        for rec in machines:
-            try:
-                result = self._ingest_record(rec, source, groups_by_id)
-                if result == "matched":
-                    matched += 1
-                else:
-                    created += 1
-            except Exception:
-                opdb_id = rec.get("opdb_id", "?")
-                logger.exception("Failed to ingest OPDB record %s", opdb_id)
-                failed += 1
-                failed_ids.append(opdb_id)
-
-        self.stdout.write(
-            f"  Machines — Matched: {matched}, Created: {created}, Failed: {failed}"
+        # --- Pre-fetch all PinballModels into lookup dicts ---
+        by_ipdb_id: dict[int, PinballModel] = {
+            pm.ipdb_id: pm for pm in PinballModel.objects.filter(ipdb_id__isnull=False)
+        }
+        by_opdb_id: dict[str, PinballModel] = {
+            pm.opdb_id: pm for pm in PinballModel.objects.filter(opdb_id__isnull=False)
+        }
+        existing_slugs: set[str] = set(
+            PinballModel.objects.values_list("slug", flat=True)
         )
 
-        # --- Ingest aliases ---
+        # --- Phase 1a: Match/create machines ---
+        new_models: list[PinballModel] = []
+        models_needing_opdb_update: list[PinballModel] = []
+        machine_models: list[tuple[PinballModel, dict]] = []
+        matched = 0
+        created = 0
+        skipped = 0
+
+        for rec in machines:
+            opdb_id = rec.get("opdb_id")
+            if not opdb_id:
+                skipped += 1
+                continue
+
+            ipdb_id = rec.get("ipdb_id")
+            name = rec.get("name", "Unknown")
+
+            pm = None
+            if ipdb_id:
+                pm = by_ipdb_id.get(ipdb_id)
+            if not pm:
+                pm = by_opdb_id.get(opdb_id)
+
+            if pm:
+                matched += 1
+                # Set opdb_id if not already set (conflict check in memory).
+                if pm.opdb_id is None and opdb_id:
+                    if opdb_id not in by_opdb_id:
+                        pm.opdb_id = opdb_id
+                        by_opdb_id[opdb_id] = pm
+                        models_needing_opdb_update.append(pm)
+                    else:
+                        logger.warning(
+                            "Cannot set opdb_id=%s on %r (ipdb_id=%s): "
+                            "already owned by %r",
+                            opdb_id,
+                            pm.name,
+                            ipdb_id,
+                            by_opdb_id[opdb_id].name,
+                        )
+                elif pm.opdb_id and pm.opdb_id != opdb_id:
+                    logger.warning(
+                        "PinballModel %r already has opdb_id=%s, skipping %s",
+                        pm.name,
+                        pm.opdb_id,
+                        opdb_id,
+                    )
+            else:
+                created += 1
+                slug = generate_unique_slug(name, existing_slugs)
+                pm = PinballModel(name=name, opdb_id=opdb_id, slug=slug)
+                new_models.append(pm)
+                by_opdb_id[opdb_id] = pm
+                if ipdb_id:
+                    by_ipdb_id[ipdb_id] = pm
+
+            machine_models.append((pm, rec))
+
+        if new_models:
+            PinballModel.objects.bulk_create(new_models)
+        if models_needing_opdb_update:
+            PinballModel.objects.bulk_update(models_needing_opdb_update, ["opdb_id"])
+
+        self.stdout.write(
+            f"  Machines — Matched: {matched}, Created: {created}, Skipped: {skipped}"
+        )
+        if new_models:
+            self.stdout.write(
+                f"    New: {format_names([pm.name for pm in new_models])}"
+            )
+
+        # --- Phase 1b: Match/create aliases ---
+        new_alias_models: list[PinballModel] = []
+        alias_models_needing_update: list[PinballModel] = []
+        alias_models: list[tuple[PinballModel, dict]] = []
         alias_linked = 0
         alias_created = 0
         alias_skipped = 0
-        alias_failed = 0
 
         for rec in aliases:
-            try:
-                result = self._ingest_alias(rec, source, groups_by_id)
-                if result == "matched":
-                    alias_linked += 1
-                elif result == "skipped":
-                    alias_skipped += 1
-                else:
-                    alias_created += 1
-            except Exception:
-                opdb_id = rec.get("opdb_id", "?")
-                logger.exception("Failed to ingest OPDB alias %s", opdb_id)
-                alias_failed += 1
-                failed_ids.append(opdb_id)
+            opdb_id = rec.get("opdb_id")
+            if not opdb_id:
+                alias_skipped += 1
+                continue
+
+            ipdb_id = rec.get("ipdb_id")
+            name = rec.get("name", "Unknown")
+
+            # Find the parent machine in memory.
+            parent_opdb_id = "-".join(opdb_id.split("-")[:2])
+            parent = by_opdb_id.get(parent_opdb_id)
+
+            if not parent:
+                logger.warning(
+                    "Alias %s (%s): parent %s not found, skipping",
+                    opdb_id,
+                    name,
+                    parent_opdb_id,
+                )
+                alias_skipped += 1
+                continue
+
+            pm = None
+            if ipdb_id:
+                pm = by_ipdb_id.get(ipdb_id)
+            if not pm:
+                pm = by_opdb_id.get(opdb_id)
+
+            if pm:
+                alias_linked += 1
+                needs_update = False
+                # Set opdb_id if not already set.
+                if pm.opdb_id is None and opdb_id:
+                    if opdb_id not in by_opdb_id:
+                        pm.opdb_id = opdb_id
+                        by_opdb_id[opdb_id] = pm
+                        needs_update = True
+                # Link to parent.
+                if pm.alias_of_id != parent.pk:
+                    pm.alias_of = parent
+                    needs_update = True
+                if needs_update:
+                    alias_models_needing_update.append(pm)
+            else:
+                alias_created += 1
+                slug = generate_unique_slug(name, existing_slugs)
+                pm = PinballModel(
+                    name=name, opdb_id=opdb_id, alias_of=parent, slug=slug
+                )
+                new_alias_models.append(pm)
+                by_opdb_id[opdb_id] = pm
+                if ipdb_id:
+                    by_ipdb_id[ipdb_id] = pm
+
+            alias_models.append((pm, rec))
+
+        if new_alias_models:
+            PinballModel.objects.bulk_create(new_alias_models)
+        if alias_models_needing_update:
+            PinballModel.objects.bulk_update(
+                alias_models_needing_update, ["opdb_id", "alias_of_id"]
+            )
 
         self.stdout.write(
             f"  Aliases — Linked: {alias_linked}, Created: {alias_created}, "
-            f"Skipped: {alias_skipped}, Failed: {alias_failed}"
+            f"Skipped: {alias_skipped}"
         )
+        if new_alias_models:
+            self.stdout.write(
+                f"    New: {format_names([pm.name for pm in new_alias_models])}"
+            )
+
+        # --- Phase 2: Collect claims ---
+        pending_claims: list[Claim] = []
+        failed = 0
+        failed_ids: list = []
+
+        for pm, rec in machine_models:
+            try:
+                self._collect_claims(pm, rec, source, groups_by_id, pending_claims)
+            except Exception:
+                opdb_id = rec.get("opdb_id", "?")
+                logger.exception("Failed to collect claims for OPDB record %s", opdb_id)
+                failed += 1
+                failed_ids.append(opdb_id)
+
+        for pm, rec in alias_models:
+            try:
+                self._collect_claims(pm, rec, source, groups_by_id, pending_claims)
+            except Exception:
+                opdb_id = rec.get("opdb_id", "?")
+                logger.exception("Failed to collect claims for OPDB alias %s", opdb_id)
+                failed += 1
+                failed_ids.append(opdb_id)
 
         if failed_ids:
             self.stderr.write(f"  Failed IDs: {failed_ids}")
 
+        # --- Bulk-assert all collected claims ---
+        claim_stats = Claim.objects.bulk_assert_claims(source, pending_claims)
+        self.stdout.write(
+            f"  Claims: {claim_stats['unchanged']} unchanged, "
+            f"{claim_stats['created']} created, "
+            f"{claim_stats['superseded']} superseded, "
+            f"{claim_stats['duplicates_removed']} duplicates removed"
+        )
+
         self.stdout.write(self.style.SUCCESS("OPDB ingestion complete."))
 
-        if failed or alias_failed:
+        if failed:
             raise SystemExit(1)
 
     # ------------------------------------------------------------------
@@ -183,271 +332,144 @@ class Command(BaseCommand):
     # ------------------------------------------------------------------
 
     def _load_groups(self, path: str) -> dict[str, dict]:
-        """Load groups JSON and create/update MachineGroup records.
+        """Load groups JSON and bulk create/update MachineGroup records.
 
         Returns a dict mapping group opdb_id → group record for later lookup.
         """
         with open(path) as f:
             data = json.load(f)
 
+        # Build lookup of raw group data.
         groups_by_id: dict[str, dict] = {}
-        created = 0
-        updated = 0
-
         for rec in data:
             opdb_id = rec.get("opdb_id")
-            if not opdb_id:
-                continue
+            if opdb_id:
+                groups_by_id[opdb_id] = rec
 
-            groups_by_id[opdb_id] = rec
+        # Pre-fetch existing groups.
+        existing_groups: dict[str, MachineGroup] = {
+            g.opdb_id: g for g in MachineGroup.objects.all()
+        }
+        existing_slugs: set[str] = set(
+            MachineGroup.objects.values_list("slug", flat=True)
+        )
 
-            _, was_created = MachineGroup.objects.update_or_create(
-                opdb_id=opdb_id,
-                defaults={
-                    "name": rec.get("name", ""),
-                    "shortname": rec.get("shortname") or "",
-                },
-            )
-            if was_created:
-                created += 1
+        new_groups: list[MachineGroup] = []
+        updated_groups: list[MachineGroup] = []
+        unchanged = 0
+
+        for opdb_id, rec in groups_by_id.items():
+            name = rec.get("name", "")
+            shortname = rec.get("shortname") or ""
+
+            existing = existing_groups.get(opdb_id)
+            if existing:
+                # Check if update is needed.
+                if existing.name != name or existing.shortname != shortname:
+                    existing.name = name
+                    existing.shortname = shortname
+                    updated_groups.append(existing)
+                else:
+                    unchanged += 1
             else:
-                updated += 1
+                slug = generate_unique_slug(name, existing_slugs)
+                new_groups.append(
+                    MachineGroup(
+                        opdb_id=opdb_id,
+                        name=name,
+                        slug=slug,
+                        shortname=shortname,
+                    )
+                )
+
+        groups_created = len(new_groups)
+        groups_updated = len(updated_groups)
+
+        if new_groups:
+            MachineGroup.objects.bulk_create(new_groups)
+        if updated_groups:
+            MachineGroup.objects.bulk_update(updated_groups, ["name", "shortname"])
 
         self.stdout.write(
-            f"  Groups: {created} created, {updated} updated "
-            f"({len(groups_by_id)} total)"
+            f"  Groups: {groups_created} created, {groups_updated} updated, "
+            f"{unchanged} unchanged"
         )
         return groups_by_id
 
     # ------------------------------------------------------------------
-    # Machine ingestion
+    # Shared claim collection
     # ------------------------------------------------------------------
 
-    def _ingest_record(
-        self, rec: dict, source: Source, groups_by_id: dict[str, dict]
-    ) -> str:
-        opdb_id = rec.get("opdb_id")
-        ipdb_id = rec.get("ipdb_id")
-        name = rec.get("name", "Unknown")
-
-        # Try to match existing PinballModel.
-        pm = None
-        was_matched = False
-
-        # 1. Match by ipdb_id cross-reference.
-        if ipdb_id:
-            pm = PinballModel.objects.filter(ipdb_id=ipdb_id).first()
-
-        # 2. Match by opdb_id.
-        if not pm and opdb_id:
-            pm = PinballModel.objects.filter(opdb_id=opdb_id).first()
-
-        if pm:
-            was_matched = True
-            # Set opdb_id if not already set.
-            if pm.opdb_id is None and opdb_id:
-                # Check no other model already owns this opdb_id.
-                conflict = PinballModel.objects.filter(opdb_id=opdb_id).first()
-                if conflict:
-                    logger.warning(
-                        "Cannot set opdb_id=%s on %r (ipdb_id=%s): "
-                        "already owned by %r (pk=%s)",
-                        opdb_id,
-                        pm.name,
-                        ipdb_id,
-                        conflict.name,
-                        conflict.pk,
-                    )
-                else:
-                    pm.opdb_id = opdb_id
-                    pm.save(update_fields=["opdb_id"])
-            elif pm.opdb_id and opdb_id and pm.opdb_id != opdb_id:
-                logger.warning(
-                    "PinballModel %r already has opdb_id=%s, skipping %s",
-                    pm.name,
-                    pm.opdb_id,
-                    opdb_id,
-                )
-        else:
-            pm = PinballModel.objects.create(name=name, opdb_id=opdb_id)
-
-        self._assert_claims(pm, rec, source, groups_by_id)
-
-        return "matched" if was_matched else "created"
-
-    # ------------------------------------------------------------------
-    # Alias ingestion
-    # ------------------------------------------------------------------
-
-    def _ingest_alias(
-        self, rec: dict, source: Source, groups_by_id: dict[str, dict]
-    ) -> str:
-        opdb_id = rec.get("opdb_id")
-        ipdb_id = rec.get("ipdb_id")
-        name = rec.get("name", "Unknown")
-
-        # Find the parent machine. The alias opdb_id is G{group}-M{machine}-A{alias}.
-        # The parent machine's opdb_id is G{group}-M{machine} (first two segments).
-        parent_opdb_id = "-".join(opdb_id.split("-")[:2]) if opdb_id else None
-        parent = (
-            PinballModel.objects.filter(opdb_id=parent_opdb_id).first()
-            if parent_opdb_id
-            else None
-        )
-
-        if not parent:
-            logger.warning(
-                "Alias %s (%s): parent %s not found, skipping",
-                opdb_id,
-                name,
-                parent_opdb_id,
-            )
-            return "skipped"
-
-        # Try to match existing PinballModel (IPDB may have created it).
-        pm = None
-        was_matched = False
-
-        if ipdb_id:
-            pm = PinballModel.objects.filter(ipdb_id=ipdb_id).first()
-
-        if not pm and opdb_id:
-            pm = PinballModel.objects.filter(opdb_id=opdb_id).first()
-
-        if pm:
-            was_matched = True
-            # Set opdb_id if not already set.
-            if pm.opdb_id is None and opdb_id:
-                conflict = PinballModel.objects.filter(opdb_id=opdb_id).first()
-                if not conflict:
-                    pm.opdb_id = opdb_id
-            # Link to parent.
-            if pm.alias_of_id != parent.pk:
-                pm.alias_of = parent
-            pm.save()
-        else:
-            pm = PinballModel.objects.create(
-                name=name, opdb_id=opdb_id, alias_of=parent
-            )
-
-        self._assert_claims(pm, rec, source, groups_by_id)
-
-        return "matched" if was_matched else "created"
-
-    # ------------------------------------------------------------------
-    # Shared claim logic
-    # ------------------------------------------------------------------
-
-    def _assert_claims(
+    def _collect_claims(
         self,
         pm: PinballModel,
         rec: dict,
         source: Source,
         groups_by_id: dict[str, dict],
+        pending_claims: list[Claim],
     ) -> None:
-        """Assert all claims for a machine or alias record."""
+        """Collect claim objects for a machine or alias record.
+
+        Appends unsaved Claim instances to ``pending_claims`` for later bulk
+        write via ``Claim.objects.bulk_assert_claims()``.
+        """
         opdb_id = rec.get("opdb_id")
         name = rec.get("name")
 
+        def _add(field_name: str, value) -> None:
+            pending_claims.append(
+                Claim(model_id=pm.pk, field_name=field_name, value=value)
+            )
+
         if name:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="name", value=name
-            )
+            _add("name", name)
         if opdb_id:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="opdb_id", value=opdb_id
-            )
+            _add("opdb_id", opdb_id)
 
         # Manufacturer (claimed as OPDB manufacturer_id).
         mfr = rec.get("manufacturer")
         if mfr and mfr.get("manufacturer_id"):
-            Claim.objects.assert_claim(
-                model=pm,
-                source=source,
-                field_name="manufacturer",
-                value=mfr["manufacturer_id"],
-            )
+            _add("manufacturer", mfr["manufacturer_id"])
 
         # Date.
         date_str = rec.get("manufacture_date")
         if date_str:
             year, month = parse_opdb_date(date_str)
             if year is not None:
-                Claim.objects.assert_claim(
-                    model=pm, source=source, field_name="year", value=year
-                )
+                _add("year", year)
             if month is not None:
-                Claim.objects.assert_claim(
-                    model=pm, source=source, field_name="month", value=month
-                )
+                _add("month", month)
 
         # Player count.
         player_count = rec.get("player_count")
         if player_count is not None:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="player_count", value=player_count
-            )
+            _add("player_count", player_count)
 
         # Machine type.
         machine_type = map_opdb_type(rec.get("type"))
         if machine_type:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="machine_type", value=machine_type
-            )
+            _add("machine_type", machine_type)
 
         # Display type.
         display_type = map_opdb_display(rec.get("display"))
         if display_type:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="display_type", value=display_type
-            )
+            _add("display_type", display_type)
 
         # Extra data fields.
-        features = rec.get("features")
-        if features:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="features", value=features
-            )
-
-        keywords = rec.get("keywords")
-        if keywords:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="keywords", value=keywords
-            )
-
-        description = rec.get("description")
-        if description:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="description", value=description
-            )
-
-        # --- New fields ---
-
-        common_name = rec.get("common_name")
-        if common_name:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="common_name", value=common_name
-            )
-
-        shortname = rec.get("shortname")
-        if shortname:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="shortname", value=shortname
-            )
-
-        images = rec.get("images")
-        if images:
-            Claim.objects.assert_claim(
-                model=pm, source=source, field_name="images", value=images
-            )
+        for field in (
+            "features",
+            "keywords",
+            "description",
+            "common_name",
+            "shortname",
+            "images",
+        ):
+            value = rec.get(field)
+            if value:
+                _add(field, value)
 
         # Group claim (derived from opdb_id prefix).
         if opdb_id and groups_by_id:
             group_opdb_id = parse_opdb_group_id(opdb_id)
             if group_opdb_id and group_opdb_id in groups_by_id:
-                Claim.objects.assert_claim(
-                    model=pm,
-                    source=source,
-                    field_name="group",
-                    value=group_opdb_id,
-                )
+                _add("group", group_opdb_id)

--- a/backend/apps/machines/management/commands/resolve_claims.py
+++ b/backend/apps/machines/management/commands/resolve_claims.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from django.core.management.base import BaseCommand
 
 from apps.machines.resolve import resolve_all
@@ -11,6 +13,10 @@ class Command(BaseCommand):
     help = "Re-resolve all PinballModels from their active claims."
 
     def handle(self, *args, **options):
+        # Silence per-query SQL logging — bulk_update generates huge CASE WHEN
+        # statements that produce tens of MB of debug output.
+        logging.getLogger("django.db.backends").setLevel(logging.WARNING)
+
         self.stdout.write("Resolving claims...")
         count = resolve_all()
         self.stdout.write(self.style.SUCCESS(f"Resolved {count} models."))

--- a/backend/apps/machines/resolve.py
+++ b/backend/apps/machines/resolve.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import logging
 from decimal import Decimal, InvalidOperation
+from typing import Any
 
 from django.db import models
 from django.db.models import F
+from django.utils import timezone
 
 from .models import Claim, MachineGroup, Manufacturer, ManufacturerEntity, PinballModel
 
@@ -218,9 +220,244 @@ def resolve_model(pinball_model: PinballModel) -> PinballModel:
 
 
 def resolve_all() -> int:
-    """Re-resolve every PinballModel from its claims. Returns count resolved."""
-    count = 0
-    for pm in PinballModel.objects.all():
-        resolve_model(pm)
-        count += 1
-    return count
+    """Re-resolve every PinballModel from its claims (bulk-optimized).
+
+    Pre-fetches all lookup tables and claims in ~4 queries, resolves
+    in memory, then writes back with a single bulk_update().
+    """
+    # 1. Pre-fetch lookup tables (~3 queries).
+    mfr_lookups = _build_manufacturer_lookups()
+    group_lookup = _build_group_lookup()
+    field_defaults = _get_field_defaults()
+
+    # 2. Pre-fetch all active claims, grouped by model_id (~1 query).
+    claims_by_model = _build_claims_by_model()
+
+    # 3. Load all PinballModels (~1 query).
+    all_models = list(PinballModel.objects.all())
+
+    # 4. Resolve each model in memory.
+    for pm in all_models:
+        winners = claims_by_model.get(pm.pk, {})
+        _apply_resolution(pm, winners, field_defaults, mfr_lookups, group_lookup)
+
+    # 5. Detect opdb_id conflicts across all resolved models.
+    _resolve_opdb_conflicts(all_models)
+
+    # 6. Set updated_at (auto_now not triggered by bulk_update).
+    now = timezone.now()
+    for pm in all_models:
+        pm.updated_at = now
+
+    # 7. Bulk write (~1 query, batched).
+    update_fields = list(DIRECT_FIELDS.values()) + [
+        "manufacturer_id",
+        "group_id",
+        "extra_data",
+        "updated_at",
+    ]
+    # batch_size=100 is optimal for SQLite (CASE WHEN overhead grows with
+    # batch size × field count). PostgreSQL uses a more efficient UPDATE FROM
+    # VALUES syntax and handles larger batches fine.
+    PinballModel.objects.bulk_update(all_models, update_fields, batch_size=100)
+
+    return len(all_models)
+
+
+# ------------------------------------------------------------------
+# Bulk resolution helpers (used by resolve_all)
+# ------------------------------------------------------------------
+
+_field_defaults: dict[str, Any] | None = None
+
+
+def _get_field_defaults() -> dict[str, Any]:
+    """Compute reset values for all DIRECT_FIELDS (cached after first call)."""
+    global _field_defaults
+    if _field_defaults is not None:
+        return _field_defaults
+    defaults: dict[str, Any] = {}
+    for attr in DIRECT_FIELDS.values():
+        field = PinballModel._meta.get_field(attr)
+        if hasattr(field, "default") and field.default is not models.NOT_PROVIDED:
+            defaults[attr] = (
+                field.default() if callable(field.default) else field.default
+            )
+        elif field.null:
+            defaults[attr] = None
+        else:
+            defaults[attr] = ""
+    _field_defaults = defaults
+    return _field_defaults
+
+
+def _build_manufacturer_lookups() -> tuple[
+    dict[int, Manufacturer],
+    dict[int, Manufacturer],
+    dict[str, Manufacturer],
+    dict[str, Manufacturer],
+]:
+    """Pre-fetch all manufacturer data into four lookup dicts."""
+    ipdb_id_to_mfr: dict[int, Manufacturer] = {}
+    for entity in ManufacturerEntity.objects.select_related("manufacturer").all():
+        if entity.ipdb_manufacturer_id is not None:
+            ipdb_id_to_mfr[entity.ipdb_manufacturer_id] = entity.manufacturer
+
+    opdb_id_to_mfr: dict[int, Manufacturer] = {}
+    name_to_mfr: dict[str, Manufacturer] = {}
+    trade_name_to_mfr: dict[str, Manufacturer] = {}
+    for mfr in Manufacturer.objects.all():
+        if mfr.opdb_manufacturer_id is not None:
+            opdb_id_to_mfr[mfr.opdb_manufacturer_id] = mfr
+        if mfr.name:
+            name_to_mfr[mfr.name.lower()] = mfr
+        if mfr.trade_name:
+            trade_name_to_mfr[mfr.trade_name.lower()] = mfr
+
+    return ipdb_id_to_mfr, opdb_id_to_mfr, name_to_mfr, trade_name_to_mfr
+
+
+def _build_group_lookup() -> dict[str, MachineGroup]:
+    """Pre-fetch all groups into {opdb_id: MachineGroup}."""
+    return {g.opdb_id: g for g in MachineGroup.objects.all()}
+
+
+def _build_claims_by_model() -> dict[int, dict[str, Claim]]:
+    """Pre-fetch all active claims, pick winner per (model_id, field_name).
+
+    Returns {model_id: {field_name: winning_claim}}.
+    """
+    claims = (
+        Claim.objects.filter(is_active=True)
+        .select_related("source")
+        .order_by("model_id", "field_name", "-source__priority", "-created_at")
+    )
+
+    result: dict[int, dict[str, Claim]] = {}
+    for claim in claims:
+        model_winners = result.setdefault(claim.model_id, {})
+        # First claim per (model_id, field_name) group is the winner.
+        if claim.field_name not in model_winners:
+            model_winners[claim.field_name] = claim
+
+    return result
+
+
+def _resolve_manufacturer_bulk(
+    value,
+    source_slug: str,
+    mfr_lookups: tuple[
+        dict[int, Manufacturer],
+        dict[int, Manufacturer],
+        dict[str, Manufacturer],
+        dict[str, Manufacturer],
+    ],
+) -> Manufacturer | None:
+    """Same logic as _resolve_manufacturer() but uses pre-fetched dicts."""
+    if value is None or value == "":
+        return None
+
+    ipdb_id_to_mfr, opdb_id_to_mfr, name_to_mfr, trade_name_to_mfr = mfr_lookups
+
+    try:
+        numeric_id = int(value)
+
+        if source_slug != "opdb":
+            mfr = ipdb_id_to_mfr.get(numeric_id)
+            if mfr:
+                return mfr
+
+        if source_slug != "ipdb":
+            mfr = opdb_id_to_mfr.get(numeric_id)
+            if mfr:
+                return mfr
+    except ValueError, TypeError:
+        pass
+
+    name = str(value).strip()
+    if not name:
+        return None
+
+    mfr = name_to_mfr.get(name.lower())
+    if mfr:
+        return mfr
+
+    mfr = trade_name_to_mfr.get(name.lower())
+    if mfr:
+        return mfr
+
+    logger.warning("Unmatched manufacturer claim value: %r", value)
+    return None
+
+
+def _resolve_group_bulk(
+    value, group_lookup: dict[str, MachineGroup]
+) -> MachineGroup | None:
+    """Same logic as _resolve_group() but uses pre-fetched dict."""
+    if value is None or value == "":
+        return None
+    group = group_lookup.get(str(value))
+    if not group:
+        logger.warning("Unmatched group claim value: %r", value)
+    return group
+
+
+def _apply_resolution(
+    pm: PinballModel,
+    winners: dict[str, Claim],
+    field_defaults: dict[str, Any],
+    mfr_lookups: tuple,
+    group_lookup: dict[str, MachineGroup],
+) -> None:
+    """Apply claim winners to a PinballModel instance in memory."""
+    # Reset FK fields.
+    pm.manufacturer = None
+    pm.group = None
+
+    # Reset all DIRECT_FIELDS to defaults.
+    for attr, default in field_defaults.items():
+        setattr(pm, attr, default)
+
+    # Fresh extra_data dict (never shared between models).
+    extra_data: dict = {}
+
+    # Apply winners.
+    for field_name, claim in winners.items():
+        if field_name == "manufacturer":
+            pm.manufacturer = _resolve_manufacturer_bulk(
+                claim.value, source_slug=claim.source.slug, mfr_lookups=mfr_lookups
+            )
+        elif field_name == "group":
+            pm.group = _resolve_group_bulk(claim.value, group_lookup)
+        elif field_name in DIRECT_FIELDS:
+            attr = DIRECT_FIELDS[field_name]
+            setattr(pm, attr, _coerce(field_name, claim.value))
+        else:
+            extra_data[field_name] = claim.value
+
+    pm.extra_data = extra_data
+
+
+def _resolve_opdb_conflicts(all_models: list[PinballModel]) -> None:
+    """Clear opdb_id on models that would cause UNIQUE constraint violations.
+
+    First model encountered (by queryset order) wins ownership.
+    """
+    seen_opdb_ids: dict[str, PinballModel] = {}
+    for pm in all_models:
+        if not pm.opdb_id:
+            continue
+        if pm.opdb_id in seen_opdb_ids:
+            owner = seen_opdb_ids[pm.opdb_id]
+            logger.warning(
+                "Cannot resolve opdb_id=%s onto '%s' (pk=%s): "
+                "already owned by '%s' (pk=%s)",
+                pm.opdb_id,
+                pm.name,
+                pm.pk,
+                owner.name,
+                owner.pk,
+            )
+            pm.opdb_id = None
+        else:
+            seen_opdb_ids[pm.opdb_id] = pm

--- a/backend/apps/machines/resolve.py
+++ b/backend/apps/machines/resolve.py
@@ -154,6 +154,7 @@ def resolve_model(pinball_model: PinballModel) -> PinballModel:
     """
     claims = (
         Claim.objects.filter(model=pinball_model, is_active=True)
+        .select_related("source")
         .annotate(source_priority=F("source__priority"))
         .order_by("field_name", "-source_priority", "-created_at")
     )

--- a/backend/apps/machines/tests/test_bulk_assert_claims.py
+++ b/backend/apps/machines/tests/test_bulk_assert_claims.py
@@ -1,0 +1,216 @@
+"""Tests for ClaimManager.bulk_assert_claims()."""
+
+import pytest
+
+from apps.machines.models import Claim, Manufacturer, PinballModel, Source
+
+
+@pytest.fixture
+def source(db):
+    return Source.objects.create(
+        name="IPDB", slug="ipdb", source_type="database", priority=10
+    )
+
+
+@pytest.fixture
+def other_source(db):
+    return Source.objects.create(
+        name="OPDB", slug="opdb", source_type="database", priority=20
+    )
+
+
+@pytest.fixture
+def manufacturer(db):
+    return Manufacturer.objects.create(name="Williams")
+
+
+@pytest.fixture
+def pm1(db, manufacturer):
+    return PinballModel.objects.create(
+        name="Medieval Madness", manufacturer=manufacturer, year=1997
+    )
+
+
+@pytest.fixture
+def pm2(db, manufacturer):
+    return PinballModel.objects.create(
+        name="Monster Bash", manufacturer=manufacturer, year=1998
+    )
+
+
+class TestBulkAssertClaimsCreate:
+    """First run: no existing claims, everything is new."""
+
+    def test_creates_all_claims(self, source, pm1, pm2):
+        pending = [
+            Claim(model_id=pm1.pk, field_name="year", value=1997),
+            Claim(model_id=pm1.pk, field_name="name", value="Medieval Madness"),
+            Claim(model_id=pm2.pk, field_name="year", value=1998),
+        ]
+        stats = Claim.objects.bulk_assert_claims(source, pending)
+
+        assert stats["created"] == 3
+        assert stats["unchanged"] == 0
+        assert stats["superseded"] == 0
+        assert stats["duplicates_removed"] == 0
+
+        assert Claim.objects.filter(is_active=True, source=source).count() == 3
+
+    def test_all_created_claims_are_active(self, source, pm1):
+        pending = [
+            Claim(model_id=pm1.pk, field_name="year", value=1997),
+        ]
+        Claim.objects.bulk_assert_claims(source, pending)
+
+        claim = Claim.objects.get(
+            model=pm1, source=source, field_name="year", is_active=True
+        )
+        assert claim.value == 1997
+
+
+class TestBulkAssertClaimsIdempotent:
+    """Second run with same data: nothing should be written."""
+
+    def test_unchanged_on_second_run(self, source, pm1, pm2):
+        pending = [
+            Claim(model_id=pm1.pk, field_name="year", value=1997),
+            Claim(model_id=pm2.pk, field_name="year", value=1998),
+        ]
+        Claim.objects.bulk_assert_claims(source, pending)
+
+        # Run again with identical data.
+        pending2 = [
+            Claim(model_id=pm1.pk, field_name="year", value=1997),
+            Claim(model_id=pm2.pk, field_name="year", value=1998),
+        ]
+        stats = Claim.objects.bulk_assert_claims(source, pending2)
+
+        assert stats["created"] == 0
+        assert stats["superseded"] == 0
+        assert stats["unchanged"] == 2
+
+        # Still only 2 active claims, no extras.
+        assert Claim.objects.filter(is_active=True, source=source).count() == 2
+        # No deactivated claims (nothing was superseded).
+        assert Claim.objects.filter(is_active=False, source=source).count() == 0
+
+
+class TestBulkAssertClaimsSupersede:
+    """Changed values should deactivate old claims and create new ones."""
+
+    def test_supersedes_changed_value(self, source, pm1):
+        pending1 = [Claim(model_id=pm1.pk, field_name="year", value=1997)]
+        Claim.objects.bulk_assert_claims(source, pending1)
+
+        pending2 = [Claim(model_id=pm1.pk, field_name="year", value=1998)]
+        stats = Claim.objects.bulk_assert_claims(source, pending2)
+
+        assert stats["created"] == 1
+        assert stats["superseded"] == 1
+        assert stats["unchanged"] == 0
+
+        # One active, one deactivated.
+        assert (
+            Claim.objects.filter(
+                model=pm1, source=source, field_name="year", is_active=True
+            ).count()
+            == 1
+        )
+        assert (
+            Claim.objects.filter(
+                model=pm1, source=source, field_name="year", is_active=False
+            ).count()
+            == 1
+        )
+
+        # Active claim has the new value.
+        active = Claim.objects.get(
+            model=pm1, source=source, field_name="year", is_active=True
+        )
+        assert active.value == 1998
+
+    def test_supersedes_changed_citation(self, source, pm1):
+        pending1 = [
+            Claim(model_id=pm1.pk, field_name="year", value=1997, citation="old")
+        ]
+        Claim.objects.bulk_assert_claims(source, pending1)
+
+        pending2 = [
+            Claim(model_id=pm1.pk, field_name="year", value=1997, citation="new")
+        ]
+        stats = Claim.objects.bulk_assert_claims(source, pending2)
+
+        assert stats["created"] == 1
+        assert stats["superseded"] == 1
+
+
+class TestBulkAssertClaimsDeduplicate:
+    """Duplicate (model_id, field_name) pairs: last-write-wins."""
+
+    def test_deduplicates_pending(self, source, pm1):
+        pending = [
+            Claim(model_id=pm1.pk, field_name="year", value=1997),
+            Claim(model_id=pm1.pk, field_name="year", value=1998),  # Should win
+        ]
+        stats = Claim.objects.bulk_assert_claims(source, pending)
+
+        assert stats["duplicates_removed"] == 1
+        assert stats["created"] == 1
+
+        active = Claim.objects.get(
+            model=pm1, source=source, field_name="year", is_active=True
+        )
+        assert active.value == 1998
+
+    def test_no_constraint_violation_on_duplicates(self, source, pm1):
+        """Duplicates should not cause IntegrityError."""
+        pending = [
+            Claim(model_id=pm1.pk, field_name="name", value="V1"),
+            Claim(model_id=pm1.pk, field_name="name", value="V2"),
+            Claim(model_id=pm1.pk, field_name="name", value="V3"),
+        ]
+        # Should not raise.
+        stats = Claim.objects.bulk_assert_claims(source, pending)
+        assert stats["duplicates_removed"] == 2
+        assert (
+            Claim.objects.filter(
+                model=pm1, source=source, field_name="name", is_active=True
+            ).count()
+            == 1
+        )
+
+
+class TestBulkAssertClaimsIsolation:
+    """Claims from different sources should not interfere."""
+
+    def test_does_not_touch_other_sources(self, source, other_source, pm1):
+        # Set up claims from both sources.
+        Claim.objects.assert_claim(
+            model=pm1, source=other_source, field_name="year", value=1997
+        )
+
+        pending = [Claim(model_id=pm1.pk, field_name="year", value=1998)]
+        Claim.objects.bulk_assert_claims(source, pending)
+
+        # Other source's claim is untouched.
+        other_claim = Claim.objects.get(
+            model=pm1, source=other_source, field_name="year", is_active=True
+        )
+        assert other_claim.value == 1997
+
+        # This source's claim is also active.
+        this_claim = Claim.objects.get(
+            model=pm1, source=source, field_name="year", is_active=True
+        )
+        assert this_claim.value == 1998
+
+
+class TestBulkAssertClaimsSourceSet:
+    """The source FK should be set by bulk_assert_claims."""
+
+    def test_source_is_set_on_pending_claims(self, source, pm1):
+        pending = [Claim(model_id=pm1.pk, field_name="year", value=1997)]
+        Claim.objects.bulk_assert_claims(source, pending)
+
+        claim = Claim.objects.get(model=pm1, field_name="year", is_active=True)
+        assert claim.source == source

--- a/backend/apps/machines/tests/test_resolve.py
+++ b/backend/apps/machines/tests/test_resolve.py
@@ -1,13 +1,15 @@
 import pytest
+from django.utils import timezone
 
 from apps.machines.models import (
     Claim,
+    MachineGroup,
     Manufacturer,
     ManufacturerEntity,
     PinballModel,
     Source,
 )
-from apps.machines.resolve import resolve_model
+from apps.machines.resolve import resolve_all, resolve_model
 
 
 @pytest.fixture
@@ -178,3 +180,135 @@ class TestResolveModel:
         assert resolved.year == 1992
         assert resolved.extra_data["toys"] == "Thing hand, bookcase"
         assert resolved.educational_text == "A seminal game."
+
+
+@pytest.mark.django_db
+class TestResolveAll:
+    def test_basic(self):
+        ipdb = Source.objects.create(
+            name="IPDB", slug="ipdb", source_type="database", priority=10
+        )
+        pm1 = PinballModel.objects.create(name="P1", slug="p1")
+        pm2 = PinballModel.objects.create(name="P2", slug="p2")
+        pm3 = PinballModel.objects.create(name="P3", slug="p3")
+
+        Claim.objects.assert_claim(pm1, ipdb, "name", "Medieval Madness")
+        Claim.objects.assert_claim(pm1, ipdb, "year", 1997)
+        Claim.objects.assert_claim(pm2, ipdb, "name", "The Addams Family")
+        Claim.objects.assert_claim(pm3, ipdb, "name", "Twilight Zone")
+        Claim.objects.assert_claim(pm3, ipdb, "machine_type", "SS")
+
+        before = timezone.now()
+        count = resolve_all()
+        assert count == 3
+
+        pm1.refresh_from_db()
+        pm2.refresh_from_db()
+        pm3.refresh_from_db()
+        assert pm1.name == "Medieval Madness"
+        assert pm1.year == 1997
+        assert pm2.name == "The Addams Family"
+        assert pm3.name == "Twilight Zone"
+        assert pm3.machine_type == "SS"
+
+        # updated_at should be refreshed.
+        assert pm1.updated_at >= before
+        assert pm2.updated_at >= before
+        assert pm3.updated_at >= before
+
+    def test_matches_resolve_model(self):
+        """Bulk resolve produces identical results to per-model resolve."""
+        ipdb = Source.objects.create(
+            name="IPDB", slug="ipdb", source_type="database", priority=10
+        )
+        opdb = Source.objects.create(
+            name="OPDB", slug="opdb", source_type="database", priority=20
+        )
+        mfr = Manufacturer.objects.create(name="Williams", opdb_manufacturer_id=7)
+        ManufacturerEntity.objects.create(
+            manufacturer=mfr, name="Williams Corp", ipdb_manufacturer_id=42
+        )
+        MachineGroup.objects.create(opdb_id="G1111", name="Medieval Madness", slug="mm")
+
+        pm_bulk = PinballModel.objects.create(name="P1", slug="p1")
+        pm_single = PinballModel.objects.create(name="P2", slug="p2")
+
+        # Same claims on both models.
+        for pm in (pm_bulk, pm_single):
+            Claim.objects.assert_claim(pm, ipdb, "name", "Medieval Madness")
+            Claim.objects.assert_claim(pm, opdb, "year", 1997)
+            Claim.objects.assert_claim(pm, ipdb, "manufacturer", 42)
+            Claim.objects.assert_claim(pm, opdb, "group", "G1111")
+            Claim.objects.assert_claim(pm, ipdb, "abbreviation", "MM")
+            Claim.objects.assert_claim(pm, ipdb, "machine_type", "SS")
+
+        # Resolve pm_single with the per-model path.
+        resolve_model(pm_single)
+        pm_single.refresh_from_db()
+
+        # Resolve pm_bulk with the bulk path.
+        resolve_all()
+        pm_bulk.refresh_from_db()
+
+        assert pm_bulk.name == pm_single.name
+        assert pm_bulk.year == pm_single.year
+        assert pm_bulk.manufacturer_id == pm_single.manufacturer_id
+        assert pm_bulk.group_id == pm_single.group_id
+        assert pm_bulk.machine_type == pm_single.machine_type
+        assert pm_bulk.extra_data == pm_single.extra_data
+
+    def test_opdb_conflict(self):
+        """Two models resolving to same opdb_id — first by name order wins."""
+        ipdb = Source.objects.create(
+            name="IPDB", slug="ipdb", source_type="database", priority=10
+        )
+        # "Alpha" sorts before "Beta" — Alpha should keep the opdb_id.
+        pm_a = PinballModel.objects.create(name="Alpha", slug="alpha")
+        pm_b = PinballModel.objects.create(name="Beta", slug="beta")
+
+        Claim.objects.assert_claim(pm_a, ipdb, "opdb_id", "GCONFLICT-M1")
+        Claim.objects.assert_claim(pm_b, ipdb, "opdb_id", "GCONFLICT-M1")
+
+        resolve_all()
+        pm_a.refresh_from_db()
+        pm_b.refresh_from_db()
+
+        assert pm_a.opdb_id == "GCONFLICT-M1"
+        assert pm_b.opdb_id is None
+
+    def test_stale_values_cleared(self):
+        ipdb = Source.objects.create(
+            name="IPDB", slug="ipdb", source_type="database", priority=10
+        )
+        pm = PinballModel.objects.create(name="P1", slug="p1")
+
+        Claim.objects.assert_claim(pm, ipdb, "year", 1997)
+        Claim.objects.assert_claim(pm, ipdb, "theme", "Medieval")
+        Claim.objects.assert_claim(pm, ipdb, "abbreviation", "MM")
+        resolve_all()
+        pm.refresh_from_db()
+        assert pm.year == 1997
+        assert pm.theme == "Medieval"
+        assert pm.extra_data["abbreviation"] == "MM"
+
+        # Deactivate all claims.
+        Claim.objects.filter(model=pm, is_active=True).update(is_active=False)
+        resolve_all()
+        pm.refresh_from_db()
+        assert pm.year is None
+        assert pm.theme == ""
+        assert pm.extra_data == {}
+
+    def test_query_count(self, django_assert_max_num_queries):
+        ipdb = Source.objects.create(
+            name="IPDB", slug="ipdb", source_type="database", priority=10
+        )
+        for i in range(5):
+            pm = PinballModel.objects.create(name=f"Model {i}", slug=f"model-{i}")
+            Claim.objects.assert_claim(pm, ipdb, "name", f"Resolved {i}")
+            Claim.objects.assert_claim(pm, ipdb, "year", 2000 + i)
+
+        # Should be ~6 queries: 2 manufacturer lookups + 1 groups + 1 claims
+        # + 1 models + 1 bulk_update.
+        with django_assert_max_num_queries(10):
+            resolve_all()


### PR DESCRIPTION
## Summary
- Replace per-record ORM calls with in-memory matching and bulk operations across all ingest commands, reducing ~270k DB queries to ~77 for the full pipeline
- Bulk-ify `resolve_claims`: pre-fetch all lookup tables and claims into memory, resolve in a loop, write back with a single `bulk_update()` — reducing ~31k queries to ~6
- Add `bulk_assert_claims()` to ClaimManager with diff-and-patch semantics (deduplicate, compare, only write delta)
- Simplify `scrape_images`: remove interactive batch pausing, add manual image overrides for machines scrapers can't find

## Details

### resolve_claims
Pre-fetch manufacturer, group, and claim lookup tables (~4 queries), resolve every PinballModel in memory, then write back with `bulk_update(batch_size=100)`. Keeps `resolve_model()` unchanged for single-model use. Suppresses SQL debug logging to avoid tens of MB of CASE WHEN output.

### ingest_ipdb
Pre-fetch all PinballModels by ipdb_id into a dict, match in memory, bulk_create new models, then collect claims/credits per record.

### ingest_opdb
Pre-fetch into two dicts (by_ipdb_id, by_opdb_id), multi-key matching with in-memory conflict checks. Bulk create/update for machines and aliases. Records without opdb_id are skipped for idempotency.

### ingest_manufacturers
Bulk create/update for brands and entities. Summary logging for newly created items.

### scrape_images
Removed interactive batch pausing. Added `MANUAL_IMAGES` dict for hand-picked URLs (Pokémon models). Manual entries are checked first before any network strategies.

## Performance
| Area | Before | After |
| --- | --- | --- |
| ingest_ipdb PinballModel | ~10,000 queries | 2 |
| ingest_opdb machines | ~20,000 queries | 3 |
| ingest_opdb aliases | ~8,000 queries | 2 |
| Claims (all commands) | ~220,000 queries | ~70 |
| resolve_claims | ~31,000 queries | ~6 |
| **Total pipeline** | **~300,000** | **~83** |

Verified against real data: full pipeline including resolve runs in ~15s locally.

## Test plan
- [x] 196 tests pass (`uv run pytest`)
- [x] Lint and format clean (`ruff check`, `ruff format --check`)
- [x] Ran full pipeline against real data (6,858 models)
- [x] Verified idempotency (second run creates 0 new records)
- [x] Bulk resolve produces identical results to per-model resolve (equivalence test)
- [x] Edge case tests for OPDB conflict branches, missing IDs, alias linking, opdb_id conflicts, stale value clearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)