### PR TITLE
perf: optimize API with caching, prefetching, and persistent DB connections

### DIFF
--- a/backend/apps/machines/tests/test_api.py
+++ b/backend/apps/machines/tests/test_api.py
@@ -381,6 +381,35 @@ class TestManufacturersAPI:
         assert len(data["models"]) == 1
         assert data["models"][0]["name"] == "Medieval Madness"
 
+    def test_get_manufacturer_entities_ordered_by_years(self, client, manufacturer):
+        """Entities are returned ordered by years_active."""
+        # Created in scrambled order to ensure ordering isn't a PK fluke.
+        ManufacturerEntity.objects.create(
+            manufacturer=manufacturer,
+            name="Williams Latest",
+            ipdb_manufacturer_id=352,
+            years_active="1999-2010",
+        )
+        ManufacturerEntity.objects.create(
+            manufacturer=manufacturer,
+            name="Williams Early",
+            ipdb_manufacturer_id=350,
+            years_active="1943-1985",
+        )
+        ManufacturerEntity.objects.create(
+            manufacturer=manufacturer,
+            name="Williams Middle",
+            ipdb_manufacturer_id=351,
+            years_active="1985-1999",
+        )
+        resp = client.get(f"/api/manufacturers/{manufacturer.slug}")
+        entities = resp.json()["entities"]
+        assert [e["name"] for e in entities] == [
+            "Williams Early",
+            "Williams Middle",
+            "Williams Latest",
+        ]
+
     def test_list_all_manufacturers_thumbnail_prefers_year(
         self, client, manufacturer, db
     ):

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -31,6 +31,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django.middleware.gzip.GZipMiddleware",
+    "django.middleware.http.ConditionalGetMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -65,6 +67,8 @@ WSGI_APPLICATION = "config.wsgi.application"
 DATABASES = {
     "default": dj_database_url.config(
         default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}",
+        conn_max_age=600,
+        conn_health_checks=True,
     ),
 }
 


### PR DESCRIPTION
## Problem

API endpoints on Railway production are **5–500x slower** than localhost. Root causes:

1. **No persistent DB connections** — Django opens a fresh Postgres TCP+TLS connection per request (~150–200ms overhead)
2. **No compression** — `/api/models/all/` sends 1,242 KB of uncompressed JSON
3. **N+1 queries** — manufacturer list fires ~100 extra queries; model detail fires 2 extra; manufacturer detail fires 2 extra
4. **No cache headers** — browser re-fetches identical data on every navigation

### Pre-fix production TTFB (cold)

| Endpoint | Production TTFB | Localhost TTFB | Slowdown |
|---|---|---|---|
| `/api/models/all/` | 1,844ms | 154ms | 12x |
| `/api/manufacturers/all/` | 1,190ms | 266ms | 4x |
| `/api/people/all/` | 2,225ms | 111ms | 20x |
| `/api/groups/all/` | 445ms | 84ms | 5x |
| `/api/sources/` | 1,346ms | 1ms | 1,346x |
| `/api/models/medieval-madness` | 267ms | 6ms | 45x |
| `/api/manufacturers/williams` | 1,649ms | 13ms | 127x |
| `/api/people/pat-lawlor` | 1,630ms | 3ms | 543x |

### Post-fix localhost TTFB

| Endpoint | Before | After | Change |
|---|---|---|---|
| `/api/models/?page=1` | 276ms | 220ms | -20% |
| `/api/models/all/` | 154ms | 166ms | +8% |
| `/api/manufacturers/all/` | 266ms | **119ms** | **-55%** |
| `/api/people/all/` | 111ms | 128ms | +15% |
| `/api/groups/all/` | 84ms | 89ms | +6% |
| `/api/sources/` | 1ms | 1ms | — |
| `/api/models/medieval-madness` | 6ms | 5ms | — |
| `/api/manufacturers/williams` | 14ms | 14ms | — |
| `/api/people/pat-lawlor` | 3ms | 3ms | — |

The `manufacturers/all` N+1 fix is a clear **-55%** win. The small +8–15% on `/all/` endpoints is GZip + ETag hashing overhead — on localhost there's no network to save, but on production this trades ~15ms of CPU for 1+ seconds of transfer savings.

### Uncompressed response sizes

| Endpoint | Size |
|---|---|
| `/api/models/all/` | 1,242 KB |
| `/api/groups/all/` | 289 KB |
| `/api/manufacturers/all/` | 130 KB |
| `/api/people/all/` | 86 KB |
| `/api/manufacturers/williams` | 82 KB |

## Changes

### GZip compression
Added `GZipMiddleware` as first middleware. `/api/models/all/` drops from 1,242 KB → ~179 KB (86% reduction). Transfer time drops from ~1.25s to ~0.15s.

### HTTP cache headers (Cache-Control + ETag)
- `Cache-Control: public, max-age=300` on all read-only endpoints — browser serves from cache for 5 minutes (0ms)
- `ConditionalGetMiddleware` auto-generates ETags — after cache expires, browser gets a 304 if data hasn't changed

### Persistent DB connections
`conn_max_age=600` + `conn_health_checks=True` — connections stay alive for 10 minutes instead of being destroyed after each request. Eliminates ~150–200ms of TCP+TLS setup per request during active browsing.

### N+1 query fixes

| Endpoint | Before | After |
|---|---|---|
| `/api/manufacturers/all/` | ~100 queries (1 per manufacturer for thumbnail) | 2 queries (single `Prefetch` with `.only()`) |
| `/api/models/{slug}` | 3 queries (main + credits + claims) | 1 query (prefetch credits + active_claims) |
| `/api/manufacturers/{slug}` | 3 queries (main + entities + models) | 1 query (prefetch entities with ordering + non-alias models) |

### New test
Entity ordering test with 3 entities created in scrambled PK order to verify `order_by("years_active")` is applied.

## Files changed

| File | Change |
|---|---|
| `backend/config/settings.py` | GZipMiddleware, ConditionalGetMiddleware, conn_max_age, conn_health_checks |
| `backend/apps/machines/api.py` | cache_control decorators on 9 endpoints, Prefetch optimizations for 3 endpoints |
| `backend/apps/machines/tests/test_api.py` | New entity ordering test |

No new dependencies.

## Test plan
- [x] `make test` — 201 tests pass
- [x] `make lint` — clean
- [ ] Deploy to Railway and re-benchmark all endpoints
- [ ] Verify Cache-Control + ETag headers in browser devtools
- [ ] Decide if further caching (Redis) is needed based on measured results

🤖 Generated with [Claude Code](https://claude.com/claude-code)