### PR TITLE
Fix missed README Node 24 update and quiet SQL logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Django + SvelteKit monorepo. Django owns the data model, APIs, and admin UI. Sve
 
 ## Quickstart
 
-**Requirements**: Python 3.14+, Node 22+, [uv](https://docs.astral.sh/uv/), [pnpm](https://pnpm.io/) (or enable via `corepack enable`)
+**Requirements**: Python 3.14+, Node 24+, [uv](https://docs.astral.sh/uv/), [pnpm](https://pnpm.io/) (or enable via `corepack enable`)
 
 ```bash
 cp .env.example .env

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -142,7 +142,7 @@ LOGGING = {
             "level": "ERROR",
         },
         "django.db.backends": {
-            "level": "DEBUG" if DEBUG else "WARNING",
+            "level": "WARNING",
         },
     },
 }


### PR DESCRIPTION
## Summary
- Update README requirements from Node 22+ to Node 24+ (missed in #26)
- Disable verbose SQL query logging in dev (`django.db.backends` → `WARNING`)

## Test plan
- [ ] `make dev` — no SQL queries in Django console output
- [ ] README shows correct Node version

🤖 Generated with [Claude Code](https://claude.com/claude-code)