### PR TITLE
perf: immutable cache headers for SvelteKit + ETag for SPA shell

### DIFF
--- a/backend/config/middleware.py
+++ b/backend/config/middleware.py
@@ -1,0 +1,20 @@
+from whitenoise.middleware import WhiteNoiseMiddleware
+
+
+class SvelteKitWhiteNoiseMiddleware(WhiteNoiseMiddleware):
+    """Extend WhiteNoise's immutable-file detection for SvelteKit.
+
+    WhiteNoise's default ``immutable_file_test`` uses Django's static-files
+    manifest to identify content-hashed assets under ``STATIC_ROOT``.  It
+    always returns ``False`` for files served from ``WHITENOISE_ROOT``
+    because their URLs don't start with the ``/static/`` prefix.
+
+    SvelteKit places all content-hashed bundles under ``_app/immutable/``,
+    so we add a path-based check for those while preserving the parent
+    behaviour for Django's own hashed static files.
+    """
+
+    def immutable_file_test(self, path, url):
+        if "_app/immutable/" in url:
+            return True
+        return super().immutable_file_test(path, url)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -34,7 +34,7 @@ MIDDLEWARE = [
     "django.middleware.gzip.GZipMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "config.middleware.SvelteKitWhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -31,7 +31,11 @@ _ASSET_EXTENSIONS = {
 
 
 def _serve_html(filepath):
-    return HttpResponse(filepath.read_bytes(), content_type="text/html")
+    resp = HttpResponse(filepath.read_bytes(), content_type="text/html")
+    # Allow browser caching but always revalidate. ConditionalGetMiddleware
+    # adds ETag so repeat requests get a fast 304 Not Modified.
+    resp["Cache-Control"] = "no-cache"
+    return resp
 
 
 def frontend_spa(request, path=""):


### PR DESCRIPTION
## Summary
- Subclass WhiteNoiseMiddleware to detect SvelteKit's `_app/immutable/` assets as immutable, giving them `Cache-Control: max-age=315360000, public, immutable`. WhiteNoise's default detection only works for Django's STATIC_ROOT (hex-hash manifest), not WHITENOISE_ROOT files.
- Add `Cache-Control: no-cache` to the SPA shell response so ConditionalGetMiddleware can serve `304 Not Modified` with ETag on repeat visits.

## Test plan
- [ ] Deploy to Railway and verify `_app/immutable/*.js` responses have `Cache-Control: max-age=315360000, public, immutable`
- [ ] Verify `favicon.png` still has short cache (`max-age=60`)
- [ ] Verify SPA shell (`/`) has `Cache-Control: no-cache` and ETag header
- [ ] Verify Django admin static files still get immutable headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)