### PR TITLE
perf: add server-side cache for /all/ API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Thumbs.db
 # Django
 backend/staticfiles/
 backend/media/
+backend/cache/
 
 # Data dumps (large JSON files, not committed)
 data/

--- a/backend/apps/machines/apps.py
+++ b/backend/apps/machines/apps.py
@@ -5,3 +5,8 @@ class MachinesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.machines"
     verbose_name = "Pinball Machines"
+
+    def ready(self):
+        from . import signals
+
+        signals.connect()

--- a/backend/apps/machines/cache.py
+++ b/backend/apps/machines/cache.py
@@ -1,0 +1,16 @@
+"""Cache keys and invalidation helpers for the machines app."""
+
+from __future__ import annotations
+
+from django.core.cache import cache
+
+MODELS_ALL_KEY = "machines:models:all"
+MANUFACTURERS_ALL_KEY = "machines:manufacturers:all"
+PEOPLE_ALL_KEY = "machines:people:all"
+
+
+def invalidate_all() -> None:
+    """Delete all cached /all/ endpoint data."""
+    cache.delete(MODELS_ALL_KEY)
+    cache.delete(MANUFACTURERS_ALL_KEY)
+    cache.delete(PEOPLE_ALL_KEY)

--- a/backend/apps/machines/management/commands/ingest_all.py
+++ b/backend/apps/machines/management/commands/ingest_all.py
@@ -48,19 +48,24 @@ class Command(BaseCommand):
         opdb_groups = options["opdb_groups"]
         opdb_changelog = options["opdb_changelog"]
 
-        for step in STEPS:
-            self.stdout.write(self.style.MIGRATE_HEADING(f"Running {step}..."))
-            kwargs = {}
-            if step == "ingest_manufacturers":
-                kwargs = {"ipdb": ipdb_path, "opdb": opdb_path}
-            elif step == "ingest_ipdb":
-                kwargs = {"ipdb": ipdb_path}
-            elif step == "ingest_opdb":
-                kwargs = {
-                    "opdb": opdb_path,
-                    "groups": opdb_groups,
-                    "changelog": opdb_changelog,
-                }
-            call_command(step, stdout=self.stdout, stderr=self.stderr, **kwargs)
+        from apps.machines.cache import invalidate_all
+
+        try:
+            for step in STEPS:
+                self.stdout.write(self.style.MIGRATE_HEADING(f"Running {step}..."))
+                kwargs = {}
+                if step == "ingest_manufacturers":
+                    kwargs = {"ipdb": ipdb_path, "opdb": opdb_path}
+                elif step == "ingest_ipdb":
+                    kwargs = {"ipdb": ipdb_path}
+                elif step == "ingest_opdb":
+                    kwargs = {
+                        "opdb": opdb_path,
+                        "groups": opdb_groups,
+                        "changelog": opdb_changelog,
+                    }
+                call_command(step, stdout=self.stdout, stderr=self.stderr, **kwargs)
+        finally:
+            invalidate_all()
 
         self.stdout.write(self.style.SUCCESS("Full ingestion pipeline complete."))

--- a/backend/apps/machines/management/commands/resolve_claims.py
+++ b/backend/apps/machines/management/commands/resolve_claims.py
@@ -19,4 +19,7 @@ class Command(BaseCommand):
 
         self.stdout.write("Resolving claims...")
         count = resolve_all()
+        from apps.machines.cache import invalidate_all
+
+        invalidate_all()
         self.stdout.write(self.style.SUCCESS(f"Resolved {count} models."))

--- a/backend/apps/machines/management/commands/scrape_images.py
+++ b/backend/apps/machines/management/commands/scrape_images.py
@@ -225,6 +225,11 @@ class Command(BaseCommand):
                     )
                 )
 
+        if not dry_run:
+            from apps.machines.cache import invalidate_all
+
+            invalidate_all()
+
         action = "would be updated" if dry_run else "updated"
         self.stdout.write(
             self.style.SUCCESS(f"\nDone! {found_count}/{total} machines {action}.")

--- a/backend/apps/machines/signals.py
+++ b/backend/apps/machines/signals.py
@@ -1,0 +1,23 @@
+"""Signal handlers to invalidate cached /all/ endpoint data on model changes."""
+
+from __future__ import annotations
+
+from django.db.models.signals import post_delete, post_save
+
+from .cache import invalidate_all
+
+
+def _invalidate_cache(sender, **kwargs):
+    invalidate_all()
+
+
+def connect():
+    """Connect cache-invalidation signals. Called from AppConfig.ready()."""
+    from .models import DesignCredit, Manufacturer, Person, PinballModel
+
+    for model in (PinballModel, Manufacturer, Person, DesignCredit):
+        uid = f"invalidate_cache_{model.__name__}"
+        post_save.connect(_invalidate_cache, sender=model, dispatch_uid=f"{uid}_save")
+        post_delete.connect(
+            _invalidate_cache, sender=model, dispatch_uid=f"{uid}_delete"
+        )

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -72,6 +72,15 @@ DATABASES = {
     ),
 }
 
+# Server-side cache: file-based so all gunicorn workers + management commands
+# share the same cache via the filesystem. Invalidated explicitly on data changes.
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+        "LOCATION": BASE_DIR / "cache",
+    }
+}
+
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"


### PR DESCRIPTION
## Summary

- Cache serialized responses for `/models/all/`, `/manufacturers/all/`, and `/people/all/` using Django's `FileBasedCache` (shared across gunicorn workers + management commands via filesystem)
- Invalidate explicitly via Django signals on admin saves (`PinballModel`, `Manufacturer`, `Person`, `DesignCredit`) and at the end of management commands (`ingest_all`, `resolve_claims`, `scrape_images`)
- No new dependencies or infrastructure — uses Django's built-in file-based cache backend

## Test plan

- [x] All 39 API tests pass (3 new cache-specific tests)
- [x] Lint passes (ruff + eslint/prettier)
- [ ] Manual: `make dev`, hit `/api/models/all/` twice, confirm second request skips DB queries
- [ ] Verify admin model save clears cache (edit a model in `/admin/`, confirm `/api/models/all/` reflects the change immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)