### PR TITLE
Prerender top-level nav pages

### DIFF
--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -22,7 +22,7 @@ def health(request):
     with connection.cursor() as cursor:
         cursor.execute("SELECT 1")
     if not settings.DEBUG:
-        if not (settings.FRONTEND_BUILD_DIR / "index.html").is_file():
+        if not (settings.FRONTEND_BUILD_DIR / "200.html").is_file():
             raise RuntimeError("Frontend build missing")
     return {"status": "ok"}
 

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -43,7 +43,7 @@ def frontend_spa(request, path=""):
 
     WhiteNoise handles requests for physical files (JS bundles, CSS, images).
     This catch-all serves HTML for all other routes, trying prerendered pages
-    first, then falling back to the SPA shell (index.html).
+    first, then falling back to the SPA shell (200.html).
     """
     build_dir = settings.FRONTEND_BUILD_DIR
 
@@ -51,6 +51,12 @@ def frontend_spa(request, path=""):
     suffix = PurePosixPath(path).suffix
     if suffix and suffix in _ASSET_EXTENSIONS:
         raise Http404
+
+    # Root path: serve prerendered index.html (homepage)
+    if not path:
+        index = build_dir / "index.html"
+        if index.is_file():
+            return _serve_html(index)
 
     # Try prerendered HTML: path.html (trailingSlash: 'never', the default)
     if path:
@@ -64,9 +70,9 @@ def frontend_spa(request, path=""):
             return _serve_html(prerendered_dir)
 
     # Fall back to SPA shell
-    index = build_dir / "index.html"
-    if index.is_file():
-        return _serve_html(index)
+    spa_shell = build_dir / "200.html"
+    if spa_shell.is_file():
+        return _serve_html(spa_shell)
 
     raise Http404("Frontend not built")
 

--- a/backend/tests/test_frontend_spa.py
+++ b/backend/tests/test_frontend_spa.py
@@ -108,6 +108,9 @@ def _make_build_dir(tmp_path, files=None):
     build_dir = tmp_path / "frontend_build"
     build_dir.mkdir()
     (build_dir / "index.html").write_text(
+        "<!doctype html><html><body>Prerendered homepage</body></html>"
+    )
+    (build_dir / "200.html").write_text(
         "<!doctype html><html><body>SPA shell</body></html>"
     )
     for relpath, content in (files or {}).items():
@@ -117,8 +120,8 @@ def _make_build_dir(tmp_path, files=None):
     return build_dir
 
 
-def test_spa_route_serves_index_html(tmp_path):
-    """A generic SPA route should serve the fallback index.html."""
+def test_spa_route_serves_200_html(tmp_path):
+    """A generic SPA route should serve the fallback 200.html."""
     build_dir = _make_build_dir(tmp_path)
     request = RequestFactory().get("/some/spa/route")
     with override_settings(FRONTEND_BUILD_DIR=build_dir):
@@ -202,12 +205,12 @@ def test_path_traversal_blocked(tmp_path):
     assert "SPA shell" in content
 
 
-def test_root_path_serves_index(tmp_path):
-    """GET / should serve the SPA shell index.html."""
+def test_root_path_serves_prerendered_index(tmp_path):
+    """GET / should serve the prerendered index.html (homepage)."""
     build_dir = _make_build_dir(tmp_path)
     request = RequestFactory().get("/")
     with override_settings(FRONTEND_BUILD_DIR=build_dir):
         response = frontend_spa(request, path="")
     assert response.status_code == 200
     content = response.content.decode()
-    assert "SPA shell" in content
+    assert "Prerendered homepage" in content

--- a/frontend/src/lib/async-loader.svelte.ts
+++ b/frontend/src/lib/async-loader.svelte.ts
@@ -1,0 +1,35 @@
+import { onMount } from 'svelte';
+
+/**
+ * Reactive async data loader for use inside Svelte components.
+ *
+ * Fetches data in `onMount` and exposes reactive `data`, `loading`,
+ * and `error` properties via getters.
+ */
+export function createAsyncLoader<T>(fetcher: () => Promise<T>, initial: NoInfer<T>) {
+	let data = $state(initial);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	onMount(async () => {
+		try {
+			data = await fetcher();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load data';
+		} finally {
+			loading = false;
+		}
+	});
+
+	return {
+		get data() {
+			return data;
+		},
+		get loading() {
+			return loading;
+		},
+		get error() {
+			return error;
+		}
+	};
+}

--- a/frontend/src/lib/components/FilterableGrid.svelte
+++ b/frontend/src/lib/components/FilterableGrid.svelte
@@ -12,6 +12,7 @@
 		items,
 		filterFn,
 		loading = false,
+		error = null,
 		placeholder = 'Search...',
 		entityName = 'result',
 		entityNamePlural = `${entityName}s`,
@@ -20,6 +21,7 @@
 		items: T[];
 		filterFn: (item: T, query: string) => boolean;
 		loading?: boolean;
+		error?: string | null;
 		placeholder?: string;
 		entityName?: string;
 		entityNamePlural?: string;
@@ -74,6 +76,8 @@
 				<SkeletonCard />
 			{/each}
 		</CardGrid>
+	{:else if error}
+		<p class="error">{error}</p>
 	{:else}
 		{#if showSearch}
 			<SearchBox bind:value={searchQuery} {placeholder} />
@@ -102,6 +106,12 @@
 		color: var(--color-text-muted);
 		font-size: var(--font-size-1);
 		margin-bottom: var(--size-4);
+	}
+
+	.error {
+		text-align: center;
+		color: var(--color-error);
+		padding: var(--size-6) 0;
 	}
 
 	.sentinel {

--- a/frontend/src/lib/components/FilterableGrid.svelte
+++ b/frontend/src/lib/components/FilterableGrid.svelte
@@ -2,13 +2,16 @@
 	import type { Snippet } from 'svelte';
 	import SearchBox from './SearchBox.svelte';
 	import CardGrid from './CardGrid.svelte';
+	import SkeletonCard from './SkeletonCard.svelte';
 	import { normalizeText } from '$lib/util';
 
 	const SEARCH_THRESHOLD = 12;
+	const SKELETON_INDICES = Array.from({ length: 12 }, (_, i) => i);
 
 	let {
 		items,
 		filterFn,
+		loading = false,
 		placeholder = 'Search...',
 		entityName = 'result',
 		entityNamePlural = `${entityName}s`,
@@ -16,6 +19,7 @@
 	}: {
 		items: T[];
 		filterFn: (item: T, query: string) => boolean;
+		loading?: boolean;
 		placeholder?: string;
 		entityName?: string;
 		entityNamePlural?: string;
@@ -64,19 +68,27 @@
 </script>
 
 <div class="filterable-grid">
-	{#if showSearch}
-		<SearchBox bind:value={searchQuery} {placeholder} />
-		<p class="count">{countLabel}</p>
-	{/if}
+	{#if loading}
+		<CardGrid>
+			{#each SKELETON_INDICES as i (i)}
+				<SkeletonCard />
+			{/each}
+		</CardGrid>
+	{:else}
+		{#if showSearch}
+			<SearchBox bind:value={searchQuery} {placeholder} />
+			<p class="count">{countLabel}</p>
+		{/if}
 
-	<CardGrid>
-		{#each visibleItems as item (item)}
-			{@render children(item)}
-		{/each}
-	</CardGrid>
+		<CardGrid>
+			{#each visibleItems as item (item)}
+				{@render children(item)}
+			{/each}
+		</CardGrid>
 
-	{#if hasMore}
-		<div class="sentinel" bind:this={sentinel}></div>
+		{#if hasMore}
+			<div class="sentinel" bind:this={sentinel}></div>
+		{/if}
 	{/if}
 </div>
 

--- a/frontend/src/lib/components/SkeletonCard.svelte
+++ b/frontend/src/lib/components/SkeletonCard.svelte
@@ -1,0 +1,61 @@
+<div class="skeleton-card">
+	<div class="skeleton-img shimmer"></div>
+	<div class="skeleton-body">
+		<div class="skeleton-title shimmer"></div>
+		<div class="skeleton-meta shimmer"></div>
+	</div>
+</div>
+
+<style>
+	@keyframes shimmer {
+		0% {
+			background-position: -200% 0;
+		}
+		100% {
+			background-position: 200% 0;
+		}
+	}
+
+	.shimmer {
+		background: linear-gradient(
+			90deg,
+			var(--color-border-soft) 25%,
+			var(--color-surface) 50%,
+			var(--color-border-soft) 75%
+		);
+		background-size: 200% 100%;
+		animation: shimmer 1.5s ease-in-out infinite;
+		border-radius: var(--radius-1);
+	}
+
+	.skeleton-card {
+		display: flex;
+		flex-direction: column;
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-2);
+		overflow: hidden;
+	}
+
+	.skeleton-img {
+		width: 100%;
+		height: 8rem;
+	}
+
+	.skeleton-body {
+		padding: var(--size-3);
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-2);
+	}
+
+	.skeleton-title {
+		height: 1rem;
+		width: 70%;
+	}
+
+	.skeleton-meta {
+		height: 0.75rem;
+		width: 45%;
+	}
+</style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,27 +1,15 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import client from '$lib/api/client';
+	import { createAsyncLoader } from '$lib/async-loader.svelte';
 	import FilterableGrid from '$lib/components/FilterableGrid.svelte';
 	import MachineCard from '$lib/components/MachineCard.svelte';
 	import { SITE_NAME } from '$lib/constants';
 	import { normalizeText } from '$lib/util';
 
-	async function fetchModels() {
+	const models = createAsyncLoader(async () => {
 		const { data } = await client.GET('/api/models/all/');
 		return data ?? [];
-	}
-
-	type Models = Awaited<ReturnType<typeof fetchModels>>;
-	let models = $state<Models>([]);
-	let loading = $state(true);
-
-	onMount(async () => {
-		try {
-			models = await fetchModels();
-		} finally {
-			loading = false;
-		}
-	});
+	}, []);
 </script>
 
 <svelte:head>
@@ -30,8 +18,9 @@
 </svelte:head>
 
 <FilterableGrid
-	items={models}
-	{loading}
+	items={models.data}
+	loading={models.loading}
+	error={models.error}
 	filterFn={(item, q) =>
 		normalizeText(item.name).includes(q) ||
 		(item.manufacturer_name ? normalizeText(item.manufacturer_name).includes(q) : false)}

--- a/frontend/src/routes/+page.ts
+++ b/frontend/src/routes/+page.ts
@@ -1,14 +1,1 @@
-import client from '$lib/api/client';
-import { error } from '@sveltejs/kit';
-import type { PageLoad } from './$types';
-
-export const prerender = false;
-export const ssr = false;
-
-export const load: PageLoad = async () => {
-	const { data } = await client.GET('/api/models/all/');
-
-	if (!data) error(500, 'Failed to load models');
-
-	return { models: data };
-};
+export const prerender = true;

--- a/frontend/src/routes/api-docs/+page.ts
+++ b/frontend/src/routes/api-docs/+page.ts
@@ -1,2 +1,1 @@
-export const prerender = false;
-export const ssr = false;
+export const prerender = true;

--- a/frontend/src/routes/groups/+page.svelte
+++ b/frontend/src/routes/groups/+page.svelte
@@ -1,27 +1,15 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import client from '$lib/api/client';
+	import { createAsyncLoader } from '$lib/async-loader.svelte';
 	import FilterableGrid from '$lib/components/FilterableGrid.svelte';
 	import GroupCard from '$lib/components/GroupCard.svelte';
 	import { pageTitle } from '$lib/constants';
 	import { normalizeText } from '$lib/util';
 
-	async function fetchGroups() {
+	const groups = createAsyncLoader(async () => {
 		const { data } = await client.GET('/api/groups/all/');
 		return data ?? [];
-	}
-
-	type Groups = Awaited<ReturnType<typeof fetchGroups>>;
-	let groups = $state<Groups>([]);
-	let loading = $state(true);
-
-	onMount(async () => {
-		try {
-			groups = await fetchGroups();
-		} finally {
-			loading = false;
-		}
-	});
+	}, []);
 </script>
 
 <svelte:head>
@@ -30,8 +18,9 @@
 </svelte:head>
 
 <FilterableGrid
-	items={groups}
-	{loading}
+	items={groups.data}
+	loading={groups.loading}
+	error={groups.error}
 	filterFn={(item, q) =>
 		normalizeText(item.name).includes(q) ||
 		(item.shortname ? normalizeText(item.shortname).includes(q) : false)}

--- a/frontend/src/routes/groups/+page.svelte
+++ b/frontend/src/routes/groups/+page.svelte
@@ -1,18 +1,37 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+	import client from '$lib/api/client';
 	import FilterableGrid from '$lib/components/FilterableGrid.svelte';
 	import GroupCard from '$lib/components/GroupCard.svelte';
 	import { pageTitle } from '$lib/constants';
 	import { normalizeText } from '$lib/util';
 
-	let { data } = $props();
+	async function fetchGroups() {
+		const { data } = await client.GET('/api/groups/all/');
+		return data ?? [];
+	}
+
+	type Groups = Awaited<ReturnType<typeof fetchGroups>>;
+	let groups = $state<Groups>([]);
+	let loading = $state(true);
+
+	onMount(async () => {
+		try {
+			groups = await fetchGroups();
+		} finally {
+			loading = false;
+		}
+	});
 </script>
 
 <svelte:head>
 	<title>{pageTitle('Groups')}</title>
+	<link rel="preload" as="fetch" href="/api/groups/all/" crossorigin="anonymous" />
 </svelte:head>
 
 <FilterableGrid
-	items={data.groups}
+	items={groups}
+	{loading}
 	filterFn={(item, q) =>
 		normalizeText(item.name).includes(q) ||
 		(item.shortname ? normalizeText(item.shortname).includes(q) : false)}

--- a/frontend/src/routes/groups/+page.ts
+++ b/frontend/src/routes/groups/+page.ts
@@ -1,14 +1,1 @@
-import client from '$lib/api/client';
-import { error } from '@sveltejs/kit';
-import type { PageLoad } from './$types';
-
-export const prerender = false;
-export const ssr = false;
-
-export const load: PageLoad = async () => {
-	const { data } = await client.GET('/api/groups/all/');
-
-	if (!data) error(500, 'Failed to load groups');
-
-	return { groups: data };
-};
+export const prerender = true;

--- a/frontend/src/routes/manufacturers/+page.svelte
+++ b/frontend/src/routes/manufacturers/+page.svelte
@@ -1,27 +1,15 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import client from '$lib/api/client';
+	import { createAsyncLoader } from '$lib/async-loader.svelte';
 	import FilterableGrid from '$lib/components/FilterableGrid.svelte';
 	import ManufacturerCard from '$lib/components/ManufacturerCard.svelte';
 	import { pageTitle } from '$lib/constants';
 	import { normalizeText } from '$lib/util';
 
-	async function fetchManufacturers() {
+	const manufacturers = createAsyncLoader(async () => {
 		const { data } = await client.GET('/api/manufacturers/all/');
 		return data ?? [];
-	}
-
-	type Manufacturers = Awaited<ReturnType<typeof fetchManufacturers>>;
-	let manufacturers = $state<Manufacturers>([]);
-	let loading = $state(true);
-
-	onMount(async () => {
-		try {
-			manufacturers = await fetchManufacturers();
-		} finally {
-			loading = false;
-		}
-	});
+	}, []);
 </script>
 
 <svelte:head>
@@ -30,8 +18,9 @@
 </svelte:head>
 
 <FilterableGrid
-	items={manufacturers}
-	{loading}
+	items={manufacturers.data}
+	loading={manufacturers.loading}
+	error={manufacturers.error}
 	filterFn={(item, q) =>
 		normalizeText(item.name).includes(q) ||
 		(item.trade_name ? normalizeText(item.trade_name).includes(q) : false)}

--- a/frontend/src/routes/manufacturers/+page.svelte
+++ b/frontend/src/routes/manufacturers/+page.svelte
@@ -1,18 +1,37 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+	import client from '$lib/api/client';
 	import FilterableGrid from '$lib/components/FilterableGrid.svelte';
 	import ManufacturerCard from '$lib/components/ManufacturerCard.svelte';
 	import { pageTitle } from '$lib/constants';
 	import { normalizeText } from '$lib/util';
 
-	let { data } = $props();
+	async function fetchManufacturers() {
+		const { data } = await client.GET('/api/manufacturers/all/');
+		return data ?? [];
+	}
+
+	type Manufacturers = Awaited<ReturnType<typeof fetchManufacturers>>;
+	let manufacturers = $state<Manufacturers>([]);
+	let loading = $state(true);
+
+	onMount(async () => {
+		try {
+			manufacturers = await fetchManufacturers();
+		} finally {
+			loading = false;
+		}
+	});
 </script>
 
 <svelte:head>
 	<title>{pageTitle('Manufacturers')}</title>
+	<link rel="preload" as="fetch" href="/api/manufacturers/all/" crossorigin="anonymous" />
 </svelte:head>
 
 <FilterableGrid
-	items={data.manufacturers}
+	items={manufacturers}
+	{loading}
 	filterFn={(item, q) =>
 		normalizeText(item.name).includes(q) ||
 		(item.trade_name ? normalizeText(item.trade_name).includes(q) : false)}

--- a/frontend/src/routes/manufacturers/+page.ts
+++ b/frontend/src/routes/manufacturers/+page.ts
@@ -1,14 +1,1 @@
-import client from '$lib/api/client';
-import { error } from '@sveltejs/kit';
-import type { PageLoad } from './$types';
-
-export const prerender = false;
-export const ssr = false;
-
-export const load: PageLoad = async () => {
-	const { data } = await client.GET('/api/manufacturers/all/');
-
-	if (!data) error(500, 'Failed to load manufacturers');
-
-	return { manufacturers: data };
-};
+export const prerender = true;

--- a/frontend/src/routes/people/+page.svelte
+++ b/frontend/src/routes/people/+page.svelte
@@ -1,27 +1,15 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import client from '$lib/api/client';
+	import { createAsyncLoader } from '$lib/async-loader.svelte';
 	import FilterableGrid from '$lib/components/FilterableGrid.svelte';
 	import PersonCard from '$lib/components/PersonCard.svelte';
 	import { pageTitle } from '$lib/constants';
 	import { normalizeText } from '$lib/util';
 
-	async function fetchPeople() {
+	const people = createAsyncLoader(async () => {
 		const { data } = await client.GET('/api/people/all/');
 		return data ?? [];
-	}
-
-	type People = Awaited<ReturnType<typeof fetchPeople>>;
-	let people = $state<People>([]);
-	let loading = $state(true);
-
-	onMount(async () => {
-		try {
-			people = await fetchPeople();
-		} finally {
-			loading = false;
-		}
-	});
+	}, []);
 </script>
 
 <svelte:head>
@@ -30,8 +18,9 @@
 </svelte:head>
 
 <FilterableGrid
-	items={people}
-	{loading}
+	items={people.data}
+	loading={people.loading}
+	error={people.error}
 	filterFn={(item, q) => normalizeText(item.name).includes(q)}
 	placeholder="Search people..."
 	entityName="person"

--- a/frontend/src/routes/people/+page.svelte
+++ b/frontend/src/routes/people/+page.svelte
@@ -1,18 +1,37 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+	import client from '$lib/api/client';
 	import FilterableGrid from '$lib/components/FilterableGrid.svelte';
 	import PersonCard from '$lib/components/PersonCard.svelte';
 	import { pageTitle } from '$lib/constants';
 	import { normalizeText } from '$lib/util';
 
-	let { data } = $props();
+	async function fetchPeople() {
+		const { data } = await client.GET('/api/people/all/');
+		return data ?? [];
+	}
+
+	type People = Awaited<ReturnType<typeof fetchPeople>>;
+	let people = $state<People>([]);
+	let loading = $state(true);
+
+	onMount(async () => {
+		try {
+			people = await fetchPeople();
+		} finally {
+			loading = false;
+		}
+	});
 </script>
 
 <svelte:head>
 	<title>{pageTitle('People')}</title>
+	<link rel="preload" as="fetch" href="/api/people/all/" crossorigin="anonymous" />
 </svelte:head>
 
 <FilterableGrid
-	items={data.people}
+	items={people}
+	{loading}
 	filterFn={(item, q) => normalizeText(item.name).includes(q)}
 	placeholder="Search people..."
 	entityName="person"

--- a/frontend/src/routes/people/+page.ts
+++ b/frontend/src/routes/people/+page.ts
@@ -1,14 +1,1 @@
-import client from '$lib/api/client';
-import { error } from '@sveltejs/kit';
-import type { PageLoad } from './$types';
-
-export const prerender = false;
-export const ssr = false;
-
-export const load: PageLoad = async () => {
-	const { data } = await client.GET('/api/people/all/');
-
-	if (!data) error(500, 'Failed to load people');
-
-	return { people: data };
-};
+export const prerender = true;

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -11,10 +11,19 @@ const config = {
 		adapter: adapter({
 			pages: 'build',
 			assets: 'build',
-			fallback: 'index.html',
+			fallback: '200.html',
 			precompress: false,
 			strict: false
-		})
+		}),
+		prerender: {
+			handleHttpError: ({ path, message }) => {
+				// API endpoints are served by Django, not SvelteKit — ignore
+				// them when the prerender crawler discovers <link rel="preload">
+				// hints in prerendered pages.
+				if (path.startsWith('/api/')) return;
+				throw new Error(message);
+			}
+		}
 	}
 };
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	plugins: [sveltekit()],
 	server: {
 		proxy: {
-			'/api': {
+			'/api/': {
 				target: 'http://127.0.0.1:8000',
 				changeOrigin: true
 			},


### PR DESCRIPTION
## Summary
- **Prerender all top-level pages** (/, /groups, /manufacturers, /people, /api-docs) so the browser gets real HTML instead of an empty SPA shell, with `<link rel="preload">` hints to kick off API fetches early
- **Rename SPA fallback** from `index.html` to `200.html` so the prerendered homepage can own `index.html`; update backend routing to serve prerendered pages first, then fall back to the SPA shell
- **Extract `createAsyncLoader` utility** to replace duplicated onMount/state/loading boilerplate across all 4 list pages, with proper error handling surfaced to users via a new `error` prop on `FilterableGrid`
- **Fix Vite dev proxy** (`/api` → `/api/`) so `/api-docs` routes to SvelteKit instead of Django

## Test plan
- [x] All 5 nav pages return pre-rendered HTML with correct `<title>`, nav `active` class, and skeleton cards on localhost
- [x] `/api/` proxy still forwards to Django (verified `/api/models/all/` returns JSON)
- [x] `svelte-check` passes with 0 errors
- [x] ESLint + Prettier pass
- [x] `make test` passes (204 backend + 1 frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)