### PR TITLE
Fix dark mode background on pre-rendered pages

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -10,6 +10,20 @@
 			href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&display=swap"
 			rel="stylesheet"
 		/>
+		<style>
+			/* Critical dark-mode background inlined to prevent flash on pre-rendered pages.
+			   Values must stay in sync with app.css. */
+			html {
+				background-color: #fbf7f0;
+				color: #333333;
+			}
+			@media (prefers-color-scheme: dark) {
+				html {
+					background-color: #1f1f1f;
+					color: #cccccc;
+				}
+			}
+		</style>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
## Summary
- Adds an inline `<style>` in `app.html` that sets `html` background-color and text color for both light and dark modes
- This ensures the correct background renders immediately, before external CSS files load
- The inline style is present in every page (pre-rendered and SPA shell), eliminating the race condition where the page briefly or permanently shows a light background for dark-mode users

## Context
After merging #30 (pre-rendered pages), dark-mode users sometimes see the light cream background (`#fbf7f0`) instead of the dark background (`#1f1f1f`). The issue is permanent until refresh. Components (header, cards) render correctly in dark mode because their scoped styles load as external CSS `<link>` tags, but the `html` element background depends on CSS custom properties that may not be applied in time.

The fix is a standard pattern for pre-rendered static sites: inline the most critical theme styles so they're applied from the very first paint.

**Note:** The hardcoded values in `app.html` must stay in sync with `app.css`. A comment marks this.

## Test plan
- [ ] Visit the site in dark mode — background should be dark on first paint
- [ ] Verify the inline style appears in both `build/index.html` and `build/200.html`
- [ ] Navigate between pages — dark background should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)