### PR TITLE
fix(ingest): pass --csv flag from ingest_all to ingest_signs

### DIFF
--- a/backend/apps/catalog/management/commands/ingest_all.py
+++ b/backend/apps/catalog/management/commands/ingest_all.py
@@ -1,6 +1,6 @@
 """Orchestrate the full ingestion pipeline.
 
-Runs: ingest_manufacturers → ingest_ipdb → ingest_opdb → resolve_claims.
+Runs: ingest_manufacturers → ingest_ipdb → ingest_opdb → ingest_signs → resolve_claims.
 """
 
 from __future__ import annotations
@@ -42,12 +42,18 @@ class Command(BaseCommand):
             default="../data/dump1/opdb_changelog.json",
             help="Path to OPDB changelog JSON dump.",
         )
+        parser.add_argument(
+            "--csv",
+            default="../data/dump1/machine_sign_copy.csv",
+            help="Path to machine_sign_copy.csv for ingest_signs.",
+        )
 
     def handle(self, *args, **options):
         ipdb_path = options["ipdb"]
         opdb_path = options["opdb"]
         opdb_groups = options["opdb_groups"]
         opdb_changelog = options["opdb_changelog"]
+        csv_path = options["csv"]
 
         from apps.catalog.cache import invalidate_all
 
@@ -65,6 +71,8 @@ class Command(BaseCommand):
                         "groups": opdb_groups,
                         "changelog": opdb_changelog,
                     }
+                elif step == "ingest_signs":
+                    kwargs = {"csv": csv_path}
                 call_command(step, stdout=self.stdout, stderr=self.stderr, **kwargs)
         finally:
             invalidate_all()

--- a/docs/Ingest.md
+++ b/docs/Ingest.md
@@ -65,13 +65,9 @@ uv run python manage.py ingest_all \
   --ipdb /tmp/dump1/ipdbdatabase.json \
   --opdb /tmp/dump1/opdb_export_machines.json \
   --opdb-groups /tmp/dump1/opdb_export_groups.json \
-  --opdb-changelog /tmp/dump1/opdb_changelog.json
-
-uv run python manage.py ingest_signs --csv /tmp/dump1/machine_sign_copy.csv
+  --opdb-changelog /tmp/dump1/opdb_changelog.json \
+  --csv /tmp/dump1/machine_sign_copy.csv
 ```
-
-> `ingest_signs` must be run separately because `ingest_all` does not expose
-> a `--csv` flag to override the default path.
 
 ## Resetting the production database
 


### PR DESCRIPTION
## Summary

`ingest_all` now passes `--csv` through to `ingest_signs`, fixing a silent failure on Railway where the default CSV path doesn't exist in the container.

- Adds `--csv` argument to `ingest_all` (same default as `ingest_signs`)
- Updates `Ingest.md` to use the single consolidated `ingest_all` command

## Test plan

- [ ] Run `uv run python manage.py ingest_all --help` and confirm `--csv` appears
- [ ] Run the full ingest on Railway using the updated command in `Ingest.md` and verify `ingest_signs` completes without error