### PR TITLE
fix(frontend): disable prerendering on / and /search

### DIFF
--- a/frontend/src/routes/+page.ts
+++ b/frontend/src/routes/+page.ts
@@ -1,1 +1,1 @@
-export const prerender = true;
+export const prerender = false;

--- a/frontend/src/routes/search/+page.ts
+++ b/frontend/src/routes/search/+page.ts
@@ -1,1 +1,1 @@
-export const prerender = true;
+export const prerender = false;


### PR DESCRIPTION
## Summary

Both `/` and `/search` read `url.searchParams` at component init time to hydrate the search query from the URL. This is incompatible with SvelteKit's prerendering, which doesn't provide `searchParams`. Disables prerendering on both pages.

## Test plan

- [ ] `pnpm build` succeeds without prerender errors
- [ ] Railway deploy succeeds
- [ ] Search on `/` works, URL updates with `?q=`, back button restores query
- [ ] `/search` works the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)