### PR TITLE
fix(ingest): update scrape_images to use title, add new data files to docs

### DIFF
--- a/backend/apps/catalog/management/commands/scrape_images.py
+++ b/backend/apps/catalog/management/commands/scrape_images.py
@@ -68,10 +68,10 @@ def _has_images(extra_data: dict) -> bool:
 
 
 def _try_group_sibling(pm: MachineModel) -> list[str] | None:
-    """Copy image URLs from a sibling in the same group."""
-    if not pm.group:
+    """Copy image URLs from a sibling in the same title."""
+    if not pm.title:
         return None
-    for sib in pm.group.machine_models.exclude(pk=pm.pk):
+    for sib in pm.title.machine_models.exclude(pk=pm.pk):
         ed = sib.extra_data or {}
 
         images = ed.get("images")

--- a/docs/Ingest.md
+++ b/docs/Ingest.md
@@ -4,13 +4,18 @@ Pinbase is populated from several external data sources via Django management co
 
 ## Data sources
 
-| Source           | File                        | Command                |
-| ---------------- | --------------------------- | ---------------------- |
-| IPDB             | `ipdbdatabase.json`         | `ingest_ipdb`          |
-| OPDB machines    | `opdb_export_machines.json` | `ingest_opdb`          |
-| OPDB groups      | `opdb_export_groups.json`   | `ingest_opdb`          |
-| OPDB changelog   | `opdb_changelog.json`       | `ingest_opdb`          |
-| Museum sign copy | `machine_sign_copy.csv`     | `ingest_pinbase_signs` |
+| Source               | File                             | Command                |
+| -------------------- | -------------------------------- | ---------------------- |
+| IPDB                 | `ipdbdatabase.json`              | `ingest_ipdb`          |
+| OPDB machines        | `opdb_export_machines.json`      | `ingest_opdb`          |
+| OPDB groups          | `opdb_export_groups.json`        | `ingest_opdb`          |
+| OPDB changelog       | `opdb_changelog.json`            | `ingest_opdb`          |
+| Museum sign copy     | `machine_sign_copy.csv`          | `ingest_pinbase_signs` |
+| Fandom games         | `fandom_games.json`              | `ingest_fandom`        |
+| Fandom manufacturers | `fandom_manufacturers.json`      | `ingest_fandom`        |
+| Fandom persons       | `fandom_persons.json`            | `ingest_fandom`        |
+| Pinball Map machines | `pinballmap_machines.json`       | —                      |
+| Pinball Map groups   | `pinballmap_machine_groups.json` | —                      |
 
 All source files live in `data/dump1/` and are **not committed** to the repo.
 They are stored in a private GitHub Gist:
@@ -53,6 +58,11 @@ files = [
     'opdb_export_groups.json',
     'opdb_changelog.json',
     'machine_sign_copy.csv',
+    'fandom_games.json',
+    'fandom_manufacturers.json',
+    'fandom_persons.json',
+    'pinballmap_machines.json',
+    'pinballmap_machine_groups.json',
 ]
 [urllib.request.urlretrieve(base + f, '/tmp/dump1/' + f) or print('Downloaded', f) for f in files]
 "


### PR DESCRIPTION
## Summary
- Fix `AttributeError` in `scrape_images` command — `MachineModel.group` was renamed to `title`
- Add fandom and pinballmap data files to Ingest.md data sources table and gist download snippet
- Uploaded the 5 new data files to the GitHub Gist

## Test plan
- [x] Backend tests pass
- [ ] Run `scrape_images --year-min 2019` on prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)