### PR TITLE
fix(frontend): strip punctuation in search to match near-miss titles

### DIFF
--- a/frontend/src/lib/util.test.ts
+++ b/frontend/src/lib/util.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeText } from './util';
+
+describe('normalizeText', () => {
+	it('lowercases text', () => {
+		expect(normalizeText('Hello World')).toBe('hello world');
+	});
+
+	it('strips diacritics', () => {
+		expect(normalizeText('café')).toBe('cafe');
+		expect(normalizeText('naïve')).toBe('naive');
+	});
+
+	it('strips punctuation so colon-separated words match', () => {
+		expect(normalizeText('Ultraman: Kaiju Rumble')).toBe('ultraman kaiju rumble');
+	});
+
+	it('strips hyphens', () => {
+		expect(normalizeText('Spider-Man')).toBe('spiderman');
+	});
+
+	it('strips apostrophes', () => {
+		expect(normalizeText("Ripley's Believe It or Not")).toBe('ripleys believe it or not');
+	});
+
+	it('collapses multiple spaces', () => {
+		expect(normalizeText('foo   bar')).toBe('foo bar');
+	});
+
+	it('trims leading and trailing whitespace', () => {
+		expect(normalizeText('  hello  ')).toBe('hello');
+	});
+
+	it('handles empty string', () => {
+		expect(normalizeText('')).toBe('');
+	});
+});

--- a/frontend/src/lib/util.ts
+++ b/frontend/src/lib/util.ts
@@ -1,7 +1,10 @@
-/** Strip diacritics and lowercase for accent-insensitive search. */
+/** Normalize text for search: strip diacritics, punctuation, and collapse whitespace. */
 export function normalizeText(s: string): string {
 	return s
 		.normalize('NFD')
-		.replace(/[\u0300-\u036f]/g, '')
+		.replace(/[\u0300-\u036f]/g, '') // strip diacritics
+		.replace(/[^\w\s]/g, '') // strip punctuation
+		.replace(/\s+/g, ' ') // collapse whitespace
+		.trim()
 		.toLowerCase();
 }


### PR DESCRIPTION
## Summary

Search now strips punctuation (colons, hyphens, apostrophes, etc.) and collapses whitespace during text normalization, so queries like "Ultraman Kaiju Rumble" correctly find "Ultraman: Kaiju Rumble".

- Updated `normalizeText()` in `util.ts` to strip `[^\w\s]` characters and collapse runs of whitespace
- Added unit tests for the normalization function

## Test plan

- [ ] Search for `Ultraman Kaiju Rumble` — should find "Ultraman: Kaiju Rumble"
- [ ] Search for `Spiderman` — should find "Spider-Man" (if present)
- [ ] Search for `Ripleys` — should find "Ripley's Believe It or Not" (if present)
- [ ] Verify accented character search still works (e.g., `cafe` matches "Café")
- [ ] Verify faceted title filtering on `/titles` still works with search queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)