### PR TITLE
fix(search): restore model-to-title roll-up and cache titles

### DIFF
--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -15,6 +15,7 @@ from .constants import DEFAULT_PAGE_SIZE
 from .helpers import _extract_image_urls, _serialize_title_machine
 from .machine_models import DesignCreditSchema, MachineModelDetailSchema
 from .schemas import SeriesRefSchema, ThemeSchema, TitleMachineSchema
+from ..cache import TITLES_ALL_KEY
 
 # ---------------------------------------------------------------------------
 # Schemas
@@ -426,7 +427,13 @@ def list_titles(request, display: str = ""):
 @decorate_view(cache_control(public=True, max_age=300))
 def list_all_titles(request):
     """Return every title with minimal fields (no pagination)."""
+    from django.core.cache import cache
+
     from ..models import Title
+
+    result = cache.get(TITLES_ALL_KEY)
+    if result is not None:
+        return result
 
     qs = (
         Title.objects.annotate(
@@ -442,7 +449,9 @@ def list_all_titles(request):
         .prefetch_related(_title_models_prefetch(), "series")
         .order_by(F("latest_year").desc(nulls_last=True), "name")
     )
-    return [_serialize_title_list(t) for t in qs]
+    result = [_serialize_title_list(t) for t in qs]
+    cache.set(TITLES_ALL_KEY, result, timeout=None)
+    return result
 
 
 @titles_router.get("/{slug}", response=TitleDetailSchema)

--- a/backend/apps/catalog/cache.py
+++ b/backend/apps/catalog/cache.py
@@ -7,6 +7,7 @@ from django.core.cache import cache
 MODELS_ALL_KEY = "catalog:models:all"
 MANUFACTURERS_ALL_KEY = "catalog:manufacturers:all"
 PEOPLE_ALL_KEY = "catalog:people:all"
+TITLES_ALL_KEY = "catalog:titles:all"
 
 
 def invalidate_all() -> None:
@@ -14,3 +15,4 @@ def invalidate_all() -> None:
     cache.delete(MODELS_ALL_KEY)
     cache.delete(MANUFACTURERS_ALL_KEY)
     cache.delete(PEOPLE_ALL_KEY)
+    cache.delete(TITLES_ALL_KEY)

--- a/backend/apps/catalog/signals.py
+++ b/backend/apps/catalog/signals.py
@@ -18,6 +18,7 @@ def connect():
         MachineModel,
         Manufacturer,
         Person,
+        Title,
     )
 
     for model in (
@@ -25,6 +26,7 @@ def connect():
         Manufacturer,
         Person,
         DesignCredit,
+        Title,
     ):
         uid = f"invalidate_cache_{model.__name__}"
         post_save.connect(_invalidate_cache, sender=model, dispatch_uid=f"{uid}_save")

--- a/backend/apps/catalog/tests/test_api.py
+++ b/backend/apps/catalog/tests/test_api.py
@@ -2,7 +2,7 @@ import pytest
 from django.core.cache import cache
 from django.test import Client
 
-from apps.catalog.cache import MODELS_ALL_KEY
+from apps.catalog.cache import MODELS_ALL_KEY, TITLES_ALL_KEY
 from apps.catalog.models import (
     CorporateEntity,
     DesignCredit,
@@ -509,6 +509,33 @@ class TestAllEndpointCache:
         resp2 = client.get("/api/models/all/")
         assert len(resp2.json()) == count_before + 1
 
+    def test_titles_all_caches_on_second_request(self, client, machine_model):
+        resp1 = client.get("/api/titles/all/")
+        assert resp1.status_code == 200
+        assert cache.get(TITLES_ALL_KEY) is not None
+
+        resp2 = client.get("/api/titles/all/")
+        assert resp2.json() == resp1.json()
+
+    def test_title_save_invalidates_cache(self, client, db):
+        title = Title.objects.create(
+            name="Cactus Canyon", opdb_id="CC1", short_name="CC"
+        )
+        client.get("/api/titles/all/")
+        assert cache.get(TITLES_ALL_KEY) is not None
+
+        title.name = "Cactus Canyon Continued"
+        title.save()
+        assert cache.get(TITLES_ALL_KEY) is None
+
+    def test_new_title_appears_after_invalidation(self, client, machine_model):
+        resp1 = client.get("/api/titles/all/")
+        count_before = len(resp1.json())
+
+        Title.objects.create(name="Godzilla", opdb_id="GZ1", short_name="GZ")
+        resp2 = client.get("/api/titles/all/")
+        assert len(resp2.json()) == count_before + 1
+
 
 class TestSourcesAPI:
     def test_list_sources(self, client, source):
@@ -584,6 +611,12 @@ class TestSystemsAPI:
 
 class TestTitlesAllFacets:
     """Test that /api/titles/all/ returns enriched facet data."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        cache.clear()
+        yield
+        cache.clear()
 
     @pytest.fixture
     def faceted_title(self, db, manufacturer, solid_state):

--- a/frontend/src/lib/components/SearchResults.svelte
+++ b/frontend/src/lib/components/SearchResults.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { SvelteSet } from 'svelte/reactivity';
 	import client from '$lib/api/client';
 	import { createAsyncLoader } from '$lib/async-loader.svelte';
 	import CardGrid from '$lib/components/grid/CardGrid.svelte';
@@ -24,6 +25,11 @@
 		return data ?? [];
 	}, []);
 
+	const models = createAsyncLoader(async () => {
+		const { data } = await client.GET('/api/models/all/');
+		return data ?? [];
+	}, []);
+
 	const people = createAsyncLoader(async () => {
 		const { data } = await client.GET('/api/people/all/');
 		return data ?? [];
@@ -42,9 +48,29 @@
 		return fields.some((f) => f != null && normalizeText(String(f)).includes(q));
 	}
 
+	let matchedModels = $derived.by(() => {
+		if (!isSearching) return [];
+		return models.data.filter(
+			(m) =>
+				textMatches(normalizedQuery, m.name, m.shortname) ||
+				(m.search_text && normalizeText(m.search_text).includes(normalizedQuery))
+		);
+	});
+
+	// Title slugs from matched models for roll-up
+	let rollupTitleSlugs = $derived.by(() => {
+		const slugs = new SvelteSet<string>();
+		for (const m of matchedModels) {
+			if (m.title_slug) slugs.add(m.title_slug);
+		}
+		return slugs;
+	});
+
 	let matchedTitles = $derived.by(() => {
 		if (!isSearching) return [];
-		return titles.data.filter((t) => textMatches(normalizedQuery, t.name, t.short_name));
+		return titles.data.filter(
+			(t) => textMatches(normalizedQuery, t.name, t.short_name) || rollupTitleSlugs.has(t.slug)
+		);
 	});
 
 	let matchedManufacturers = $derived.by(() => {
@@ -65,7 +91,9 @@
 		matchedTitles.length + matchedManufacturers.length + matchedPeople.length
 	);
 
-	let anyLoading = $derived(titles.loading || manufacturers.loading || people.loading);
+	let anyLoading = $derived(
+		titles.loading || models.loading || manufacturers.loading || people.loading
+	);
 
 	function toggleGroup(group: string) {
 		expanded[group] = !expanded[group];


### PR DESCRIPTION
## Summary
- **Restore model search roll-up**: SearchResults now fetches `/api/models/all/` and matches against model names/shortnames/search_text. Matched models' `title_slug` values roll up into title results, so searching "Blood Sucker Edition" surfaces the parent title.
- **Cache `/api/titles/all/`**: Add server-side `cache.get`/`cache.set` matching the pattern used by models, manufacturers, and people endpoints.
- **Wire Title into cache invalidation**: Add `Title` to the signal handlers so title saves/deletes clear the cache. Add `TITLES_ALL_KEY` to `invalidate_all()`.
- **Tests**: Add titles cache tests (caching, invalidation, new-title-after-invalidation). Fix `TestTitlesAllFacets` cache fixture to include teardown.

## Context
The model roll-up was lost in bac3a24 when `SearchResults` was extracted as a shared component. The `/api/titles/all/` endpoint was the only `/all/` endpoint without server-side caching.

## Test plan
- [ ] Search for "Blood Sucker Edition" — should surface "Ultraman: Kaiju Rumble (SE)" title (once alias names are added to search_text in a follow-up)
- [ ] Search for "Ultraman Kaiju Rumble" — should match title directly
- [ ] Search for "Medieval Madness" — should match both title and model
- [ ] Verify `/api/titles/all/` returns cached response on second request
- [ ] `make test` passes (403 backend + 58 frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)