### PR TITLE
fix(api): include aliases in /api/models/all/ for search

### DIFF
--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -433,19 +433,30 @@ def _build_search_text(pm) -> str:
 @models_router.get("/all/", response=list[MachineModelGridSchema])
 @decorate_view(cache_control(public=True, max_age=300))
 def list_all_models(request):
-    """Return every non-alias model with minimal fields (no pagination)."""
+    """Return every model (including aliases) with minimal fields (no pagination)."""
     from django.core.cache import cache
 
-    from ..models import DesignCredit
+    from ..models import DesignCredit, MachineModel
 
     result = cache.get(MODELS_ALL_KEY)
     if result is not None:
         return result
     qs = (
-        _build_model_list_qs()
+        MachineModel.objects.select_related(
+            "manufacturer",
+            "technology_generation",
+            "display_type",
+            "title",
+            "system",
+            "display_subtype",
+            "cabinet",
+            "game_format",
+        )
         .prefetch_related(
+            "themes",
             "tags",
             "gameplay_features",
+            "aliases",
             "manufacturer__entities__addresses",
             Prefetch(
                 "credits",
@@ -454,12 +465,7 @@ def list_all_models(request):
                 ).select_related("person"),
             ),
         )
-        .select_related(
-            "system",
-            "display_subtype",
-            "cabinet",
-            "game_format",
-        )
+        .order_by("name")
     )
     result = []
     for pm in qs:

--- a/backend/apps/catalog/tests/test_api_models.py
+++ b/backend/apps/catalog/tests/test_api_models.py
@@ -77,6 +77,16 @@ class TestModelsAPI:
         assert data["count"] == 1
         assert data["items"][0]["name"] == "Medieval Madness"
 
+    def test_all_models_includes_aliases(self, client, machine_model):
+        MachineModel.objects.create(
+            name="Medieval Madness (LE)",
+            alias_of=machine_model,
+        )
+        resp = client.get("/api/models/all/")
+        names = [m["name"] for m in resp.json()]
+        assert "Medieval Madness" in names
+        assert "Medieval Madness (LE)" in names
+
     def test_list_models_thumbnail(self, client, manufacturer, db):
         MachineModel.objects.create(
             name="With Image",


### PR DESCRIPTION
## Summary

Aliases (LE, SE, and other variant models) were excluded from the `/api/models/all/` endpoint, making them unfindable via search. The endpoint now returns all models including aliases.

- Built queryset directly in `list_all_models` instead of reusing `_build_model_list_qs()` which always filters `alias_of__isnull=True`
- The paginated `/api/models/` endpoint (used by technology-generations page) still excludes aliases

## Test plan

- [ ] Search for an alias name (e.g. "Blood Sucker Edition") and verify it appears in results
- [ ] Verify the technology-generations page still excludes aliases
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)