### PR TITLE
feat: show parent game and sibling variants on model detail page

### DIFF
--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -121,6 +121,9 @@ class MachineModelDetailSchema(Schema):
     gameplay_features: list[GameplayFeatureSchema] = []
     franchise: Optional[FranchiseRefSchema] = None
     series: list[SeriesRefSchema] = []
+    alias_of_name: Optional[str] = None
+    alias_of_slug: Optional[str] = None
+    variant_siblings: list[AliasSchema] = []
     title_models: list[TitleMachineSchema] = []
 
 
@@ -250,6 +253,19 @@ def _serialize_model_detail(pm) -> dict:
         for alias in pm.aliases.all()
     ]
 
+    # Build sibling variants: other aliases of the same parent.
+    variant_siblings = []
+    if pm.alias_of_id is not None:
+        variant_siblings = [
+            {
+                "name": sib.name,
+                "slug": sib.slug,
+                "variant_features": _extract_variant_features(sib.extra_data or {}),
+            }
+            for sib in pm.alias_of.aliases.all()
+            if sib.pk != pm.pk
+        ]
+
     return {
         "name": pm.name,
         "slug": pm.slug,
@@ -287,6 +303,9 @@ def _serialize_model_detail(pm) -> dict:
         "hero_image_url": hero_image_url,
         "variant_features": variant_features,
         "aliases": aliases,
+        "alias_of_name": pm.alias_of.name if pm.alias_of else None,
+        "alias_of_slug": pm.alias_of.slug if pm.alias_of else None,
+        "variant_siblings": variant_siblings,
         "title_name": pm.title.name if pm.title else None,
         "title_slug": pm.title.slug if pm.title else None,
         "cabinet_name": pm.cabinet.name if pm.cabinet else None,
@@ -314,7 +333,9 @@ def _serialize_model_detail(pm) -> dict:
         "title_models": [
             _serialize_title_machine(sibling)
             for sibling in (pm.title.machine_models.all() if pm.title else [])
-            if sibling.alias_of_id is None and sibling.pk != pm.pk
+            if sibling.alias_of_id is None
+            and sibling.pk != pm.pk
+            and sibling.pk != pm.alias_of_id
         ],
     }
 
@@ -333,8 +354,10 @@ def _model_detail_qs():
         "display_subtype",
         "cabinet",
         "game_format",
+        "alias_of",
     ).prefetch_related(
         "aliases",
+        "alias_of__aliases",
         "themes",
         "gameplay_features",
         "title__series",

--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -211,6 +211,34 @@
 			</section>
 		{/if}
 
+		{#if model.alias_of_slug}
+			<section class="sidebar-section">
+				<h3>Parent Game</h3>
+				<p class="sidebar-note">This machine is a variant of:</p>
+				<ul class="sidebar-list">
+					<li>
+						<a href={resolve(`/models/${model.alias_of_slug}`)}>{model.alias_of_name}</a>
+					</li>
+				</ul>
+			</section>
+		{/if}
+
+		{#if model.variant_siblings && model.variant_siblings.length > 0}
+			<section class="sidebar-section">
+				<h3>Other Variants</h3>
+				<ul class="sidebar-list">
+					{#each model.variant_siblings as sibling (sibling.slug)}
+						<li>
+							<a href={resolve(`/models/${sibling.slug}`)}>{sibling.name}</a>
+							{#if sibling.variant_features.length > 0}
+								<span class="muted">{sibling.variant_features.join(', ')}</span>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			</section>
+		{/if}
+
 		{#if model.title_models && model.title_models.length > 0}
 			<section class="sidebar-section">
 				<h3>Other Models</h3>
@@ -411,6 +439,12 @@
 	.rating-label {
 		font-size: var(--font-size-0);
 		color: var(--color-text-muted);
+	}
+
+	.sidebar-note {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+		margin: 0 0 var(--size-1) 0;
 	}
 
 	.sidebar-list {

--- a/frontend/src/routes/models/[slug]/+page.ts
+++ b/frontend/src/routes/models/[slug]/+page.ts
@@ -5,7 +5,8 @@ export const load: PageLoad = async ({ parent }) => {
 	const { model } = await parent();
 
 	// Single-model titles: redirect to the canonical title page.
-	if (model.title_slug && model.title_models.length === 0) {
+	// Never redirect variant models — they have their own detail page.
+	if (model.title_slug && model.title_models.length === 0 && !model.alias_of_slug) {
 		redirect(301, `/titles/${model.title_slug}`);
 	}
 };


### PR DESCRIPTION
## Summary

Variant model detail pages now show structured sidebar sections instead of lumping the parent into "Other Models".

- **Parent Game** section with "This machine is a variant of:" text and link to the parent model
- **Other Variants** section listing sibling variants with their variant features
- **Other Models** section now excludes the parent to avoid duplication
- Variant models no longer redirect to the title page when they're the only non-parent model in the title

## Test plan

- [ ] Visit a variant model page (e.g. `/models/ultraman-kaiju-rumble-blood-sucker-edition`) and verify "Parent Game" section appears with link to the parent
- [ ] Verify "Other Variants" section lists sibling variants (if any exist)
- [ ] Verify "Other Models" does not include the parent model
- [ ] Visit a non-variant model page and verify sidebar is unchanged (no "Parent Game" or "Other Variants" sections)
- [ ] Verify clicking a variant from a title page no longer redirects back to the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)