### PR TITLE
fix(frontend): fix search URL sync and re-enable prerendering

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { replaceState } from '$app/navigation';
+	import { afterNavigate, replaceState } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { page } from '$app/state';
+	import { onMount } from 'svelte';
 	import SearchBox from '$lib/components/SearchBox.svelte';
 	import SearchResults from '$lib/components/SearchResults.svelte';
 	import { SITE_NAME } from '$lib/constants';
@@ -9,20 +9,30 @@
 
 	const MIN_QUERY_LENGTH = 2;
 
-	let searchQuery = $state(page.url.searchParams.get('q') ?? '');
+	let searchQuery = $state('');
+	let lastSyncedQ = '';
 
-	// Sync query to URL
+	// Sync URL → state. Uses window.location directly because page.url
+	// may still reflect the prerendered URL (no query params) during hydration.
+	function syncFromUrl() {
+		const urlQ = new URLSearchParams(window.location.search).get('q') ?? '';
+		searchQuery = urlQ;
+		lastSyncedQ = urlQ.trim();
+	}
+
+	// onMount guarantees we read the real browser URL after hydration.
+	onMount(syncFromUrl);
+
+	// afterNavigate handles back/forward navigation (does NOT fire on replaceState).
+	afterNavigate(syncFromUrl);
+
+	// State → URL: update query string as user types.
 	$effect(() => {
 		const q = searchQuery.trim();
-		const currentQ = page.url.searchParams.get('q') ?? '';
-		if (q !== currentQ) {
-			const url = new URL(page.url);
-			if (q) {
-				url.searchParams.set('q', q);
-			} else {
-				url.searchParams.delete('q');
-			}
-			replaceState(`${resolve('/')}${url.search}`, {});
+		if (q !== lastSyncedQ) {
+			lastSyncedQ = q;
+			const search = q ? `?q=${encodeURIComponent(q)}` : '';
+			replaceState(`${resolve('/')}${search}`, {});
 		}
 	});
 
@@ -31,6 +41,10 @@
 
 <svelte:head>
 	<title>{SITE_NAME}</title>
+	<link rel="preload" as="fetch" href="/api/titles/all/" crossorigin="anonymous" />
+	<link rel="preload" as="fetch" href="/api/manufacturers/all/" crossorigin="anonymous" />
+	<link rel="preload" as="fetch" href="/api/models/all/" crossorigin="anonymous" />
+	<link rel="preload" as="fetch" href="/api/people/all/" crossorigin="anonymous" />
 </svelte:head>
 
 <div class="search-page">

--- a/frontend/src/routes/+page.ts
+++ b/frontend/src/routes/+page.ts
@@ -1,1 +1,1 @@
-export const prerender = false;
+export const prerender = true;

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -1,31 +1,45 @@
 <script lang="ts">
-	import { replaceState } from '$app/navigation';
-	import { page } from '$app/state';
+	import { afterNavigate, replaceState } from '$app/navigation';
+	import { onMount } from 'svelte';
 	import SearchBox from '$lib/components/SearchBox.svelte';
 	import SearchResults from '$lib/components/SearchResults.svelte';
 	import { SITE_NAME } from '$lib/constants';
 	import { resolveHref } from '$lib/utils';
 
-	let searchQuery = $state(page.url.searchParams.get('q') ?? '');
+	let searchQuery = $state('');
+	let lastSyncedQ = '';
 
-	// Sync query to URL
+	// Sync URL → state. Uses window.location directly because page.url
+	// may still reflect the prerendered URL (no query params) during hydration.
+	function syncFromUrl() {
+		const urlQ = new URLSearchParams(window.location.search).get('q') ?? '';
+		searchQuery = urlQ;
+		lastSyncedQ = urlQ.trim();
+	}
+
+	// onMount guarantees we read the real browser URL after hydration.
+	onMount(syncFromUrl);
+
+	// afterNavigate handles back/forward navigation (does NOT fire on replaceState).
+	afterNavigate(syncFromUrl);
+
+	// State → URL: update query string as user types.
 	$effect(() => {
 		const q = searchQuery.trim();
-		const currentQ = page.url.searchParams.get('q') ?? '';
-		if (q !== currentQ) {
-			const url = new URL(page.url);
-			if (q) {
-				url.searchParams.set('q', q);
-			} else {
-				url.searchParams.delete('q');
-			}
-			replaceState(`${resolveHref('/search')}${url.search}`, {});
+		if (q !== lastSyncedQ) {
+			lastSyncedQ = q;
+			const search = q ? `?q=${encodeURIComponent(q)}` : '';
+			replaceState(`${resolveHref('/search')}${search}`, {});
 		}
 	});
 </script>
 
 <svelte:head>
 	<title>Search — {SITE_NAME}</title>
+	<link rel="preload" as="fetch" href="/api/titles/all/" crossorigin="anonymous" />
+	<link rel="preload" as="fetch" href="/api/manufacturers/all/" crossorigin="anonymous" />
+	<link rel="preload" as="fetch" href="/api/models/all/" crossorigin="anonymous" />
+	<link rel="preload" as="fetch" href="/api/people/all/" crossorigin="anonymous" />
 </svelte:head>
 
 <div class="search-page">

--- a/frontend/src/routes/search/+page.ts
+++ b/frontend/src/routes/search/+page.ts
@@ -1,1 +1,1 @@
-export const prerender = false;
+export const prerender = true;


### PR DESCRIPTION
## Summary
- Fix search query not populating on back/forward navigation or direct URL load with `?q=` param
- Re-enable prerendering on `/` and `/search` (disabled since 928067e)
- Add `<link rel="preload">` hints for all four search API endpoints on both pages

## Details
The root cause was `page.url.searchParams` being read at component init time, which:
1. Never re-ran on back/forward navigation (SvelteKit reuses components)
2. Is forbidden during prerendering per SvelteKit docs

Replaced with `onMount` + `afterNavigate` reading `window.location.search` directly, plus a sentinel-guarded `$effect` for syncing typed input back to the URL. `afterNavigate` does not fire on `replaceState`, preventing feedback loops.

## Test plan
- [ ] Open `http://localhost:5173/search?q=kaiju` in a new tab — search box is populated, results show
- [ ] Type a query on `/search` — URL updates as you type
- [ ] Click a result, hit back — search box and results are restored
- [ ] Same tests on `/` (home page)
- [ ] `pnpm build` succeeds (both pages prerender)

🤖 Generated with [Claude Code](https://claude.com/claude-code)