### PR TITLE
feat(api): hide internal APIs from OpenAPI docs

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from ninja import Router, Schema
 
-auth_router = Router(tags=["auth"])
+auth_router = Router(tags=["auth", "private"])
 
 
 class AuthStatusSchema(Schema):

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -522,7 +522,10 @@ def get_model(request, slug: str):
 
 
 @models_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=MachineModelDetailSchema
+    "/{slug}/claims/",
+    auth=django_auth,
+    response=MachineModelDetailSchema,
+    tags=["private"],
 )
 def patch_model_claims(request, slug: str, data: ClaimPatchSchema):
     """Assert per-field claims from the authenticated user, then re-resolve the model."""

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -256,7 +256,10 @@ def get_manufacturer(request, slug: str):
 
 
 @manufacturers_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=ManufacturerDetailSchema
+    "/{slug}/claims/",
+    auth=django_auth,
+    response=ManufacturerDetailSchema,
+    tags=["private"],
 )
 def patch_manufacturer_claims(request, slug: str, data: ClaimPatchSchema):
     """Assert per-field claims from the authenticated user, then re-resolve."""

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -194,7 +194,9 @@ def get_person(request, slug: str):
     return _serialize_person_detail(person)
 
 
-@people_router.patch("/{slug}/claims/", auth=django_auth, response=PersonDetailSchema)
+@people_router.patch(
+    "/{slug}/claims/", auth=django_auth, response=PersonDetailSchema, tags=["private"]
+)
 def patch_person_claims(request, slug: str, data: ClaimPatchSchema):
     """Assert per-field claims from the authenticated user, then re-resolve."""
     from apps.provenance.models import Claim

--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -45,8 +45,8 @@ class ReviewClaimSchema(Schema):
     review_links: list[ReviewLinkSchema] = []
 
 
-sources_router = Router(tags=["sources"])
-review_router = Router(tags=["review"])
+sources_router = Router(tags=["sources", "private"])
+review_router = Router(tags=["review", "private"])
 
 
 @sources_router.get("/", response=list[SourceSchema])

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -22,7 +22,7 @@ api = NinjaAPI(
 )
 
 
-@api.get("/health")
+@api.get("/health", tags=["private"])
 def health(request):
     from django.db import connection
 

--- a/frontend/src/routes/api-docs/+page.svelte
+++ b/frontend/src/routes/api-docs/+page.svelte
@@ -18,28 +18,69 @@
 		}
 	`;
 
+	/** Tags to hide from the public API docs (endpoints still work). */
+	const PRIVATE_TAGS = new Set(['auth', 'sources', 'review', 'health']);
+
+	/** Tags whose PATCH endpoints should be hidden (internal editing). */
+	const HIDE_PATCH_TAGS = new Set(['models', 'manufacturers', 'people']);
+
+	function filterSchema(schema: Record<string, unknown>): Record<string, unknown> {
+		const paths = schema.paths as Record<string, Record<string, Record<string, unknown>>>;
+		const filtered: typeof paths = {};
+		for (const [path, methods] of Object.entries(paths)) {
+			const kept: Record<string, Record<string, unknown>> = {};
+			for (const [method, details] of Object.entries(methods)) {
+				const tags = (details.tags as string[]) ?? [];
+				const isPrivate = tags.length > 0 && tags.every((t) => PRIVATE_TAGS.has(t));
+				const isHiddenPatch = method === 'patch' && tags.some((t) => HIDE_PATCH_TAGS.has(t));
+				if (!isPrivate && !isHiddenPatch) {
+					kept[method] = details;
+				}
+			}
+			if (Object.keys(kept).length > 0) {
+				filtered[path] = kept;
+			}
+		}
+		return { ...schema, paths: filtered };
+	}
+
 	$effect(() => {
-		const script = document.createElement('script');
-		script.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference';
-		script.onload = () => {
-			// @ts-expect-error — Scalar loaded via CDN
-			Scalar.createApiReference('#scalar-api-reference', {
-				url: '/api/openapi.json',
-				theme: 'none',
-				layout: 'modern',
-				showSidebar: true,
-				hideClientButton: true,
-				customCss: scalarCustomCss
-			});
-			scalarLoaded = true;
-		};
-		script.onerror = () => {
-			scalarError = 'Failed to load API reference. Please try refreshing the page.';
-		};
-		document.head.appendChild(script);
+		const controller = new AbortController();
+
+		(async () => {
+			let spec: Record<string, unknown>;
+			try {
+				const res = await fetch('/api/openapi.json', { signal: controller.signal });
+				spec = filterSchema(await res.json());
+			} catch {
+				if (!controller.signal.aborted) {
+					scalarError = 'Failed to load API reference. Please try refreshing the page.';
+				}
+				return;
+			}
+
+			const script = document.createElement('script');
+			script.src = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference';
+			script.onload = () => {
+				// @ts-expect-error — Scalar loaded via CDN
+				Scalar.createApiReference('#scalar-api-reference', {
+					content: JSON.stringify(spec),
+					theme: 'none',
+					layout: 'modern',
+					showSidebar: true,
+					hideClientButton: true,
+					customCss: scalarCustomCss
+				});
+				scalarLoaded = true;
+			};
+			script.onerror = () => {
+				scalarError = 'Failed to load API reference. Please try refreshing the page.';
+			};
+			document.head.appendChild(script);
+		})();
 
 		return () => {
-			script.remove();
+			controller.abort();
 		};
 	});
 </script>

--- a/frontend/src/routes/api-docs/+page.svelte
+++ b/frontend/src/routes/api-docs/+page.svelte
@@ -18,12 +18,7 @@
 		}
 	`;
 
-	/** Tags to hide from the public API docs (endpoints still work). */
-	const PRIVATE_TAGS = new Set(['auth', 'sources', 'review', 'health']);
-
-	/** Tags whose PATCH endpoints should be hidden (internal editing). */
-	const HIDE_PATCH_TAGS = new Set(['models', 'manufacturers', 'people']);
-
+	/** Remove endpoints tagged "private" from the OpenAPI spec before display. */
 	function filterSchema(schema: Record<string, unknown>): Record<string, unknown> {
 		const paths = schema.paths as Record<string, Record<string, Record<string, unknown>>>;
 		const filtered: typeof paths = {};
@@ -31,9 +26,7 @@
 			const kept: Record<string, Record<string, unknown>> = {};
 			for (const [method, details] of Object.entries(methods)) {
 				const tags = (details.tags as string[]) ?? [];
-				const isPrivate = tags.length > 0 && tags.every((t) => PRIVATE_TAGS.has(t));
-				const isHiddenPatch = method === 'patch' && tags.some((t) => HIDE_PATCH_TAGS.has(t));
-				if (!isPrivate && !isHiddenPatch) {
+				if (!tags.includes('private')) {
 					kept[method] = details;
 				}
 			}


### PR DESCRIPTION
## Summary
- Add `"private"` tag to internal endpoints (auth, sources, review, health, claims PATCH)
- Frontend filters out any endpoint tagged `"private"` before passing the spec to Scalar
- The full unfiltered OpenAPI spec at `/api/openapi.json` is unchanged
- To hide a new endpoint from docs, just add `tags=["private"]` to it

## Test plan
- [ ] `make test` passes (all hooks, lint, types, tests)
- [ ] Visit `/api-docs` — no auth/sources/review/health sections, no PATCH claims endpoints
- [ ] `curl /api/openapi.json` still contains all endpoints including private ones
- [ ] Frontend type generation (`make bootstrap`) still works with full schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)