### PR TITLE
feat(ingest): add ingest_pinbase_models command and title name overrides

### DIFF
--- a/backend/apps/catalog/management/commands/ingest_all.py
+++ b/backend/apps/catalog/management/commands/ingest_all.py
@@ -2,7 +2,8 @@
 
 Runs: ingest_pinbase_taxonomy → ingest_pinbase_manufacturers →
       ingest_pinbase_corporate_entities → ingest_pinbase_systems → ingest_ipdb →
-      ingest_opdb → ingest_pinbase_series → ingest_pinbase_titles → ingest_pinbase_signs →
+      ingest_opdb → generate_ipdb_titles → ingest_pinbase_models →
+      ingest_pinbase_series → ingest_pinbase_titles → ingest_pinbase_signs →
       resolve_claims.
 """
 
@@ -20,6 +21,7 @@ STEPS = [
     "ingest_ipdb",
     "ingest_opdb",
     "generate_ipdb_titles",
+    "ingest_pinbase_models",
     "ingest_pinbase_series",
     "ingest_pinbase_titles",
     "ingest_pinbase_signs",

--- a/backend/apps/catalog/management/commands/ingest_pinbase_models.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_models.py
@@ -1,0 +1,103 @@
+"""Assert editorial claims for MachineModels from data/models.json.
+
+Runs after ingest_opdb (so MachineModels exist). Matches by opdb_id and
+asserts claims with the pinbase source (priority 300), which outranks OPDB.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
+
+from apps.catalog.models import MachineModel
+from apps.provenance.models import Claim, Source
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PATH = Path(__file__).parents[5] / "data" / "models.json"
+
+# Fields stored as claim values (claim field_name → JSON key).
+CLAIM_FIELDS = {
+    "name": "name",
+    "display_type": "display_type_slug",
+    "description": "description",
+}
+
+
+class Command(BaseCommand):
+    help = "Assert editorial claims for MachineModels from data/models.json."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--path",
+            default=str(DEFAULT_PATH),
+            help="Path to models.json.",
+        )
+
+    def handle(self, *args, **options):
+        path = options["path"]
+        with open(path) as f:
+            entries = json.load(f)
+
+        ct_id = ContentType.objects.get_for_model(MachineModel).pk
+
+        source, _ = Source.objects.get_or_create(
+            slug="pinbase",
+            defaults={
+                "name": "Pinbase",
+                "source_type": Source.SourceType.EDITORIAL,
+                "priority": 300,
+                "description": "Pinbase curated data.",
+            },
+        )
+
+        by_opdb_id: dict[str, MachineModel] = {
+            mm.opdb_id: mm for mm in MachineModel.objects.filter(opdb_id__isnull=False)
+        }
+
+        pending_claims: list[Claim] = []
+        matched = 0
+        skipped = 0
+
+        for entry in entries:
+            opdb_id = entry.get("opdb_id")
+            if not opdb_id:
+                # Entries without opdb_id (e.g. slug-only) are not yet
+                # supported for claim assertion — skip silently.
+                skipped += 1
+                continue
+
+            mm = by_opdb_id.get(opdb_id)
+            if mm is None:
+                logger.warning("No MachineModel for opdb_id %r — skipping", opdb_id)
+                skipped += 1
+                continue
+
+            matched += 1
+            for claim_field, json_key in CLAIM_FIELDS.items():
+                value = entry.get(json_key)
+                if value:
+                    pending_claims.append(
+                        Claim(
+                            content_type_id=ct_id,
+                            object_id=mm.pk,
+                            field_name=claim_field,
+                            value=value,
+                        )
+                    )
+
+        self.stdout.write(f"  Matched: {matched}, Skipped: {skipped}")
+
+        claim_stats = Claim.objects.bulk_assert_claims(source, pending_claims)
+        self.stdout.write(
+            f"  Claims: {claim_stats['unchanged']} unchanged, "
+            f"{claim_stats['created']} created, "
+            f"{claim_stats['superseded']} superseded, "
+            f"{claim_stats['duplicates_removed']} duplicates removed"
+        )
+
+        self.stdout.write(self.style.SUCCESS("Models seed ingestion complete."))

--- a/backend/apps/catalog/management/commands/ingest_pinbase_titles.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_titles.py
@@ -43,8 +43,9 @@ class Command(BaseCommand):
         franchises_by_slug = {f.slug: f for f in Franchise.objects.all()}
         series_by_slug = {s.slug: s for s in Series.objects.all()}
 
-        franchise_set = membership_set = skipped = 0
+        franchise_set = membership_set = name_set = skipped = 0
         franchise_changed: list[Title] = []
+        name_changed: list[Title] = []
         series_memberships: dict[Series, list[Title]] = defaultdict(list)
 
         for entry in entries:
@@ -57,6 +58,13 @@ class Command(BaseCommand):
                 )
                 skipped += 1
                 continue
+
+            # Override name if provided.
+            name = entry.get("name")
+            if name and title.name != name:
+                title.name = name
+                name_changed.append(title)
+                name_set += 1
 
             # Set franchise FK.
             franchise_slug = entry.get("franchise_slug")
@@ -89,12 +97,20 @@ class Command(BaseCommand):
                 t.updated_at = now
             Title.objects.bulk_update(franchise_changed, ["franchise", "updated_at"])
 
+        # Bulk update name changes.
+        if name_changed:
+            now = timezone.now()
+            for t in name_changed:
+                t.updated_at = now
+            Title.objects.bulk_update(name_changed, ["name", "updated_at"])
+
         # Batch M2M adds per series.
         for series, titles in series_memberships.items():
             series.titles.add(*titles)
 
         self.stdout.write(
             f"  Titles: {franchise_set} franchise links, "
-            f"{membership_set} series memberships, {skipped} skipped"
+            f"{membership_set} series memberships, "
+            f"{name_set} name overrides, {skipped} skipped"
         )
         self.stdout.write(self.style.SUCCESS("Titles seed ingestion complete."))

--- a/backend/apps/catalog/tests/test_ingest_pinbase_models.py
+++ b/backend/apps/catalog/tests/test_ingest_pinbase_models.py
@@ -1,0 +1,156 @@
+"""Tests for the ingest_pinbase_models command."""
+
+import json
+import tempfile
+
+import pytest
+from django.core.management import call_command
+
+from apps.catalog.models import MachineModel
+from apps.catalog.resolve import resolve_model
+from apps.provenance.models import Claim, Source
+
+
+@pytest.fixture
+def opdb_source(db):
+    return Source.objects.create(
+        slug="opdb", name="OPDB", source_type="database", priority=200
+    )
+
+
+@pytest.fixture
+def model_with_opdb_name(db, opdb_source):
+    """A MachineModel with an OPDB name claim containing an abbreviation."""
+    mm = MachineModel.objects.create(
+        name="Foo (LE)",
+        opdb_id="Gtest-Mtest",
+    )
+    Claim.objects.bulk_assert_claims(
+        opdb_source,
+        [
+            Claim(
+                content_type=mm.claims.model.content_type_field.related_model.objects.get_for_model(
+                    MachineModel
+                ),
+                object_id=mm.pk,
+                field_name="name",
+                value="Foo (LE)",
+            )
+        ],
+    )
+    return mm
+
+
+@pytest.fixture
+def model_with_opdb_name_simple(db, opdb_source):
+    """A MachineModel with an OPDB name claim — simpler setup."""
+    from django.contrib.contenttypes.models import ContentType
+
+    mm = MachineModel.objects.create(
+        name="Foo (LE)",
+        opdb_id="Gtest-Mtest",
+    )
+    ct = ContentType.objects.get_for_model(MachineModel)
+    Claim.objects.bulk_assert_claims(
+        opdb_source,
+        [
+            Claim(
+                content_type_id=ct.pk,
+                object_id=mm.pk,
+                field_name="name",
+                value="Foo (LE)",
+            )
+        ],
+    )
+    return mm
+
+
+def _write_models_json(entries):
+    """Write entries to a temp file and return the path."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    json.dump(entries, f)
+    f.close()
+    return f.name
+
+
+@pytest.mark.django_db
+class TestIngestPinbaseModels:
+    def test_creates_name_claim(self, model_with_opdb_name_simple):
+        mm = model_with_opdb_name_simple
+        path = _write_models_json(
+            [{"opdb_id": "Gtest-Mtest", "name": "Foo (Limited Edition)"}]
+        )
+
+        call_command("ingest_pinbase_models", path=path)
+
+        source = Source.objects.get(slug="pinbase")
+        claim = mm.claims.get(source=source, field_name="name", is_active=True)
+        assert claim.value == "Foo (Limited Edition)"
+
+    def test_pinbase_wins_resolution(self, model_with_opdb_name_simple):
+        mm = model_with_opdb_name_simple
+        path = _write_models_json(
+            [{"opdb_id": "Gtest-Mtest", "name": "Foo (Limited Edition)"}]
+        )
+
+        call_command("ingest_pinbase_models", path=path)
+        resolve_model(mm)
+        mm.refresh_from_db()
+
+        assert mm.name == "Foo (Limited Edition)"
+
+    def test_skips_unknown_opdb_id(self, db):
+        path = _write_models_json([{"opdb_id": "Gfake-Mfake", "name": "Nonexistent"}])
+        # Should not raise
+        call_command("ingest_pinbase_models", path=path)
+
+    def test_idempotent(self, model_with_opdb_name_simple):
+        mm = model_with_opdb_name_simple
+        path = _write_models_json(
+            [{"opdb_id": "Gtest-Mtest", "name": "Foo (Limited Edition)"}]
+        )
+
+        call_command("ingest_pinbase_models", path=path)
+        call_command("ingest_pinbase_models", path=path)
+
+        source = Source.objects.get(slug="pinbase")
+        assert (
+            mm.claims.filter(source=source, field_name="name", is_active=True).count()
+            == 1
+        )
+
+    def test_description_claim(self, model_with_opdb_name_simple):
+        mm = model_with_opdb_name_simple
+        path = _write_models_json(
+            [
+                {
+                    "opdb_id": "Gtest-Mtest",
+                    "name": "Foo (Limited Edition)",
+                    "description": "A test description",
+                }
+            ]
+        )
+
+        call_command("ingest_pinbase_models", path=path)
+
+        source = Source.objects.get(slug="pinbase")
+        claim = mm.claims.get(source=source, field_name="description", is_active=True)
+        assert claim.value == "A test description"
+
+    def test_display_type_claim(self, model_with_opdb_name_simple):
+        mm = model_with_opdb_name_simple
+        path = _write_models_json(
+            [
+                {
+                    "opdb_id": "Gtest-Mtest",
+                    "name": "Foo (Limited Edition)",
+                    "display_type_slug": "alphanumeric",
+                }
+            ]
+        )
+
+        call_command("ingest_pinbase_models", path=path)
+
+        source = Source.objects.get(slug="pinbase")
+        claim = mm.claims.get(source=source, field_name="display_type", is_active=True)
+        assert claim.value == "alphanumeric"

--- a/data/models.json
+++ b/data/models.json
@@ -5,5 +5,397 @@
     "opdb_id": "GPBBv-ME0x0",
     "display_type_slug": "alphanumeric",
     "description": "OPDB incorrectly lists display as DMD; Screech is a 1976 Inder EM with a digital score display fitted over factory-installed reels — the player-visible display is what matters for classification"
+  },
+  {
+    "opdb_id": "Ge1py-MkPj1-AOppL",
+    "name": "ABBA (Collector's Edition)"
+  },
+  {
+    "opdb_id": "Ge1py-MkPj1-A1XDN",
+    "name": "ABBA (Limited Edition)"
+  },
+  {
+    "opdb_id": "G43W4-MrRpw",
+    "name": "AC/DC (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gr16e-M5Rbv",
+    "name": "Aerosmith (Limited Edition)"
+  },
+  {
+    "opdb_id": "G4PBO-MYep0",
+    "name": "Alien (Limited Edition)"
+  },
+  {
+    "opdb_id": "GbPxB-MkPol-A9j2b",
+    "name": "Avatar: The Battle for Pandora (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GbPxB-MkPol-A93vd",
+    "name": "Avatar: The Battle for Pandora (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gj66P-MXr0E-ARkqN",
+    "name": "Avengers: Infinity Quest (Limited Edition)"
+  },
+  {
+    "opdb_id": "GK1Kv-ME0E0-A9PJq",
+    "name": "Barry O's Barbecue Challenge (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GK1Kv-ME0E0-AO7ZV",
+    "name": "Barry O's Barbecue Challenge (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRoz4-MrRPw",
+    "name": "Batman 66 (Limited Edition)"
+  },
+  {
+    "opdb_id": "GrO7w-MDR9W",
+    "name": "Black Knight (Limited Edition)"
+  },
+  {
+    "opdb_id": "GD7Ld-MBRP4-A1e4P",
+    "name": "Black Knight: Sword of Rage (Limited Edition)"
+  },
+  {
+    "opdb_id": "G6lnq-M6153",
+    "name": "Deadpool (Limited Edition)"
+  },
+  {
+    "opdb_id": "G4X2l-MYepl-ARXxn",
+    "name": "Dialed In! (Collector's Edition)"
+  },
+  {
+    "opdb_id": "G4X2l-MYepl-A1WXy",
+    "name": "Dialed In! (Limited Edition)"
+  },
+  {
+    "opdb_id": "GrkL5-MJoNN",
+    "name": "Disney TRON: Legacy (Limited Edition)"
+  },
+  {
+    "opdb_id": "GK1Ej-MePok-A1zKx",
+    "name": "Dungeons & Dragons: The Tyrant's Eye (Limited Edition)"
+  },
+  {
+    "opdb_id": "G5KXk-MLqNz",
+    "name": "Eight Ball Deluxe (Limited Edition)"
+  },
+  {
+    "opdb_id": "G2LWd-M4o3Y-AOwoL",
+    "name": "Elton John (Collector's Edition)"
+  },
+  {
+    "opdb_id": "G2LWd-M4o3Y-A1e22",
+    "name": "Elton John (Premium Edition)"
+  },
+  {
+    "opdb_id": "GZVOd-MwNxZ-AR8vV",
+    "name": "Elvira's House of Horrors (Limited Edition)"
+  },
+  {
+    "opdb_id": "GYWvw-MKNP4",
+    "name": "Evil Dead (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GpeoL-MkPz1-A944p",
+    "name": "Foo Fighters (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gj6PZ-Mb5z6-A9Lbd",
+    "name": "Galactic Tank Force (Limited Edition)"
+  },
+  {
+    "opdb_id": "G41d5-M9REd",
+    "name": "Game of Thrones (Limited Edition)"
+  },
+  {
+    "opdb_id": "GR9Nr-MVKol",
+    "name": "Ghostbusters (Limited Edition)"
+  },
+  {
+    "opdb_id": "GweeP-Ml9pZ-A9vXB",
+    "name": "Godzilla (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRWvz-MP37P",
+    "name": "Guardians of the Galaxy (Limited Edition)"
+  },
+  {
+    "opdb_id": "GqZZ1-MZeoE",
+    "name": "Guns N' Roses (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GqZZ1-M85y9",
+    "name": "Guns N' Roses (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gj66Z-Mp4BN-A9Y6n",
+    "name": "Halloween (Collector's Edition)"
+  },
+  {
+    "opdb_id": "Gj66Z-Mp4BN",
+    "name": "Halloween (Standard Edition)"
+  },
+  {
+    "opdb_id": "GWyBj-MdEbK-AOPdq",
+    "name": "Harry Potter (Collector's Edition)"
+  },
+  {
+    "opdb_id": "G4dOQ-MW970",
+    "name": "Iron Maiden: Legacy of the Beast (Limited Edition)"
+  },
+  {
+    "opdb_id": "GLWll-M1r8O-A1kx7",
+    "name": "JAWS (Limited Edition)"
+  },
+  {
+    "opdb_id": "GQKyP-MP3OK-A1KoX",
+    "name": "James Bond 007 (Limited Edition)"
+  },
+  {
+    "opdb_id": "GrZBr-MyNZz",
+    "name": "James Cameron's Avatar (Limited Edition)"
+  },
+  {
+    "opdb_id": "GQK1P-Ml95Z-A9bjw",
+    "name": "John Wick (Limited Edition)"
+  },
+  {
+    "opdb_id": "GK17D-MKNKd-AOyKv",
+    "name": "Jurassic Park (Limited Edition)"
+  },
+  {
+    "opdb_id": "G4qX5-Ml9jb",
+    "name": "KISS (Limited Edition)"
+  },
+  {
+    "opdb_id": "GEL0V-MyN8E-ARq7n",
+    "name": "King Kong: Myth of Terror Island (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gweel-ME0pP-AR0N5",
+    "name": "Led Zeppelin (Limited Edition)"
+  },
+  {
+    "opdb_id": "GJ2K0-M85re-A1qdn",
+    "name": "Looney Tunes (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GJ2K0-M85re",
+    "name": "Looney Tunes (Standard Edition)"
+  },
+  {
+    "opdb_id": "GrqZX-MDEPd",
+    "name": "Lord of the Rings (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRBE4-MOE4l",
+    "name": "Metallica (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRBE4-MOE4l-A1KQR",
+    "name": "Metallica Master of Puppets (Limited Edition)"
+  },
+  {
+    "opdb_id": "GO0q3-MOEy8-ARrPz",
+    "name": "Metallica Remastered (Limited Edition)"
+  },
+  {
+    "opdb_id": "GrPOR-MLq5x",
+    "name": "Mustang (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRbPY-MBR24",
+    "name": "Pirates of the Caribbean (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GRbPY-MePOP-A9pVl",
+    "name": "Pirates of the Caribbean (Limited Edition)"
+  },
+  {
+    "opdb_id": "GV8wB-MRjKd-ARz2r",
+    "name": "Pokémon (Limited Edition)"
+  },
+  {
+    "opdb_id": "GoEkx-MdEzN-AR50E",
+    "name": "Pulp Fiction (Limited Edition)"
+  },
+  {
+    "opdb_id": "GoEkx-MdEzN-ARJQz",
+    "name": "Pulp Fiction (Standard Edition)"
+  },
+  {
+    "opdb_id": "GELkO-Ml9zZ-AO3yd",
+    "name": "Queen (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GELkO-Ml9zZ-AOjEb",
+    "name": "Queen (Limited Edition)"
+  },
+  {
+    "opdb_id": "GQKb2-MYek0",
+    "name": "Rick and Morty (Standard Edition)"
+  },
+  {
+    "opdb_id": "G5pp2-MBRK4",
+    "name": "Rob Zombie's Spookshow International (Limited Edition)"
+  },
+  {
+    "opdb_id": "G2Lkd-M0ope-A97xV",
+    "name": "Rush (Limited Edition)"
+  },
+  {
+    "opdb_id": "GllPz-MBRrV-A9vWL",
+    "name": "Scooby-Doo (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GllPz-MBRrV",
+    "name": "Scooby-Doo (Standard Edition)"
+  },
+  {
+    "opdb_id": "Gryw4-MNEKn",
+    "name": "Star Trek (Limited Edition)"
+  },
+  {
+    "opdb_id": "G5vLR-MZebq",
+    "name": "Star Wars (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gxv81-Mo1rp-A9Qew",
+    "name": "Star Wars: Fall of the Empire (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gzy89-M0oPy-A9xXV",
+    "name": "Stranger Things (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gd2Xb-MRjpZ-A92v0",
+    "name": "Teenage Mutant Ninja Turtles (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRzNR-MyNq8",
+    "name": "The Avengers (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRzNR-MyNq8-A1oeR",
+    "name": "The Avengers Hulk (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gd2ox-MW9qj-A1loo",
+    "name": "The Godfather (Collector's Edition)"
+  },
+  {
+    "opdb_id": "Gd2ox-MW9qj-AReW2",
+    "name": "The Godfather (Limited Edition)"
+  },
+  {
+    "opdb_id": "G5bYr-MLezO-A9dNe",
+    "name": "The Hobbit (Limited Edition)"
+  },
+  {
+    "opdb_id": "GBLLP-MW900-A1KoQ",
+    "name": "The Mandalorian (Limited Edition)"
+  },
+  {
+    "opdb_id": "GbPde-Mp43l-AO4Do",
+    "name": "The Munsters (Limited Edition)"
+  },
+  {
+    "opdb_id": "GkBnQ-MBRxV-A96qp",
+    "name": "The Princess Bride (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GkBnQ-MBRxV-ARB7b",
+    "name": "The Princess Bride (Limited Edition)"
+  },
+  {
+    "opdb_id": "GredR-Mb5jN",
+    "name": "The Rolling Stones (Limited Edition)"
+  },
+  {
+    "opdb_id": "G0lkp-MZeqp-AOdky",
+    "name": "The Texas Chainsaw Massacre (Collector's Edition)"
+  },
+  {
+    "opdb_id": "G0lkp-MZeqp",
+    "name": "The Texas Chainsaw Massacre (Standard Edition)"
+  },
+  {
+    "opdb_id": "G7ZEz-MyN3K-ARl3o",
+    "name": "The Uncanny X-Men (Limited Edition)"
+  },
+  {
+    "opdb_id": "G5nz5-MP3r1",
+    "name": "The Walking Dead (Limited Edition)"
+  },
+  {
+    "opdb_id": "Gj6DE-MePEz-AR5Pz",
+    "name": "The Walking Dead Remastered (Limited Edition)"
+  },
+  {
+    "opdb_id": "G4xyR-MJ2v0-AOPQQ",
+    "name": "The Wizard of Oz (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRD79-M0odk-AObBw",
+    "name": "Total Nuclear Annihilation (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GJ2o0-MrRye-AO62p",
+    "name": "Toy Story 4 (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GJ2o0-MrRye-ARNwE",
+    "name": "Toy Story 4 (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRnPz-Mx0XO",
+    "name": "Transformers (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRnPz-Mx0XO-AOxV9",
+    "name": "Transformers Autobot Crimson (Limited Edition)"
+  },
+  {
+    "opdb_id": "GRnPz-Mx0XO-ARzL1",
+    "name": "Transformers Decepticon Violet (Limited Edition)"
+  },
+  {
+    "opdb_id": "GBLLd-MdEON-A9QJL",
+    "name": "Ultraman: Kaiju Rumble (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GBLLd-MdEON",
+    "name": "Ultraman: Kaiju Rumble (Standard Edition)"
+  },
+  {
+    "opdb_id": "G3EBl-MRj6e-ARzbx",
+    "name": "Venom (Limited Edition)"
+  },
+  {
+    "opdb_id": "GN6WW-MnKPq-AOPQq",
+    "name": "Weird Al's Museum of Natural Hilarity (Limited Edition)"
+  },
+  {
+    "opdb_id": "GYWBZ-MW9B0-A9jqd",
+    "name": "Willy Wonka & The Chocolate Factory (Collector's Edition)"
+  },
+  {
+    "opdb_id": "GYWBZ-MW9B0",
+    "name": "Willy Wonka & The Chocolate Factory (Limited Edition)"
+  },
+  {
+    "opdb_id": "Grj6X-MJNV1",
+    "name": "X-Men (Limited Edition)"
+  },
+  {
+    "opdb_id": "Grj6X-MJNV1-AOwN1",
+    "name": "X-Men Magneto (Limited Edition)"
+  },
+  {
+    "opdb_id": "Grj6X-MJNV1-AO209",
+    "name": "X-Men Wolverine (Limited Edition)"
   }
 ]

--- a/data/titles.json
+++ b/data/titles.json
@@ -421,7 +421,7 @@
   },
   {
     "slug": "james-bond-007-60th-anniversary-le",
-    "name": "James Bond 007 60th Anniversary (LE)",
+    "name": "James Bond 007 60th Anniversary (Limited Edition)",
     "opdb_group_id": "Ge1Dy",
     "franchise_slug": "james-bond"
   },
@@ -1077,5 +1077,20 @@
     "name": "X-Men",
     "opdb_group_id": "Grj6X",
     "franchise_slug": "x-men"
+  },
+  {
+    "slug": "evil-dead-ce",
+    "name": "Evil Dead (Collector's Edition)",
+    "opdb_group_id": "GYWvw"
+  },
+  {
+    "slug": "the-texas-chainsaw-massacre-se",
+    "name": "The Texas Chainsaw Massacre (Standard Edition)",
+    "opdb_group_id": "G0lkp"
+  },
+  {
+    "slug": "ultraman-kaiju-rumble-se",
+    "name": "Ultraman: Kaiju Rumble (Standard Edition)",
+    "opdb_group_id": "GBLLd"
   }
 ]


### PR DESCRIPTION
## Summary
- Add new `ingest_pinbase_models` management command that asserts editorial claims (name, display_type, description) on MachineModels from `data/models.json`, using the pinbase source (priority 300) to outrank OPDB defaults
- Expand abbreviated model names (LE → Limited Edition, CE → Collector's Edition, SE → Standard Edition, etc.) across ~100 models in `data/models.json`
- Extend `ingest_pinbase_titles` to support name overrides from `data/titles.json`
- Add new title entries (Evil Dead CE, Texas Chainsaw Massacre SE, Ultraman SE) and fix James Bond 007 name abbreviation

## Test plan
- [x] New tests in `test_ingest_pinbase_models.py` covering claim creation, resolution priority, idempotency, unknown opdb_id handling, and multi-field claims
- [ ] Run `make ingest` end-to-end to verify the new step integrates correctly in the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)