### PR TITLE
feat: show model → variant hierarchy on title and model detail pages

### DIFF
--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -98,6 +98,23 @@ def _extract_variant_features(extra_data: dict) -> list[str]:
 def _serialize_title_machine(pm) -> dict:
     """Serialize a MachineModel for use in title/theme/system machine lists."""
     thumbnail_url, _ = _extract_image_urls(pm.extra_data or {})
+
+    # Include variants (aliases) only when prefetched to avoid N+1 queries.
+    aliases = (
+        pm.aliases.all()
+        if "aliases" in getattr(pm, "_prefetched_objects_cache", {})
+        else []
+    )
+    variants = [
+        {
+            "name": a.name,
+            "slug": a.slug,
+            "year": a.year,
+            "thumbnail_url": _extract_image_urls(a.extra_data or {})[0],
+        }
+        for a in aliases
+    ]
+
     return {
         "name": pm.name,
         "slug": pm.slug,
@@ -108,4 +125,5 @@ def _serialize_title_machine(pm) -> dict:
             pm.technology_generation.name if pm.technology_generation else None
         ),
         "thumbnail_url": thumbnail_url,
+        "variants": variants,
     }

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -334,8 +334,6 @@ def _serialize_model_detail(pm) -> dict:
             _serialize_title_machine(sibling)
             for sibling in (pm.title.machine_models.all() if pm.title else [])
             if sibling.alias_of_id is None
-            and sibling.pk != pm.pk
-            and sibling.pk != pm.alias_of_id
         ],
     }
 
@@ -365,6 +363,7 @@ def _model_detail_qs():
             "title__machine_models",
             queryset=MachineModel.objects.filter(alias_of__isnull=True)
             .select_related("manufacturer", "technology_generation")
+            .prefetch_related("aliases")
             .order_by("year", "name"),
         ),
         Prefetch(

--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -27,6 +27,15 @@ class ThemeSchema(Schema):
     slug: str
 
 
+class TitleMachineVariantSchema(Schema):
+    """A variant (alias) of a machine model, shown nested under its parent."""
+
+    name: str
+    slug: str
+    year: Optional[int] = None
+    thumbnail_url: Optional[str] = None
+
+
 class TitleMachineSchema(Schema):
     """A machine model shown in a list context (title detail, theme detail, etc.)."""
 
@@ -37,6 +46,7 @@ class TitleMachineSchema(Schema):
     manufacturer_slug: Optional[str] = None
     technology_generation_name: Optional[str] = None
     thumbnail_url: Optional[str] = None
+    variants: list[TitleMachineVariantSchema] = []
 
 
 class RelatedTitleSchema(Schema):

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -351,9 +351,9 @@ def _serialize_title_detail(title) -> dict:
     # Agreed specs across all models.
     agreed_specs = _compute_agreed_specs(model_objs) if model_objs else {}
 
-    # For single-model titles, include full model detail inline.
+    # For single-model titles with no variants, include full model detail inline.
     model_detail = None
-    if len(machines) == 1:
+    if len(machines) == 1 and not machines[0].get("variants"):
         from .machine_models import _model_detail_qs, _serialize_model_detail
 
         pm = _model_detail_qs().get(slug=machines[0]["slug"])
@@ -391,7 +391,7 @@ def _title_models_prefetch():
             "cabinet",
             "game_format",
         )
-        .prefetch_related("themes", "credits__person")
+        .prefetch_related("themes", "credits__person", "aliases")
         .order_by("year", "name"),
     )
 

--- a/backend/apps/catalog/management/commands/ingest_pinbase_titles.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_titles.py
@@ -43,9 +43,10 @@ class Command(BaseCommand):
         franchises_by_slug = {f.slug: f for f in Franchise.objects.all()}
         series_by_slug = {s.slug: s for s in Series.objects.all()}
 
-        franchise_set = membership_set = name_set = skipped = 0
+        franchise_set = membership_set = name_set = slug_set = skipped = 0
         franchise_changed: list[Title] = []
         name_changed: list[Title] = []
+        pending_slugs: dict[int, str] = {}  # title.pk → desired slug
         series_memberships: dict[Series, list[Title]] = defaultdict(list)
 
         for entry in entries:
@@ -58,6 +59,11 @@ class Command(BaseCommand):
                 )
                 skipped += 1
                 continue
+
+            # Override slug if provided.
+            slug = entry.get("slug")
+            if slug and title.slug != slug:
+                pending_slugs[title.pk] = slug
 
             # Override name if provided.
             name = entry.get("name")
@@ -97,6 +103,36 @@ class Command(BaseCommand):
                 t.updated_at = now
             Title.objects.bulk_update(franchise_changed, ["franchise", "updated_at"])
 
+        # Update slugs in two passes to handle swaps (e.g. A→B and B→C).
+        # Filter out slugs that would conflict with titles not being renamed.
+        if pending_slugs:
+            pks_being_renamed = set(pending_slugs.keys())
+            desired_slugs = set(pending_slugs.values())
+            conflicting = set(
+                Title.objects.filter(slug__in=desired_slugs)
+                .exclude(pk__in=pks_being_renamed)
+                .values_list("slug", flat=True)
+            )
+            safe_slugs = {
+                pk: slug
+                for pk, slug in pending_slugs.items()
+                if slug not in conflicting
+            }
+            for slug in conflicting:
+                logger.warning("Slug %r already taken — skipping rename", slug)
+
+            if safe_slugs:
+                now = timezone.now()
+                # Pass 1: move to temporary slugs.
+                for pk, slug in safe_slugs.items():
+                    Title.objects.filter(pk=pk).update(
+                        slug=f"_tmp_{pk}", updated_at=now
+                    )
+                # Pass 2: move to final slugs.
+                for pk, slug in safe_slugs.items():
+                    Title.objects.filter(pk=pk).update(slug=slug)
+                slug_set = len(safe_slugs)
+
         # Bulk update name changes.
         if name_changed:
             now = timezone.now()
@@ -111,6 +147,7 @@ class Command(BaseCommand):
         self.stdout.write(
             f"  Titles: {franchise_set} franchise links, "
             f"{membership_set} series memberships, "
-            f"{name_set} name overrides, {skipped} skipped"
+            f"{name_set} name overrides, {slug_set} slug overrides, "
+            f"{skipped} skipped"
         )
         self.stdout.write(self.style.SUCCESS("Titles seed ingestion complete."))

--- a/data/titles.json
+++ b/data/titles.json
@@ -420,8 +420,8 @@
     "franchise_slug": "james-bond"
   },
   {
-    "slug": "james-bond-007-60th-anniversary-le",
-    "name": "James Bond 007 60th Anniversary (Limited Edition)",
+    "slug": "james-bond-007-60th-anniversary",
+    "name": "James Bond 007 60th Anniversary",
     "opdb_group_id": "Ge1Dy",
     "franchise_slug": "james-bond"
   },
@@ -1079,18 +1079,18 @@
     "franchise_slug": "x-men"
   },
   {
-    "slug": "evil-dead-ce",
-    "name": "Evil Dead (Collector's Edition)",
+    "slug": "evil-dead",
+    "name": "Evil Dead",
     "opdb_group_id": "GYWvw"
   },
   {
-    "slug": "the-texas-chainsaw-massacre-se",
-    "name": "The Texas Chainsaw Massacre (Standard Edition)",
+    "slug": "the-texas-chainsaw-massacre",
+    "name": "The Texas Chainsaw Massacre",
     "opdb_group_id": "G0lkp"
   },
   {
-    "slug": "ultraman-kaiju-rumble-se",
-    "name": "Ultraman: Kaiju Rumble (Standard Edition)",
+    "slug": "ultraman-kaiju-rumble",
+    "name": "Ultraman: Kaiju Rumble",
     "opdb_group_id": "GBLLd"
   }
 ]

--- a/frontend/src/lib/components/ModelHierarchy.svelte
+++ b/frontend/src/lib/components/ModelHierarchy.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	interface Variant {
+		name: string;
+		slug: string;
+		year?: number | null;
+	}
+
+	interface Model {
+		name: string;
+		slug: string;
+		year?: number | null;
+		variants: Variant[];
+	}
+
+	let {
+		models,
+		heading = 'Models',
+		currentSlug = undefined,
+		aliasOfSlug = undefined,
+		excludeSlug = undefined
+	}: {
+		models: Model[];
+		heading?: string;
+		currentSlug?: string;
+		aliasOfSlug?: string;
+		excludeSlug?: string;
+	} = $props();
+
+	function sortedVariants(variants: Variant[]): Variant[] {
+		return [...variants].sort((a, b) => (a.year ?? 0) - (b.year ?? 0));
+	}
+
+	let filteredModels = $derived(
+		excludeSlug ? models.filter((m) => m.slug !== excludeSlug) : models
+	);
+</script>
+
+{#if filteredModels.length > 0}
+	<section class="sidebar-section">
+		<h3>{heading}</h3>
+		<ul class="sidebar-list">
+			{#each filteredModels as parent (parent.slug)}
+				<li
+					class:current={currentSlug !== undefined &&
+						(parent.slug === currentSlug || parent.slug === aliasOfSlug)}
+				>
+					<a href={resolve(`/models/${parent.slug}`)}>{parent.name}</a>
+					{#if parent.year}
+						<span class="muted">{parent.year}</span>
+					{/if}
+				</li>
+				{#each sortedVariants(parent.variants) as variant (variant.slug)}
+					<li
+						class="variant-indent"
+						class:current={currentSlug !== undefined && variant.slug === currentSlug}
+					>
+						<a href={resolve(`/models/${variant.slug}`)}>{variant.name}</a>
+						{#if variant.year}
+							<span class="muted">{variant.year}</span>
+						{/if}
+					</li>
+				{/each}
+			{/each}
+		</ul>
+	</section>
+{/if}
+
+<style>
+	.sidebar-section {
+		padding-bottom: var(--size-3);
+		border-bottom: 1px solid var(--color-border-soft);
+	}
+
+	.sidebar-section h3 {
+		font-size: var(--font-size-1);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-1);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.sidebar-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.sidebar-list li {
+		display: flex;
+		align-items: baseline;
+		padding: var(--size-1) 0;
+		font-size: var(--font-size-0);
+	}
+
+	.sidebar-list li > a {
+		flex: 1;
+	}
+
+	.sidebar-list li:not(:last-child):not(.variant-indent):not(:has(+ .variant-indent)) {
+		border-bottom: 1px solid var(--color-border-soft);
+	}
+
+	.muted {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-0);
+	}
+
+	.variant-indent {
+		margin-left: var(--size-4);
+	}
+
+	.variant-indent::before {
+		content: '└';
+		margin-right: var(--size-2);
+		color: var(--color-text-muted);
+	}
+
+	.current > a {
+		font-weight: 600;
+		color: var(--color-accent);
+	}
+</style>

--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -3,6 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
+	import ModelHierarchy from '$lib/components/ModelHierarchy.svelte';
 	import TwoColumnLayout from '$lib/components/TwoColumnLayout.svelte';
 
 	let { data, children } = $props();
@@ -214,7 +215,6 @@
 		{#if model.alias_of_slug}
 			<section class="sidebar-section">
 				<h3>Parent Game</h3>
-				<p class="sidebar-note">This machine is a variant of:</p>
 				<ul class="sidebar-list">
 					<li>
 						<a href={resolve(`/models/${model.alias_of_slug}`)}>{model.alias_of_name}</a>
@@ -239,21 +239,11 @@
 			</section>
 		{/if}
 
-		{#if model.title_models && model.title_models.length > 0}
-			<section class="sidebar-section">
-				<h3>Other Models</h3>
-				<ul class="sidebar-list">
-					{#each model.title_models as sibling (sibling.slug)}
-						<li>
-							<a href={resolve(`/models/${sibling.slug}`)}>{sibling.name}</a>
-							{#if sibling.year}
-								<span class="muted">{sibling.year}</span>
-							{/if}
-						</li>
-					{/each}
-				</ul>
-			</section>
-		{/if}
+		<ModelHierarchy
+			models={model.title_models}
+			heading="Other Models"
+			excludeSlug={model.alias_of_slug ?? model.slug}
+		/>
 
 		<div class="external-ids">
 			{#if model.ipdb_id}
@@ -439,12 +429,6 @@
 	.rating-label {
 		font-size: var(--font-size-0);
 		color: var(--color-text-muted);
-	}
-
-	.sidebar-note {
-		font-size: var(--font-size-0);
-		color: var(--color-text-muted);
-		margin: 0 0 var(--size-1) 0;
 	}
 
 	.sidebar-list {

--- a/frontend/src/routes/models/[slug]/+page.ts
+++ b/frontend/src/routes/models/[slug]/+page.ts
@@ -4,9 +4,14 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const { model } = await parent();
 
-	// Single-model titles: redirect to the canonical title page.
+	// Single-model titles with no variants: redirect to the canonical title page.
 	// Never redirect variant models — they have their own detail page.
-	if (model.title_slug && model.title_models.length === 0 && !model.alias_of_slug) {
+	if (
+		model.title_slug &&
+		model.title_models.length === 1 &&
+		model.title_models[0].variants.length === 0 &&
+		!model.alias_of_slug
+	) {
 		redirect(301, `/titles/${model.title_slug}`);
 	}
 };

--- a/frontend/src/routes/titles/[slug]/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
-	import CardGrid from '$lib/components/grid/CardGrid.svelte';
 	import MachineCard from '$lib/components/cards/MachineCard.svelte';
 	import ModelDetailBody from '$lib/components/ModelDetailBody.svelte';
+	import ModelHierarchy from '$lib/components/ModelHierarchy.svelte';
 	import CreditsList from '$lib/components/CreditsList.svelte';
 	import TwoColumnLayout from '$lib/components/TwoColumnLayout.svelte';
 	import { pageTitle } from '$lib/constants';
@@ -152,8 +152,8 @@
 				{#if title.machines.length === 0}
 					<p class="empty">No machines in this title.</p>
 				{:else}
-					<CardGrid>
-						{#each title.machines as machine (machine.slug)}
+					{#each title.machines as machine (machine.slug)}
+						<div class="model-group">
 							<MachineCard
 								slug={machine.slug}
 								name={machine.name}
@@ -161,8 +161,17 @@
 								manufacturerName={machine.manufacturer_name}
 								year={machine.year}
 							/>
-						{/each}
-					</CardGrid>
+							{#if machine.variants.length > 0}
+								<ul class="variant-list">
+									{#each machine.variants as variant (variant.slug)}
+										<li>
+											<a href={resolve(`/models/${variant.slug}`)}>{variant.name}</a>
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						</div>
+					{/each}
 				{/if}
 			{:else if activeTab === 'people'}
 				<CreditsList credits={title.credits} />
@@ -374,20 +383,8 @@
 				</section>
 			{/if}
 
-			{#if title.machines.length > 1}
-				<section class="sidebar-section">
-					<h3>Models</h3>
-					<ul class="sidebar-list">
-						{#each title.machines as machine (machine.slug)}
-							<li>
-								<a href={resolve(`/models/${machine.slug}`)}>{machine.name}</a>
-								{#if machine.year}
-									<span class="muted">{machine.year}</span>
-								{/if}
-							</li>
-						{/each}
-					</ul>
-				</section>
+			{#if title.machines.length > 0}
+				<ModelHierarchy models={title.machines} />
 			{/if}
 		{/if}
 	{/snippet}
@@ -517,6 +514,28 @@
 		text-align: center;
 	}
 
+	.model-group {
+		margin-bottom: var(--size-4);
+	}
+
+	.variant-list {
+		list-style: none;
+		padding: 0 0 0 var(--size-6);
+		margin: var(--size-2) 0 0 0;
+	}
+
+	.variant-list li {
+		padding: var(--size-1) 0;
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+	}
+
+	.variant-list li::before {
+		content: '└';
+		margin-right: var(--size-2);
+		color: var(--color-text-muted);
+	}
+
 	/* Sidebar */
 	.sidebar-section {
 		padding-bottom: var(--size-3);
@@ -593,11 +612,6 @@
 
 	.sidebar-list li:not(:last-child) {
 		border-bottom: 1px solid var(--color-border-soft);
-	}
-
-	.muted {
-		color: var(--color-text-muted);
-		font-size: var(--font-size-0);
 	}
 
 	.external-ids {


### PR DESCRIPTION
## Summary

- Show nested model → variant hierarchy on title detail pages (main content and sidebar) and model detail sidebar
- Variants (aliases) displayed indented under parent models with └ markers and year badges
- Title names/slugs for edition variants (SE, CE, LE) cleaned to remove suffixes (e.g., `/titles/ultraman-kaiju-rumble` instead of `/titles/ultraman-kaiju-rumble-se`)
- Titles with variants no longer hoist to single-model view
- Extracted shared `ModelHierarchy.svelte` component used by both title and model pages
- Model detail sidebar keeps existing Variants/Parent Game/Other Variants sections, adds "Other Models" hierarchy for sibling models under the same title
- Variant years shown when they differ from parent (24% of aliases have different years)

## Test plan

- [ ] Visit `/titles/ultraman-kaiju-rumble` — should show 1 parent model with 2 variants nested underneath
- [ ] Visit `/titles/godzilla-stern` — should show multiple parent models with variants nested and sorted by year
- [ ] Visit an old single-model title (e.g., a 1960s game) — should still hoist to inline model detail
- [ ] Visit `/models/ultraman-kaiju-rumble-ce` — sidebar should show Parent Game, Other Variants, and Other Models sections
- [ ] Visit `/models/ultraman-kaiju-rumble-se` — sidebar should show Variants section and Other Models
- [ ] Verify variant names are left-aligned in sidebar hierarchy
- [ ] Run `make test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)