### PR TITLE
fix: correct Pulp Fiction and Elton John variant names

### DIFF
--- a/backend/apps/catalog/management/commands/ingest_pinbase_models.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_models.py
@@ -73,7 +73,11 @@ class Command(BaseCommand):
 
             mm = by_opdb_id.get(opdb_id)
             if mm is None:
-                logger.warning("No MachineModel for opdb_id %r — skipping", opdb_id)
+                logger.warning(
+                    "No MachineModel for opdb_id %r (%s) — skipping",
+                    opdb_id,
+                    entry.get("name", "unknown"),
+                )
                 skipped += 1
                 continue
 

--- a/data/models.json
+++ b/data/models.json
@@ -88,7 +88,7 @@
   },
   {
     "opdb_id": "G2LWd-M4o3Y-A1e22",
-    "name": "Elton John (Premium Edition)"
+    "name": "Elton John (Platinum Edition)"
   },
   {
     "opdb_id": "GZVOd-MwNxZ-AR8vV",
@@ -224,7 +224,7 @@
   },
   {
     "opdb_id": "GoEkx-MdEzN-ARJQz",
-    "name": "Pulp Fiction (Standard Edition)"
+    "name": "Pulp Fiction (Special Edition)"
   },
   {
     "opdb_id": "GELkO-Ml9zZ-AO3yd",


### PR DESCRIPTION
## Summary
- Fix edition names in `data/models.json`: Pulp Fiction → Special Edition, Elton John → Platinum Edition
- Include model name in skip-warning log messages during ingestion for easier debugging

## Test plan
- [ ] Run `make ingest` and verify corrected names appear
- [ ] Trigger a skip scenario and confirm the warning now includes the model name

🤖 Generated with [Claude Code](https://claude.com/claude-code)