### PR TITLE
feat: per-item provenance-tracked abbreviations

### DIFF
--- a/backend/apps/catalog/admin.py
+++ b/backend/apps/catalog/admin.py
@@ -19,6 +19,7 @@ from .models import (
     GameplayFeature,
     MachineModel,
     Manufacturer,
+    ModelAbbreviation,
     Person,
     Series,
     System,
@@ -27,6 +28,7 @@ from .models import (
     TechnologySubgeneration,
     Theme,
     Title,
+    TitleAbbreviation,
 )
 from .resolve import (
     DIRECT_FIELDS,
@@ -270,11 +272,36 @@ class ManufacturerAdmin(ProvenanceSaveMixin, admin.ModelAdmin):
         return obj.entities.count()
 
 
+class TitleAbbreviationInline(admin.TabularInline):
+    """Read-only inline — abbreviations are materialized from relationship claims."""
+
+    model = TitleAbbreviation
+    extra = 0
+    readonly_fields = ("value",)
+    can_delete = False
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
+class ModelAbbreviationInline(admin.TabularInline):
+    """Read-only inline — abbreviations are materialized from relationship claims."""
+
+    model = ModelAbbreviation
+    extra = 0
+    readonly_fields = ("value",)
+    can_delete = False
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
 @admin.register(Title)
 class TitleAdmin(admin.ModelAdmin):
-    list_display = ("name", "short_name", "opdb_id", "machine_model_count")
-    search_fields = ("name", "short_name", "opdb_id")
+    list_display = ("name", "opdb_id", "machine_model_count")
+    search_fields = ("name", "opdb_id")
     prepopulated_fields = {"slug": ("name",)}
+    inlines = (TitleAbbreviationInline,)
 
     @admin.display(description="Machine Models")
     def machine_model_count(self, obj):
@@ -402,7 +429,13 @@ class MachineModelAdmin(ProvenanceSaveMixin, admin.ModelAdmin):
         "cabinet",
         "game_format",
     )
-    inlines = (CreditInline, ThemeInline, GameplayFeatureInline, ClaimInline)
+    inlines = (
+        CreditInline,
+        ThemeInline,
+        GameplayFeatureInline,
+        ModelAbbreviationInline,
+        ClaimInline,
+    )
 
     fieldsets = (
         (

--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -21,7 +21,7 @@ from .helpers import _extract_image_urls
 class TitleRefSchema(Schema):
     name: str
     slug: str
-    short_name: str
+    abbreviations: list[str] = []
     machine_count: int = 0
     manufacturer_name: Optional[str] = None
     year: Optional[int] = None
@@ -59,7 +59,7 @@ def _serialize_title_list(title) -> dict:
     return {
         "name": title.name,
         "slug": title.slug,
-        "short_name": title.short_name,
+        "abbreviations": [a.value for a in title.abbreviations.all()],
         "machine_count": title.machine_count,
         "manufacturer_name": manufacturer_name,
         "year": year,
@@ -102,12 +102,13 @@ def get_franchise(request, slug: str):
             filter=Q(machine_models__alias_of__isnull=True),
         )
     ).prefetch_related(
+        "abbreviations",
         Prefetch(
             "machine_models",
             queryset=MachineModel.objects.filter(alias_of__isnull=True)
             .select_related("manufacturer")
             .order_by("year", "name"),
-        )
+        ),
     )
     franchise = get_object_or_404(
         Franchise.objects.prefetch_related(Prefetch("titles", queryset=titles_qs)),

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -44,7 +44,7 @@ class MachineModelGridSchema(Schema):
     manufacturer_name: Optional[str] = None
     technology_generation_name: Optional[str] = None
     thumbnail_url: Optional[str] = None
-    shortname: Optional[str] = None
+    abbreviations: list[str] = []
     search_text: Optional[str] = None
     title_slug: Optional[str] = None
 
@@ -103,6 +103,7 @@ class MachineModelDetailSchema(Schema):
     ipdb_rating: Optional[float] = None
     pinside_rating: Optional[float] = None
     title_description: str = ""
+    abbreviations: list[str] = []
     extra_data: dict
     credits: list[CreditSchema]
     activity: list[ClaimSchema]
@@ -296,6 +297,7 @@ def _serialize_model_detail(pm) -> dict:
         if pm.pinside_rating is not None
         else None,
         "title_description": pm.title.description if pm.title else "",
+        "abbreviations": [a.value for a in pm.abbreviations.all()],
         "extra_data": pm.extra_data or {},
         "credits": credits,
         "activity": activity,
@@ -358,6 +360,7 @@ def _model_detail_qs():
         "alias_of__aliases",
         "themes",
         "gameplay_features",
+        "abbreviations",
         "title__series",
         Prefetch(
             "title__machine_models",
@@ -446,9 +449,8 @@ def _build_search_text(pm) -> str:
         parts.append(gf.name)
     for credit in pm.credits.all():
         parts.append(credit.person.name)
-    shortname = (pm.extra_data or {}).get("shortname")
-    if shortname:
-        parts.append(shortname)
+    for abbr in pm.abbreviations.all():
+        parts.append(abbr.value)
     return " | ".join(parts)
 
 
@@ -479,6 +481,7 @@ def list_all_models(request):
             "tags",
             "gameplay_features",
             "aliases",
+            "abbreviations",
             "manufacturer__entities__addresses",
             Prefetch(
                 "credits",
@@ -504,7 +507,7 @@ def list_all_models(request):
                     pm.technology_generation.name if pm.technology_generation else None
                 ),
                 "thumbnail_url": thumbnail_url,
-                "shortname": pm.extra_data.get("shortname") or None,
+                "abbreviations": [a.value for a in pm.abbreviations.all()],
                 "search_text": _build_search_text(pm),
                 "title_slug": pm.title.slug if pm.title else None,
             }

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -21,7 +21,7 @@ from .machine_models import CreditSchema
 class TitleRefSchema(Schema):
     name: str
     slug: str
-    short_name: str
+    abbreviations: list[str] = []
     machine_count: int = 0
     manufacturer_name: Optional[str] = None
     year: Optional[int] = None
@@ -63,7 +63,7 @@ def _serialize_title_list(title) -> dict:
     return {
         "name": title.name,
         "slug": title.slug,
-        "short_name": title.short_name,
+        "abbreviations": [a.value for a in title.abbreviations.all()],
         "machine_count": title.machine_count,
         "manufacturer_name": manufacturer_name,
         "year": year,
@@ -127,12 +127,13 @@ def get_series(request, slug: str):
             filter=Q(machine_models__alias_of__isnull=True),
         )
     ).prefetch_related(
+        "abbreviations",
         Prefetch(
             "machine_models",
             queryset=MachineModel.objects.filter(alias_of__isnull=True)
             .select_related("manufacturer")
             .order_by("year", "name"),
-        )
+        ),
     )
     credits_qs = Credit.objects.filter(
         series__isnull=False,

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -30,7 +30,7 @@ class FacetRef(Schema):
 class TitleListSchema(Schema):
     name: str
     slug: str
-    short_name: str
+    abbreviations: list[str] = []
     machine_count: int = 0
     manufacturer_name: Optional[str] = None
     manufacturer_slug: Optional[str] = None
@@ -76,7 +76,7 @@ class AgreedSpecsSchema(Schema):
 class TitleDetailSchema(Schema):
     name: str
     slug: str
-    short_name: str
+    abbreviations: list[str] = []
     description: str = ""
     needs_review: bool = False
     needs_review_notes: str = ""
@@ -161,7 +161,7 @@ def _serialize_title_list(title) -> dict:
     return {
         "name": title.name,
         "slug": title.slug,
-        "short_name": title.short_name,
+        "abbreviations": [a.value for a in title.abbreviations.all()],
         "machine_count": title.machine_count,
         "manufacturer_name": manufacturer_name,
         "manufacturer_slug": manufacturer_slug,
@@ -363,7 +363,7 @@ def _serialize_title_detail(title) -> dict:
     return {
         "name": title.name,
         "slug": title.slug,
-        "short_name": title.short_name,
+        "abbreviations": [a.value for a in title.abbreviations.all()],
         "description": title.description,
         "needs_review": title.needs_review,
         "needs_review_notes": title.needs_review_notes,
@@ -418,7 +418,7 @@ def list_titles(request, display: str = ""):
         qs = qs.filter(machine_models__display_type__slug=display).distinct()
     qs = (
         qs.select_related("franchise")
-        .prefetch_related(_title_models_prefetch(), "series")
+        .prefetch_related(_title_models_prefetch(), "series", "abbreviations")
         .order_by("name")
     )
     return [_serialize_title_list(t) for t in qs]
@@ -447,7 +447,7 @@ def list_all_titles(request):
             ),
         )
         .select_related("franchise")
-        .prefetch_related(_title_models_prefetch(), "series")
+        .prefetch_related(_title_models_prefetch(), "series", "abbreviations")
         .order_by(F("latest_year").desc(nulls_last=True), "name")
     )
     result = [_serialize_title_list(t) for t in qs]
@@ -461,7 +461,9 @@ def get_title(request, slug: str):
     from ..models import Title
 
     title = get_object_or_404(
-        Title.objects.prefetch_related(_title_models_prefetch(), "series"),
+        Title.objects.prefetch_related(
+            _title_models_prefetch(), "series", "abbreviations"
+        ),
         slug=slug,
     )
     return _serialize_title_detail(title)

--- a/backend/apps/catalog/claims.py
+++ b/backend/apps/catalog/claims.py
@@ -24,6 +24,7 @@ RELATIONSHIP_SCHEMAS: dict[str, dict[str, str]] = {
     "theme": {"theme_slug": "theme"},
     "tag": {"tag_slug": "tag"},
     "gameplay_feature": {"gameplay_feature_slug": "gameplay_feature"},
+    "abbreviation": {"value": "value"},
 }
 
 RELATIONSHIP_NAMESPACES = frozenset(RELATIONSHIP_SCHEMAS)

--- a/backend/apps/catalog/management/commands/ingest_ipdb.py
+++ b/backend/apps/catalog/management/commands/ingest_ipdb.py
@@ -52,7 +52,6 @@ CLAIM_FIELDS = {
     "Notes": "notes",
     "Toys": "toys",
     "MarketingSlogans": "marketing_slogans",
-    "CommonAbbreviations": "abbreviation",
     "ModelNumber": "model_number",
 }
 
@@ -325,6 +324,25 @@ class Command(BaseCommand):
                     value=value,
                 )
             )
+
+        # Common abbreviations: each abbreviation becomes its own relationship claim.
+        raw_abbrevs = rec.get("CommonAbbreviations")
+        if raw_abbrevs:
+            for abbrev in str(raw_abbrevs).split(","):
+                abbrev = unescape(abbrev.strip())
+                if abbrev:
+                    claim_key, value = build_relationship_claim(
+                        "abbreviation", {"value": abbrev}
+                    )
+                    pending_claims.append(
+                        Claim(
+                            content_type_id=ct_id,
+                            object_id=pm.pk,
+                            field_name="abbreviation",
+                            claim_key=claim_key,
+                            value=value,
+                        )
+                    )
 
         # Manufacturer: resolve at ingest time to a slug claim.
         mfr_id = rec.get("ManufacturerId")

--- a/backend/apps/catalog/management/commands/ingest_opdb.py
+++ b/backend/apps/catalog/management/commands/ingest_opdb.py
@@ -21,6 +21,7 @@ from apps.catalog.ingestion.parsers import (
     parse_opdb_date,
     parse_opdb_group_id,
 )
+from apps.catalog.claims import build_relationship_claim
 from apps.catalog.models import MachineModel, Manufacturer, Title
 from apps.provenance.models import Claim, Source
 
@@ -524,7 +525,6 @@ class Command(BaseCommand):
 
         for opdb_id, rec in groups_by_id.items():
             name = rec.get("name", "")
-            short_name = rec.get("shortname") or ""
 
             existing = existing_titles.get(opdb_id)
             if existing:
@@ -536,7 +536,6 @@ class Command(BaseCommand):
                         opdb_id=opdb_id,
                         name=name,
                         slug=slug,
-                        short_name=short_name,
                     )
                 )
 
@@ -547,7 +546,7 @@ class Command(BaseCommand):
         # Re-fetch all titles so we have PKs for claim assertions.
         all_titles: dict[str, Title] = {t.opdb_id: t for t in Title.objects.all()}
 
-        # Collect name and short_name claims for all titles from this source.
+        # Collect name and abbreviation claims for all titles from this source.
         pending_claims: list[Claim] = []
         touched_ids: set[int] = set()
 
@@ -570,12 +569,16 @@ class Command(BaseCommand):
                     )
                 )
             if short_name:
+                claim_key, value = build_relationship_claim(
+                    "abbreviation", {"value": short_name}
+                )
                 pending_claims.append(
                     Claim(
                         content_type_id=ct_id,
                         object_id=title.pk,
-                        field_name="short_name",
-                        value=short_name,
+                        field_name="abbreviation",
+                        claim_key=claim_key,
+                        value=value,
                     )
                 )
 
@@ -584,12 +587,17 @@ class Command(BaseCommand):
         # Resolve touched titles so fields reflect winning claims.
         from apps.catalog.models import Franchise
 
+        from apps.catalog.resolve import resolve_all_title_abbreviations
+
         franchise_lookup = {f.slug: f for f in Franchise.objects.all()}
         _resolve_bulk(
             Title,
             TITLE_DIRECT_FIELDS,
             fk_handlers={"franchise": ("franchise", franchise_lookup)},
             object_ids=touched_ids,
+        )
+        resolve_all_title_abbreviations(
+            list(Title.objects.all()), title_ids=touched_ids
         )
 
         self.stdout.write(f"  Titles: {titles_created} created, {unchanged} unchanged")
@@ -680,10 +688,26 @@ class Command(BaseCommand):
         if opdb_features:
             _add("variant_features", opdb_features)
 
-        for field in ("keywords", "description", "common_name", "shortname", "images"):
+        for field in ("keywords", "description", "common_name", "images"):
             value = rec.get(field)
             if value:
                 _add(field, value)
+
+        # Shortname becomes a relationship claim for abbreviations.
+        shortname = rec.get("shortname")
+        if shortname:
+            claim_key, abbr_value = build_relationship_claim(
+                "abbreviation", {"value": shortname}
+            )
+            pending_claims.append(
+                Claim(
+                    content_type_id=ct_id,
+                    object_id=pm.pk,
+                    field_name="abbreviation",
+                    claim_key=claim_key,
+                    value=abbr_value,
+                )
+            )
 
         # Group claim (derived from opdb_id prefix).
         if opdb_id and groups_by_id:

--- a/backend/apps/catalog/migrations/0001_initial.py
+++ b/backend/apps/catalog/migrations/0001_initial.py
@@ -768,14 +768,6 @@ class Migration(migrations.Migration):
                 ),
                 ("name", models.CharField(max_length=300)),
                 ("slug", models.SlugField(blank=True, max_length=300, unique=True)),
-                (
-                    "short_name",
-                    models.CharField(
-                        blank=True,
-                        help_text='Common abbreviation, e.g., "MM" for Medieval Madness',
-                        max_length=50,
-                    ),
-                ),
                 ("description", models.TextField(blank=True)),
                 (
                     "needs_review",
@@ -877,5 +869,63 @@ class Migration(migrations.Migration):
             index=models.Index(
                 fields=["display_type"], name="catalog_mac_display_2a6560_idx"
             ),
+        ),
+        migrations.CreateModel(
+            name="TitleAbbreviation",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("value", models.CharField(max_length=50)),
+                (
+                    "title",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="abbreviations",
+                        to="catalog.title",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["value"],
+                "unique_together": {("title", "value")},
+            },
+        ),
+        migrations.CreateModel(
+            name="ModelAbbreviation",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("value", models.CharField(max_length=50)),
+                (
+                    "machine_model",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="abbreviations",
+                        to="catalog.machinemodel",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["value"],
+                "unique_together": {("machine_model", "value")},
+            },
         ),
     ]

--- a/backend/apps/catalog/models.py
+++ b/backend/apps/catalog/models.py
@@ -397,8 +397,9 @@ class Title(TimeStampedModel):
 
     OPDB calls this a "group" (e.g., "Medieval Madness" spans the 1997 original,
     the 2015 remake, and LE/SE variants). We use "Title" as it is the natural
-    pinball-world term. Title fields (name, short_name, description, franchise)
-    are resolved from claims, just like MachineModel and Manufacturer.
+    pinball-world term. Title fields (name, description, franchise) and
+    abbreviations are resolved from claims, just like MachineModel and
+    Manufacturer.
     """
 
     opdb_id = models.CharField(
@@ -409,11 +410,6 @@ class Title(TimeStampedModel):
     )
     name = models.CharField(max_length=300)
     slug = models.SlugField(max_length=300, unique=True, blank=True)
-    short_name = models.CharField(
-        max_length=50,
-        blank=True,
-        help_text='Common abbreviation, e.g., "MM" for Medieval Madness',
-    )
     description = models.TextField(blank=True)
     franchise = models.ForeignKey(
         Franchise,
@@ -438,14 +434,37 @@ class Title(TimeStampedModel):
         ordering = ["name"]
 
     def __str__(self) -> str:
-        if self.short_name:
-            return f"{self.name} ({self.short_name})"
         return self.name
 
     def save(self, *args, **kwargs):
         if not self.slug:
             self.slug = unique_slug(self, self.name, "title")
         super().save(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# TitleAbbreviation
+# ---------------------------------------------------------------------------
+
+
+class TitleAbbreviation(TimeStampedModel):
+    """A common abbreviation for a Title, e.g. "MM" for Medieval Madness.
+
+    Materialized from provenance claims; each abbreviation is individually
+    tracked with source attribution.
+    """
+
+    title = models.ForeignKey(
+        Title, on_delete=models.CASCADE, related_name="abbreviations"
+    )
+    value = models.CharField(max_length=50)
+
+    class Meta:
+        ordering = ["value"]
+        unique_together = [("title", "value")]
+
+    def __str__(self) -> str:
+        return self.value
 
 
 # ---------------------------------------------------------------------------
@@ -715,6 +734,31 @@ class MachineModel(TimeStampedModel):
                 parts.append(str(self.year))
             self.slug = unique_slug(self, " ".join(parts), "model")
         super().save(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# ModelAbbreviation
+# ---------------------------------------------------------------------------
+
+
+class ModelAbbreviation(TimeStampedModel):
+    """A common abbreviation for a MachineModel, e.g. "TS4LE" for Toy Story 4 LE.
+
+    Materialized from provenance claims; each abbreviation is individually
+    tracked with source attribution.
+    """
+
+    machine_model = models.ForeignKey(
+        MachineModel, on_delete=models.CASCADE, related_name="abbreviations"
+    )
+    value = models.CharField(max_length=50)
+
+    class Meta:
+        ordering = ["value"]
+        unique_together = [("machine_model", "value")]
+
+    def __str__(self) -> str:
+        return self.value
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -50,9 +50,12 @@ from ._relationships import (
     _resolve_all_gameplay_features,
     _resolve_all_tags,
     resolve_all_credits,
+    resolve_all_model_abbreviations,
     resolve_all_themes,
+    resolve_all_title_abbreviations,
     resolve_credits,
     resolve_gameplay_features,
+    resolve_model_abbreviations,
     resolve_tags,
     resolve_themes,
 )
@@ -205,6 +208,7 @@ def resolve_model(machine_model: MachineModel) -> MachineModel:
     resolve_themes(machine_model)
     resolve_gameplay_features(machine_model)
     resolve_tags(machine_model)
+    resolve_model_abbreviations(machine_model)
 
     return machine_model
 
@@ -226,6 +230,9 @@ def resolve_all() -> int:
         TITLE_DIRECT_FIELDS,
         fk_handlers={"franchise": ("franchise", franchise_lookup)},
     )
+
+    # 0c. Resolve title abbreviations.
+    resolve_all_title_abbreviations(list(Title.objects.all()))
 
     # 1. Pre-fetch lookup tables.
     mfr_lookup = _build_manufacturer_lookup()
@@ -298,6 +305,9 @@ def resolve_all() -> int:
 
     # 11. Bulk-resolve tag relationships.
     _resolve_all_tags(all_models)
+
+    # 12. Bulk-resolve model abbreviations.
+    resolve_all_model_abbreviations(all_models)
 
     return len(all_models)
 

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -83,7 +83,6 @@ _PERSON_INT_FIELDS: frozenset[str] = frozenset(
 
 TITLE_DIRECT_FIELDS: dict[str, str] = {
     "name": "name",
-    "short_name": "short_name",
     "description": "description",
 }
 
@@ -423,6 +422,11 @@ def resolve_title(title: Title) -> Title:
     else:
         title.franchise = None
     title.save()
+
+    # Resolve relationship claims after scalar save.
+    from ._relationships import resolve_title_abbreviations
+
+    resolve_title_abbreviations(title)
     return title
 
 

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -1,4 +1,5 @@
-"""Resolution logic for relationship claims (credits, themes, gameplay features, tags).
+"""Resolution logic for relationship claims (credits, themes, gameplay features, tags,
+abbreviations).
 
 Includes both single-object and bulk variants for each relationship type.
 """
@@ -16,9 +17,12 @@ from ..models import (
     CreditRole,
     GameplayFeature,
     MachineModel,
+    ModelAbbreviation,
     Person,
     Tag,
     Theme,
+    Title,
+    TitleAbbreviation,
 )
 from ._helpers import _pick_relationship_winners
 
@@ -568,3 +572,221 @@ def _resolve_all_tags(all_models: list[MachineModel]) -> None:
         through.objects.filter(pk__in=to_delete_pks).delete()
     if to_create:
         through.objects.bulk_create(to_create, batch_size=2000)
+
+
+# ------------------------------------------------------------------
+# Single-object abbreviation resolvers
+# ------------------------------------------------------------------
+
+
+def resolve_title_abbreviations(title: Title) -> None:
+    """Resolve abbreviation claims into TitleAbbreviation rows for a single Title."""
+    winners = _pick_relationship_winners(title, "abbreviation")
+
+    desired: set[str] = set()
+    for claim in winners.values():
+        val = claim.value
+        if not val.get("exists", True):
+            continue
+        desired.add(val["value"])
+
+    existing = set(title.abbreviations.values_list("value", flat=True))
+
+    # Create new abbreviations.
+    for value in desired - existing:
+        TitleAbbreviation.objects.create(title=title, value=value)
+
+    # Remove stale abbreviations.
+    if stale := existing - desired:
+        title.abbreviations.filter(value__in=stale).delete()
+
+
+def resolve_model_abbreviations(machine_model: MachineModel) -> None:
+    """Resolve abbreviation claims into ModelAbbreviation rows for a single MachineModel."""
+    winners = _pick_relationship_winners(machine_model, "abbreviation")
+
+    desired: set[str] = set()
+    for claim in winners.values():
+        val = claim.value
+        if not val.get("exists", True):
+            continue
+        desired.add(val["value"])
+
+    existing = set(machine_model.abbreviations.values_list("value", flat=True))
+
+    for value in desired - existing:
+        ModelAbbreviation.objects.create(machine_model=machine_model, value=value)
+
+    if stale := existing - desired:
+        machine_model.abbreviations.filter(value__in=stale).delete()
+
+
+# ------------------------------------------------------------------
+# Bulk abbreviation resolvers
+# ------------------------------------------------------------------
+
+
+def resolve_all_title_abbreviations(
+    all_titles: list[Title],
+    *,
+    title_ids: set[int] | None = None,
+) -> None:
+    """Bulk-resolve abbreviation claims into TitleAbbreviation rows."""
+    from django.contrib.contenttypes.models import ContentType
+
+    ct = ContentType.objects.get_for_model(Title)
+
+    # Pre-fetch active abbreviation claims with priority annotation.
+    abbr_qs = Claim.objects.filter(
+        is_active=True, content_type=ct, field_name="abbreviation"
+    )
+    if title_ids is not None:
+        abbr_qs = abbr_qs.filter(object_id__in=title_ids)
+    abbr_claims = (
+        abbr_qs.select_related("source", "user__profile")
+        .annotate(
+            effective_priority=Case(
+                When(source__isnull=False, then=F("source__priority")),
+                When(user__isnull=False, then=F("user__profile__priority")),
+                default=Value(0),
+                output_field=IntegerField(),
+            )
+        )
+        .order_by("object_id", "claim_key", "-effective_priority", "-created_at")
+    )
+
+    # Pick winner per (object_id, claim_key).
+    winners_by_title: dict[int, list[Claim]] = {}
+    seen: set[tuple[int, str]] = set()
+    for claim in abbr_claims:
+        key = (claim.object_id, claim.claim_key)
+        if key not in seen:
+            seen.add(key)
+            winners_by_title.setdefault(claim.object_id, []).append(claim)
+
+    # Desired abbreviation values from winning claims.
+    desired_by_title: dict[int, set[str]] = {}
+    for title_id, claims_list in winners_by_title.items():
+        desired: set[str] = set()
+        for claim in claims_list:
+            val = claim.value
+            if not val.get("exists", True):
+                continue
+            desired.add(val["value"])
+        desired_by_title[title_id] = desired
+
+    # Pre-fetch existing TitleAbbreviation rows.
+    all_title_ids = title_ids if title_ids is not None else {t.pk for t in all_titles}
+    existing_by_title: dict[int, set[str]] = {}
+    for row in TitleAbbreviation.objects.filter(title_id__in=all_title_ids).values_list(
+        "title_id", "value"
+    ):
+        existing_by_title.setdefault(row[0], set()).add(row[1])
+
+    # Diff and apply.
+    to_create = []
+    to_delete_pks: list[int] = []
+
+    for title_id in all_title_ids:
+        desired = desired_by_title.get(title_id, set())
+        existing = existing_by_title.get(title_id, set())
+
+        for value in desired - existing:
+            to_create.append(TitleAbbreviation(title_id=title_id, value=value))
+
+    # Build a lookup for deletions.
+    for row in TitleAbbreviation.objects.filter(title_id__in=all_title_ids).values_list(
+        "pk", "title_id", "value"
+    ):
+        pk, title_id, value = row
+        desired = desired_by_title.get(title_id, set())
+        if value not in desired:
+            to_delete_pks.append(pk)
+
+    if to_delete_pks:
+        TitleAbbreviation.objects.filter(pk__in=to_delete_pks).delete()
+    if to_create:
+        TitleAbbreviation.objects.bulk_create(to_create, batch_size=2000)
+
+
+def resolve_all_model_abbreviations(
+    all_models: list[MachineModel],
+    *,
+    model_ids: set[int] | None = None,
+) -> None:
+    """Bulk-resolve abbreviation claims into ModelAbbreviation rows."""
+    from django.contrib.contenttypes.models import ContentType
+
+    ct = ContentType.objects.get_for_model(MachineModel)
+
+    # Pre-fetch active abbreviation claims with priority annotation.
+    abbr_qs = Claim.objects.filter(
+        is_active=True, content_type=ct, field_name="abbreviation"
+    )
+    if model_ids is not None:
+        abbr_qs = abbr_qs.filter(object_id__in=model_ids)
+    abbr_claims = (
+        abbr_qs.select_related("source", "user__profile")
+        .annotate(
+            effective_priority=Case(
+                When(source__isnull=False, then=F("source__priority")),
+                When(user__isnull=False, then=F("user__profile__priority")),
+                default=Value(0),
+                output_field=IntegerField(),
+            )
+        )
+        .order_by("object_id", "claim_key", "-effective_priority", "-created_at")
+    )
+
+    # Pick winner per (object_id, claim_key).
+    winners_by_model: dict[int, list[Claim]] = {}
+    seen: set[tuple[int, str]] = set()
+    for claim in abbr_claims:
+        key = (claim.object_id, claim.claim_key)
+        if key not in seen:
+            seen.add(key)
+            winners_by_model.setdefault(claim.object_id, []).append(claim)
+
+    # Desired abbreviation values from winning claims.
+    desired_by_model: dict[int, set[str]] = {}
+    for model_id, claims_list in winners_by_model.items():
+        desired: set[str] = set()
+        for claim in claims_list:
+            val = claim.value
+            if not val.get("exists", True):
+                continue
+            desired.add(val["value"])
+        desired_by_model[model_id] = desired
+
+    # Pre-fetch existing ModelAbbreviation rows.
+    all_model_ids = model_ids if model_ids is not None else {pm.pk for pm in all_models}
+    existing_by_model: dict[int, set[str]] = {}
+    for row in ModelAbbreviation.objects.filter(
+        machine_model_id__in=all_model_ids
+    ).values_list("machine_model_id", "value"):
+        existing_by_model.setdefault(row[0], set()).add(row[1])
+
+    # Diff and apply.
+    to_create = []
+    to_delete_pks: list[int] = []
+
+    for model_id in all_model_ids:
+        desired = desired_by_model.get(model_id, set())
+        existing = existing_by_model.get(model_id, set())
+
+        for value in desired - existing:
+            to_create.append(ModelAbbreviation(machine_model_id=model_id, value=value))
+
+    # Build a lookup for deletions.
+    for row in ModelAbbreviation.objects.filter(
+        machine_model_id__in=all_model_ids
+    ).values_list("pk", "machine_model_id", "value"):
+        pk, model_id, value = row
+        desired = desired_by_model.get(model_id, set())
+        if value not in desired:
+            to_delete_pks.append(pk)
+
+    if to_delete_pks:
+        ModelAbbreviation.objects.filter(pk__in=to_delete_pks).delete()
+    if to_create:
+        ModelAbbreviation.objects.bulk_create(to_create, batch_size=2000)

--- a/backend/apps/catalog/tests/test_api.py
+++ b/backend/apps/catalog/tests/test_api.py
@@ -23,12 +23,8 @@ class TestSystemsAPI:
 
     @pytest.fixture
     def system_with_machines(self, system, manufacturer):
-        t1 = Title.objects.create(
-            name="Medieval Madness", opdb_id="G5pe4-s", short_name="MM"
-        )
-        t2 = Title.objects.create(
-            name="No Good Gofers", opdb_id="T-ngg", short_name="NGG"
-        )
+        t1 = Title.objects.create(name="Medieval Madness", opdb_id="G5pe4-s")
+        t2 = Title.objects.create(name="No Good Gofers", opdb_id="T-ngg")
         MachineModel.objects.create(
             name="Medieval Madness",
             manufacturer=manufacturer,

--- a/backend/apps/catalog/tests/test_api_cache.py
+++ b/backend/apps/catalog/tests/test_api_cache.py
@@ -45,9 +45,7 @@ class TestAllEndpointCache:
         assert resp2.json() == resp1.json()
 
     def test_title_save_invalidates_cache(self, client, db):
-        title = Title.objects.create(
-            name="Cactus Canyon", opdb_id="CC1", short_name="CC"
-        )
+        title = Title.objects.create(name="Cactus Canyon", opdb_id="CC1")
         client.get("/api/titles/all/")
         assert cache.get(TITLES_ALL_KEY) is not None
 
@@ -59,6 +57,6 @@ class TestAllEndpointCache:
         resp1 = client.get("/api/titles/all/")
         count_before = len(resp1.json())
 
-        Title.objects.create(name="Godzilla", opdb_id="GZ1", short_name="GZ")
+        Title.objects.create(name="Godzilla", opdb_id="GZ1")
         resp2 = client.get("/api/titles/all/")
         assert len(resp2.json()) == count_before + 1

--- a/backend/apps/catalog/tests/test_api_manufacturers.py
+++ b/backend/apps/catalog/tests/test_api_manufacturers.py
@@ -17,9 +17,7 @@ class TestManufacturersAPI:
         assert data["items"][0]["model_count"] == 1
 
     def test_get_manufacturer_detail(self, client, manufacturer, machine_model):
-        title = Title.objects.create(
-            name="Medieval Madness", opdb_id="G5pe4", short_name="MM"
-        )
+        title = Title.objects.create(name="Medieval Madness", opdb_id="G5pe4")
         machine_model.title = title
         machine_model.save()
         CorporateEntity.objects.create(
@@ -91,12 +89,8 @@ class TestManufacturersAPI:
         assert data[0]["thumbnail_url"] == "https://img.opdb.org/year-md.jpg"
 
     def test_get_manufacturer_detail_nulls_last(self, client, manufacturer, db):
-        t1 = Title.objects.create(
-            name="No Year Title", opdb_id="T-noyear", short_name="NYT"
-        )
-        t2 = Title.objects.create(
-            name="Has Year Title", opdb_id="T-hasyear", short_name="HYT"
-        )
+        t1 = Title.objects.create(name="No Year Title", opdb_id="T-noyear")
+        t2 = Title.objects.create(name="Has Year Title", opdb_id="T-hasyear")
         MachineModel.objects.create(
             name="No Year Game",
             manufacturer=manufacturer,

--- a/backend/apps/catalog/tests/test_api_models.py
+++ b/backend/apps/catalog/tests/test_api_models.py
@@ -161,9 +161,7 @@ class TestModelsAPI:
         assert data["aliases"][0]["variant_features"] == ["Gold trim"]
 
     def test_get_model_detail_title(self, client, machine_model, db):
-        title = Title.objects.create(
-            name="Medieval Madness", opdb_id="G5pe4", short_name="MM"
-        )
+        title = Title.objects.create(name="Medieval Madness", opdb_id="G5pe4")
         machine_model.title = title
         machine_model.save()
         resp = client.get(f"/api/models/{machine_model.slug}")

--- a/backend/apps/catalog/tests/test_api_people.py
+++ b/backend/apps/catalog/tests/test_api_people.py
@@ -18,9 +18,7 @@ class TestPeopleAPI:
         assert data["items"][0]["credit_count"] == 1
 
     def test_get_person_detail(self, client, person, machine_model, credit_roles):
-        title = Title.objects.create(
-            name="Medieval Madness", opdb_id="G5pe4-p", short_name="MM"
-        )
+        title = Title.objects.create(name="Medieval Madness", opdb_id="G5pe4-p")
         machine_model.title = title
         machine_model.save()
         role = CreditRole.objects.get(slug="design")

--- a/backend/apps/catalog/tests/test_api_titles.py
+++ b/backend/apps/catalog/tests/test_api_titles.py
@@ -20,9 +20,7 @@ from .conftest import SAMPLE_IMAGES
 class TestTitlesAPI:
     @pytest.fixture
     def title(self, db):
-        return Title.objects.create(
-            name="Medieval Madness", opdb_id="G5pe4", short_name="MM"
-        )
+        return Title.objects.create(name="Medieval Madness", opdb_id="G5pe4")
 
     @pytest.fixture
     def title_with_machines(self, title, manufacturer):
@@ -48,7 +46,7 @@ class TestTitlesAPI:
         assert data["count"] == 1
         item = data["items"][0]
         assert item["name"] == "Medieval Madness"
-        assert item["short_name"] == "MM"
+        assert item["abbreviations"] == []
         assert item["machine_count"] == 2
 
     def test_list_titles_thumbnail(self, client, title_with_machines):
@@ -109,9 +107,7 @@ class TestTitlesAllFacets:
 
     @pytest.fixture
     def faceted_title(self, db, manufacturer, solid_state, credit_roles):
-        title = Title.objects.create(
-            name="Medieval Madness", opdb_id="G5pe4", short_name="MM"
-        )
+        title = Title.objects.create(name="Medieval Madness", opdb_id="G5pe4")
         franchise = Franchise.objects.create(name="Castle Games")
         title.franchise = franchise
         title.save()
@@ -221,7 +217,7 @@ class TestTitlesAllFacets:
 
     def test_all_titles_empty_title(self, client, db):
         """Title with no models returns empty facet arrays."""
-        Title.objects.create(name="Empty", opdb_id="EMPTY", short_name="E")
+        Title.objects.create(name="Empty", opdb_id="EMPTY")
         resp = client.get("/api/titles/all/")
         data = resp.json()
         item = data[0]

--- a/backend/apps/catalog/tests/test_claims.py
+++ b/backend/apps/catalog/tests/test_claims.py
@@ -32,13 +32,17 @@ class TestMakeClaimKey:
         key = make_claim_key("recipient", person="pat-lawlor", year=None)
         assert key == "recipient|person:pat-lawlor|year:null"
 
-    def test_pipe_in_value_raises(self):
-        with pytest.raises(ValueError, match="reserved"):
-            make_claim_key("credit", person="bad|value")
+    def test_pipe_in_value_escaped(self):
+        key = make_claim_key("credit", person="bad|value")
+        assert key == "credit|person:bad%7Cvalue"
 
-    def test_colon_in_value_raises(self):
-        with pytest.raises(ValueError, match="reserved"):
-            make_claim_key("credit", person="bad:value")
+    def test_colon_in_value_escaped(self):
+        key = make_claim_key("credit", person="bad:value")
+        assert key == "credit|person:bad%3Avalue"
+
+    def test_percent_in_value_escaped(self):
+        key = make_claim_key("credit", person="100%")
+        assert key == "credit|person:100%25"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/catalog/tests/test_ingest_opdb.py
+++ b/backend/apps/catalog/tests/test_ingest_opdb.py
@@ -101,8 +101,8 @@ class TestIngestOpdbNewFields:
     def test_claims_shortname(self):
         pm = MachineModel.objects.get(opdb_id="G2222-MTest2")
         source = Source.objects.get(slug="opdb")
-        claim = pm.claims.get(source=source, field_name="shortname", is_active=True)
-        assert claim.value == "SEG"
+        claim = pm.claims.get(source=source, field_name="abbreviation", is_active=True)
+        assert claim.value == {"value": "SEG", "exists": True}
 
     def test_claims_images(self):
         pm = MachineModel.objects.get(opdb_id="G1111-MTest1")
@@ -127,7 +127,7 @@ class TestIngestOpdbGroups:
         assert Title.objects.count() == 3
         mm = Title.objects.get(opdb_id="G1111")
         assert mm.name == "Medieval Madness"
-        assert mm.short_name == "MM"
+        assert list(mm.abbreviations.values_list("value", flat=True)) == ["MM"]
 
     def test_group_claim_on_machine(self):
         pm = MachineModel.objects.get(opdb_id="G1111-MTest1")

--- a/backend/apps/catalog/tests/test_resolve.py
+++ b/backend/apps/catalog/tests/test_resolve.py
@@ -66,11 +66,20 @@ class TestResolveModel:
 
     def test_extra_data_catchall(self, pm, ipdb):
         Claim.objects.assert_claim(pm, "model_number", "20021", source=ipdb)
-        Claim.objects.assert_claim(pm, "abbreviation", "MM", source=ipdb)
 
         resolved = resolve_model(pm)
         assert resolved.extra_data["model_number"] == "20021"
-        assert resolved.extra_data["abbreviation"] == "MM"
+
+    def test_abbreviation_relationship_claim(self, pm, ipdb):
+        from apps.catalog.claims import build_relationship_claim
+
+        claim_key, value = build_relationship_claim("abbreviation", {"value": "MM"})
+        Claim.objects.assert_claim(
+            pm, "abbreviation", value, source=ipdb, claim_key=claim_key
+        )
+
+        resolved = resolve_model(pm)
+        assert list(resolved.abbreviations.values_list("value", flat=True)) == ["MM"]
 
     def test_manufacturer_resolution_by_slug(self, pm, ipdb):
         mfr = Manufacturer.objects.create(name="Williams", slug="williams")
@@ -113,11 +122,9 @@ class TestResolveModel:
     def test_stale_values_cleared_on_re_resolve(self, pm, ipdb):
         Claim.objects.assert_claim(pm, "year", 1997, source=ipdb)
         Claim.objects.assert_claim(pm, "player_count", 4, source=ipdb)
-        Claim.objects.assert_claim(pm, "abbreviation", "MM", source=ipdb)
         resolve_model(pm)
         assert pm.year == 1997
         assert pm.player_count == 4
-        assert pm.extra_data["abbreviation"] == "MM"
 
         pm.claims.filter(is_active=True).update(is_active=False)
         resolve_model(pm)
@@ -189,12 +196,18 @@ class TestResolveAll:
         pm_bulk = MachineModel.objects.create(name="P1", slug="p1")
         pm_single = MachineModel.objects.create(name="P2", slug="p2")
 
+        from apps.catalog.claims import build_relationship_claim
+
+        abbr_key, abbr_val = build_relationship_claim("abbreviation", {"value": "MM"})
+
         for pm in (pm_bulk, pm_single):
             Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=ipdb)
             Claim.objects.assert_claim(pm, "year", 1997, source=opdb)
             Claim.objects.assert_claim(pm, "manufacturer", "williams", source=ipdb)
             Claim.objects.assert_claim(pm, "group", "G1111", source=opdb)
-            Claim.objects.assert_claim(pm, "abbreviation", "MM", source=ipdb)
+            Claim.objects.assert_claim(
+                pm, "abbreviation", abbr_val, source=ipdb, claim_key=abbr_key
+            )
             Claim.objects.assert_claim(
                 pm, "technology_generation", "solid-state", source=ipdb
             )
@@ -237,12 +250,10 @@ class TestResolveAll:
 
         Claim.objects.assert_claim(pm, "year", 1997, source=ipdb)
         Claim.objects.assert_claim(pm, "player_count", 4, source=ipdb)
-        Claim.objects.assert_claim(pm, "abbreviation", "MM", source=ipdb)
         resolve_all()
         pm.refresh_from_db()
         assert pm.year == 1997
         assert pm.player_count == 4
-        assert pm.extra_data["abbreviation"] == "MM"
 
         pm.claims.filter(is_active=True).update(is_active=False)
         resolve_all()
@@ -260,7 +271,7 @@ class TestResolveAll:
             Claim.objects.assert_claim(pm, "name", f"Resolved {i}", source=ipdb)
             Claim.objects.assert_claim(pm, "year", 2000 + i, source=ipdb)
 
-        with django_assert_max_num_queries(50):
+        with django_assert_max_num_queries(55):
             resolve_all()
 
 

--- a/backend/apps/catalog/tests/test_resolve_bulk.py
+++ b/backend/apps/catalog/tests/test_resolve_bulk.py
@@ -34,7 +34,6 @@ class TestResolveBulkTitle:
         t2 = Title.objects.create(opdb_id="G2", name="", slug="t2")
 
         Claim.objects.assert_claim(t1, "name", "Godzilla", source=opdb)
-        Claim.objects.assert_claim(t1, "short_name", "GZ", source=opdb)
         Claim.objects.assert_claim(t2, "name", "Blackout", source=opdb)
 
         _resolve_bulk(Title, TITLE_DIRECT_FIELDS)
@@ -42,9 +41,7 @@ class TestResolveBulkTitle:
         t1.refresh_from_db()
         t2.refresh_from_db()
         assert t1.name == "Godzilla"
-        assert t1.short_name == "GZ"
         assert t2.name == "Blackout"
-        assert t2.short_name == ""
 
     def test_winner_by_priority(self, opdb, editorial):
         t = Title.objects.create(opdb_id="G1", name="", slug="t1")

--- a/backend/apps/provenance/models.py
+++ b/backend/apps/provenance/models.py
@@ -18,13 +18,19 @@ from apps.core.models import TimeStampedModel, unique_slug
 _RESERVED = frozenset("|:")
 
 
+def _escape_claim_value(s: str) -> str:
+    """Percent-escape reserved delimiters in claim key identity values."""
+    return s.replace("%", "%25").replace("|", "%7C").replace(":", "%3A")
+
+
 def make_claim_key(field_name: str, **identity_parts: object) -> str:
     """Build a canonical claim_key from field_name and sorted identity parts.
 
     For scalar claims, call with just field_name (returns field_name unchanged).
     For relationship claims, pass identity parts as keyword arguments.
 
-    Raises ValueError if any identity value contains reserved delimiters (| or :).
+    Reserved characters (``|`` and ``:``) in identity values are
+    percent-escaped so the key remains unambiguous.
     """
     if not identity_parts:
         return field_name
@@ -32,9 +38,7 @@ def make_claim_key(field_name: str, **identity_parts: object) -> str:
     for k in sorted(identity_parts):
         v = identity_parts[k]
         s = "null" if v is None else str(v)
-        if _RESERVED & set(s):
-            raise ValueError(f"Identity value {s!r} for {k!r} contains reserved chars")
-        parts.append(f"{k}:{s}")
+        parts.append(f"{k}:{_escape_claim_value(s)}")
     return "|".join(parts)
 
 

--- a/frontend/src/lib/components/SearchResults.svelte
+++ b/frontend/src/lib/components/SearchResults.svelte
@@ -52,7 +52,7 @@
 		if (!isSearching) return [];
 		return models.data.filter(
 			(m) =>
-				textMatches(normalizedQuery, m.name, m.shortname) ||
+				textMatches(normalizedQuery, m.name, ...(m.abbreviations ?? [])) ||
 				(m.search_text && normalizeText(m.search_text).includes(normalizedQuery))
 		);
 	});
@@ -69,7 +69,9 @@
 	let matchedTitles = $derived.by(() => {
 		if (!isSearching) return [];
 		return titles.data.filter(
-			(t) => textMatches(normalizedQuery, t.name, t.short_name) || rollupTitleSlugs.has(t.slug)
+			(t) =>
+				textMatches(normalizedQuery, t.name, ...(t.abbreviations ?? [])) ||
+				rollupTitleSlugs.has(t.slug)
 		);
 	});
 

--- a/frontend/src/lib/facet-engine.test.ts
+++ b/frontend/src/lib/facet-engine.test.ts
@@ -21,7 +21,7 @@ function makeTitle(overrides: Partial<FacetedTitle> = {}): FacetedTitle {
 	return {
 		name: 'Test Title',
 		slug: 'test-title',
-		short_name: 'TT',
+		abbreviations: ['TT'],
 		machine_count: 1,
 		tech_generations: [],
 		display_types: [],
@@ -37,7 +37,7 @@ function makeTitle(overrides: Partial<FacetedTitle> = {}): FacetedTitle {
 const medievalMadness = makeTitle({
 	name: 'Medieval Madness',
 	slug: 'medieval-madness',
-	short_name: 'MM',
+	abbreviations: ['MM'],
 	manufacturer_name: 'Williams',
 	manufacturer_slug: 'williams',
 	year: 1997,
@@ -56,7 +56,7 @@ const medievalMadness = makeTitle({
 const mandalorian = makeTitle({
 	name: 'The Mandalorian',
 	slug: 'the-mandalorian',
-	short_name: 'Mando',
+	abbreviations: ['Mando'],
 	manufacturer_name: 'Stern',
 	manufacturer_slug: 'stern',
 	year: 2021,
@@ -76,7 +76,7 @@ const mandalorian = makeTitle({
 const eightBall = makeTitle({
 	name: 'Eight Ball Deluxe',
 	slug: 'eight-ball-deluxe',
-	short_name: 'EBD',
+	abbreviations: ['EBD'],
 	manufacturer_name: 'Bally',
 	manufacturer_slug: 'bally',
 	year: 1981,

--- a/frontend/src/lib/facet-engine.ts
+++ b/frontend/src/lib/facet-engine.ts
@@ -17,7 +17,7 @@ export interface FacetRef {
 export interface FacetedTitle {
 	name: string;
 	slug: string;
-	short_name: string;
+	abbreviations: string[];
 	machine_count: number;
 	manufacturer_name?: string | null;
 	manufacturer_slug?: string | null;
@@ -157,7 +157,7 @@ function matchesQuery(t: FacetedTitle, q: string): boolean {
 	if (!q) return true;
 	return (
 		normalizeText(t.name).includes(q) ||
-		normalizeText(t.short_name).includes(q) ||
+		t.abbreviations.some((a) => normalizeText(a).includes(q)) ||
 		(t.manufacturer_name != null && normalizeText(t.manufacturer_name).includes(q))
 	);
 }

--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -144,6 +144,10 @@
 						{/each}
 					</dd>
 				{/if}
+				{#if model.abbreviations.length > 0}
+					<dt>Abbrs</dt>
+					<dd>{model.abbreviations.join(', ')}</dd>
+				{/if}
 				{#if model.cabinet_name}
 					<dt>Cabinet</dt>
 					<dd>{model.cabinet_name}</dd>

--- a/frontend/src/routes/titles/[slug]/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/+page.svelte
@@ -220,6 +220,10 @@
 							{/each}
 						</dd>
 					{/if}
+					{#if md.abbreviations.length > 0}
+						<dt>Abbrs</dt>
+						<dd>{md.abbreviations.join(', ')}</dd>
+					{/if}
 					{#if md.cabinet_name}
 						<dt>Cabinet</dt>
 						<dd>{md.cabinet_name}</dd>
@@ -341,6 +345,10 @@
 									<a href={resolve(`/themes/${theme.slug}`)}>{theme.name}</a>
 								{/each}
 							</dd>
+						{/if}
+						{#if title.abbreviations.length > 0}
+							<dt>Abbrs</dt>
+							<dd>{title.abbreviations.join(', ')}</dd>
 						{/if}
 						{#if specs.cabinet_name}
 							<dt>Cabinet</dt>


### PR DESCRIPTION
## Summary

- Replace `Title.short_name` CharField with `TitleAbbreviation` and `ModelAbbreviation` FK tables, each individually tracked as relationship claims (same pattern as themes, tags, credits)
- Ingest IPDB `CommonAbbreviations` (comma-separated, per model) and OPDB `shortname` (per title and model) as separate per-value abbreviation claims with full provenance
- Escape reserved characters (`|`, `:`) in claim key identity values via percent-encoding so abbreviations like `ST:TNG` work correctly
- Display abbreviations in sidebar specs (after Themes) on both model and title pages; abbreviations are searchable

## Test plan

- [x] All 432 backend tests pass
- [x] All 58 frontend tests pass
- [x] All pre-commit hooks pass (ruff, eslint, type check, tests)
- [x] Full `ingest_all` completes successfully including colon-containing abbreviations
- [ ] Verify abbreviations appear in sidebar on model detail pages (e.g. `/titles/star-trek-the-next-generation`)
- [ ] Verify search finds models by abbreviation (e.g. searching "tng")
- [ ] `make bootstrap` on fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)