### PR TITLE
Move franchise from header to sidebar

### DIFF
--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -49,9 +49,6 @@
 						}) + ' '}{/if}{model.year}</span
 				>
 			{/if}
-			{#if model.franchise}
-				<span>{model.franchise.name}</span>
-			{/if}
 		</div>
 		{#if model.variant_features.length > 0}
 			<div class="features">
@@ -133,6 +130,12 @@
 					<dt>System</dt>
 					<dd>
 						<a href={resolve(`/systems/${model.system_slug}`)}>{model.system_name}</a>
+					</dd>
+				{/if}
+				{#if model.franchise}
+					<dt>Franchise</dt>
+					<dd>
+						<a href={resolve(`/franchises/${model.franchise.slug}`)}>{model.franchise.name}</a>
 					</dd>
 				{/if}
 				{#if model.themes.length > 0}


### PR DESCRIPTION
## Summary
- Removed franchise name from the header meta area (where it appeared after month/year, redundantly repeating text already in the model name)
- Added franchise as a linked entry in the sidebar Specifications section, between System and Themes

## Test plan
- [ ] Visit a model with a franchise (e.g. Star Wars: Fall of the Empire) and confirm franchise no longer appears in the header meta
- [ ] Confirm franchise appears in the sidebar Specifications as a clickable link
- [ ] Visit a model without a franchise and confirm no "Franchise" row in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)