### PR TITLE
refactor: extract sidebar components and show year on variants

### DIFF
--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -77,6 +77,7 @@ class CreditSchema(Schema):
 class AliasSchema(Schema):
     name: str
     slug: str
+    year: Optional[int] = None
     variant_features: list[str] = []
 
 
@@ -124,6 +125,7 @@ class MachineModelDetailSchema(Schema):
     series: list[SeriesRefSchema] = []
     alias_of_name: Optional[str] = None
     alias_of_slug: Optional[str] = None
+    alias_of_year: Optional[int] = None
     variant_siblings: list[AliasSchema] = []
     title_models: list[TitleMachineSchema] = []
 
@@ -250,6 +252,7 @@ def _serialize_model_detail(pm) -> dict:
         {
             "name": alias.name,
             "slug": alias.slug,
+            "year": alias.year,
             "variant_features": _extract_variant_features(alias.extra_data or {}),
         }
         for alias in pm.aliases.all()
@@ -262,6 +265,7 @@ def _serialize_model_detail(pm) -> dict:
             {
                 "name": sib.name,
                 "slug": sib.slug,
+                "year": sib.year,
                 "variant_features": _extract_variant_features(sib.extra_data or {}),
             }
             for sib in pm.alias_of.aliases.all()
@@ -307,6 +311,7 @@ def _serialize_model_detail(pm) -> dict:
         "aliases": aliases,
         "alias_of_name": pm.alias_of.name if pm.alias_of else None,
         "alias_of_slug": pm.alias_of.slug if pm.alias_of else None,
+        "alias_of_year": pm.alias_of.year if pm.alias_of else None,
         "variant_siblings": variant_siblings,
         "title_name": pm.title.name if pm.title else None,
         "title_slug": pm.title.slug if pm.title else None,

--- a/frontend/src/lib/components/ExternalLinksSidebarSection.svelte
+++ b/frontend/src/lib/components/ExternalLinksSidebarSection.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import SidebarSection from './SidebarSection.svelte';
+
+	let {
+		ipdbId,
+		opdbId,
+		pinsideId,
+		note = 'See this on other sites:'
+	}: {
+		ipdbId?: number | null;
+		opdbId?: string | null;
+		pinsideId?: number | null;
+		note?: string;
+	} = $props();
+</script>
+
+{#if ipdbId || opdbId || pinsideId}
+	<SidebarSection heading="External Links" {note}>
+		<div class="external-ids">
+			{#if ipdbId}
+				<a href="https://www.ipdb.org/machine.cgi?id={ipdbId}"> Internet Pinball Database </a>
+			{/if}
+			{#if opdbId}
+				<a href="https://opdb.org/machines/{opdbId}">Open Pinball Database</a>
+			{/if}
+			{#if pinsideId}
+				<a href="https://pinside.com/pinball/machine/{pinsideId}">Pinside</a>
+			{/if}
+		</div>
+	</SidebarSection>
+{/if}
+
+<style>
+	.external-ids {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--size-3);
+		font-size: var(--font-size-0);
+	}
+</style>

--- a/frontend/src/lib/components/ModelHierarchy.svelte
+++ b/frontend/src/lib/components/ModelHierarchy.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import SidebarList from './SidebarList.svelte';
+	import SidebarSection from './SidebarSection.svelte';
 
 	interface Variant {
 		name: string;
@@ -38,9 +40,8 @@
 </script>
 
 {#if filteredModels.length > 0}
-	<section class="sidebar-section">
-		<h3>{heading}</h3>
-		<ul class="sidebar-list">
+	<SidebarSection {heading}>
+		<SidebarList>
 			{#each filteredModels as parent (parent.slug)}
 				<li
 					class:current={currentSlug !== undefined &&
@@ -63,43 +64,23 @@
 					</li>
 				{/each}
 			{/each}
-		</ul>
-	</section>
+		</SidebarList>
+	</SidebarSection>
 {/if}
 
 <style>
-	.sidebar-section {
-		padding-bottom: var(--size-3);
-		border-bottom: 1px solid var(--color-border-soft);
-	}
-
-	.sidebar-section h3 {
-		font-size: var(--font-size-1);
-		font-weight: 600;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-1);
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
-	.sidebar-list {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-
-	.sidebar-list li {
+	li {
 		display: flex;
 		align-items: baseline;
 		padding: var(--size-1) 0;
 		font-size: var(--font-size-0);
 	}
 
-	.sidebar-list li > a {
+	li > a {
 		flex: 1;
 	}
 
-	.sidebar-list li:not(:last-child):not(.variant-indent):not(:has(+ .variant-indent)) {
+	li:not(:last-child):not(.variant-indent):not(:has(+ .variant-indent)) {
 		border-bottom: 1px solid var(--color-border-soft);
 	}
 

--- a/frontend/src/lib/components/RatingsSidebarSection.svelte
+++ b/frontend/src/lib/components/RatingsSidebarSection.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import SidebarSection from './SidebarSection.svelte';
+
+	let {
+		ipdbRating,
+		pinsideRating
+	}: {
+		ipdbRating?: number | null;
+		pinsideRating?: number | null;
+	} = $props();
+</script>
+
+{#if ipdbRating || pinsideRating}
+	<SidebarSection heading="Ratings">
+		<div class="rating-row">
+			{#if ipdbRating}
+				<div class="rating-badge">
+					<span class="rating-value">{ipdbRating.toFixed(1)}</span>
+					<span class="rating-label">IPDB</span>
+				</div>
+			{/if}
+			{#if pinsideRating}
+				<div class="rating-badge">
+					<span class="rating-value">{pinsideRating.toFixed(1)}</span>
+					<span class="rating-label">Pinside</span>
+				</div>
+			{/if}
+		</div>
+	</SidebarSection>
+{/if}
+
+<style>
+	.rating-row {
+		display: flex;
+		gap: var(--size-3);
+	}
+
+	.rating-badge {
+		display: flex;
+		align-items: baseline;
+		gap: var(--size-1);
+	}
+
+	.rating-value {
+		font-size: var(--font-size-3);
+		font-weight: 700;
+		color: var(--color-accent);
+	}
+
+	.rating-label {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+	}
+</style>

--- a/frontend/src/lib/components/SidebarList.svelte
+++ b/frontend/src/lib/components/SidebarList.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<ul class="sidebar-list">
+	{@render children()}
+</ul>
+
+<style>
+	.sidebar-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+</style>

--- a/frontend/src/lib/components/SidebarListItem.svelte
+++ b/frontend/src/lib/components/SidebarListItem.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<li class="sidebar-list-item">
+	{@render children()}
+</li>
+
+<style>
+	.sidebar-list-item {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		padding: var(--size-1) 0;
+		font-size: var(--font-size-0);
+	}
+
+	.sidebar-list-item:not(:last-child) {
+		border-bottom: 1px solid var(--color-border-soft);
+	}
+</style>

--- a/frontend/src/lib/components/SidebarSection.svelte
+++ b/frontend/src/lib/components/SidebarSection.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { heading, note, children }: { heading: string; note?: string; children: Snippet } = $props();
+</script>
+
+<section class="sidebar-section">
+	<h3>{heading}</h3>
+	{#if note}
+		<p class="note">{note}</p>
+	{/if}
+	{@render children()}
+</section>
+
+<style>
+	.sidebar-section {
+		padding-bottom: var(--size-3);
+		border-bottom: 1px solid var(--color-border-soft);
+	}
+
+	.sidebar-section h3 {
+		font-size: var(--font-size-1);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-1);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.note {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+		margin: 0 0 var(--size-2);
+	}
+</style>

--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -3,7 +3,12 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
+	import ExternalLinksSidebarSection from '$lib/components/ExternalLinksSidebarSection.svelte';
 	import ModelHierarchy from '$lib/components/ModelHierarchy.svelte';
+	import RatingsSidebarSection from '$lib/components/RatingsSidebarSection.svelte';
+	import SidebarList from '$lib/components/SidebarList.svelte';
+	import SidebarListItem from '$lib/components/SidebarListItem.svelte';
+	import SidebarSection from '$lib/components/SidebarSection.svelte';
 	import TwoColumnLayout from '$lib/components/TwoColumnLayout.svelte';
 
 	let { data, children } = $props();
@@ -95,8 +100,7 @@
 	{/snippet}
 
 	{#snippet sidebar()}
-		<section class="sidebar-section">
-			<h3>Specifications</h3>
+		<SidebarSection heading="Specifications">
 			<dl>
 				{#if model.technology_generation_slug}
 					<dt>Generation</dt>
@@ -182,69 +186,51 @@
 					</dd>
 				{/if}
 			</dl>
-		</section>
+		</SidebarSection>
 
-		{#if model.ipdb_rating || model.pinside_rating}
-			<section class="sidebar-section">
-				<h3>Ratings</h3>
-				<div class="rating-row">
-					{#if model.ipdb_rating}
-						<div class="rating-badge">
-							<span class="rating-value">{model.ipdb_rating.toFixed(1)}</span>
-							<span class="rating-label">IPDB</span>
-						</div>
-					{/if}
-					{#if model.pinside_rating}
-						<div class="rating-badge">
-							<span class="rating-value">{model.pinside_rating.toFixed(1)}</span>
-							<span class="rating-label">Pinside</span>
-						</div>
-					{/if}
-				</div>
-			</section>
-		{/if}
+		<RatingsSidebarSection ipdbRating={model.ipdb_rating} pinsideRating={model.pinside_rating} />
 
 		{#if model.aliases.length > 0}
-			<section class="sidebar-section">
-				<h3>Variants</h3>
-				<ul class="sidebar-list">
+			<SidebarSection heading="Variants">
+				<SidebarList>
 					{#each model.aliases as alias (alias.slug)}
-						<li>
+						<SidebarListItem>
 							<a href={resolve(`/models/${alias.slug}`)}>{alias.name}</a>
-							{#if alias.variant_features.length > 0}
-								<span class="muted">{alias.variant_features.join(', ')}</span>
+							{#if alias.year}
+								<span class="muted">{alias.year}</span>
 							{/if}
-						</li>
+						</SidebarListItem>
 					{/each}
-				</ul>
-			</section>
+				</SidebarList>
+			</SidebarSection>
 		{/if}
 
 		{#if model.alias_of_slug}
-			<section class="sidebar-section">
-				<h3>Parent Game</h3>
-				<ul class="sidebar-list">
-					<li>
+			<SidebarSection heading="Parent Game">
+				<SidebarList>
+					<SidebarListItem>
 						<a href={resolve(`/models/${model.alias_of_slug}`)}>{model.alias_of_name}</a>
-					</li>
-				</ul>
-			</section>
+						{#if model.alias_of_year}
+							<span class="muted">{model.alias_of_year}</span>
+						{/if}
+					</SidebarListItem>
+				</SidebarList>
+			</SidebarSection>
 		{/if}
 
 		{#if model.variant_siblings && model.variant_siblings.length > 0}
-			<section class="sidebar-section">
-				<h3>Other Variants</h3>
-				<ul class="sidebar-list">
+			<SidebarSection heading="Other Variants">
+				<SidebarList>
 					{#each model.variant_siblings as sibling (sibling.slug)}
-						<li>
+						<SidebarListItem>
 							<a href={resolve(`/models/${sibling.slug}`)}>{sibling.name}</a>
-							{#if sibling.variant_features.length > 0}
-								<span class="muted">{sibling.variant_features.join(', ')}</span>
+							{#if sibling.year}
+								<span class="muted">{sibling.year}</span>
 							{/if}
-						</li>
+						</SidebarListItem>
 					{/each}
-				</ul>
-			</section>
+				</SidebarList>
+			</SidebarSection>
 		{/if}
 
 		<ModelHierarchy
@@ -253,25 +239,12 @@
 			excludeSlug={model.alias_of_slug ?? model.slug}
 		/>
 
-		{#if model.ipdb_id || model.opdb_id || model.pinside_id}
-			<section class="sidebar-section">
-				<h3>External Links</h3>
-				<p class="section-note">See this model on other sites:</p>
-				<div class="external-ids">
-					{#if model.ipdb_id}
-						<a href="https://www.ipdb.org/machine.cgi?id={model.ipdb_id}">
-							Internet Pinball Database
-						</a>
-					{/if}
-					{#if model.opdb_id}
-						<a href="https://opdb.org/machines/{model.opdb_id}"> Open Pinball Database </a>
-					{/if}
-					{#if model.pinside_id}
-						<a href="https://pinside.com/pinball/machine/{model.pinside_id}"> Pinside </a>
-					{/if}
-				</div>
-			</section>
-		{/if}
+		<ExternalLinksSidebarSection
+			ipdbId={model.ipdb_id}
+			opdbId={model.opdb_id}
+			pinsideId={model.pinside_id}
+			note="See this model on other sites:"
+		/>
 	{/snippet}
 </TwoColumnLayout>
 
@@ -374,98 +347,31 @@
 	}
 
 	/* Sidebar */
-	.sidebar-section {
-		padding-bottom: var(--size-3);
-		border-bottom: 1px solid var(--color-border-soft);
-	}
-
-	.sidebar-section h3 {
-		font-size: var(--font-size-1);
-		font-weight: 600;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-1);
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
-	.sidebar-section dl {
+	dl {
 		display: grid;
 		grid-template-columns: auto 1fr;
 		gap: 0 var(--size-3);
 		align-items: baseline;
 	}
 
-	.sidebar-section dt,
-	.sidebar-section dd {
+	dt,
+	dd {
 		font-size: var(--font-size-0);
 		margin: 0;
 		padding: 2px 0;
 	}
 
-	.sidebar-section dt {
+	dt {
 		color: var(--color-text-muted);
 		font-weight: 500;
 	}
 
-	.sidebar-section dd {
+	dd {
 		color: var(--color-text-primary);
-	}
-
-	.rating-row {
-		display: flex;
-		gap: var(--size-3);
-	}
-
-	.rating-badge {
-		display: flex;
-		align-items: baseline;
-		gap: var(--size-1);
-	}
-
-	.rating-value {
-		font-size: var(--font-size-3);
-		font-weight: 700;
-		color: var(--color-accent);
-	}
-
-	.rating-label {
-		font-size: var(--font-size-0);
-		color: var(--color-text-muted);
-	}
-
-	.sidebar-list {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-
-	.sidebar-list li {
-		display: flex;
-		justify-content: space-between;
-		align-items: baseline;
-		padding: var(--size-1) 0;
-		font-size: var(--font-size-0);
-	}
-
-	.sidebar-list li:not(:last-child) {
-		border-bottom: 1px solid var(--color-border-soft);
 	}
 
 	.muted {
 		color: var(--color-text-muted);
-		font-size: var(--font-size-0);
-	}
-
-	.section-note {
-		font-size: var(--font-size-0);
-		color: var(--color-text-muted);
-		margin: 0 0 var(--size-2);
-	}
-
-	.external-ids {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--size-3);
 		font-size: var(--font-size-0);
 	}
 </style>

--- a/frontend/src/routes/titles/[slug]/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/+page.svelte
@@ -4,6 +4,11 @@
 	import ModelDetailBody from '$lib/components/ModelDetailBody.svelte';
 	import ModelHierarchy from '$lib/components/ModelHierarchy.svelte';
 	import CreditsList from '$lib/components/CreditsList.svelte';
+	import ExternalLinksSidebarSection from '$lib/components/ExternalLinksSidebarSection.svelte';
+	import RatingsSidebarSection from '$lib/components/RatingsSidebarSection.svelte';
+	import SidebarList from '$lib/components/SidebarList.svelte';
+	import SidebarListItem from '$lib/components/SidebarListItem.svelte';
+	import SidebarSection from '$lib/components/SidebarSection.svelte';
 	import TwoColumnLayout from '$lib/components/TwoColumnLayout.svelte';
 	import { pageTitle } from '$lib/constants';
 	import { resolveHref } from '$lib/utils';
@@ -176,8 +181,7 @@
 	{#snippet sidebar()}
 		{#if md}
 			<!-- Single-model: full specs from model detail -->
-			<section class="sidebar-section">
-				<h3>Specifications</h3>
+			<SidebarSection heading="Specifications">
 				<dl>
 					{#if md.technology_generation_slug}
 						<dt>Generation</dt>
@@ -246,68 +250,35 @@
 						</dd>
 					{/if}
 				</dl>
-			</section>
+			</SidebarSection>
 
-			{#if md.ipdb_rating || md.pinside_rating}
-				<section class="sidebar-section">
-					<h3>Ratings</h3>
-					<div class="rating-row">
-						{#if md.ipdb_rating}
-							<div class="rating-badge">
-								<span class="rating-value">{md.ipdb_rating.toFixed(1)}</span>
-								<span class="rating-label">IPDB</span>
-							</div>
-						{/if}
-						{#if md.pinside_rating}
-							<div class="rating-badge">
-								<span class="rating-value">{md.pinside_rating.toFixed(1)}</span>
-								<span class="rating-label">Pinside</span>
-							</div>
-						{/if}
-					</div>
-				</section>
-			{/if}
+			<RatingsSidebarSection ipdbRating={md.ipdb_rating} pinsideRating={md.pinside_rating} />
 
 			{#if md.aliases.length > 0}
-				<section class="sidebar-section">
-					<h3>Variants</h3>
-					<ul class="sidebar-list">
+				<SidebarSection heading="Variants">
+					<SidebarList>
 						{#each md.aliases as alias (alias.slug)}
-							<li>
+							<SidebarListItem>
 								<a href={resolve(`/models/${alias.slug}`)}>{alias.name}</a>
-								{#if alias.variant_features.length > 0}
-									<span class="muted">{alias.variant_features.join(', ')}</span>
+								{#if alias.year}
+									<span class="muted">{alias.year}</span>
 								{/if}
-							</li>
+							</SidebarListItem>
 						{/each}
-					</ul>
-				</section>
+					</SidebarList>
+				</SidebarSection>
 			{/if}
 
-			{#if md.ipdb_id || md.opdb_id || md.pinside_id}
-				<section class="sidebar-section">
-					<h3>External Links</h3>
-					<p class="section-note">See this title on other sites:</p>
-					<div class="external-ids">
-						{#if md.ipdb_id}
-							<a href="https://www.ipdb.org/machine.cgi?id={md.ipdb_id}">
-								Internet Pinball Database
-							</a>
-						{/if}
-						{#if md.opdb_id}
-							<a href="https://opdb.org/machines/{md.opdb_id}"> Open Pinball Database </a>
-						{/if}
-						{#if md.pinside_id}
-							<a href="https://pinside.com/pinball/machine/{md.pinside_id}"> Pinside </a>
-						{/if}
-					</div>
-				</section>
-			{/if}
+			<ExternalLinksSidebarSection
+				ipdbId={md.ipdb_id}
+				opdbId={md.opdb_id}
+				pinsideId={md.pinside_id}
+				note="See this title on other sites:"
+			/>
 		{:else}
 			<!-- Multi-model: agreed specs across all models -->
 			{#if specs.technology_generation_slug || specs.display_type_slug || specs.player_count || specs.system_slug || specs.cabinet_name || specs.game_format_name || specs.display_subtype_name || specs.production_quantity || (specs.themes && specs.themes.length > 0) || title.abbreviations.length > 0}
-				<section class="sidebar-section">
-					<h3>Specifications</h3>
+				<SidebarSection heading="Specifications">
 					<dl>
 						{#if specs.technology_generation_slug}
 							<dt>Generation</dt>
@@ -369,20 +340,19 @@
 							<dd>{specs.display_subtype_name}</dd>
 						{/if}
 					</dl>
-				</section>
+				</SidebarSection>
 			{/if}
 
 			{#if title.series.length > 0}
-				<section class="sidebar-section">
-					<h3>Series</h3>
-					<ul class="sidebar-list">
+				<SidebarSection heading="Series">
+					<SidebarList>
 						{#each title.series as s (s.slug)}
-							<li>
+							<SidebarListItem>
 								<a href={resolve(`/series/${s.slug}`)}>{s.name}</a>
-							</li>
+							</SidebarListItem>
 						{/each}
-					</ul>
-				</section>
+					</SidebarList>
+				</SidebarSection>
 			{/if}
 
 			{#if title.machines.length > 0}
@@ -539,93 +509,26 @@
 	}
 
 	/* Sidebar */
-	.sidebar-section {
-		padding-bottom: var(--size-3);
-		border-bottom: 1px solid var(--color-border-soft);
-	}
-
-	.sidebar-section h3 {
-		font-size: var(--font-size-1);
-		font-weight: 600;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-1);
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
-	.sidebar-section dl {
+	dl {
 		display: grid;
 		grid-template-columns: auto 1fr;
 		gap: 0 var(--size-3);
 		align-items: baseline;
 	}
 
-	.sidebar-section dt,
-	.sidebar-section dd {
+	dt,
+	dd {
 		font-size: var(--font-size-0);
 		margin: 0;
 		padding: 2px 0;
 	}
 
-	.sidebar-section dt {
+	dt {
 		color: var(--color-text-muted);
 		font-weight: 500;
 	}
 
-	.sidebar-section dd {
+	dd {
 		color: var(--color-text-primary);
-	}
-
-	.rating-row {
-		display: flex;
-		gap: var(--size-3);
-	}
-
-	.rating-badge {
-		display: flex;
-		align-items: baseline;
-		gap: var(--size-1);
-	}
-
-	.rating-value {
-		font-size: var(--font-size-3);
-		font-weight: 700;
-		color: var(--color-accent);
-	}
-
-	.rating-label {
-		font-size: var(--font-size-0);
-		color: var(--color-text-muted);
-	}
-
-	.sidebar-list {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-
-	.sidebar-list li {
-		display: flex;
-		justify-content: space-between;
-		align-items: baseline;
-		padding: var(--size-1) 0;
-		font-size: var(--font-size-0);
-	}
-
-	.sidebar-list li:not(:last-child) {
-		border-bottom: 1px solid var(--color-border-soft);
-	}
-
-	.section-note {
-		font-size: var(--font-size-0);
-		color: var(--color-text-muted);
-		margin: 0 0 var(--size-2);
-	}
-
-	.external-ids {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--size-3);
-		font-size: var(--font-size-0);
 	}
 </style>


### PR DESCRIPTION
## Summary
- Extract 5 reusable sidebar components (`SidebarSection`, `SidebarList`, `SidebarListItem`, `RatingsSidebarSection`, `ExternalLinksSidebarSection`) from duplicated markup across title and model detail pages
- Show year instead of redundant variant features text on Variants, Other Variants, and Parent Game sidebar lists
- Add `year` to `AliasSchema` and `alias_of_year` to `MachineModelDetailSchema`

## Test plan
- [ ] Visit a title page with a single model (e.g. `/titles/star-wars-fall-of-the-empire`) — verify Specifications, Ratings, Variants, External Links sections render correctly
- [ ] Visit a title page with multiple models — verify Specifications, Series sections render correctly
- [ ] Visit a model detail page (e.g. `/models/star-wars-fall-of-the-empire-premium`) — verify all sidebar sections render correctly
- [ ] Visit a variant model page (e.g. `/models/star-wars-fall-of-the-empire-limited-edition`) — verify Parent Game shows with year, Other Variants show with year

🤖 Generated with [Claude Code](https://claude.com/claude-code)