### PR TITLE
refactor(frontend): extract HeroHeader, NeedsReviewBanner, and Tab components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@ This file provides guidance to AI programming agents when working with code in t
 `except ExcType1, ExcType2:` is **valid Python 3** and is ruff-format's preferred style.
 Do NOT add parentheses. `except (ExcType1, ExcType2):` will be reverted by ruff-format every time. Stop trying to fix it.
 
-## Svelte 5 — Non-Negotiable
+## Svelte, HTML, CSSS
+
+### You MUST use Svelte 5 — Non-Negotiable
 
 The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). Do NOT use legacy Svelte 4 patterns:
 
@@ -21,6 +23,10 @@ The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). D
 - `createEventDispatcher` → use callback props
 - `<slot>` → use `{@render children()}` snippets
 - `$$props` / `$$restProps` → use `$props()` with rest syntax
+
+### CSS — Non-Negotiable
+
+NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.
 
 ## Project Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ This file provides guidance to AI programming agents when working with code in t
 `except ExcType1, ExcType2:` is **valid Python 3** and is ruff-format's preferred style.
 Do NOT add parentheses. `except (ExcType1, ExcType2):` will be reverted by ruff-format every time. Stop trying to fix it.
 
-## Svelte 5 — Non-Negotiable
+## Svelte, HTML, CSSS
+
+### You MUST use Svelte 5 — Non-Negotiable
 
 The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). Do NOT use legacy Svelte 4 patterns:
 
@@ -21,6 +23,10 @@ The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). D
 - `createEventDispatcher` → use callback props
 - `<slot>` → use `{@render children()}` snippets
 - `$$props` / `$$restProps` → use `$props()` with rest syntax
+
+### CSS — Non-Negotiable
+
+NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.
 
 ## Project Overview
 

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -22,7 +22,9 @@ This file provides guidance to AI programming agents when working with code in t
 `except ExcType1, ExcType2:` is **valid Python 3** and is ruff-format's preferred style.
 Do NOT add parentheses. `except (ExcType1, ExcType2):` will be reverted by ruff-format every time. Stop trying to fix it.
 
-## Svelte 5 — Non-Negotiable
+## Svelte, HTML, CSSS
+
+### You MUST use Svelte 5 — Non-Negotiable
 
 The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). Do NOT use legacy Svelte 4 patterns:
 
@@ -32,6 +34,10 @@ The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). D
 - `createEventDispatcher` → use callback props
 - `<slot>` → use `{@render children()}` snippets
 - `$$props` / `$$restProps` → use `$props()` with rest syntax
+
+### CSS — Non-Negotiable
+
+NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.
 
 ## Project Overview
 

--- a/frontend/src/lib/components/HeroHeader.svelte
+++ b/frontend/src/lib/components/HeroHeader.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+	let {
+		name,
+		heroImageUrl = null,
+		heroImageAlt = '',
+		parentLink = null,
+		metaItems = []
+	}: {
+		name: string;
+		heroImageUrl?: string | null;
+		heroImageAlt?: string;
+		parentLink?: { text: string; href: string } | null;
+		metaItems?: Array<{ text: string; href?: string }>;
+	} = $props();
+</script>
+
+{#snippet content()}
+	{#if parentLink}
+		<a class="kicker" href={parentLink.href}>{parentLink.text}</a>
+	{/if}
+	<h1>{name}</h1>
+	{#if metaItems.length > 0}
+		<div class="meta">
+			{#each metaItems as item, i (i)}
+				<span>
+					{#if item.href}
+						<a href={item.href}>{item.text}</a>
+					{:else}
+						{item.text}
+					{/if}
+				</span>
+			{/each}
+		</div>
+	{/if}
+{/snippet}
+
+{#if heroImageUrl}
+	<div class="hero-banner">
+		<img class="hero-bg" src={heroImageUrl} alt={heroImageAlt} />
+		<div class="hero-scrim"></div>
+		<header class="hero-header">
+			{@render content()}
+		</header>
+	</div>
+{:else}
+	<header>
+		{@render content()}
+	</header>
+{/if}
+
+<style>
+	/* Kicker / parent link */
+	.kicker {
+		font-size: var(--font-size-1);
+		font-weight: 500;
+		color: var(--color-text-muted);
+		text-decoration: none;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.kicker:hover {
+		color: var(--color-accent);
+	}
+
+	/* Heading */
+	h1 {
+		font-size: var(--font-size-7);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-2);
+	}
+
+	/* Meta */
+	.meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--size-2);
+		font-size: var(--font-size-2);
+		color: var(--color-text-muted);
+	}
+
+	.meta span:not(:last-child)::after {
+		content: '·';
+		margin-left: var(--size-2);
+	}
+
+	/* Plain header (no image) */
+	header {
+		margin-bottom: var(--size-5);
+	}
+
+	/* Hero banner with overlaid text */
+	.hero-banner {
+		position: relative;
+		overflow: hidden;
+		border-radius: var(--radius-3);
+		min-height: 14rem;
+		max-height: 22rem;
+		margin-bottom: var(--size-5);
+		display: flex;
+		align-items: flex-end;
+		background-color: var(--color-surface);
+	}
+
+	.hero-bg {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		object-position: center 20%;
+		z-index: 0;
+	}
+
+	.hero-scrim {
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		background: linear-gradient(
+			to top,
+			rgba(0, 0, 0, 0.85) 0%,
+			rgba(0, 0, 0, 0.5) 40%,
+			rgba(0, 0, 0, 0.1) 70%,
+			transparent 100%
+		);
+		pointer-events: none;
+	}
+
+	.hero-header {
+		position: relative;
+		z-index: 2;
+		padding: var(--size-5) var(--size-5) var(--size-4);
+		width: 100%;
+		margin-bottom: 0;
+	}
+
+	/* Hero overrides — light-on-dark text */
+	.hero-header .kicker {
+		color: rgba(255, 255, 255, 0.7);
+	}
+
+	.hero-header .kicker:hover {
+		color: #ffffff;
+	}
+
+	.hero-header h1 {
+		color: #ffffff;
+		text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+	}
+
+	.hero-header .meta {
+		color: rgba(255, 255, 255, 0.85);
+	}
+
+	.hero-header .meta a {
+		color: rgba(255, 255, 255, 0.9);
+		text-decoration: underline;
+		text-decoration-color: rgba(255, 255, 255, 0.4);
+	}
+
+	.hero-header .meta a:hover {
+		color: #ffffff;
+		text-decoration-color: #ffffff;
+	}
+
+	.hero-header .meta span:not(:last-child)::after {
+		color: rgba(255, 255, 255, 0.5);
+	}
+
+	/* Responsive */
+	@media (max-width: 40rem) {
+		.hero-banner {
+			min-height: 10rem;
+			max-height: 16rem;
+			border-radius: 0;
+			margin-left: calc(-1 * var(--size-5));
+			margin-right: calc(-1 * var(--size-5));
+		}
+
+		.hero-header {
+			padding: var(--size-3) var(--size-4) var(--size-3);
+		}
+
+		.hero-header h1 {
+			font-size: var(--font-size-5);
+		}
+
+		.hero-header .meta {
+			font-size: var(--font-size-0);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/NeedsReviewBanner.svelte
+++ b/frontend/src/lib/components/NeedsReviewBanner.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import type { components } from '$lib/api/schema';
+	import { resolveHref } from '$lib/utils';
+
+	type ReviewLink = components['schemas']['ReviewLinkSchema'];
+
+	let { notes, links }: { notes: string; links: ReviewLink[] } = $props();
+</script>
+
+<aside class="review-banner">
+	<strong>Needs review</strong>
+	<p>{notes}</p>
+	{#if links.length > 0}
+		<p class="review-links">
+			{#each links as link, i (link.url)}
+				{#if i > 0}
+					·
+				{/if}
+				{#if link.url.startsWith('/')}
+					<a href={resolveHref(link.url)}>{link.label}</a>
+				{:else}
+					<a href={link.url}>{link.label}</a>
+				{/if}
+			{/each}
+		</p>
+	{/if}
+</aside>
+
+<style>
+	.review-banner {
+		background-color: color-mix(in srgb, var(--color-warning) 12%, transparent);
+		border: 1px solid var(--color-warning);
+		border-radius: var(--radius-2);
+		padding: var(--size-3) var(--size-4);
+		margin-bottom: var(--size-5);
+		font-size: var(--font-size-1);
+		color: var(--color-text-primary);
+	}
+
+	.review-banner strong {
+		color: var(--color-warning);
+	}
+
+	.review-banner p {
+		margin-top: var(--size-1);
+	}
+
+	.review-links a {
+		color: var(--color-warning);
+		text-decoration: underline;
+	}
+</style>

--- a/frontend/src/lib/components/Tab.svelte
+++ b/frontend/src/lib/components/Tab.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		active = false,
+		href,
+		onclick,
+		children
+	}: {
+		active?: boolean;
+		href?: string;
+		onclick?: () => void;
+		children: Snippet;
+	} = $props();
+</script>
+
+{#if href}
+	<a class="tab" class:active {href}>
+		{@render children()}
+	</a>
+{:else if onclick}
+	<button class="tab" class:active {onclick}>
+		{@render children()}
+	</button>
+{:else}
+	<span class="tab" class:active>
+		{@render children()}
+	</span>
+{/if}
+
+<style>
+	.tab {
+		padding: var(--size-2) var(--size-4);
+		font-size: var(--font-size-1);
+		font-weight: 500;
+		color: var(--color-text-muted);
+		text-decoration: none;
+		border: none;
+		background: none;
+		cursor: pointer;
+		border-bottom: 2px solid transparent;
+		margin-bottom: -2px;
+		transition:
+			color 0.15s,
+			border-color 0.15s;
+	}
+
+	.tab:hover {
+		color: var(--color-text-primary);
+	}
+
+	.tab.active {
+		color: var(--color-accent);
+		border-bottom-color: var(--color-accent);
+	}
+</style>

--- a/frontend/src/lib/components/TabNav.svelte
+++ b/frontend/src/lib/components/TabNav.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<nav class="tabs" aria-label="Page sections">
+	{@render children()}
+</nav>
+
+<style>
+	.tabs {
+		display: flex;
+		gap: 0;
+		border-bottom: 2px solid var(--color-border-soft);
+		margin-bottom: var(--size-6);
+	}
+</style>

--- a/frontend/src/lib/components/TwoColumnLayout.svelte
+++ b/frontend/src/lib/components/TwoColumnLayout.svelte
@@ -2,150 +2,24 @@
 	import type { Snippet } from 'svelte';
 
 	let {
-		heroImageUrl = null,
-		heroImageAlt = '',
-		header,
 		main,
 		sidebar
 	}: {
-		heroImageUrl?: string | null;
-		heroImageAlt?: string;
-		header: Snippet;
 		main: Snippet;
 		sidebar: Snippet;
 	} = $props();
 </script>
 
-<article>
-	{#if heroImageUrl}
-		<div class="hero-banner">
-			<img class="hero-bg" src={heroImageUrl} alt={heroImageAlt} />
-			<div class="hero-scrim"></div>
-			<header class="hero-header">
-				{@render header()}
-			</header>
-		</div>
-	{:else}
-		<header>
-			{@render header()}
-		</header>
-	{/if}
-
-	<div class="two-col">
-		<div class="main-col">
-			{@render main()}
-		</div>
-		<aside class="sidebar">
-			{@render sidebar()}
-		</aside>
+<div class="two-col">
+	<div class="main-col">
+		{@render main()}
 	</div>
-</article>
+	<aside class="sidebar">
+		{@render sidebar()}
+	</aside>
+</div>
 
 <style>
-	/* Hero banner with overlaid text */
-	.hero-banner {
-		position: relative;
-		overflow: hidden;
-		border-radius: var(--radius-3);
-		min-height: 14rem;
-		max-height: 22rem;
-		margin-bottom: var(--size-5);
-		display: flex;
-		align-items: flex-end;
-		background-color: var(--color-surface);
-	}
-
-	.hero-bg {
-		position: absolute;
-		inset: 0;
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		object-position: center 20%;
-		z-index: 0;
-	}
-
-	.hero-scrim {
-		position: absolute;
-		inset: 0;
-		z-index: 1;
-		background: linear-gradient(
-			to top,
-			rgba(0, 0, 0, 0.85) 0%,
-			rgba(0, 0, 0, 0.5) 40%,
-			rgba(0, 0, 0, 0.1) 70%,
-			transparent 100%
-		);
-		pointer-events: none;
-	}
-
-	.hero-header {
-		position: relative;
-		z-index: 2;
-		padding: var(--size-5) var(--size-5) var(--size-4);
-		width: 100%;
-		margin-bottom: 0;
-	}
-
-	.hero-header :global(h1) {
-		color: #ffffff;
-		text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
-	}
-
-	.hero-header :global(.meta) {
-		color: rgba(255, 255, 255, 0.85);
-	}
-
-	.hero-header :global(.meta a) {
-		color: rgba(255, 255, 255, 0.9);
-		text-decoration: underline;
-		text-decoration-color: rgba(255, 255, 255, 0.4);
-	}
-
-	.hero-header :global(.meta a:hover) {
-		color: #ffffff;
-		text-decoration-color: #ffffff;
-	}
-
-	.hero-header :global(.meta span:not(:last-child)::after) {
-		color: rgba(255, 255, 255, 0.5);
-	}
-
-	.hero-header :global(.chip) {
-		background-color: rgba(255, 255, 255, 0.15);
-		border-color: rgba(255, 255, 255, 0.25);
-		color: rgba(255, 255, 255, 0.9);
-		backdrop-filter: blur(4px);
-	}
-
-	@media (max-width: 40rem) {
-		.hero-banner {
-			min-height: 10rem;
-			max-height: 16rem;
-			border-radius: 0;
-			margin-left: calc(-1 * var(--size-5));
-			margin-right: calc(-1 * var(--size-5));
-		}
-
-		.hero-header {
-			padding: var(--size-3) var(--size-4) var(--size-3);
-		}
-
-		.hero-header :global(h1) {
-			font-size: var(--font-size-5);
-		}
-
-		.hero-header :global(.meta) {
-			font-size: var(--font-size-0);
-		}
-	}
-
-	/* Plain header (no image) */
-	header {
-		margin-bottom: var(--size-5);
-	}
-
-	/* Two-column layout */
 	.two-col {
 		display: grid;
 		grid-template-columns: 1fr;
@@ -158,7 +32,6 @@
 		}
 	}
 
-	/* Sidebar */
 	.sidebar {
 		display: flex;
 		flex-direction: column;

--- a/frontend/src/routes/manufacturers/[slug]/+layout.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+layout.svelte
@@ -3,6 +3,8 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
+	import TabNav from '$lib/components/TabNav.svelte';
+	import Tab from '$lib/components/Tab.svelte';
 
 	let { data, children } = $props();
 	let mfr = $derived(data.manufacturer);
@@ -37,20 +39,16 @@
 		{/if}
 	</header>
 
-	<nav class="tabs" aria-label="Page sections">
-		<a class="tab" class:active={isDetail} href={resolve(`/manufacturers/${slug}`)}>Titles</a>
+	<TabNav>
+		<Tab active={isDetail} href={resolve(`/manufacturers/${slug}`)}>Titles</Tab>
 		{#if mfr.systems.length > 0}
-			<a class="tab" class:active={isSystems} href={resolve(`/manufacturers/${slug}/systems`)}>
-				Systems
-			</a>
+			<Tab active={isSystems} href={resolve(`/manufacturers/${slug}/systems`)}>Systems</Tab>
 		{/if}
 		{#if auth.isAuthenticated}
-			<a class="tab" class:active={isEdit} href={resolve(`/manufacturers/${slug}/edit`)}>Edit</a>
+			<Tab active={isEdit} href={resolve(`/manufacturers/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<a class="tab" class:active={isActivity} href={resolve(`/manufacturers/${slug}/activity`)}>
-			Activity
-		</a>
-	</nav>
+		<Tab active={isActivity} href={resolve(`/manufacturers/${slug}/activity`)}>Activity</Tab>
+	</TabNav>
 
 	{@render children()}
 </article>
@@ -82,34 +80,5 @@
 		color: var(--color-text-secondary);
 		margin-top: var(--size-2);
 		line-height: var(--font-lineheight-3);
-	}
-
-	.tabs {
-		display: flex;
-		gap: 0;
-		border-bottom: 2px solid var(--color-border-soft);
-		margin-bottom: var(--size-6);
-	}
-
-	.tab {
-		padding: var(--size-2) var(--size-4);
-		font-size: var(--font-size-1);
-		font-weight: 500;
-		color: var(--color-text-muted);
-		text-decoration: none;
-		border-bottom: 2px solid transparent;
-		margin-bottom: -2px;
-		transition:
-			color 0.15s,
-			border-color 0.15s;
-	}
-
-	.tab:hover {
-		color: var(--color-text-primary);
-	}
-
-	.tab.active {
-		color: var(--color-accent);
-		border-bottom-color: var(--color-accent);
 	}
 </style>

--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -4,11 +4,14 @@
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
 	import ExternalLinksSidebarSection from '$lib/components/ExternalLinksSidebarSection.svelte';
+	import HeroHeader from '$lib/components/HeroHeader.svelte';
 	import ModelHierarchy from '$lib/components/ModelHierarchy.svelte';
 	import RatingsSidebarSection from '$lib/components/RatingsSidebarSection.svelte';
 	import SidebarList from '$lib/components/SidebarList.svelte';
 	import SidebarListItem from '$lib/components/SidebarListItem.svelte';
 	import SidebarSection from '$lib/components/SidebarSection.svelte';
+	import TabNav from '$lib/components/TabNav.svelte';
+	import Tab from '$lib/components/Tab.svelte';
 	import TwoColumnLayout from '$lib/components/TwoColumnLayout.svelte';
 
 	let { data, children } = $props();
@@ -25,280 +28,246 @@
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
 	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+
+	let parentLink = $derived(
+		model.title_slug && model.title_name
+			? { text: model.title_name, href: resolve(`/titles/${model.title_slug}`) }
+			: null
+	);
+
+	let metaItems = $derived.by(() => {
+		const items: Array<{ text: string; href?: string }> = [];
+		if (model.manufacturer_name) {
+			items.push({
+				text: model.manufacturer_name,
+				href: resolve(`/manufacturers/${model.manufacturer_slug}`)
+			});
+		}
+		if (model.year) {
+			const yearText = model.month
+				? `${new Date(model.year, model.month - 1).toLocaleString('en', { month: 'long' })} ${model.year}`
+				: `${model.year}`;
+			items.push({ text: yearText });
+		}
+		return items;
+	});
 </script>
 
 <svelte:head>
 	<title>{pageTitle(model.name)}</title>
 </svelte:head>
 
-<TwoColumnLayout heroImageUrl={model.hero_image_url} heroImageAlt="{model.name} backglass">
-	{#snippet header()}
-		{#if model.title_slug}
-			<a class="kicker" href={resolve(`/titles/${model.title_slug}`)}>
-				{model.title_name}
-			</a>
-		{/if}
-		<h1>{model.name}</h1>
-		<div class="meta">
-			{#if model.manufacturer_name}
-				<span>
-					<a href={resolve(`/manufacturers/${model.manufacturer_slug}`)}>
-						{model.manufacturer_name}
-					</a>
-				</span>
+<article>
+	<HeroHeader
+		name={model.name}
+		heroImageUrl={model.hero_image_url}
+		heroImageAlt="{model.name} backglass"
+		{parentLink}
+		{metaItems}
+	/>
+
+	<TwoColumnLayout>
+		{#snippet main()}
+			{#if model.title_description && isOnlyModelInTitle}
+				<section class="prose">
+					<h2>About</h2>
+					<p>{model.title_description}</p>
+				</section>
 			{/if}
-			{#if model.year}
-				<span
-					>{#if model.month}{new Date(model.year, model.month - 1).toLocaleString('en', {
-							month: 'long'
-						}) + ' '}{/if}{model.year}</span
+
+			{#if model.extra_data.notes}
+				<section class="prose">
+					<h2>Notes</h2>
+					<p>{model.extra_data.notes}</p>
+				</section>
+			{/if}
+
+			{#if model.extra_data.Notes}
+				<section class="prose">
+					<h2>Notes</h2>
+					<p>{model.extra_data.Notes}</p>
+				</section>
+			{/if}
+
+			<TabNav>
+				<Tab active={isDetail} href={resolve(`/models/${slug}`)}>People</Tab>
+				{#if auth.isAuthenticated}
+					<Tab active={isEdit} href={resolve(`/models/${slug}/edit`)}>Edit</Tab>
+				{/if}
+				<Tab active={isActivity} href={resolve(`/models/${slug}/activity`)}>Activity</Tab>
+			</TabNav>
+
+			{@render children()}
+		{/snippet}
+
+		{#snippet sidebar()}
+			<SidebarSection heading="Specifications">
+				<dl>
+					{#if model.technology_generation_slug}
+						<dt>Generation</dt>
+						<dd>
+							<a href={resolve(`/technology-generations/${model.technology_generation_slug}`)}
+								>{model.technology_generation_name}</a
+							>
+						</dd>
+					{/if}
+					{#if model.display_type_slug}
+						<dt>Display Type</dt>
+						<dd>
+							<a href={resolve(`/display-types/${model.display_type_slug}`)}
+								>{model.display_type_name}</a
+							>
+						</dd>
+					{/if}
+					{#if model.player_count}
+						<dt>Players</dt>
+						<dd>{model.player_count}</dd>
+					{/if}
+					{#if model.flipper_count}
+						<dt>Flippers</dt>
+						<dd>{model.flipper_count}</dd>
+					{/if}
+					{#if model.production_quantity}
+						<dt>Units Made</dt>
+						<dd>{model.production_quantity}</dd>
+					{/if}
+					{#if model.system_slug}
+						<dt>System</dt>
+						<dd>
+							<a href={resolve(`/systems/${model.system_slug}`)}>{model.system_name}</a>
+						</dd>
+					{/if}
+					{#if model.franchise}
+						<dt>Franchise</dt>
+						<dd>
+							<a href={resolve(`/franchises/${model.franchise.slug}`)}>{model.franchise.name}</a>
+						</dd>
+					{/if}
+					{#if model.themes.length > 0}
+						<dt>Themes</dt>
+						<dd>
+							{#each model.themes as theme, i (theme.slug)}
+								{#if i > 0},{/if}
+								<a href={resolve(`/themes/${theme.slug}`)}>{theme.name}</a>
+							{/each}
+						</dd>
+					{/if}
+					{#if model.abbreviations.length > 0}
+						<dt>Abbrs</dt>
+						<dd>{model.abbreviations.join(', ')}</dd>
+					{/if}
+					{#if model.cabinet_name}
+						<dt>Cabinet</dt>
+						<dd>{model.cabinet_name}</dd>
+					{/if}
+					{#if model.game_format_name}
+						<dt>Format</dt>
+						<dd>{model.game_format_name}</dd>
+					{/if}
+					{#if model.display_subtype_name}
+						<dt>Display</dt>
+						<dd>{model.display_subtype_name}</dd>
+					{/if}
+					{#if model.gameplay_features.length > 0}
+						<dt>Features</dt>
+						<dd>
+							{#each model.gameplay_features as feature, i (feature.slug)}
+								{#if i > 0},{/if}
+								{feature.name}
+							{/each}
+						</dd>
+					{/if}
+					{#if model.variant_features.length > 0}
+						<dt>Features</dt>
+						<dd>{model.variant_features.join(', ')}</dd>
+					{/if}
+					{#if model.series.length > 0}
+						<dt>Series</dt>
+						<dd>
+							{#each model.series as s, i (s.slug)}
+								{#if i > 0},{/if}
+								<a href={resolve(`/series/${s.slug}`)}>{s.name}</a>
+							{/each}
+						</dd>
+					{/if}
+				</dl>
+			</SidebarSection>
+
+			<RatingsSidebarSection ipdbRating={model.ipdb_rating} pinsideRating={model.pinside_rating} />
+
+			{#if model.title_slug}
+				<SidebarSection heading="Parent Title">
+					<SidebarList>
+						<SidebarListItem>
+							<a href={resolve(`/titles/${model.title_slug}`)}>{model.title_name}</a>
+						</SidebarListItem>
+					</SidebarList>
+				</SidebarSection>
+			{/if}
+
+			{#if model.variants.length > 0}
+				<SidebarSection
+					heading="Variants of this Model"
+					note="These play identically, differing only cosmetically:"
 				>
+					<SidebarList>
+						{#each model.variants as variant (variant.slug)}
+							<SidebarListItem>
+								<a href={resolve(`/models/${variant.slug}`)}>{variant.name}</a>
+								{#if variant.year}
+									<span class="muted">{variant.year}</span>
+								{/if}
+							</SidebarListItem>
+						{/each}
+					</SidebarList>
+				</SidebarSection>
 			{/if}
-		</div>
-		{#if model.variant_features.length > 0}
-			<div class="features">
-				{#each model.variant_features as feature (feature)}
-					<span class="chip">{feature}</span>
-				{/each}
-			</div>
-		{/if}
-	{/snippet}
 
-	{#snippet main()}
-		{#if model.title_description && isOnlyModelInTitle}
-			<section class="prose">
-				<h2>About</h2>
-				<p>{model.title_description}</p>
-			</section>
-		{/if}
-
-		{#if model.extra_data.notes}
-			<section class="prose">
-				<h2>Notes</h2>
-				<p>{model.extra_data.notes}</p>
-			</section>
-		{/if}
-
-		{#if model.extra_data.Notes}
-			<section class="prose">
-				<h2>Notes</h2>
-				<p>{model.extra_data.Notes}</p>
-			</section>
-		{/if}
-
-		<nav class="tabs" aria-label="Page sections">
-			<a class="tab" class:active={isDetail} href={resolve(`/models/${slug}`)}>People</a>
-			{#if auth.isAuthenticated}
-				<a class="tab" class:active={isEdit} href={resolve(`/models/${slug}/edit`)}>Edit</a>
-			{/if}
-			<a class="tab" class:active={isActivity} href={resolve(`/models/${slug}/activity`)}>
-				Activity
-			</a>
-		</nav>
-
-		{@render children()}
-	{/snippet}
-
-	{#snippet sidebar()}
-		<SidebarSection heading="Specifications">
-			<dl>
-				{#if model.technology_generation_slug}
-					<dt>Generation</dt>
-					<dd>
-						<a href={resolve(`/technology-generations/${model.technology_generation_slug}`)}
-							>{model.technology_generation_name}</a
-						>
-					</dd>
-				{/if}
-				{#if model.display_type_slug}
-					<dt>Display Type</dt>
-					<dd>
-						<a href={resolve(`/display-types/${model.display_type_slug}`)}
-							>{model.display_type_name}</a
-						>
-					</dd>
-				{/if}
-				{#if model.player_count}
-					<dt>Players</dt>
-					<dd>{model.player_count}</dd>
-				{/if}
-				{#if model.flipper_count}
-					<dt>Flippers</dt>
-					<dd>{model.flipper_count}</dd>
-				{/if}
-				{#if model.production_quantity}
-					<dt>Units Made</dt>
-					<dd>{model.production_quantity}</dd>
-				{/if}
-				{#if model.system_slug}
-					<dt>System</dt>
-					<dd>
-						<a href={resolve(`/systems/${model.system_slug}`)}>{model.system_name}</a>
-					</dd>
-				{/if}
-				{#if model.franchise}
-					<dt>Franchise</dt>
-					<dd>
-						<a href={resolve(`/franchises/${model.franchise.slug}`)}>{model.franchise.name}</a>
-					</dd>
-				{/if}
-				{#if model.themes.length > 0}
-					<dt>Themes</dt>
-					<dd>
-						{#each model.themes as theme, i (theme.slug)}
-							{#if i > 0},{/if}
-							<a href={resolve(`/themes/${theme.slug}`)}>{theme.name}</a>
-						{/each}
-					</dd>
-				{/if}
-				{#if model.abbreviations.length > 0}
-					<dt>Abbrs</dt>
-					<dd>{model.abbreviations.join(', ')}</dd>
-				{/if}
-				{#if model.cabinet_name}
-					<dt>Cabinet</dt>
-					<dd>{model.cabinet_name}</dd>
-				{/if}
-				{#if model.game_format_name}
-					<dt>Format</dt>
-					<dd>{model.game_format_name}</dd>
-				{/if}
-				{#if model.display_subtype_name}
-					<dt>Display</dt>
-					<dd>{model.display_subtype_name}</dd>
-				{/if}
-				{#if model.gameplay_features.length > 0}
-					<dt>Features</dt>
-					<dd>
-						{#each model.gameplay_features as feature, i (feature.slug)}
-							{#if i > 0},{/if}
-							{feature.name}
-						{/each}
-					</dd>
-				{/if}
-				{#if model.series.length > 0}
-					<dt>Series</dt>
-					<dd>
-						{#each model.series as s, i (s.slug)}
-							{#if i > 0},{/if}
-							<a href={resolve(`/series/${s.slug}`)}>{s.name}</a>
-						{/each}
-					</dd>
-				{/if}
-			</dl>
-		</SidebarSection>
-
-		<RatingsSidebarSection ipdbRating={model.ipdb_rating} pinsideRating={model.pinside_rating} />
-
-		{#if model.variants.length > 0}
-			<SidebarSection heading="Variants">
-				<SidebarList>
-					{#each model.variants as variant (variant.slug)}
+			{#if model.variant_of_slug}
+				<SidebarSection heading="Parent Game">
+					<SidebarList>
 						<SidebarListItem>
-							<a href={resolve(`/models/${variant.slug}`)}>{variant.name}</a>
-							{#if variant.year}
-								<span class="muted">{variant.year}</span>
+							<a href={resolve(`/models/${model.variant_of_slug}`)}>{model.variant_of_name}</a>
+							{#if model.variant_of_year}
+								<span class="muted">{model.variant_of_year}</span>
 							{/if}
 						</SidebarListItem>
-					{/each}
-				</SidebarList>
-			</SidebarSection>
-		{/if}
+					</SidebarList>
+				</SidebarSection>
+			{/if}
 
-		{#if model.variant_of_slug}
-			<SidebarSection heading="Parent Game">
-				<SidebarList>
-					<SidebarListItem>
-						<a href={resolve(`/models/${model.variant_of_slug}`)}>{model.variant_of_name}</a>
-						{#if model.variant_of_year}
-							<span class="muted">{model.variant_of_year}</span>
-						{/if}
-					</SidebarListItem>
-				</SidebarList>
-			</SidebarSection>
-		{/if}
+			{#if model.variant_siblings && model.variant_siblings.length > 0}
+				<SidebarSection heading="Other Variants">
+					<SidebarList>
+						{#each model.variant_siblings as sibling (sibling.slug)}
+							<SidebarListItem>
+								<a href={resolve(`/models/${sibling.slug}`)}>{sibling.name}</a>
+								{#if sibling.year}
+									<span class="muted">{sibling.year}</span>
+								{/if}
+							</SidebarListItem>
+						{/each}
+					</SidebarList>
+				</SidebarSection>
+			{/if}
 
-		{#if model.variant_siblings && model.variant_siblings.length > 0}
-			<SidebarSection heading="Other Variants">
-				<SidebarList>
-					{#each model.variant_siblings as sibling (sibling.slug)}
-						<SidebarListItem>
-							<a href={resolve(`/models/${sibling.slug}`)}>{sibling.name}</a>
-							{#if sibling.year}
-								<span class="muted">{sibling.year}</span>
-							{/if}
-						</SidebarListItem>
-					{/each}
-				</SidebarList>
-			</SidebarSection>
-		{/if}
+			<ModelHierarchy
+				models={model.title_models}
+				heading="Other Models In Title"
+				excludeSlug={model.variant_of_slug ?? model.slug}
+			/>
 
-		<ModelHierarchy
-			models={model.title_models}
-			heading="Other Models"
-			excludeSlug={model.variant_of_slug ?? model.slug}
-		/>
-
-		<ExternalLinksSidebarSection
-			ipdbId={model.ipdb_id}
-			opdbId={model.opdb_id}
-			pinsideId={model.pinside_id}
-			note="See this model on other sites:"
-		/>
-	{/snippet}
-</TwoColumnLayout>
+			<ExternalLinksSidebarSection
+				ipdbId={model.ipdb_id}
+				opdbId={model.opdb_id}
+				pinsideId={model.pinside_id}
+				note="See this model on other sites:"
+			/>
+		{/snippet}
+	</TwoColumnLayout>
+</article>
 
 <style>
-	.kicker {
-		font-size: var(--font-size-1);
-		font-weight: 500;
-		color: var(--color-text-muted);
-		text-decoration: none;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-	}
-
-	.kicker:hover {
-		color: var(--color-accent);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
-	}
-
-	.meta {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--size-2);
-		font-size: var(--font-size-2);
-		color: var(--color-text-muted);
-	}
-
-	.meta span:not(:last-child)::after {
-		content: '·';
-		margin-left: var(--size-2);
-	}
-
-	.features {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--size-2);
-		margin-top: var(--size-3);
-	}
-
-	.chip {
-		display: inline-block;
-		padding: var(--size-1) var(--size-3);
-		font-size: var(--font-size-0);
-		background-color: var(--color-surface);
-		border: 1px solid var(--color-border-soft);
-		border-radius: var(--radius-round);
-		color: var(--color-text-muted);
-	}
-
 	/* Main column */
 	.prose {
 		margin-bottom: var(--size-5);
@@ -315,35 +284,6 @@
 		font-size: var(--font-size-2);
 		color: var(--color-text-primary);
 		line-height: var(--font-lineheight-3);
-	}
-
-	.tabs {
-		display: flex;
-		gap: 0;
-		border-bottom: 2px solid var(--color-border-soft);
-		margin-bottom: var(--size-6);
-	}
-
-	.tab {
-		padding: var(--size-2) var(--size-4);
-		font-size: var(--font-size-1);
-		font-weight: 500;
-		color: var(--color-text-muted);
-		text-decoration: none;
-		border-bottom: 2px solid transparent;
-		margin-bottom: -2px;
-		transition:
-			color 0.15s,
-			border-color 0.15s;
-	}
-
-	.tab:hover {
-		color: var(--color-text-primary);
-	}
-
-	.tab.active {
-		color: var(--color-accent);
-		border-bottom-color: var(--color-accent);
 	}
 
 	/* Sidebar */

--- a/frontend/src/routes/people/[slug]/+layout.svelte
+++ b/frontend/src/routes/people/[slug]/+layout.svelte
@@ -3,6 +3,8 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
+	import TabNav from '$lib/components/TabNav.svelte';
+	import Tab from '$lib/components/Tab.svelte';
 
 	let { data, children } = $props();
 	let person = $derived(data.person);
@@ -28,15 +30,13 @@
 		<h1>{person.name}</h1>
 	</header>
 
-	<nav class="tabs" aria-label="Page sections">
-		<a class="tab" class:active={isDetail} href={resolve(`/people/${slug}`)}>Titles</a>
+	<TabNav>
+		<Tab active={isDetail} href={resolve(`/people/${slug}`)}>Titles</Tab>
 		{#if auth.isAuthenticated}
-			<a class="tab" class:active={isEdit} href={resolve(`/people/${slug}/edit`)}>Edit</a>
+			<Tab active={isEdit} href={resolve(`/people/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<a class="tab" class:active={isActivity} href={resolve(`/people/${slug}/activity`)}>
-			Activity
-		</a>
-	</nav>
+		<Tab active={isActivity} href={resolve(`/people/${slug}/activity`)}>Activity</Tab>
+	</TabNav>
 
 	{@render children()}
 </article>
@@ -55,34 +55,5 @@
 		font-weight: 700;
 		color: var(--color-text-primary);
 		margin-bottom: var(--size-2);
-	}
-
-	.tabs {
-		display: flex;
-		gap: 0;
-		border-bottom: 2px solid var(--color-border-soft);
-		margin-bottom: var(--size-6);
-	}
-
-	.tab {
-		padding: var(--size-2) var(--size-4);
-		font-size: var(--font-size-1);
-		font-weight: 500;
-		color: var(--color-text-muted);
-		text-decoration: none;
-		border-bottom: 2px solid transparent;
-		margin-bottom: -2px;
-		transition:
-			color 0.15s,
-			border-color 0.15s;
-	}
-
-	.tab:hover {
-		color: var(--color-text-primary);
-	}
-
-	.tab.active {
-		color: var(--color-accent);
-		border-bottom-color: var(--color-accent);
 	}
 </style>

--- a/frontend/src/routes/titles/[slug]/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/+page.svelte
@@ -5,13 +5,16 @@
 	import ModelHierarchy from '$lib/components/ModelHierarchy.svelte';
 	import CreditsList from '$lib/components/CreditsList.svelte';
 	import ExternalLinksSidebarSection from '$lib/components/ExternalLinksSidebarSection.svelte';
+	import HeroHeader from '$lib/components/HeroHeader.svelte';
 	import RatingsSidebarSection from '$lib/components/RatingsSidebarSection.svelte';
 	import SidebarList from '$lib/components/SidebarList.svelte';
 	import SidebarListItem from '$lib/components/SidebarListItem.svelte';
 	import SidebarSection from '$lib/components/SidebarSection.svelte';
+	import TabNav from '$lib/components/TabNav.svelte';
+	import Tab from '$lib/components/Tab.svelte';
 	import TwoColumnLayout from '$lib/components/TwoColumnLayout.svelte';
 	import { pageTitle } from '$lib/constants';
-	import { resolveHref } from '$lib/utils';
+	import NeedsReviewBanner from '$lib/components/NeedsReviewBanner.svelte';
 	import { auth } from '$lib/auth.svelte';
 
 	let { data } = $props();
@@ -24,6 +27,27 @@
 	$effect(() => {
 		if (md) auth.load();
 	});
+
+	let metaItems = $derived.by(() => {
+		if (!md) return [];
+		const items: Array<{ text: string; href?: string }> = [];
+		if (md.manufacturer_name) {
+			items.push({
+				text: md.manufacturer_name,
+				href: resolve(`/manufacturers/${md.manufacturer_slug}`)
+			});
+		}
+		if (md.year) {
+			const yearText = md.month
+				? `${new Date(md.year, md.month - 1).toLocaleString('en', { month: 'long' })} ${md.year}`
+				: `${md.year}`;
+			items.push({ text: yearText });
+		}
+		if (md.franchise) {
+			items.push({ text: md.franchise.name });
+		}
+		return items;
+	});
 </script>
 
 <svelte:head>
@@ -31,404 +55,291 @@
 </svelte:head>
 
 {#if title.needs_review}
-	<aside class="review-banner">
-		<strong>Needs review</strong>
-		<p>{title.needs_review_notes}</p>
-		{#if title.review_links.length > 0}
-			<p class="review-links">
-				{#each title.review_links as link, i (link.url)}
-					{#if i > 0}
-						·
-					{/if}
-					{#if link.url.startsWith('/')}
-						<a href={resolveHref(link.url)}>{link.label}</a>
-					{:else}
-						<a href={link.url}>{link.label}</a>
-					{/if}
-				{/each}
-			</p>
-		{/if}
-	</aside>
+	<NeedsReviewBanner notes={title.needs_review_notes} links={title.review_links} />
 {/if}
 
-<TwoColumnLayout
-	heroImageUrl={md ? md.hero_image_url : title.hero_image_url}
-	heroImageAlt="{title.name} backglass"
->
-	{#snippet header()}
-		<h1>{title.name}</h1>
-		{#if md}
-			<div class="meta">
-				{#if md.manufacturer_name}
-					<span>
-						<a href={resolve(`/manufacturers/${md.manufacturer_slug}`)}>
-							{md.manufacturer_name}
-						</a>
-					</span>
-				{/if}
-				{#if md.year}
-					<span
-						>{#if md.month}{new Date(md.year, md.month - 1).toLocaleString('en', {
-								month: 'long'
-							}) + ' '}{/if}{md.year}</span
-					>
-				{/if}
-				{#if md.franchise}
-					<span>{md.franchise.name}</span>
-				{/if}
-			</div>
-			{#if md.variant_features.length > 0}
-				<div class="features">
-					{#each md.variant_features as feature (feature)}
-						<span class="chip">{feature}</span>
-					{/each}
-				</div>
-			{/if}
-		{/if}
-		{#if title.series.length > 0}
-			<p class="series-list">
-				Series:
-				{#each title.series as s, i (s.slug)}
-					{#if i > 0},{/if}
-					<a href={resolve(`/series/${s.slug}`)}>{s.name}</a>
-				{/each}
-			</p>
-		{/if}
-	{/snippet}
+<article>
+	<HeroHeader
+		name={title.name}
+		heroImageUrl={md ? md.hero_image_url : title.hero_image_url}
+		heroImageAlt="{title.name} backglass"
+		{metaItems}
+	/>
 
-	{#snippet main()}
-		{#if title.description}
-			<section class="prose">
-				<h2>About</h2>
-				<p>{title.description}</p>
-			</section>
-		{/if}
-
-		{#if md}
-			{#if md.extra_data.notes}
+	<TwoColumnLayout>
+		{#snippet main()}
+			{#if title.description}
 				<section class="prose">
-					<h2>Notes</h2>
-					<p>{md.extra_data.notes}</p>
+					<h2>About</h2>
+					<p>{title.description}</p>
 				</section>
 			{/if}
 
-			{#if md.extra_data.Notes}
-				<section class="prose">
-					<h2>Notes</h2>
-					<p>{md.extra_data.Notes}</p>
-				</section>
-			{/if}
-
-			<nav class="tabs" aria-label="Page sections">
-				<span class="tab active">People</span>
-				{#if auth.isAuthenticated}
-					<a class="tab" href={resolve(`/models/${md.slug}/edit`)}>Edit</a>
+			{#if md}
+				{#if md.extra_data.notes}
+					<section class="prose">
+						<h2>Notes</h2>
+						<p>{md.extra_data.notes}</p>
+					</section>
 				{/if}
-				<a class="tab" href={resolve(`/models/${md.slug}/activity`)}>Activity</a>
-			</nav>
 
-			<ModelDetailBody model={md} />
-		{:else}
-			<nav class="tabs" aria-label="Page sections">
-				<button
-					class="tab"
-					class:active={activeTab === 'machines'}
-					onclick={() => (activeTab = 'machines')}
-				>
-					Models ({title.machines.length +
-						title.machines.reduce((n, m) => n + (m.variants?.length ?? 0), 0)})
-				</button>
-				<button
-					class="tab"
-					class:active={activeTab === 'people'}
-					onclick={() => (activeTab = 'people')}
-				>
-					People
-				</button>
-			</nav>
-
-			{#if activeTab === 'machines'}
-				{#if title.machines.length === 0}
-					<p class="empty">No models in this title.</p>
-				{:else}
-					{#each title.machines as machine (machine.slug)}
-						<div class="model-group">
-							<MachineCard
-								slug={machine.slug}
-								name={machine.name}
-								thumbnailUrl={machine.thumbnail_url}
-								manufacturerName={machine.manufacturer_name}
-								year={machine.year}
-							/>
-							{#if machine.variants.length > 0}
-								<ul class="variant-list">
-									{#each machine.variants as variant (variant.slug)}
-										<li>
-											<a href={resolve(`/models/${variant.slug}`)}>{variant.name}</a>
-										</li>
-									{/each}
-								</ul>
-							{/if}
-						</div>
-					{/each}
+				{#if md.extra_data.Notes}
+					<section class="prose">
+						<h2>Notes</h2>
+						<p>{md.extra_data.Notes}</p>
+					</section>
 				{/if}
-			{:else if activeTab === 'people'}
-				<CreditsList credits={title.credits} />
-			{/if}
-		{/if}
-	{/snippet}
 
-	{#snippet sidebar()}
-		{#if md}
-			<!-- Single-model: full specs from model detail -->
-			<SidebarSection heading="Specifications">
-				<dl>
-					{#if md.technology_generation_slug}
-						<dt>Generation</dt>
-						<dd>
-							<a href={resolve(`/technology-generations/${md.technology_generation_slug}`)}
-								>{md.technology_generation_name}</a
-							>
-						</dd>
+				<TabNav>
+					<Tab active>People</Tab>
+					{#if auth.isAuthenticated}
+						<Tab href={resolve(`/models/${md.slug}/edit`)}>Edit</Tab>
 					{/if}
-					{#if md.display_type_slug}
-						<dt>Display Type</dt>
-						<dd>
-							<a href={resolve(`/display-types/${md.display_type_slug}`)}>{md.display_type_name}</a>
-						</dd>
-					{/if}
-					{#if md.player_count}
-						<dt>Players</dt>
-						<dd>{md.player_count}</dd>
-					{/if}
-					{#if md.flipper_count}
-						<dt>Flippers</dt>
-						<dd>{md.flipper_count}</dd>
-					{/if}
-					{#if md.production_quantity}
-						<dt>Units Made</dt>
-						<dd>{md.production_quantity}</dd>
-					{/if}
-					{#if md.system_slug}
-						<dt>System</dt>
-						<dd>
-							<a href={resolve(`/systems/${md.system_slug}`)}>{md.system_name}</a>
-						</dd>
-					{/if}
-					{#if md.themes.length > 0}
-						<dt>Themes</dt>
-						<dd>
-							{#each md.themes as theme, i (theme.slug)}
-								{#if i > 0},{/if}
-								<a href={resolve(`/themes/${theme.slug}`)}>{theme.name}</a>
-							{/each}
-						</dd>
-					{/if}
-					{#if md.abbreviations.length > 0}
-						<dt>Abbrs</dt>
-						<dd>{md.abbreviations.join(', ')}</dd>
-					{/if}
-					{#if md.cabinet_name}
-						<dt>Cabinet</dt>
-						<dd>{md.cabinet_name}</dd>
-					{/if}
-					{#if md.game_format_name}
-						<dt>Format</dt>
-						<dd>{md.game_format_name}</dd>
-					{/if}
-					{#if md.display_subtype_name}
-						<dt>Display</dt>
-						<dd>{md.display_subtype_name}</dd>
-					{/if}
-					{#if md.gameplay_features.length > 0}
-						<dt>Features</dt>
-						<dd>
-							{#each md.gameplay_features as feature, i (feature.slug)}
-								{#if i > 0},{/if}
-								{feature.name}
-							{/each}
-						</dd>
-					{/if}
-				</dl>
-			</SidebarSection>
+					<Tab href={resolve(`/models/${md.slug}/activity`)}>Activity</Tab>
+				</TabNav>
 
-			<RatingsSidebarSection ipdbRating={md.ipdb_rating} pinsideRating={md.pinside_rating} />
+				<ModelDetailBody model={md} />
+			{:else}
+				<TabNav>
+					<Tab active={activeTab === 'machines'} onclick={() => (activeTab = 'machines')}>
+						Models ({title.machines.length +
+							title.machines.reduce((n, m) => n + (m.variants?.length ?? 0), 0)})
+					</Tab>
+					<Tab active={activeTab === 'people'} onclick={() => (activeTab = 'people')}>People</Tab>
+				</TabNav>
 
-			{#if md.variants.length > 0}
-				<SidebarSection heading="Variants">
-					<SidebarList>
-						{#each md.variants as variant (variant.slug)}
-							<SidebarListItem>
-								<a href={resolve(`/models/${variant.slug}`)}>{variant.name}</a>
-								{#if variant.year}
-									<span class="muted">{variant.year}</span>
+				{#if activeTab === 'machines'}
+					{#if title.machines.length === 0}
+						<p class="empty">No models in this title.</p>
+					{:else}
+						{#each title.machines as machine (machine.slug)}
+							<div class="model-group">
+								<MachineCard
+									slug={machine.slug}
+									name={machine.name}
+									thumbnailUrl={machine.thumbnail_url}
+									manufacturerName={machine.manufacturer_name}
+									year={machine.year}
+								/>
+								{#if machine.variants.length > 0}
+									<ul class="variant-list">
+										{#each machine.variants as variant (variant.slug)}
+											<li>
+												<a href={resolve(`/models/${variant.slug}`)}>{variant.name}</a>
+											</li>
+										{/each}
+									</ul>
 								{/if}
-							</SidebarListItem>
+							</div>
 						{/each}
-					</SidebarList>
-				</SidebarSection>
+					{/if}
+				{:else if activeTab === 'people'}
+					<CreditsList credits={title.credits} />
+				{/if}
 			{/if}
+		{/snippet}
 
-			<ExternalLinksSidebarSection
-				ipdbId={md.ipdb_id}
-				opdbId={md.opdb_id}
-				pinsideId={md.pinside_id}
-				note="See this title on other sites:"
-			/>
-		{:else}
-			<!-- Multi-model: agreed specs across all models -->
-			{#if specs.technology_generation_slug || specs.display_type_slug || specs.player_count || specs.system_slug || specs.cabinet_name || specs.game_format_name || specs.display_subtype_name || specs.production_quantity || (specs.themes && specs.themes.length > 0) || title.abbreviations.length > 0}
+		{#snippet sidebar()}
+			{#if md}
+				<!-- Single-model: full specs from model detail -->
 				<SidebarSection heading="Specifications">
 					<dl>
-						{#if specs.technology_generation_slug}
+						{#if md.technology_generation_slug}
 							<dt>Generation</dt>
 							<dd>
-								<a href={resolve(`/technology-generations/${specs.technology_generation_slug}`)}
-									>{specs.technology_generation_name}</a
+								<a href={resolve(`/technology-generations/${md.technology_generation_slug}`)}
+									>{md.technology_generation_name}</a
 								>
 							</dd>
 						{/if}
-						{#if specs.display_type_slug}
+						{#if md.display_type_slug}
 							<dt>Display Type</dt>
 							<dd>
-								<a href={resolve(`/display-types/${specs.display_type_slug}`)}
-									>{specs.display_type_name}</a
+								<a href={resolve(`/display-types/${md.display_type_slug}`)}
+									>{md.display_type_name}</a
 								>
 							</dd>
 						{/if}
-						{#if specs.player_count}
+						{#if md.player_count}
 							<dt>Players</dt>
-							<dd>{specs.player_count}</dd>
+							<dd>{md.player_count}</dd>
 						{/if}
-						{#if specs.flipper_count}
+						{#if md.flipper_count}
 							<dt>Flippers</dt>
-							<dd>{specs.flipper_count}</dd>
+							<dd>{md.flipper_count}</dd>
 						{/if}
-						{#if specs.production_quantity}
+						{#if md.production_quantity}
 							<dt>Units Made</dt>
-							<dd>{specs.production_quantity}</dd>
+							<dd>{md.production_quantity}</dd>
 						{/if}
-						{#if specs.system_slug}
+						{#if md.system_slug}
 							<dt>System</dt>
 							<dd>
-								<a href={resolve(`/systems/${specs.system_slug}`)}>{specs.system_name}</a>
+								<a href={resolve(`/systems/${md.system_slug}`)}>{md.system_name}</a>
 							</dd>
 						{/if}
-						{#if specs.themes && specs.themes.length > 0}
+						{#if md.themes.length > 0}
 							<dt>Themes</dt>
 							<dd>
-								{#each specs.themes as theme, i (theme.slug)}
+								{#each md.themes as theme, i (theme.slug)}
 									{#if i > 0},{/if}
 									<a href={resolve(`/themes/${theme.slug}`)}>{theme.name}</a>
 								{/each}
 							</dd>
 						{/if}
-						{#if title.abbreviations.length > 0}
+						{#if md.abbreviations.length > 0}
 							<dt>Abbrs</dt>
-							<dd>{title.abbreviations.join(', ')}</dd>
+							<dd>{md.abbreviations.join(', ')}</dd>
 						{/if}
-						{#if specs.cabinet_name}
+						{#if md.cabinet_name}
 							<dt>Cabinet</dt>
-							<dd>{specs.cabinet_name}</dd>
+							<dd>{md.cabinet_name}</dd>
 						{/if}
-						{#if specs.game_format_name}
+						{#if md.game_format_name}
 							<dt>Format</dt>
-							<dd>{specs.game_format_name}</dd>
+							<dd>{md.game_format_name}</dd>
 						{/if}
-						{#if specs.display_subtype_name}
+						{#if md.display_subtype_name}
 							<dt>Display</dt>
-							<dd>{specs.display_subtype_name}</dd>
+							<dd>{md.display_subtype_name}</dd>
+						{/if}
+						{#if md.gameplay_features.length > 0}
+							<dt>Features</dt>
+							<dd>
+								{#each md.gameplay_features as feature, i (feature.slug)}
+									{#if i > 0},{/if}
+									{feature.name}
+								{/each}
+							</dd>
+						{/if}
+						{#if md.variant_features.length > 0}
+							<dt>Variant</dt>
+							<dd>{md.variant_features.join(', ')}</dd>
+						{/if}
+						{#if md.series.length > 0}
+							<dt>Series</dt>
+							<dd>
+								{#each md.series as s, i (s.slug)}
+									{#if i > 0},{/if}
+									<a href={resolve(`/series/${s.slug}`)}>{s.name}</a>
+								{/each}
+							</dd>
 						{/if}
 					</dl>
 				</SidebarSection>
-			{/if}
 
-			{#if title.series.length > 0}
-				<SidebarSection heading="Series">
-					<SidebarList>
-						{#each title.series as s (s.slug)}
-							<SidebarListItem>
-								<a href={resolve(`/series/${s.slug}`)}>{s.name}</a>
-							</SidebarListItem>
-						{/each}
-					</SidebarList>
-				</SidebarSection>
-			{/if}
+				<RatingsSidebarSection ipdbRating={md.ipdb_rating} pinsideRating={md.pinside_rating} />
 
-			{#if title.machines.length > 0}
-				<ModelHierarchy models={title.machines} />
+				{#if md.variants.length > 0}
+					<SidebarSection heading="Variants">
+						<SidebarList>
+							{#each md.variants as variant (variant.slug)}
+								<SidebarListItem>
+									<a href={resolve(`/models/${variant.slug}`)}>{variant.name}</a>
+									{#if variant.year}
+										<span class="muted">{variant.year}</span>
+									{/if}
+								</SidebarListItem>
+							{/each}
+						</SidebarList>
+					</SidebarSection>
+				{/if}
+
+				<ExternalLinksSidebarSection
+					ipdbId={md.ipdb_id}
+					opdbId={md.opdb_id}
+					pinsideId={md.pinside_id}
+					note="See this title on other sites:"
+				/>
+			{:else}
+				<!-- Multi-model: agreed specs across all models -->
+				{#if specs.technology_generation_slug || specs.display_type_slug || specs.player_count || specs.system_slug || specs.cabinet_name || specs.game_format_name || specs.display_subtype_name || specs.production_quantity || (specs.themes && specs.themes.length > 0) || title.abbreviations.length > 0}
+					<SidebarSection heading="Specifications">
+						<dl>
+							{#if specs.technology_generation_slug}
+								<dt>Generation</dt>
+								<dd>
+									<a href={resolve(`/technology-generations/${specs.technology_generation_slug}`)}
+										>{specs.technology_generation_name}</a
+									>
+								</dd>
+							{/if}
+							{#if specs.display_type_slug}
+								<dt>Display Type</dt>
+								<dd>
+									<a href={resolve(`/display-types/${specs.display_type_slug}`)}
+										>{specs.display_type_name}</a
+									>
+								</dd>
+							{/if}
+							{#if specs.player_count}
+								<dt>Players</dt>
+								<dd>{specs.player_count}</dd>
+							{/if}
+							{#if specs.flipper_count}
+								<dt>Flippers</dt>
+								<dd>{specs.flipper_count}</dd>
+							{/if}
+							{#if specs.production_quantity}
+								<dt>Units Made</dt>
+								<dd>{specs.production_quantity}</dd>
+							{/if}
+							{#if specs.system_slug}
+								<dt>System</dt>
+								<dd>
+									<a href={resolve(`/systems/${specs.system_slug}`)}>{specs.system_name}</a>
+								</dd>
+							{/if}
+							{#if specs.themes && specs.themes.length > 0}
+								<dt>Themes</dt>
+								<dd>
+									{#each specs.themes as theme, i (theme.slug)}
+										{#if i > 0},{/if}
+										<a href={resolve(`/themes/${theme.slug}`)}>{theme.name}</a>
+									{/each}
+								</dd>
+							{/if}
+							{#if title.abbreviations.length > 0}
+								<dt>Abbrs</dt>
+								<dd>{title.abbreviations.join(', ')}</dd>
+							{/if}
+							{#if specs.cabinet_name}
+								<dt>Cabinet</dt>
+								<dd>{specs.cabinet_name}</dd>
+							{/if}
+							{#if specs.game_format_name}
+								<dt>Format</dt>
+								<dd>{specs.game_format_name}</dd>
+							{/if}
+							{#if specs.display_subtype_name}
+								<dt>Display</dt>
+								<dd>{specs.display_subtype_name}</dd>
+							{/if}
+						</dl>
+					</SidebarSection>
+				{/if}
+
+				{#if title.series.length > 0}
+					<SidebarSection heading="Series">
+						<SidebarList>
+							{#each title.series as s (s.slug)}
+								<SidebarListItem>
+									<a href={resolve(`/series/${s.slug}`)}>{s.name}</a>
+								</SidebarListItem>
+							{/each}
+						</SidebarList>
+					</SidebarSection>
+				{/if}
+
+				{#if title.machines.length > 0}
+					<ModelHierarchy models={title.machines} />
+				{/if}
 			{/if}
-		{/if}
-	{/snippet}
-</TwoColumnLayout>
+		{/snippet}
+	</TwoColumnLayout>
+</article>
 
 <style>
-	.review-banner {
-		background-color: color-mix(in srgb, var(--color-warning) 12%, transparent);
-		border: 1px solid var(--color-warning);
-		border-radius: var(--radius-2);
-		padding: var(--size-3) var(--size-4);
-		margin-bottom: var(--size-5);
-		font-size: var(--font-size-1);
-		color: var(--color-text-primary);
-	}
-
-	.review-banner strong {
-		color: var(--color-warning);
-	}
-
-	.review-banner p {
-		margin-top: var(--size-1);
-	}
-
-	.review-links a {
-		color: var(--color-warning);
-		text-decoration: underline;
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
-	}
-
-	.series-list {
-		font-size: var(--font-size-1);
-		color: var(--color-text-muted);
-		margin-top: var(--size-1);
-	}
-
-	.meta {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--size-2);
-		font-size: var(--font-size-2);
-		color: var(--color-text-muted);
-	}
-
-	.meta span:not(:last-child)::after {
-		content: '·';
-		margin-left: var(--size-2);
-	}
-
-	.features {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--size-2);
-		margin-top: var(--size-3);
-	}
-
-	.chip {
-		display: inline-block;
-		padding: var(--size-1) var(--size-3);
-		font-size: var(--font-size-0);
-		background-color: var(--color-surface);
-		border: 1px solid var(--color-border-soft);
-		border-radius: var(--radius-round);
-		color: var(--color-text-muted);
-	}
-
 	/* Main column */
 	.prose {
 		margin-bottom: var(--size-5);
@@ -445,38 +356,6 @@
 		font-size: var(--font-size-2);
 		color: var(--color-text-primary);
 		line-height: var(--font-lineheight-3);
-	}
-
-	.tabs {
-		display: flex;
-		gap: 0;
-		border-bottom: 2px solid var(--color-border-soft);
-		margin-bottom: var(--size-6);
-	}
-
-	.tab {
-		padding: var(--size-2) var(--size-4);
-		font-size: var(--font-size-1);
-		font-weight: 500;
-		color: var(--color-text-muted);
-		text-decoration: none;
-		border: none;
-		background: none;
-		cursor: pointer;
-		border-bottom: 2px solid transparent;
-		margin-bottom: -2px;
-		transition:
-			color 0.15s,
-			border-color 0.15s;
-	}
-
-	.tab:hover {
-		color: var(--color-text-primary);
-	}
-
-	.tab.active {
-		color: var(--color-accent);
-		border-bottom-color: var(--color-accent);
 	}
 
 	.empty {


### PR DESCRIPTION
## Summary

Extract hero banner, header metadata, needs-review banner, and tab navigation out of `TwoColumnLayout` and individual route layouts into dedicated reusable components (`HeroHeader`, `NeedsReviewBanner`, `Tab`, `TabNav`). `TwoColumnLayout` now only handles the two-column grid.

- New `HeroHeader` component handles the hero image banner, title, subtitle, and metadata
- New `NeedsReviewBanner` component handles the review status indicator
- New `Tab` and `TabNav` components handle tabbed navigation
- Route layouts (models, manufacturers, people, titles) simplified to compose these components

## Test plan

- [ ] Verify model detail pages render hero header, tabs, and content correctly
- [ ] Verify manufacturer detail pages render correctly
- [ ] Verify people detail pages render correctly
- [ ] Verify title detail pages render correctly
- [ ] Verify needs-review banner appears for items needing review
- [ ] Verify tab navigation works across all detail page types

🤖 Generated with [Claude Code](https://claude.com/claude-code)