### PR TITLE
feat: migrate variant_of to claims-based provenance

### DIFF
--- a/backend/apps/catalog/admin.py
+++ b/backend/apps/catalog/admin.py
@@ -378,6 +378,8 @@ class MachineModelAdmin(ProvenanceSaveMixin, admin.ModelAdmin):
     CLAIM_FIELDS = frozenset(DIRECT_FIELDS) | {
         "manufacturer",
         "title",
+        "variant_of",
+        "converted_from",
         "system",
         "technology_generation",
         "display_type",
@@ -402,6 +404,10 @@ class MachineModelAdmin(ProvenanceSaveMixin, admin.ModelAdmin):
         if field_name == "cabinet" and value is not None:
             return value.slug
         if field_name == "game_format" and value is not None:
+            return value.slug
+        if field_name == "variant_of" and value is not None:
+            return value.slug
+        if field_name == "converted_from" and value is not None:
             return value.slug
         return super()._to_claim_value(field_name, value)
 

--- a/backend/apps/catalog/management/commands/ingest_pinbase_models.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_models.py
@@ -2,8 +2,7 @@
 
 Creates MachineModel records that don't yet exist (with opdb_id, ipdb_id,
 name, slug), then asserts editorial claims with the pinbase source
-(priority 300) which outranks OPDB.  Also sets variant_of FK relationships
-based on slug references.
+(priority 300) which outranks OPDB.
 """
 
 from __future__ import annotations
@@ -30,6 +29,7 @@ CLAIM_FIELDS = {
     "description": "description",
     "is_conversion": "is_conversion",
     "converted_from": "converted_from",
+    "variant_of": "variant_of",
 }
 
 
@@ -110,7 +110,7 @@ class Command(BaseCommand):
                 for mm in MachineModel.objects.filter(opdb_id__isnull=False)
             }
 
-        # Pass 2: assert claims and set variant relationships.
+        # Pass 2: assert claims.
         pending_claims: list[Claim] = []
         matched = 0
         skipped = 0
@@ -157,68 +157,5 @@ class Command(BaseCommand):
             f"{claim_stats['superseded']} superseded, "
             f"{claim_stats['duplicates_removed']} duplicates removed"
         )
-
-        # --- variant_of: set variant_of FK based on slug references ---
-        # Build slug→MachineModel lookup from entries that have both slug and opdb_id.
-        slug_to_mm: dict[str, MachineModel] = {}
-        for entry in entries:
-            slug = entry.get("slug")
-            opdb_id = entry.get("opdb_id")
-            if slug and opdb_id:
-                mm = by_opdb_id.get(opdb_id)
-                if mm:
-                    slug_to_mm[slug] = mm
-
-        # Collect parent slugs — entries that are referenced as variant_of targets.
-        parent_slugs: set[str] = {
-            entry["variant_of"] for entry in entries if entry.get("variant_of")
-        }
-
-        variant_updated: list[MachineModel] = []
-        variant_set = 0
-
-        # First pass: clear variant_of on parent models (fixes circular references
-        # when models.json overrides an ingest_opdb heuristic).
-        for slug in parent_slugs:
-            parent = slug_to_mm.get(slug)
-            if parent and parent.variant_of_id is not None:
-                parent.variant_of = None
-                variant_updated.append(parent)
-
-        # Second pass: set variant_of on variant models.
-        for entry in entries:
-            variant_of_slug = entry.get("variant_of")
-            if not variant_of_slug:
-                continue
-
-            opdb_id = entry.get("opdb_id")
-            if not opdb_id:
-                continue
-
-            mm = by_opdb_id.get(opdb_id)
-            parent = slug_to_mm.get(variant_of_slug)
-            if not mm or not parent:
-                if not parent:
-                    logger.warning(
-                        "variant_of slug %r not found for %s",
-                        variant_of_slug,
-                        entry.get("name", opdb_id),
-                    )
-                continue
-
-            if mm.variant_of_id != parent.pk:
-                mm.variant_of = parent
-                if mm not in variant_updated:
-                    variant_updated.append(mm)
-            variant_set += 1
-
-        if variant_updated:
-            MachineModel.objects.bulk_update(variant_updated, ["variant_of_id"])
-
-        if variant_set:
-            self.stdout.write(
-                f"  Variants: {variant_set} relationships, "
-                f"{len(variant_updated)} updated"
-            )
 
         self.stdout.write(self.style.SUCCESS("Models seed ingestion complete."))

--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -121,6 +121,7 @@ def resolve_model(machine_model: MachineModel) -> MachineModel:
     # This ensures deactivated claims don't leave stale values.
     machine_model.manufacturer = None
     machine_model.title = None
+    machine_model.variant_of = None
     machine_model.converted_from = None
     machine_model.system = None
     machine_model.technology_generation = None
@@ -143,6 +144,7 @@ def resolve_model(machine_model: MachineModel) -> MachineModel:
     display_subtype_lookup = _build_display_subtype_lookup()
     cabinet_lookup = _build_cabinet_lookup()
     game_format_lookup = _build_game_format_lookup()
+    self_lookup = _build_converted_from_lookup()  # {slug: MachineModel} for self-FKs
 
     # Apply winners to the model.
     for claim_key, claim in winners.items():
@@ -174,9 +176,13 @@ def resolve_model(machine_model: MachineModel) -> MachineModel:
             machine_model.game_format = _resolve_slug_fk(
                 claim.value, game_format_lookup, "game_format"
             )
+        elif claim.field_name == "variant_of":
+            machine_model.variant_of = _resolve_slug_fk(
+                claim.value, self_lookup, "variant_of"
+            )
         elif claim.field_name == "converted_from":
             machine_model.converted_from = _resolve_slug_fk(
-                claim.value, _build_converted_from_lookup(), "converted_from"
+                claim.value, self_lookup, "converted_from"
             )
         elif claim.field_name in DIRECT_FIELDS:
             attr = DIRECT_FIELDS[claim.field_name]
@@ -278,6 +284,7 @@ def resolve_all() -> int:
             cabinet_lookup,
             game_format_lookup,
             converted_from_lookup,
+            variant_of_lookup=converted_from_lookup,
         )
 
     # 5. Conversions are not variants: clear variant_of on conversion models.
@@ -381,11 +388,13 @@ def _apply_resolution(
     cabinet_lookup: dict[str, Cabinet] | None = None,
     game_format_lookup: dict[str, GameFormat] | None = None,
     converted_from_lookup: dict[str, MachineModel] | None = None,
+    variant_of_lookup: dict[str, MachineModel] | None = None,
 ) -> None:
     """Apply claim winners to a MachineModel instance in memory."""
     # Reset FK fields.
     pm.manufacturer = None
     pm.title = None
+    pm.variant_of = None
     pm.converted_from = None
     pm.system = None
     pm.technology_generation = None
@@ -436,6 +445,11 @@ def _apply_resolution(
             if game_format_lookup is not None:
                 pm.game_format = _resolve_slug_fk(
                     claim.value, game_format_lookup, "game_format"
+                )
+        elif claim.field_name == "variant_of":
+            if variant_of_lookup is not None:
+                pm.variant_of = _resolve_slug_fk(
+                    claim.value, variant_of_lookup, "variant_of"
                 )
         elif claim.field_name == "converted_from":
             if converted_from_lookup is not None:

--- a/backend/apps/catalog/tests/test_admin.py
+++ b/backend/apps/catalog/tests/test_admin.py
@@ -236,10 +236,9 @@ class TestMachineModelAdminClaims:
         )
         assert claim.value == "G5pe4"
 
-    def test_non_claim_field_variant_of_creates_no_claim(self, admin_request):
+    def test_claim_field_variant_of_creates_claim(self, admin_request):
         parent = MachineModel.objects.create(name="Medieval Madness")
         pm = MachineModel.objects.create(name="Medieval Madness LE")
-        pm.variant_of = parent
 
         mma = MachineModelAdmin(MachineModel, AdminSite())
         form = _MockForm(
@@ -247,9 +246,13 @@ class TestMachineModelAdminClaims:
         )
         mma.save_model(admin_request, pm, form, change=True)
 
-        assert not Claim.objects.filter(
-            object_id=pm.pk, user=admin_request.user
-        ).exists()
+        claim = Claim.objects.get(
+            object_id=pm.pk,
+            user=admin_request.user,
+            field_name="variant_of",
+            is_active=True,
+        )
+        assert claim.value == parent.slug
 
     def test_new_object_asserts_claims_for_filled_fields(self, admin_request):
         pm = MachineModel.objects.create(name="Firepower")

--- a/backend/apps/catalog/tests/test_ingest_pinbase_models.py
+++ b/backend/apps/catalog/tests/test_ingest_pinbase_models.py
@@ -155,12 +155,14 @@ class TestIngestPinbaseModels:
         claim = mm.claims.get(source=source, field_name="display_type", is_active=True)
         assert claim.value == "alphanumeric"
 
-    def test_variant_of_sets_variant_of(self, db):
-        """variant_of correctly sets variant_of FK."""
-        parent = MachineModel.objects.create(
-            name="Parent Model", opdb_id="Gtest-Mparent"
+    def test_variant_of_claim(self, db):
+        """variant_of asserts a claim with the slug value."""
+        MachineModel.objects.create(
+            name="Parent Model", opdb_id="Gtest-Mparent", slug="parent-model"
         )
-        child = MachineModel.objects.create(name="Child Model", opdb_id="Gtest-Mchild")
+        child = MachineModel.objects.create(
+            name="Child Model", opdb_id="Gtest-Mchild", slug="child-model"
+        )
         path = _write_models_json(
             [
                 {"slug": "parent-model", "opdb_id": "Gtest-Mparent"},
@@ -174,19 +176,46 @@ class TestIngestPinbaseModels:
 
         call_command("ingest_pinbase_models", path=path)
 
+        source = Source.objects.get(slug="pinbase")
+        claim = child.claims.get(source=source, field_name="variant_of", is_active=True)
+        assert claim.value == "parent-model"
+
+    def test_variant_of_resolves(self, db):
+        """variant_of slug claim resolves to FK on model."""
+        parent = MachineModel.objects.create(
+            name="Parent Model", opdb_id="Gtest-Mparent", slug="parent-model"
+        )
+        child = MachineModel.objects.create(
+            name="Child Model", opdb_id="Gtest-Mchild", slug="child-model"
+        )
+        path = _write_models_json(
+            [
+                {"slug": "parent-model", "opdb_id": "Gtest-Mparent"},
+                {
+                    "slug": "child-model",
+                    "opdb_id": "Gtest-Mchild",
+                    "variant_of": "parent-model",
+                },
+            ]
+        )
+
+        call_command("ingest_pinbase_models", path=path)
+        resolve_model(child)
         child.refresh_from_db()
+
         assert child.variant_of == parent
 
     def test_variant_of_overrides_ingest(self, db):
         """variant_of from pinbase overrides a wrong variant_of from ingest_opdb."""
-        wrong_parent = MachineModel.objects.create(
-            name="Wrong Parent", opdb_id="Gtest-Mwrong"
-        )
+        MachineModel.objects.create(name="Wrong Parent", opdb_id="Gtest-Mwrong")
         right_parent = MachineModel.objects.create(
-            name="Right Parent", opdb_id="Gtest-Mright"
+            name="Right Parent", opdb_id="Gtest-Mright", slug="right-parent"
         )
         child = MachineModel.objects.create(
-            name="Child", opdb_id="Gtest-Mchild", variant_of=wrong_parent
+            name="Child",
+            opdb_id="Gtest-Mchild",
+            slug="child-model",
+            variant_of=MachineModel.objects.get(opdb_id="Gtest-Mwrong"),
         )
         path = _write_models_json(
             [
@@ -200,16 +229,22 @@ class TestIngestPinbaseModels:
         )
 
         call_command("ingest_pinbase_models", path=path)
-
+        resolve_model(child)
         child.refresh_from_db()
+
         assert child.variant_of == right_parent
 
     def test_variant_of_clears_circular_reference(self, db):
         """When models.json flips the parent/child, variant_of is cleared on new parent."""
         # ingest_opdb heuristic wrongly made model_a the parent, model_b the child.
-        model_a = MachineModel.objects.create(name="Model A (CE)", opdb_id="Gtest-Ma")
+        model_a = MachineModel.objects.create(
+            name="Model A (CE)", opdb_id="Gtest-Ma", slug="model-a-ce"
+        )
         model_b = MachineModel.objects.create(
-            name="Model B (LE)", opdb_id="Gtest-Mb", variant_of=model_a
+            name="Model B (LE)",
+            opdb_id="Gtest-Mb",
+            slug="model-b-le",
+            variant_of=model_a,
         )
         # models.json says B is the real parent, A is the variant.
         path = _write_models_json(
@@ -224,10 +259,13 @@ class TestIngestPinbaseModels:
         )
 
         call_command("ingest_pinbase_models", path=path)
-
+        # Resolution resets all FKs to None, then applies winners.
+        # model_b has no variant_of claim, so it stays None.
+        resolve_model(model_a)
+        resolve_model(model_b)
         model_a.refresh_from_db()
         model_b.refresh_from_db()
-        # B is the parent (variant_of cleared), A points to B.
+
         assert model_b.variant_of is None
         assert model_a.variant_of == model_b
 

--- a/docs/Provenance.md
+++ b/docs/Provenance.md
@@ -46,10 +46,6 @@ Resolution picks a winner per field/claim-key and materializes the result:
 
 If you think a field needs an exception, ask the user first.
 
-## Known Exceptions Pending Migration
-
-- `variant_of` on MachineModel — currently a direct FK, should be migrated to claims
-
 ## Key Code
 
 - `backend/apps/provenance/models.py` — Source, Claim, ClaimManager


### PR DESCRIPTION
## Summary

- Migrates `variant_of` from a direct FK to the claims/provenance system — the last known exception to the "every catalog field must be claims-based" rule
- Ingestion now creates scalar claims (`field_name="variant_of"`, `value=<parent_slug>`) instead of setting the FK directly via `bulk_update()`
- Resolution resolves `variant_of` from claims using the same slug-based lookup as `converted_from`
- Also adds `converted_from` to admin `CLAIM_FIELDS` (was already resolved from claims but missing from admin claim control)
- Removes the "Known Exceptions Pending Migration" section from `Provenance.md`

The existing "conversions are not variants" guard runs post-resolution, correctly clearing `variant_of` on any model where `is_conversion=True`.

## Test plan

- [x] All 441 backend + 58 frontend tests pass
- [x] Full ingestion pipeline runs successfully — 46 `variant_of` claims created
- [x] Resolution materializes variant_of FKs from claims
- [x] Conversion models correctly have `variant_of=None` after resolution (business rule enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)