### PR TITLE
Re-architect DuckDB to mirror Django claims model

### DIFF
--- a/data/explore/01_raw.sql
+++ b/data/explore/01_raw.sql
@@ -130,9 +130,6 @@ SELECT * FROM read_json_auto('data/models.json', (union_by_name = CAST('t' AS BO
 CREATE OR REPLACE VIEW pinbase_people AS
 SELECT * FROM read_json_auto('data/people.json', (union_by_name = CAST('t' AS BOOLEAN)));
 
-CREATE OR REPLACE VIEW pinbase_productions AS
-SELECT * FROM read_json_auto('data/productions.json', (union_by_name = CAST('t' AS BOOLEAN)));
-
 CREATE OR REPLACE VIEW pinbase_series AS
 SELECT * FROM read_json_auto('data/series.json');
 
@@ -147,9 +144,6 @@ SELECT * FROM read_json_auto('data/technology_generations.json');
 
 CREATE OR REPLACE VIEW pinbase_technology_subgenerations AS
 SELECT * FROM read_json_auto('data/technology_subgenerations.json');
-
-CREATE OR REPLACE VIEW pinbase_tiers AS
-SELECT * FROM read_json_auto('data/tiers.json', (union_by_name = CAST('t' AS BOOLEAN)));
 
 CREATE OR REPLACE VIEW pinbase_titles AS
 SELECT * FROM read_json_auto('data/titles.json', (union_by_name = CAST('t' AS BOOLEAN)));

--- a/data/explore/02_staging.sql
+++ b/data/explore/02_staging.sql
@@ -26,117 +26,6 @@ FROM opdb_machines
 WHERE manufacturer IS NOT NULL
 ORDER BY "name";
 
--- opdb_tiers: one row per OPDB machine (non-alias), with combo-label detection
-CREATE OR REPLACE VIEW opdb_tiers AS
-SELECT
-  opdb_id,
-  group_id AS opdb_group_id,
-  machine_id,
-  (manufacturer ->> 'name') AS manufacturer,
-  "name",
-  common_name,
-  shortname,
-  manufacture_date,
-  ipdb_id,
-  images,
-  (physical_machine = 0) AS is_combo_label,
-  technology_generation_slug,
-  display_type_slug,
-  system_slug
-FROM opdb_machines
-WHERE is_machine = 't';
-
--- opdb_models: alias models + tier defaults + synthetic (no-alias) models
-CREATE OR REPLACE VIEW opdb_models AS
-WITH
-  combo_labels AS (
-    SELECT opdb_group_id, machine_id
-    FROM opdb_tiers
-    WHERE is_combo_label
-  ),
-  alias_models AS (
-    SELECT
-      a.opdb_id,
-      a.group_id AS opdb_group_id,
-      a.machine_id,
-      a.alias_id,
-      (a.group_id || '-' || a.machine_id) AS tier_opdb_id,
-      (a.manufacturer ->> 'name') AS manufacturer,
-      a."name",
-      a.common_name,
-      a.shortname,
-      a.manufacture_date,
-      a.ipdb_id,
-      a.images,
-      CASE
-        WHEN cl.machine_id IS NOT NULL
-        THEN (row_number() OVER (PARTITION BY a.group_id, a.machine_id ORDER BY a.opdb_id) = 1)
-        ELSE CAST('f' AS BOOLEAN)
-      END AS is_default,
-      CAST('f' AS BOOLEAN) AS is_synthetic
-    FROM opdb_machines AS a
-    LEFT JOIN combo_labels AS cl
-      ON cl.opdb_group_id = a.group_id AND cl.machine_id = a.machine_id
-    WHERE a.is_alias = 't'
-  ),
-  tier_default_models AS (
-    SELECT
-      opdb_id,
-      group_id AS opdb_group_id,
-      machine_id,
-      CAST(NULL AS VARCHAR) AS alias_id,
-      opdb_id AS tier_opdb_id,
-      (manufacturer ->> 'name') AS manufacturer,
-      "name",
-      common_name,
-      shortname,
-      manufacture_date,
-      ipdb_id,
-      images,
-      CAST('t' AS BOOLEAN) AS is_default,
-      CAST('f' AS BOOLEAN) AS is_synthetic
-    FROM opdb_machines AS m
-    WHERE m.is_machine = 't'
-      AND NOT EXISTS(
-        SELECT 1 FROM combo_labels AS cl
-        WHERE cl.opdb_group_id = m.group_id AND cl.machine_id = m.machine_id
-      )
-      AND EXISTS(
-        SELECT 1 FROM opdb_machines AS a
-        WHERE a.group_id = m.group_id
-          AND a.machine_id = m.machine_id
-          AND a.is_alias = 't'
-      )
-  ),
-  synthetic_models AS (
-    SELECT
-      opdb_id,
-      group_id AS opdb_group_id,
-      machine_id,
-      CAST(NULL AS VARCHAR) AS alias_id,
-      opdb_id AS tier_opdb_id,
-      (manufacturer ->> 'name') AS manufacturer,
-      "name",
-      common_name,
-      shortname,
-      manufacture_date,
-      ipdb_id,
-      images,
-      CAST('t' AS BOOLEAN) AS is_default,
-      CAST('t' AS BOOLEAN) AS is_synthetic
-    FROM opdb_machines AS m
-    WHERE m.is_machine = 't'
-      AND NOT EXISTS(
-        SELECT 1 FROM opdb_machines AS a
-        WHERE a.group_id = m.group_id
-          AND a.machine_id = m.machine_id
-          AND a.is_alias = 't'
-      )
-  )
-(SELECT * FROM alias_models)
-UNION ALL (SELECT * FROM tier_default_models)
-UNION ALL (SELECT * FROM synthetic_models);
-
 -- opdb_keywords: unnested keyword list per machine
 CREATE OR REPLACE VIEW opdb_keywords AS
 SELECT opdb_id, "name", unnest(keywords) AS keyword
@@ -358,34 +247,52 @@ SELECT
 FROM resolved AS r;
 
 ------------------------------------------------------------
--- Cross-source merge views
+-- Cross-source merge: models
+-- Mirrors Django's MachineModel after claims resolution.
+-- Priority: pinbase (300) > OPDB (200) > IPDB (100)
 ------------------------------------------------------------
 
--- unified_models: OPDB models + IPDB-only fallback, with taxonomy resolution
-CREATE OR REPLACE VIEW unified_models AS
+CREATE OR REPLACE VIEW merged_models AS
 WITH
-  opdb AS (
+  -- Every OPDB record (machine or alias) is a candidate model.
+  -- Excludes combo_labels (physical_machine=0): synthetic groupings, not real
+  -- machines. Django's ingest_opdb also skips these.
+  opdb_base AS (
     SELECT
-      opdb_id, opdb_group_id, machine_id, alias_id, tier_opdb_id,
-      manufacturer, "name", common_name, shortname,
-      manufacture_date, ipdb_id, images, is_default, is_synthetic,
-      'opdb' AS "source"
-    FROM opdb_models
+      om.opdb_id,
+      om.group_id AS opdb_group_id,
+      om.ipdb_id,
+      (om.manufacturer ->> 'name') AS opdb_manufacturer,
+      om."name" AS opdb_name,
+      om.common_name,
+      om.shortname,
+      om.manufacture_date,
+      om.player_count,
+      om.description AS opdb_description,
+      om.features,
+      om.images,
+      om.technology_generation_slug AS opdb_tech_gen_slug,
+      om.display_type_slug AS opdb_display_type_slug,
+      om.system_slug AS opdb_system_slug,
+      om.is_machine,
+      om.is_alias
+    FROM opdb_machines AS om
+    WHERE om.is_alias = 't'
+       OR (om.is_machine = 't' AND om.physical_machine != 0)
   ),
+  -- IPDB machines not cross-referenced from any OPDB record.
   ipdb_only AS (
     SELECT
       CAST(NULL AS VARCHAR) AS opdb_id,
       CAST(NULL AS VARCHAR) AS opdb_group_id,
-      CAST(NULL AS VARCHAR) AS machine_id,
-      CAST(NULL AS VARCHAR) AS alias_id,
-      CAST(NULL AS VARCHAR) AS tier_opdb_id,
+      im.IpdbId AS ipdb_id,
       COALESCE(
         imr_mfr."name",
         NULLIF(imr.trade_name, ''),
         imr.company_name,
         im.ManufacturerShortName
-      ) AS manufacturer,
-      im.Title AS "name",
+      ) AS opdb_manufacturer,
+      im.Title AS opdb_name,
       CAST(NULL AS VARCHAR) AS common_name,
       CAST(NULL AS VARCHAR) AS shortname,
       CASE
@@ -393,7 +300,9 @@ WITH
         THEN TRY_CAST(CAST(im.DateOfManufacture AS VARCHAR) AS DATE)
         ELSE NULL
       END AS manufacture_date,
-      im.IpdbId AS ipdb_id,
+      im.Players AS player_count,
+      CAST(NULL AS VARCHAR) AS opdb_description,
+      CAST([] AS VARCHAR[]) AS features,
       CAST(main.list_value() AS STRUCT(
         title VARCHAR,
         "primary" BOOLEAN,
@@ -405,83 +314,96 @@ WITH
           small STRUCT(width BIGINT, height BIGINT)
         )
       )[]) AS images,
-      CAST('t' AS BOOLEAN) AS is_default,
-      CAST('f' AS BOOLEAN) AS is_synthetic,
-      'ipdb' AS "source"
+      im.technology_generation_slug AS opdb_tech_gen_slug,
+      im.display_type_slug AS opdb_display_type_slug,
+      im.system_slug AS opdb_system_slug,
+      CAST('t' AS BOOLEAN) AS is_machine,
+      CAST('f' AS BOOLEAN) AS is_alias
     FROM ipdb_machines AS im
     LEFT JOIN opdb_machines AS om ON im.IpdbId = om.ipdb_id
     LEFT JOIN ipdb_manufacturer_resolution AS imr ON im.Manufacturer = imr.raw_manufacturer
     LEFT JOIN pinbase_manufacturers AS imr_mfr ON imr.manufacturer_slug = imr_mfr.slug
     WHERE om.opdb_id IS NULL
   ),
-  all_models AS (
-    (SELECT * FROM opdb)
+  all_sources AS (
+    (SELECT * FROM opdb_base)
     UNION ALL
     (SELECT * FROM ipdb_only)
   )
+-- Apply pinbase editorial claims (priority 300 wins over OPDB 200 / IPDB 100).
 SELECT
-  m.*,
-  COALESCE(om.technology_generation_slug, im.technology_generation_slug) AS technology_generation_slug,
-  COALESCE(pm.display_type_slug, om.display_type_slug, im.display_type_slug) AS display_type_slug,
-  COALESCE(om.system_slug, im.system_slug) AS system_slug
-FROM all_models AS m
+  model_key(m.opdb_id, m.ipdb_id) AS model_key,
+  m.opdb_id,
+  m.opdb_group_id,
+  COALESCE(m.ipdb_id, im.IpdbId) AS ipdb_id,
+  -- Name: pinbase > OPDB/IPDB
+  COALESCE(pm."name", m.opdb_name) AS "name",
+  m.common_name,
+  m.shortname,
+  m.opdb_manufacturer AS manufacturer,
+  m.manufacture_date,
+  m.player_count,
+  -- Taxonomy: pinbase > OPDB > IPDB
+  m.opdb_tech_gen_slug AS technology_generation_slug,
+  COALESCE(pm.display_type_slug, m.opdb_display_type_slug) AS display_type_slug,
+  m.opdb_system_slug AS system_slug,
+  -- Pinbase editorial claims
+  COALESCE(pm.is_conversion, false) AS is_conversion,
+  pm.converted_from,
+  pm.variant_of,
+  pm.description AS pinbase_description,
+  -- OPDB metadata
+  m.opdb_description,
+  m.features,
+  m.images,
+  m.is_machine,
+  m.is_alias,
+  -- Source tracking
+  CASE WHEN m.opdb_id IS NOT NULL THEN 'opdb' ELSE 'ipdb' END AS primary_source,
+  (pm.slug IS NOT NULL) AS has_pinbase_claims
+FROM all_sources AS m
 LEFT JOIN pinbase_models AS pm ON m.opdb_id = pm.opdb_id
-LEFT JOIN opdb_machines AS om ON m.opdb_id = om.opdb_id
 LEFT JOIN ipdb_machines AS im ON m.ipdb_id = im.IpdbId;
 
--- unified_tiers: OPDB tiers + IPDB-only fallback, with taxonomy resolution
-CREATE OR REPLACE VIEW unified_tiers AS
+------------------------------------------------------------
+-- Cross-source merge: titles
+-- Mirrors Django's Title after claims resolution.
+-- Pinbase titles are primary; OPDB groups enrich.
+------------------------------------------------------------
+
+CREATE OR REPLACE VIEW merged_titles AS
 WITH
-  opdb AS (
+  -- Start from OPDB groups as the universe of titles.
+  opdb_base AS (
     SELECT
-      opdb_id, opdb_group_id, machine_id,
-      "name", common_name, shortname,
-      manufacture_date, ipdb_id, images, is_combo_label,
-      'opdb' AS "source"
-    FROM opdb_tiers
+      g.opdb_id AS opdb_group_id,
+      g."name" AS opdb_name,
+      g.shortname,
+      g.description AS opdb_description
+    FROM opdb_groups AS g
   ),
-  ipdb_only AS (
+  -- Pinbase titles (may reference OPDB groups, or be standalone).
+  pinbase AS (
     SELECT
-      CAST(NULL AS VARCHAR) AS opdb_id,
-      CAST(NULL AS VARCHAR) AS opdb_group_id,
-      CAST(NULL AS VARCHAR) AS machine_id,
-      im.Title AS "name",
-      CAST(NULL AS VARCHAR) AS common_name,
-      CAST(NULL AS VARCHAR) AS shortname,
-      CASE
-        WHEN im.DateOfManufacture IS NOT NULL
-        THEN TRY_CAST(CAST(im.DateOfManufacture AS VARCHAR) AS DATE)
-        ELSE NULL
-      END AS manufacture_date,
-      im.IpdbId AS ipdb_id,
-      CAST(list_value() AS STRUCT(
-        title VARCHAR,
-        "primary" BOOLEAN,
-        "type" VARCHAR,
-        urls STRUCT(medium VARCHAR, "large" VARCHAR, small VARCHAR),
-        sizes STRUCT(
-          medium STRUCT(width BIGINT, height BIGINT),
-          "large" STRUCT(width BIGINT, height BIGINT),
-          small STRUCT(width BIGINT, height BIGINT)
-        )
-      )[]) AS images,
-      CAST('f' AS BOOLEAN) AS is_combo_label,
-      'ipdb' AS "source"
-    FROM ipdb_machines AS im
-    LEFT JOIN opdb_machines AS om ON im.IpdbId = om.ipdb_id
-    WHERE om.opdb_id IS NULL
-  ),
-  all_tiers AS (
-    (SELECT * FROM opdb)
-    UNION ALL
-    (SELECT * FROM ipdb_only)
+      t.opdb_group_id,
+      t.slug,
+      t."name" AS pinbase_name,
+      t.franchise_slug,
+      t.series_slug,
+      t.abbreviations
+    FROM pinbase_titles AS t
   )
+-- Full outer join: every OPDB group + every pinbase title.
 SELECT
-  e.*,
-  COALESCE(oe.technology_generation_slug, im.technology_generation_slug) AS technology_generation_slug,
-  COALESCE(pm.display_type_slug, oe.display_type_slug, im.display_type_slug) AS display_type_slug,
-  COALESCE(oe.system_slug, im.system_slug) AS system_slug
-FROM all_tiers AS e
-LEFT JOIN pinbase_models AS pm ON e.opdb_id = pm.opdb_id
-LEFT JOIN opdb_tiers AS oe ON e.opdb_id = oe.opdb_id
-LEFT JOIN ipdb_machines AS im ON e.ipdb_id = im.IpdbId;
+  COALESCE(o.opdb_group_id, p.opdb_group_id) AS opdb_group_id,
+  p.slug AS title_slug,
+  -- Name: pinbase > OPDB
+  COALESCE(p.pinbase_name, o.opdb_name) AS "name",
+  o.shortname,
+  o.opdb_description AS description,
+  p.franchise_slug,
+  p.series_slug,
+  p.abbreviations,
+  (p.slug IS NOT NULL) AS has_pinbase_claims
+FROM opdb_base AS o
+FULL OUTER JOIN pinbase AS p ON o.opdb_group_id = p.opdb_group_id;

--- a/data/explore/03_catalog.sql
+++ b/data/explore/03_catalog.sql
@@ -74,17 +74,10 @@ SELECT
 FROM pinbase_manufacturers AS p
 LEFT JOIN fandom_manufacturers AS f ON p."name" = f.title;
 
+-- catalog_titles: pinbase-primary, OPDB-enriched.
+-- Mirrors Django's Title model after claims resolution.
 CREATE OR REPLACE VIEW catalog_titles AS
-SELECT
-  g.opdb_id AS opdb_group_id,
-  g."name",
-  g.shortname,
-  g.description,
-  t.slug AS title_slug,
-  t.franchise_slug,
-  t.series_slug
-FROM opdb_groups AS g
-LEFT JOIN pinbase_titles AS t ON g.opdb_id = t.opdb_group_id;
+SELECT * FROM merged_titles;
 
 ------------------------------------------------------------
 -- Tag-related views
@@ -110,147 +103,13 @@ GROUP BY t.slug, t."name", t.display_order, t.description
 ORDER BY t.display_order;
 
 ------------------------------------------------------------
--- Platform view (OPDB-only, picks representative machine per group)
+-- Core catalog views (from merged staging layer)
 ------------------------------------------------------------
 
-CREATE OR REPLACE VIEW catalog_platforms AS
-WITH
-  non_alias AS (
-    SELECT
-      *,
-      manufacturer."name" AS mfr_name,
-      manufacturer.full_name AS mfr_full_name
-    FROM opdb_machines
-    WHERE is_machine = CAST('t' AS BOOLEAN)
-  ),
-  ranked AS (
-    SELECT
-      *,
-      row_number() OVER (
-        PARTITION BY group_id, mfr_name
-        ORDER BY physical_machine ASC, manufacture_date ASC, opdb_id ASC
-      ) AS rn
-    FROM non_alias
-  )
-SELECT
-  group_id AS opdb_group_id,
-  mfr_name AS manufacturer,
-  mfr_full_name AS manufacturer_full_name,
-  (group_id || '-' || machine_id) AS platform_opdb_id,
-  "name",
-  manufacture_date,
-  "type",
-  display,
-  player_count,
-  description
-FROM ranked
-WHERE rn = 1;
-
-------------------------------------------------------------
--- Production views (override + auto-generated)
-------------------------------------------------------------
-
-CREATE OR REPLACE VIEW catalog_productions AS
-WITH
-  overridden_tiers AS (
-    SELECT
-      pt.opdb_id AS tier_opdb_id,
-      pt.production_slug,
-      pp.title_slug,
-      pp.slug AS production_slug,
-      pp."name" AS production_name,
-      pp.description AS production_description
-    FROM pinbase_tiers AS pt
-    INNER JOIN pinbase_productions AS pp ON pt.production_slug = pp.slug
-    WHERE pt.production_slug IS NOT NULL
-  ),
-  override_productions AS (
-    SELECT
-      ot.production_slug AS slug,
-      ot.production_name AS "name",
-      ot.production_description AS description,
-      oe.opdb_group_id,
-      oe.manufacturer,
-      oe.technology_generation_slug,
-      oe.manufacture_date,
-      oe.opdb_id AS representative_opdb_id,
-      CAST('t' AS BOOLEAN) AS is_override
-    FROM overridden_tiers AS ot
-    INNER JOIN opdb_tiers AS oe ON ot.tier_opdb_id = oe.opdb_id
-  ),
-  adjusted_base AS (
-    SELECT
-      t.opdb_group_id,
-      t.manufacturer,
-      t.technology_generation_slug,
-      min(t.manufacture_date) AS manufacture_date,
-      min(t.opdb_id) AS representative_opdb_id
-    FROM opdb_tiers AS t
-    LEFT JOIN overridden_tiers AS ot ON t.opdb_id = ot.tier_opdb_id
-    WHERE ot.tier_opdb_id IS NULL
-    GROUP BY t.opdb_group_id, t.manufacturer, t.technology_generation_slug
-  ),
-  auto_productions AS (
-    SELECT
-      CAST(NULL AS VARCHAR) AS slug,
-      CAST(NULL AS VARCHAR) AS "name",
-      CAST(NULL AS VARCHAR) AS description,
-      ab.opdb_group_id,
-      ab.manufacturer,
-      ab.technology_generation_slug,
-      ab.manufacture_date,
-      ab.representative_opdb_id,
-      CAST('f' AS BOOLEAN) AS is_override
-    FROM adjusted_base AS ab
-  )
-(SELECT * FROM auto_productions)
-UNION ALL
-(SELECT * FROM override_productions);
-
-CREATE OR REPLACE VIEW catalog_tier_productions AS
-WITH
-  overridden_tiers AS (
-    SELECT pt.opdb_id AS tier_opdb_id, pt.production_slug
-    FROM pinbase_tiers AS pt
-    WHERE pt.production_slug IS NOT NULL
-  )
-(SELECT
-  t.opdb_id AS tier_opdb_id,
-  p.slug AS production_slug,
-  p.opdb_group_id,
-  p.manufacturer,
-  p.technology_generation_slug,
-  p.is_override
-FROM opdb_tiers AS t
-INNER JOIN overridden_tiers AS ot ON t.opdb_id = ot.tier_opdb_id
-INNER JOIN catalog_productions AS p
-  ON ot.production_slug = p.slug AND p.is_override = CAST('t' AS BOOLEAN))
-UNION ALL
-(SELECT
-  t.opdb_id AS tier_opdb_id,
-  p.slug AS production_slug,
-  p.opdb_group_id,
-  p.manufacturer,
-  p.technology_generation_slug,
-  p.is_override
-FROM opdb_tiers AS t
-LEFT JOIN overridden_tiers AS ot ON t.opdb_id = ot.tier_opdb_id
-INNER JOIN catalog_productions AS p
-  ON t.opdb_group_id = p.opdb_group_id
-  AND t.manufacturer = p.manufacturer
-  AND t.technology_generation_slug IS NOT DISTINCT FROM p.technology_generation_slug
-  AND p.is_override = CAST('f' AS BOOLEAN)
-WHERE ot.tier_opdb_id IS NULL);
-
-------------------------------------------------------------
--- Thin wrappers on unified merge views
-------------------------------------------------------------
-
+-- catalog_models: the resolved machine model view.
+-- Mirrors Django's MachineModel after claims resolution.
 CREATE OR REPLACE VIEW catalog_models AS
-SELECT * FROM unified_models;
-
-CREATE OR REPLACE VIEW catalog_tiers AS
-SELECT * FROM unified_tiers;
+SELECT * FROM merged_models;
 
 ------------------------------------------------------------
 -- IPDB cross-reference
@@ -400,7 +259,7 @@ SELECT
   ps.slug,
   ps."name",
   ps.manufacturer_slug,
-  count(DISTINCT model_key(cm.opdb_id, cm.ipdb_id)) AS model_count
+  count(DISTINCT cm.model_key) AS model_count
 FROM pinbase_systems AS ps
 LEFT JOIN catalog_models AS cm ON ps.slug = cm.system_slug
 GROUP BY ps.slug, ps."name", ps.manufacturer_slug
@@ -412,7 +271,7 @@ SELECT
   tg.title AS "name",
   tg.display_order,
   tg.description,
-  count(DISTINCT model_key(cm.opdb_id, cm.ipdb_id)) AS model_count
+  count(DISTINCT cm.model_key) AS model_count
 FROM pinbase_technology_generations AS tg
 LEFT JOIN catalog_models AS cm ON tg.slug = cm.technology_generation_slug
 GROUP BY tg.slug, tg.title, tg.display_order, tg.description
@@ -424,7 +283,7 @@ SELECT
   dt.title AS "name",
   dt.display_order,
   dt.description,
-  count(DISTINCT model_key(cm.opdb_id, cm.ipdb_id)) AS model_count
+  count(DISTINCT cm.model_key) AS model_count
 FROM pinbase_display_types AS dt
 LEFT JOIN catalog_models AS cm ON dt.slug = cm.display_type_slug
 GROUP BY dt.slug, dt.title, dt.display_order, dt.description
@@ -457,21 +316,39 @@ FROM all_themes
 GROUP BY "name";
 
 ------------------------------------------------------------
--- Conversions
+-- Conversions (from pinbase editorial claims)
 ------------------------------------------------------------
 
 CREATE OR REPLACE VIEW catalog_conversions AS
 SELECT
-  pm.opdb_id AS converted_opdb_id,
-  pm."name" AS converted_name,
+  cm_conv.opdb_id AS converted_opdb_id,
+  cm_conv."name" AS converted_name,
   cm_conv.manufacturer AS converted_manufacturer,
   cm_conv.manufacture_date AS converted_date,
-  pm_src.opdb_id AS source_opdb_id,
-  pm_src."name" AS source_name,
+  cm_conv.converted_from AS source_slug,
+  cm_src.opdb_id AS source_opdb_id,
+  cm_src."name" AS source_name,
   cm_src.manufacturer AS source_manufacturer,
   cm_src.manufacture_date AS source_date
-FROM pinbase_models AS pm
-LEFT JOIN catalog_models AS cm_conv ON pm.opdb_id = cm_conv.opdb_id
-LEFT JOIN pinbase_models AS pm_src ON pm.converted_from = pm_src.slug
+FROM catalog_models AS cm_conv
+LEFT JOIN pinbase_models AS pm_src ON cm_conv.converted_from = pm_src.slug
 LEFT JOIN catalog_models AS cm_src ON pm_src.opdb_id = cm_src.opdb_id
-WHERE pm.is_conversion = true;
+WHERE cm_conv.is_conversion;
+
+------------------------------------------------------------
+-- Variant relationships (from pinbase editorial claims)
+------------------------------------------------------------
+
+CREATE OR REPLACE VIEW catalog_variants AS
+SELECT
+  cm.opdb_id AS variant_opdb_id,
+  cm."name" AS variant_name,
+  cm.manufacturer AS variant_manufacturer,
+  cm.variant_of AS production_slug,
+  pm_prod.opdb_id AS production_opdb_id,
+  cm_prod."name" AS production_name,
+  cm_prod.manufacturer AS production_manufacturer
+FROM catalog_models AS cm
+INNER JOIN pinbase_models AS pm_prod ON cm.variant_of = pm_prod.slug
+LEFT JOIN catalog_models AS cm_prod ON pm_prod.opdb_id = cm_prod.opdb_id
+WHERE cm.variant_of IS NOT NULL;

--- a/data/explore/04_checks.sql
+++ b/data/explore/04_checks.sql
@@ -12,29 +12,92 @@ CREATE TEMP TABLE IF NOT EXISTS _warnings (check_name VARCHAR, cnt BIGINT);
 -- Duplicate model keys
 INSERT INTO _violations
 SELECT 'duplicate_model_key', k FROM (
-  SELECT model_key(opdb_id, ipdb_id) AS k
+  SELECT model_key AS k
   FROM catalog_models
   GROUP BY k HAVING count(*) > 1
 );
 
--- Duplicate tier keys
+-- Pinbase model references nonexistent opdb_id
 INSERT INTO _violations
-SELECT 'duplicate_tier_key', k FROM (
-  SELECT model_key(opdb_id, ipdb_id) AS k
-  FROM catalog_tiers
-  GROUP BY k HAVING count(*) > 1
-);
+SELECT 'orphan_pinbase_model', pm.opdb_id
+FROM pinbase_models AS pm
+LEFT JOIN opdb_machines AS om ON pm.opdb_id = om.opdb_id
+WHERE om.opdb_id IS NULL;
 
--- Orphan tier_productions: tier references a production slug that doesn't exist
+-- Pinbase variant_of references nonexistent slug
 INSERT INTO _violations
-SELECT 'orphan_tier_production', tp.tier_opdb_id
-FROM catalog_tier_productions AS tp
-LEFT JOIN catalog_productions AS p
-  ON tp.production_slug = p.slug
-  AND tp.opdb_group_id = p.opdb_group_id
-  AND tp.manufacturer = p.manufacturer
-  AND tp.technology_generation_slug IS NOT DISTINCT FROM p.technology_generation_slug
-WHERE p.slug IS NULL AND tp.production_slug IS NOT NULL;
+SELECT 'orphan_variant_of', pm.slug || ' -> ' || pm.variant_of
+FROM pinbase_models AS pm
+WHERE pm.variant_of IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM pinbase_models AS pm2 WHERE pm2.slug = pm.variant_of
+  );
+
+-- Pinbase converted_from references nonexistent slug
+INSERT INTO _violations
+SELECT 'orphan_converted_from', pm.slug || ' -> ' || pm.converted_from
+FROM pinbase_models AS pm
+WHERE pm.converted_from IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM pinbase_models AS pm2 WHERE pm2.slug = pm.converted_from
+  );
+
+-- Pinbase title references nonexistent opdb_group_id
+INSERT INTO _violations
+SELECT 'orphan_pinbase_title', pt.opdb_group_id
+FROM pinbase_titles AS pt
+LEFT JOIN opdb_groups AS og ON pt.opdb_group_id = og.opdb_id
+WHERE og.opdb_id IS NULL;
+
+-- Pinbase title franchise_slug references nonexistent franchise
+INSERT INTO _violations
+SELECT 'orphan_franchise_slug', pt.slug || ' -> ' || pt.franchise_slug
+FROM pinbase_titles AS pt
+WHERE pt.franchise_slug IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM pinbase_franchises AS f WHERE f.slug = pt.franchise_slug
+  );
+
+-- Pinbase title series_slug references nonexistent series
+INSERT INTO _violations
+SELECT 'orphan_series_slug', pt.slug || ' -> ' || pt.series_slug
+FROM pinbase_titles AS pt
+WHERE pt.series_slug IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM pinbase_series AS s WHERE s.slug = pt.series_slug
+  );
+
+-- Duplicate slugs in pinbase_models
+INSERT INTO _violations
+SELECT 'duplicate_model_slug', slug
+FROM pinbase_models
+GROUP BY slug HAVING count(*) > 1;
+
+-- Duplicate opdb_ids in pinbase_models
+INSERT INTO _violations
+SELECT 'duplicate_model_opdb_id', opdb_id
+FROM pinbase_models
+GROUP BY opdb_id HAVING count(*) > 1;
+
+-- Self-referential variant_of
+INSERT INTO _violations
+SELECT 'self_variant_of', slug
+FROM pinbase_models
+WHERE variant_of = slug;
+
+-- variant_of chains (A→B where B also has variant_of)
+INSERT INTO _violations
+SELECT 'chained_variant_of', a.slug || ' -> ' || a.variant_of || ' -> ' || b.variant_of
+FROM pinbase_models AS a
+JOIN pinbase_models AS b ON a.variant_of = b.slug
+WHERE b.variant_of IS NOT NULL;
+
+-- Pinbase model references a combo_label (physical_machine=0)
+INSERT INTO _violations
+SELECT 'combo_label_model', pm.slug || ' (' || pm.opdb_id || ')'
+FROM pinbase_models AS pm
+JOIN opdb_machines AS om ON pm.opdb_id = om.opdb_id
+WHERE om.is_machine = 't' AND om.physical_machine = 0;
 
 ------------------------------------------------------------
 -- Soft warnings (data quality, not regressions)
@@ -44,6 +107,22 @@ INSERT INTO _warnings
 SELECT 'null_manufacturer', count(*)
 FROM catalog_models
 WHERE manufacturer IS NULL;
+
+INSERT INTO _warnings
+SELECT 'titles_without_pinbase_claims', count(*)
+FROM catalog_titles
+WHERE NOT has_pinbase_claims;
+
+INSERT INTO _warnings
+SELECT 'models_with_pinbase_claims', count(*)
+FROM catalog_models
+WHERE has_pinbase_claims;
+
+-- Conversions missing converted_from (we know the source but haven't recorded it)
+INSERT INTO _warnings
+SELECT 'conversion_without_source', count(*)
+FROM pinbase_models
+WHERE is_conversion AND converted_from IS NULL;
 
 -- Print warnings
 SELECT 'WARNING: ' || check_name || ' (' || cnt || ' rows)'

--- a/data/models.json
+++ b/data/models.json
@@ -166,24 +166,19 @@
     "slug": "cactus-canyon-lyman-upgrade",
     "name": "Cactus Canyon (Lyman Upgrade)",
     "opdb_id": "G4835-M2YPK-ARkb7",
-    "variant_of": "cactus-canyon-remake-special",
+    "variant_of": "cactus-canyon-remake-special-edition",
     "is_conversion": true,
-    "converted_from": "cactus-canyon-remake"
-  },
-  {
-    "slug": "cactus-canyon-remake",
-    "name": "Cactus Canyon (Remake)",
-    "opdb_id": "G4835-M2YPK"
+    "converted_from": "cactus-canyon-remake-special-edition"
   },
   {
     "slug": "cactus-canyon-remake-limited-edition",
     "name": "Cactus Canyon (Remake Limited Edition)",
     "opdb_id": "G4835-M2YPK-A9ylv",
-    "variant_of": "cactus-canyon-remake-special"
+    "variant_of": "cactus-canyon-remake-special-edition"
   },
   {
-    "slug": "cactus-canyon-remake-special",
-    "name": "Cactus Canyon (Remake Special)",
+    "slug": "cactus-canyon-remake-special-edition",
+    "name": "Cactus Canyon (Remake Special Edition)",
     "opdb_id": "G4835-M2YPK-AR5ln"
   },
   {

--- a/data/productions.json
+++ b/data/productions.json
@@ -1,8 +1,0 @@
-[
-  {
-    "slug": "mm-merlin-edition",
-    "name": "Medieval Madness (Merlin Edition)",
-    "title_slug": "medieval-madness",
-    "description": "Chicago Gaming's 2025 re-release on XL HD color display platform, a substantial hardware rework of the 2015 DMD-based remake."
-  }
-]

--- a/data/tiers.json
+++ b/data/tiers.json
@@ -1,8 +1,0 @@
-[
-  {
-    "slug": "mm-merlin-edition",
-    "name": "Medieval Madness (Merlin Edition)",
-    "opdb_id": "G5pe4-MrRrv",
-    "production_slug": "mm-merlin-edition"
-  }
-]


### PR DESCRIPTION
## Summary

- **Drop dead concepts**: tiers, productions, and platforms had no counterpart in Django and added complexity without value. Delete `tiers.json` and `productions.json` (dead data files).
- **Claims-priority merge**: Replace `unified_models`/`unified_tiers` with `merged_models` and `merged_titles` that apply pinbase editorial claims at priority 300 (over OPDB 200 / IPDB 100), mirroring Django's claims resolution.
- **Fix Cactus Canyon Remake data**: Remove combo_label entry from `models.json`, rename Special → Special Edition, rewire variant_of/converted_from references to point at real machines.
- **New views and checks**: Add `catalog_variants` view, combo_label detection, orphan FK checks, variant_of chain/self-ref guards, and `conversion_without_source` warning.

## Test plan

- [x] DuckDB rebuilds cleanly with all contract checks passing
- [x] Model count (6836) matches old database exactly
- [x] All model keys identical between old and new
- [x] No orphan pinbase references or combo_label models
- [x] Django `test_ingest_pinbase_models` tests pass
- [ ] Verify DuckDB views are usable for ad-hoc exploration

🤖 Generated with [Claude Code](https://claude.com/claude-code)