### PR TITLE
refactor: replace claims boilerplate with declarative registries

### DIFF
--- a/backend/apps/catalog/admin.py
+++ b/backend/apps/catalog/admin.py
@@ -32,6 +32,7 @@ from .models import (
 )
 from .resolve import (
     DIRECT_FIELDS,
+    FK_FIELDS,
     MANUFACTURER_DIRECT_FIELDS,
     PERSON_DIRECT_FIELDS,
     SYSTEM_DIRECT_FIELDS,
@@ -375,40 +376,11 @@ class PersonAdmin(ProvenanceSaveMixin, admin.ModelAdmin):
 
 @admin.register(MachineModel)
 class MachineModelAdmin(ProvenanceSaveMixin, admin.ModelAdmin):
-    CLAIM_FIELDS = frozenset(DIRECT_FIELDS) | {
-        "manufacturer",
-        "title",
-        "variant_of",
-        "converted_from",
-        "system",
-        "technology_generation",
-        "display_type",
-        "display_subtype",
-        "cabinet",
-        "game_format",
-    }
+    CLAIM_FIELDS = frozenset(DIRECT_FIELDS) | frozenset(FK_FIELDS)
 
     def _to_claim_value(self, field_name: str, value):
-        if field_name == "manufacturer" and value is not None:
-            return value.slug
-        if field_name == "title" and value is not None:
-            return value.opdb_id
-        if field_name == "system" and value is not None:
-            return value.slug
-        if field_name == "technology_generation" and value is not None:
-            return value.slug
-        if field_name == "display_type" and value is not None:
-            return value.slug
-        if field_name == "display_subtype" and value is not None:
-            return value.slug
-        if field_name == "cabinet" and value is not None:
-            return value.slug
-        if field_name == "game_format" and value is not None:
-            return value.slug
-        if field_name == "variant_of" and value is not None:
-            return value.slug
-        if field_name == "converted_from" and value is not None:
-            return value.slug
+        if value is not None and field_name in FK_FIELDS:
+            return getattr(value, FK_FIELDS[field_name].lookup_key)
         return super()._to_claim_value(field_name, value)
 
     def _resolve(self, obj):

--- a/backend/apps/catalog/management/commands/ingest_fandom.py
+++ b/backend/apps/catalog/management/commands/ingest_fandom.py
@@ -48,8 +48,6 @@ from apps.catalog.models import MachineModel, Manufacturer, Person
 from apps.catalog.resolve import (
     MANUFACTURER_DIRECT_FIELDS,
     PERSON_DIRECT_FIELDS,
-    _MANUFACTURER_INT_FIELDS,
-    _PERSON_INT_FIELDS,
     _resolve_bulk,
     resolve_all_credits,
 )
@@ -371,7 +369,6 @@ class Command(BaseCommand):
         _resolve_bulk(
             Person,
             PERSON_DIRECT_FIELDS,
-            int_fields=_PERSON_INT_FIELDS,
             object_ids=resolved_person_ids,
         )
 
@@ -412,7 +409,6 @@ class Command(BaseCommand):
         _resolve_bulk(
             Manufacturer,
             MANUFACTURER_DIRECT_FIELDS,
-            int_fields=_MANUFACTURER_INT_FIELDS,
             object_ids=matched_mfr_ids,
         )
 

--- a/backend/apps/catalog/management/commands/ingest_ipdb_titles.py
+++ b/backend/apps/catalog/management/commands/ingest_ipdb_titles.py
@@ -1,8 +1,8 @@
 """Create Title records for IPDB-only MachineModels that lack a title.
 
-For each IPDB-only model (ipdb_id set, opdb_id NULL) without an active "group"
+For each IPDB-only model (ipdb_id set, opdb_id NULL) without an active "title"
 claim, creates a Title with synthetic opdb_id ``ipdb:{ipdb_id}`` and asserts a
-"group" claim linking the model to it, plus a "name" claim on the Title.
+"title" claim linking the model to it, plus a "name" claim on the Title.
 
 Models whose names match existing OPDB-backed Titles are flagged with
 ``needs_review=True`` and contextual notes for human curation.
@@ -50,17 +50,17 @@ class Command(BaseCommand):
             ipdb_id__isnull=False, opdb_id__isnull=True
         )
 
-        # Find which of those already have an active "group" claim.
-        has_group_claim = set(
+        # Find which of those already have an active "title" claim.
+        has_title_claim = set(
             Claim.objects.filter(
                 content_type_id=model_ct_id,
-                field_name="group",
+                field_name="title",
                 is_active=True,
                 source=source,
             ).values_list("object_id", flat=True)
         )
 
-        candidates = [m for m in ipdb_only if m.pk not in has_group_claim]
+        candidates = [m for m in ipdb_only if m.pk not in has_title_claim]
 
         if not candidates:
             self.stdout.write("  No IPDB-only models need titles.")
@@ -83,7 +83,7 @@ class Command(BaseCommand):
         )
 
         new_titles: list[Title] = []
-        # Group claims on MachineModel linking to the synthetic title.
+        # Title claims on MachineModel linking to the synthetic title.
         model_claims: list[Claim] = []
         # Name claims on the Title itself.
         title_name_map: list[tuple[str, str]] = []  # (synthetic_id, name)
@@ -161,8 +161,8 @@ class Command(BaseCommand):
                 Claim(
                     content_type_id=model_ct_id,
                     object_id=model.pk,
-                    field_name="group",
-                    claim_key="group",
+                    field_name="title",
+                    claim_key="title",
                     value=synthetic_id,
                     needs_review=needs_review,
                     needs_review_notes=needs_review_notes,
@@ -197,7 +197,7 @@ class Command(BaseCommand):
                         )
                     )
 
-        # Assert model-level group claims.
+        # Assert model-level title claims.
         if model_claims:
             claim_stats = Claim.objects.bulk_assert_claims(source, model_claims)
             self.stdout.write(

--- a/backend/apps/catalog/management/commands/ingest_opdb.py
+++ b/backend/apps/catalog/management/commands/ingest_opdb.py
@@ -709,8 +709,8 @@ class Command(BaseCommand):
                 )
             )
 
-        # Group claim (derived from opdb_id prefix).
+        # Title claim (derived from opdb_id prefix).
         if opdb_id and groups_by_id:
             group_opdb_id = parse_opdb_group_id(opdb_id)
             if group_opdb_id and group_opdb_id in groups_by_id:
-                _add("group", group_opdb_id)
+                _add("title", group_opdb_id)

--- a/backend/apps/catalog/management/commands/ingest_pinbase_manufacturers.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_manufacturers.py
@@ -20,7 +20,6 @@ from django.core.management.base import BaseCommand
 from apps.catalog.models import Manufacturer
 from apps.catalog.resolve import (
     MANUFACTURER_DIRECT_FIELDS,
-    _MANUFACTURER_INT_FIELDS,
     _resolve_bulk,
 )
 from apps.provenance.models import Claim, Source
@@ -106,7 +105,6 @@ class Command(BaseCommand):
             _resolve_bulk(
                 Manufacturer,
                 MANUFACTURER_DIRECT_FIELDS,
-                int_fields=_MANUFACTURER_INT_FIELDS,
                 object_ids=touched_ids,
             )
 

--- a/backend/apps/catalog/management/commands/ingest_pinbase_signs.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_signs.py
@@ -115,7 +115,7 @@ class Command(BaseCommand):
         model_title: dict[int, Title] = {}
         group_claims = Claim.objects.filter(
             content_type_id=model_ct_id,
-            field_name="group",
+            field_name="title",
             is_active=True,
         ).values_list("object_id", "value")
         for obj_id, group_value in group_claims:

--- a/backend/apps/catalog/management/commands/ingest_wikidata.py
+++ b/backend/apps/catalog/management/commands/ingest_wikidata.py
@@ -32,7 +32,6 @@ from apps.catalog.claims import build_relationship_claim, make_authoritative_sco
 from apps.catalog.models import MachineModel, Person
 from apps.catalog.resolve import (
     PERSON_DIRECT_FIELDS,
-    _PERSON_INT_FIELDS,
     _resolve_bulk,
     resolve_all_credits,
 )
@@ -149,7 +148,6 @@ class Command(BaseCommand):
         _resolve_bulk(
             Person,
             PERSON_DIRECT_FIELDS,
-            int_fields=_PERSON_INT_FIELDS,
             object_ids=matched_person_ids,
         )
 

--- a/backend/apps/catalog/management/commands/ingest_wikidata_manufacturers.py
+++ b/backend/apps/catalog/management/commands/ingest_wikidata_manufacturers.py
@@ -31,7 +31,6 @@ from apps.catalog.ingestion.wikidata_sparql import (
 from apps.catalog.models import Manufacturer
 from apps.catalog.resolve import (
     MANUFACTURER_DIRECT_FIELDS,
-    _MANUFACTURER_INT_FIELDS,
     _resolve_bulk,
 )
 from apps.provenance.models import Claim, Source
@@ -198,7 +197,6 @@ class Command(BaseCommand):
         _resolve_bulk(
             Manufacturer,
             MANUFACTURER_DIRECT_FIELDS,
-            int_fields=_MANUFACTURER_INT_FIELDS,
             object_ids=matched_mfr_ids,
         )
 

--- a/backend/apps/catalog/models/title.py
+++ b/backend/apps/catalog/models/title.py
@@ -13,9 +13,9 @@ __all__ = ["Title", "TitleAbbreviation"]
 class Title(TimeStampedModel):
     """The canonical identity of a pinball game, independent of edition or variant.
 
-    OPDB calls this a "group" (e.g., "Medieval Madness" spans the 1997 original,
-    the 2015 remake, and LE/SE variants). We use "Title" as it is the natural
-    pinball-world term. Title fields (name, description, franchise) and
+    OPDB calls this a "group" in its JSON, but we use "Title" as it is the
+    natural pinball-world term (e.g., "Medieval Madness" spans the 1997
+    original, the 2015 remake, and LE/SE variants). Title fields (name, description, franchise) and
     abbreviations are resolved from claims, just like MachineModel and
     Manufacturer.
     """

--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from django.db import models
 from django.db.models import Case, F, IntegerField, Value, When
 from django.utils import timezone
 
@@ -18,34 +17,17 @@ from apps.provenance.models import Claim
 
 from ..claims import RELATIONSHIP_NAMESPACES
 from ..models import (
-    Cabinet,
-    DisplaySubtype,
-    DisplayType,
     Franchise,
-    GameFormat,
     MachineModel,
-    TechnologyGeneration,
     Title,
 )
 from ._helpers import (
     DIRECT_FIELDS,
-    _build_cabinet_lookup,
-    _build_converted_from_lookup,
-    _build_display_subtype_lookup,
-    _build_display_type_lookup,
-    _build_game_format_lookup,
-    _build_manufacturer_lookup,
-    _build_system_lookup,
-    _build_technology_generation_lookup,
-    _build_title_lookup,
+    FK_FIELDS,
     _coerce,
-    _get_field_defaults,
-    _resolve_manufacturer,
-    _resolve_manufacturer_bulk,
-    _resolve_slug_fk,
-    _resolve_system,
-    _resolve_title_fk,
-    _resolve_title_fk_bulk,
+    _resolve_fk,
+    build_fk_lookups,
+    get_field_defaults,
 )
 from ._relationships import (
     _resolve_all_gameplay_features,
@@ -72,9 +54,6 @@ from ._entities import (  # noqa: F401
     TAXONOMY_MODELS as TAXONOMY_MODELS,
     THEME_DIRECT_FIELDS as THEME_DIRECT_FIELDS,
     TITLE_DIRECT_FIELDS as TITLE_DIRECT_FIELDS,
-    _MANUFACTURER_INT_FIELDS as _MANUFACTURER_INT_FIELDS,
-    _PERSON_INT_FIELDS as _PERSON_INT_FIELDS,
-    _TAXONOMY_INT_FIELDS as _TAXONOMY_INT_FIELDS,
     _resolve_all_taxonomy,
     _resolve_bulk as _resolve_bulk,
     _resolve_single as _resolve_single,
@@ -118,77 +97,32 @@ def resolve_model(machine_model: MachineModel) -> MachineModel:
             winners[claim.claim_key] = claim
 
     # Reset all resolvable fields to defaults before applying winners.
-    # This ensures deactivated claims don't leave stale values.
-    machine_model.manufacturer = None
-    machine_model.title = None
-    machine_model.variant_of = None
-    machine_model.converted_from = None
-    machine_model.system = None
-    machine_model.technology_generation = None
-    machine_model.display_type = None
-    machine_model.display_subtype = None
-    machine_model.cabinet = None
-    machine_model.game_format = None
-    for attr in DIRECT_FIELDS.values():
-        field = machine_model._meta.get_field(attr)
-        if hasattr(field, "default") and field.default is not models.NOT_PROVIDED:
-            setattr(machine_model, attr, field.default)
-        elif field.null:
-            setattr(machine_model, attr, None)
-        else:
-            setattr(machine_model, attr, "")
-    extra_data: dict = {}
+    for spec in FK_FIELDS.values():
+        setattr(machine_model, spec.model_attr, None)
+    field_defaults = get_field_defaults(MachineModel, DIRECT_FIELDS)
+    for attr, default in field_defaults.items():
+        setattr(machine_model, attr, default)
 
-    techgen_lookup = _build_technology_generation_lookup()
-    display_type_lookup = _build_display_type_lookup()
-    display_subtype_lookup = _build_display_subtype_lookup()
-    cabinet_lookup = _build_cabinet_lookup()
-    game_format_lookup = _build_game_format_lookup()
-    self_lookup = _build_converted_from_lookup()  # {slug: MachineModel} for self-FKs
+    fk_lookups = build_fk_lookups()
+    extra_data: dict = {}
 
     # Apply winners to the model.
     for claim_key, claim in winners.items():
         if claim.field_name in RELATIONSHIP_NAMESPACES:
-            continue  # Handled by resolve_credits()
-        if claim.field_name == "manufacturer":
-            machine_model.manufacturer = _resolve_manufacturer(claim.value)
-        elif claim.field_name == "group":
-            machine_model.title = _resolve_title_fk(claim.value)
-        elif claim.field_name == "system":
-            machine_model.system = _resolve_system(claim.value, _build_system_lookup())
-        elif claim.field_name == "technology_generation":
-            machine_model.technology_generation = _resolve_slug_fk(
-                claim.value, techgen_lookup, "technology_generation"
-            )
-        elif claim.field_name == "display_type":
-            machine_model.display_type = _resolve_slug_fk(
-                claim.value, display_type_lookup, "display_type"
-            )
-        elif claim.field_name == "display_subtype":
-            machine_model.display_subtype = _resolve_slug_fk(
-                claim.value, display_subtype_lookup, "display_subtype"
-            )
-        elif claim.field_name == "cabinet":
-            machine_model.cabinet = _resolve_slug_fk(
-                claim.value, cabinet_lookup, "cabinet"
-            )
-        elif claim.field_name == "game_format":
-            machine_model.game_format = _resolve_slug_fk(
-                claim.value, game_format_lookup, "game_format"
-            )
-        elif claim.field_name == "variant_of":
-            machine_model.variant_of = _resolve_slug_fk(
-                claim.value, self_lookup, "variant_of"
-            )
-        elif claim.field_name == "converted_from":
-            machine_model.converted_from = _resolve_slug_fk(
-                claim.value, self_lookup, "converted_from"
+            continue
+        if claim.field_name in FK_FIELDS:
+            spec = FK_FIELDS[claim.field_name]
+            setattr(
+                machine_model,
+                spec.model_attr,
+                _resolve_fk(
+                    claim.field_name, claim.value, fk_lookups[claim.field_name]
+                ),
             )
         elif claim.field_name in DIRECT_FIELDS:
             attr = DIRECT_FIELDS[claim.field_name]
-            setattr(machine_model, attr, _coerce(claim.field_name, claim.value))
+            setattr(machine_model, attr, _coerce(MachineModel, attr, claim.value))
         else:
-            # Goes into extra_data catch-all.
             extra_data[claim.field_name] = claim.value
 
     machine_model.extra_data = extra_data
@@ -251,16 +185,8 @@ def resolve_all() -> int:
     resolve_all_title_abbreviations(list(Title.objects.all()))
 
     # 1. Pre-fetch lookup tables.
-    mfr_lookup = _build_manufacturer_lookup()
-    group_lookup = _build_title_lookup()
-    system_lookup = _build_system_lookup()
-    techgen_lookup = _build_technology_generation_lookup()
-    display_type_lookup = _build_display_type_lookup()
-    display_subtype_lookup = _build_display_subtype_lookup()
-    cabinet_lookup = _build_cabinet_lookup()
-    game_format_lookup = _build_game_format_lookup()
-    converted_from_lookup = _build_converted_from_lookup()
-    field_defaults = _get_field_defaults()
+    fk_lookups = build_fk_lookups()
+    field_defaults = get_field_defaults(MachineModel, DIRECT_FIELDS)
 
     # 2. Pre-fetch all active claims, grouped by object_id (~1 query).
     claims_by_model = _build_claims_by_model()
@@ -271,21 +197,7 @@ def resolve_all() -> int:
     # 4. Resolve each model in memory.
     for pm in all_models:
         winners = claims_by_model.get(pm.pk, {})
-        _apply_resolution(
-            pm,
-            winners,
-            field_defaults,
-            mfr_lookup,
-            group_lookup,
-            system_lookup,
-            techgen_lookup,
-            display_type_lookup,
-            display_subtype_lookup,
-            cabinet_lookup,
-            game_format_lookup,
-            converted_from_lookup,
-            variant_of_lookup=converted_from_lookup,
-        )
+        _apply_resolution(pm, winners, field_defaults, fk_lookups)
 
     # 5. Conversions are not variants: clear variant_of on conversion models.
     for pm in all_models:
@@ -301,20 +213,11 @@ def resolve_all() -> int:
         pm.updated_at = now
 
     # 8. Bulk write (~1 query, batched).
-    update_fields = list(DIRECT_FIELDS.values()) + [
-        "manufacturer_id",
-        "title_id",
-        "variant_of_id",
-        "system_id",
-        "technology_generation_id",
-        "display_type_id",
-        "display_subtype_id",
-        "cabinet_id",
-        "game_format_id",
-        "converted_from_id",
-        "extra_data",
-        "updated_at",
-    ]
+    update_fields = (
+        list(DIRECT_FIELDS.values())
+        + [f"{spec.model_attr}_id" for spec in FK_FIELDS.values()]
+        + ["extra_data", "updated_at"]
+    )
     # batch_size=100 is optimal for SQLite (CASE WHEN overhead grows with
     # batch size × field count). PostgreSQL uses a more efficient UPDATE FROM
     # VALUES syntax and handles larger batches fine.
@@ -379,29 +282,12 @@ def _apply_resolution(
     pm: MachineModel,
     winners: dict[str, Claim],
     field_defaults: dict[str, Any],
-    mfr_lookup: dict,
-    group_lookup: dict,
-    system_lookup: dict,
-    techgen_lookup: dict[str, TechnologyGeneration] | None = None,
-    display_type_lookup: dict[str, DisplayType] | None = None,
-    display_subtype_lookup: dict[str, DisplaySubtype] | None = None,
-    cabinet_lookup: dict[str, Cabinet] | None = None,
-    game_format_lookup: dict[str, GameFormat] | None = None,
-    converted_from_lookup: dict[str, MachineModel] | None = None,
-    variant_of_lookup: dict[str, MachineModel] | None = None,
+    fk_lookups: dict[str, dict[str, Any]],
 ) -> None:
     """Apply claim winners to a MachineModel instance in memory."""
     # Reset FK fields.
-    pm.manufacturer = None
-    pm.title = None
-    pm.variant_of = None
-    pm.converted_from = None
-    pm.system = None
-    pm.technology_generation = None
-    pm.display_type = None
-    pm.display_subtype = None
-    pm.cabinet = None
-    pm.game_format = None
+    for spec in FK_FIELDS.values():
+        setattr(pm, spec.model_attr, None)
 
     # Reset all DIRECT_FIELDS to defaults.
     for attr, default in field_defaults.items():
@@ -413,52 +299,19 @@ def _apply_resolution(
     # Apply winners.
     for claim_key, claim in winners.items():
         if claim.field_name in RELATIONSHIP_NAMESPACES:
-            continue  # Handled by bulk credit/recipient resolution
-        if claim.field_name == "manufacturer":
-            pm.manufacturer = _resolve_manufacturer_bulk(
-                claim.value,
-                mfr_lookup=mfr_lookup,
+            continue
+        if claim.field_name in FK_FIELDS:
+            spec = FK_FIELDS[claim.field_name]
+            setattr(
+                pm,
+                spec.model_attr,
+                _resolve_fk(
+                    claim.field_name, claim.value, fk_lookups.get(claim.field_name)
+                ),
             )
-        elif claim.field_name == "group":
-            pm.title = _resolve_title_fk_bulk(claim.value, group_lookup)
-        elif claim.field_name == "system":
-            pm.system = _resolve_system(claim.value, system_lookup)
-        elif claim.field_name == "technology_generation":
-            if techgen_lookup is not None:
-                pm.technology_generation = _resolve_slug_fk(
-                    claim.value, techgen_lookup, "technology_generation"
-                )
-        elif claim.field_name == "display_type":
-            if display_type_lookup is not None:
-                pm.display_type = _resolve_slug_fk(
-                    claim.value, display_type_lookup, "display_type"
-                )
-        elif claim.field_name == "display_subtype":
-            if display_subtype_lookup is not None:
-                pm.display_subtype = _resolve_slug_fk(
-                    claim.value, display_subtype_lookup, "display_subtype"
-                )
-        elif claim.field_name == "cabinet":
-            if cabinet_lookup is not None:
-                pm.cabinet = _resolve_slug_fk(claim.value, cabinet_lookup, "cabinet")
-        elif claim.field_name == "game_format":
-            if game_format_lookup is not None:
-                pm.game_format = _resolve_slug_fk(
-                    claim.value, game_format_lookup, "game_format"
-                )
-        elif claim.field_name == "variant_of":
-            if variant_of_lookup is not None:
-                pm.variant_of = _resolve_slug_fk(
-                    claim.value, variant_of_lookup, "variant_of"
-                )
-        elif claim.field_name == "converted_from":
-            if converted_from_lookup is not None:
-                pm.converted_from = _resolve_slug_fk(
-                    claim.value, converted_from_lookup, "converted_from"
-                )
         elif claim.field_name in DIRECT_FIELDS:
             attr = DIRECT_FIELDS[claim.field_name]
-            setattr(pm, attr, _coerce(claim.field_name, claim.value))
+            setattr(pm, attr, _coerce(MachineModel, attr, claim.value))
         else:
             extra_data[claim.field_name] = claim.value
 

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -9,9 +9,7 @@ Also handles taxonomy model resolution.
 from __future__ import annotations
 
 import logging
-from typing import Any
 
-from django.db import models
 from django.db.models import Case, F, IntegerField, Value, When
 from django.utils import timezone
 
@@ -34,6 +32,7 @@ from ..models import (
     Theme,
     Title,
 )
+from ._helpers import _coerce, get_field_defaults
 
 logger = logging.getLogger(__name__)
 
@@ -54,8 +53,6 @@ MANUFACTURER_DIRECT_FIELDS: dict[str, str] = {
     "website": "website",
 }
 
-_MANUFACTURER_INT_FIELDS: frozenset[str] = frozenset({"founded_year", "dissolved_year"})
-
 PERSON_DIRECT_FIELDS: dict[str, str] = {
     "name": "name",
     "bio": "bio",
@@ -69,17 +66,6 @@ PERSON_DIRECT_FIELDS: dict[str, str] = {
     "nationality": "nationality",
     "photo_url": "photo_url",
 }
-
-_PERSON_INT_FIELDS: frozenset[str] = frozenset(
-    {
-        "birth_year",
-        "birth_month",
-        "birth_day",
-        "death_year",
-        "death_month",
-        "death_day",
-    }
-)
 
 TITLE_DIRECT_FIELDS: dict[str, str] = {
     "name": "name",
@@ -107,24 +93,22 @@ TAXONOMY_DIRECT_FIELDS: dict[str, str] = {
     "display_order": "display_order",
 }
 
-_TAXONOMY_INT_FIELDS: frozenset[str] = frozenset({"display_order"})
-
 # Franchise has no display_order.
 FRANCHISE_DIRECT_FIELDS: dict[str, str] = {
     "name": "name",
 }
 
 # All taxonomy models that go through claim resolution.
-TAXONOMY_MODELS: list[tuple[type, dict[str, str], frozenset[str] | None]] = [
-    (TechnologyGeneration, TAXONOMY_DIRECT_FIELDS, _TAXONOMY_INT_FIELDS),
-    (TechnologySubgeneration, TAXONOMY_DIRECT_FIELDS, _TAXONOMY_INT_FIELDS),
-    (DisplayType, TAXONOMY_DIRECT_FIELDS, _TAXONOMY_INT_FIELDS),
-    (DisplaySubtype, TAXONOMY_DIRECT_FIELDS, _TAXONOMY_INT_FIELDS),
-    (Cabinet, TAXONOMY_DIRECT_FIELDS, _TAXONOMY_INT_FIELDS),
-    (GameFormat, TAXONOMY_DIRECT_FIELDS, _TAXONOMY_INT_FIELDS),
-    (GameplayFeature, TAXONOMY_DIRECT_FIELDS, _TAXONOMY_INT_FIELDS),
-    (Tag, TAXONOMY_DIRECT_FIELDS, _TAXONOMY_INT_FIELDS),
-    (Franchise, FRANCHISE_DIRECT_FIELDS, None),
+TAXONOMY_MODELS: list[tuple[type, dict[str, str]]] = [
+    (TechnologyGeneration, TAXONOMY_DIRECT_FIELDS),
+    (TechnologySubgeneration, TAXONOMY_DIRECT_FIELDS),
+    (DisplayType, TAXONOMY_DIRECT_FIELDS),
+    (DisplaySubtype, TAXONOMY_DIRECT_FIELDS),
+    (Cabinet, TAXONOMY_DIRECT_FIELDS),
+    (GameFormat, TAXONOMY_DIRECT_FIELDS),
+    (GameplayFeature, TAXONOMY_DIRECT_FIELDS),
+    (Tag, TAXONOMY_DIRECT_FIELDS),
+    (Franchise, FRANCHISE_DIRECT_FIELDS),
 ]
 
 
@@ -136,7 +120,6 @@ TAXONOMY_MODELS: list[tuple[type, dict[str, str], frozenset[str] | None]] = [
 def _resolve_single(
     obj,
     direct_fields: dict[str, str],
-    int_fields: frozenset[str] | None = None,
 ) -> None:
     """Resolve active claims onto a single object with only direct fields.
 
@@ -148,7 +131,6 @@ def _resolve_single(
     resolution regardless of what was previously stored.
 
     Mutates *obj* in memory; the caller is responsible for saving.
-    Pass *int_fields* to coerce matching claim values to ``int``.
     """
     claims = (
         obj.claims.filter(is_active=True)
@@ -170,25 +152,15 @@ def _resolve_single(
             winners[claim.field_name] = claim
 
     # Reset resolvable fields to defaults.
-    for attr in direct_fields.values():
-        field = obj._meta.get_field(attr)
-        if hasattr(field, "default") and field.default is not models.NOT_PROVIDED:
-            default = field.default() if callable(field.default) else field.default
-            setattr(obj, attr, default)
-        elif field.null:
-            setattr(obj, attr, None)
-        else:
-            setattr(obj, attr, "")
+    field_defaults = get_field_defaults(type(obj), direct_fields)
+    for attr, default in field_defaults.items():
+        setattr(obj, attr, default)
 
     # Apply winners.
     for field_name, claim in winners.items():
         if field_name in direct_fields:
             attr = direct_fields[field_name]
-            value = claim.value
-            if int_fields and field_name in int_fields:
-                setattr(obj, attr, None if value is None else int(value))
-            else:
-                setattr(obj, attr, "" if value is None else value)
+            setattr(obj, attr, _coerce(type(obj), attr, claim.value))
 
 
 # ------------------------------------------------------------------
@@ -199,7 +171,6 @@ def _resolve_single(
 def _resolve_bulk(
     model_class,
     direct_fields: dict[str, str],
-    int_fields: frozenset[str] | None = None,
     fk_handlers: dict[str, tuple[str, dict]] | None = None,
     object_ids: set[int] | None = None,
 ) -> int:
@@ -212,7 +183,6 @@ def _resolve_bulk(
     Parameters:
         model_class: The Django model class to resolve.
         direct_fields: Maps claim field_name to model attribute name.
-        int_fields: Claim field names whose values should be coerced to int.
         fk_handlers: Maps claim field_name to (fk_field_name, slug_lookup_dict).
             For each matching claim, resolves value via the lookup dict and
             sets the FK attribute. The lookup dict maps slug to model instance.
@@ -259,17 +229,7 @@ def _resolve_bulk(
         return 0
 
     # 3. Compute field defaults once.
-    field_defaults: dict[str, Any] = {}
-    for attr in direct_fields.values():
-        field = model_class._meta.get_field(attr)
-        if hasattr(field, "default") and field.default is not models.NOT_PROVIDED:
-            field_defaults[attr] = (
-                field.default() if callable(field.default) else field.default
-            )
-        elif field.null:
-            field_defaults[attr] = None
-        else:
-            field_defaults[attr] = ""
+    field_defaults = get_field_defaults(model_class, direct_fields)
 
     # Collect FK attribute names for bulk_update.
     fk_update_fields: list[str] = []
@@ -295,22 +255,7 @@ def _resolve_bulk(
         for field_name, claim in winners.items():
             if field_name in direct_fields:
                 attr = direct_fields[field_name]
-                value = claim.value
-                if int_fields and field_name in int_fields:
-                    if value is None:
-                        setattr(obj, attr, None)
-                    else:
-                        try:
-                            setattr(obj, attr, int(value))
-                        except ValueError, TypeError:
-                            logger.warning(
-                                "Cannot coerce %r to int for %s.%s",
-                                value,
-                                model_class.__name__,
-                                field_name,
-                            )
-                else:
-                    setattr(obj, attr, "" if value is None else value)
+                setattr(obj, attr, _coerce(model_class, attr, claim.value))
             elif fk_handlers and field_name in fk_handlers:
                 fk_field, lookup = fk_handlers[field_name]
                 slug = str(claim.value).strip() if claim.value else ""
@@ -342,62 +287,42 @@ def _resolve_bulk(
 
 
 def resolve_manufacturer(mfr: Manufacturer) -> Manufacturer:
-    """Resolve active claims into the given Manufacturer's fields.
-
-    Returns the saved Manufacturer.
-    """
-    _resolve_single(
-        mfr, MANUFACTURER_DIRECT_FIELDS, int_fields=_MANUFACTURER_INT_FIELDS
-    )
+    """Resolve active claims into the given Manufacturer's fields."""
+    _resolve_single(mfr, MANUFACTURER_DIRECT_FIELDS)
     mfr.save()
     return mfr
 
 
 def resolve_person(person: Person) -> Person:
-    """Resolve active claims into the given Person's fields.
-
-    Returns the saved Person.
-    """
-    _resolve_single(person, PERSON_DIRECT_FIELDS, int_fields=_PERSON_INT_FIELDS)
+    """Resolve active claims into the given Person's fields."""
+    _resolve_single(person, PERSON_DIRECT_FIELDS)
     person.save()
     return person
 
 
 def resolve_theme(theme: Theme) -> Theme:
-    """Resolve active claims into the given Theme's fields.
-
-    Returns the saved Theme.
-    """
+    """Resolve active claims into the given Theme's fields."""
     _resolve_single(theme, THEME_DIRECT_FIELDS)
     theme.save()
     return theme
 
 
 def resolve_corporate_entity(entity: CorporateEntity) -> CorporateEntity:
-    """Resolve active claims into the given CorporateEntity's fields.
-
-    Returns the saved CorporateEntity.
-    """
+    """Resolve active claims into the given CorporateEntity's fields."""
     _resolve_single(entity, CORPORATE_ENTITY_DIRECT_FIELDS)
     entity.save()
     return entity
 
 
 def resolve_system(system: System) -> System:
-    """Resolve active claims into the given System's fields.
-
-    Returns the saved System.
-    """
+    """Resolve active claims into the given System's fields."""
     _resolve_single(system, SYSTEM_DIRECT_FIELDS)
     system.save()
     return system
 
 
 def resolve_title(title: Title) -> Title:
-    """Resolve active claims into the given Title's fields.
-
-    Returns the saved Title.
-    """
+    """Resolve active claims into the given Title's fields."""
     _resolve_single(title, TITLE_DIRECT_FIELDS)
     # Handle franchise FK.
     franchise_claim = (
@@ -437,5 +362,5 @@ def resolve_title(title: Title) -> Title:
 
 def _resolve_all_taxonomy() -> None:
     """Resolve claims for all taxonomy models."""
-    for model_class, direct_fields, int_fields in TAXONOMY_MODELS:
-        _resolve_bulk(model_class, direct_fields, int_fields=int_fields)
+    for model_class, direct_fields in TAXONOMY_MODELS:
+        _resolve_bulk(model_class, direct_fields)

--- a/backend/apps/catalog/resolve/_helpers.py
+++ b/backend/apps/catalog/resolve/_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
@@ -41,45 +42,104 @@ DIRECT_FIELDS: dict[str, str] = {
     "is_conversion": "is_conversion",
 }
 
-# Fields that should be coerced to int (nullable).
-_INT_FIELDS = {
-    "year",
-    "month",
-    "player_count",
-    "flipper_count",
-    "ipdb_id",
-    "pinside_id",
+
+# ------------------------------------------------------------------
+# FK field registry
+# ------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FKFieldSpec:
+    """Descriptor for a foreign-key field resolved from claims."""
+
+    model_attr: str  # e.g. "title", "manufacturer"
+    target_model: type  # e.g. Title, Manufacturer
+    lookup_key: str  # field on target model used for lookup, e.g. "slug" or "opdb_id"
+
+
+FK_FIELDS: dict[str, FKFieldSpec] = {
+    "title": FKFieldSpec("title", Title, "opdb_id"),
+    "manufacturer": FKFieldSpec("manufacturer", Manufacturer, "slug"),
+    "system": FKFieldSpec("system", System, "slug"),
+    "technology_generation": FKFieldSpec(
+        "technology_generation", TechnologyGeneration, "slug"
+    ),
+    "display_type": FKFieldSpec("display_type", DisplayType, "slug"),
+    "display_subtype": FKFieldSpec("display_subtype", DisplaySubtype, "slug"),
+    "cabinet": FKFieldSpec("cabinet", Cabinet, "slug"),
+    "game_format": FKFieldSpec("game_format", GameFormat, "slug"),
+    "variant_of": FKFieldSpec("variant_of", MachineModel, "slug"),
+    "converted_from": FKFieldSpec("converted_from", MachineModel, "slug"),
 }
 
-# Fields that should be coerced to Decimal (nullable).
-_DECIMAL_FIELDS = {"ipdb_rating", "pinside_rating"}
 
-# Fields that should be coerced to bool.
-_BOOL_FIELDS = {"is_conversion"}
+def build_fk_lookups() -> dict[str, dict[str, Any]]:
+    """Pre-fetch all FK lookup tables. Returns {claim_field_name: {key: instance}}."""
+    lookups: dict[str, dict[str, Any]] = {}
+    for field_name, spec in FK_FIELDS.items():
+        lookups[field_name] = {
+            getattr(obj, spec.lookup_key): obj
+            for obj in spec.target_model.objects.all()
+        }
+    return lookups
 
 
-def _coerce(field_name: str, value):
+def _resolve_fk(
+    field_name: str,
+    value,
+    lookup: dict[str, Any] | None = None,
+) -> Any | None:
+    """Resolve a claim value to an FK instance, optionally using a pre-fetched lookup."""
+    if not value:
+        return None
+    spec = FK_FIELDS[field_name]
+    key = str(value).strip()
+    if not key:
+        return None
+    if lookup is not None:
+        result = lookup.get(key)
+    else:
+        result = spec.target_model.objects.filter(**{spec.lookup_key: key}).first()
+    if not result:
+        logger.warning("Unmatched %s claim value: %r", field_name, value)
+    return result
+
+
+# ------------------------------------------------------------------
+# Type coercion (auto-detected from Django model field)
+# ------------------------------------------------------------------
+
+
+def _coerce(model_class: type[models.Model], attr: str, value):
     """Coerce a JSON claim value to the type expected by the model field."""
     if value is None or value == "":
-        return None
+        field = model_class._meta.get_field(attr)
+        return None if field.null else ""
 
-    if field_name in _INT_FIELDS:
+    field = model_class._meta.get_field(attr)
+
+    if isinstance(
+        field,
+        models.IntegerField
+        | models.SmallIntegerField
+        | models.PositiveIntegerField
+        | models.PositiveSmallIntegerField
+        | models.BigIntegerField,
+    ):
         try:
             return int(value)
         except ValueError, TypeError:
-            logger.warning("Cannot coerce %r to int for field %s", value, field_name)
-            return None
+            logger.warning("Cannot coerce %r to int for field %s", value, attr)
+            return None if field.null else 0
 
-    if field_name in _DECIMAL_FIELDS:
+    if isinstance(field, models.DecimalField):
         try:
             return Decimal(str(value))
         except InvalidOperation, ValueError, TypeError:
-            logger.warning(
-                "Cannot coerce %r to Decimal for field %s", value, field_name
-            )
-            return None
+            logger.warning("Cannot coerce %r to Decimal for field %s", value, attr)
+            return None if field.null else Decimal(0)
 
-    if field_name in _BOOL_FIELDS:
+    if isinstance(field, models.BooleanField):
         if isinstance(value, bool):
             return value
         if isinstance(value, str):
@@ -89,139 +149,19 @@ def _coerce(field_name: str, value):
     return value
 
 
-def _resolve_title_fk(value) -> Title | None:
-    """Resolve a group claim value to a Title instance.
-
-    The value is expected to be an OPDB group ID string (e.g., "G5pe4").
-    """
-    if value is None or value == "":
-        return None
-    title = Title.objects.filter(opdb_id=str(value)).first()
-    if not title:
-        logger.warning("Unmatched group claim value: %r", value)
-    return title
-
-
-def _resolve_manufacturer(value) -> Manufacturer | None:
-    """Resolve a manufacturer claim value (slug) to a Manufacturer instance."""
-    if value is None or value == "":
-        return None
-    slug = str(value).strip()
-    if not slug:
-        return None
-    mfr = Manufacturer.objects.filter(slug=slug).first()
-    if not mfr:
-        logger.warning("Unmatched manufacturer claim slug: %r", value)
-    return mfr
-
-
 # ------------------------------------------------------------------
-# Lookup builders (used by bulk resolution)
+# Field defaults
 # ------------------------------------------------------------------
 
 
-def _build_manufacturer_lookup() -> dict[str, Manufacturer]:
-    """Pre-fetch all manufacturers into {slug: Manufacturer}."""
-    return {m.slug: m for m in Manufacturer.objects.all()}
-
-
-def _build_title_lookup() -> dict[str, Title]:
-    """Pre-fetch all titles into {opdb_id: Title}."""
-    return {t.opdb_id: t for t in Title.objects.all()}
-
-
-def _build_system_lookup() -> dict[str, System]:
-    """Pre-fetch all systems into {slug: System}."""
-    return {s.slug: s for s in System.objects.all()}
-
-
-def _resolve_system(value, system_lookup: dict[str, System]) -> System | None:
-    if not value:
-        return None
-    result = system_lookup.get(str(value))
-    if not result:
-        logger.warning("Unmatched system claim slug: %r", value)
-    return result
-
-
-def _build_technology_generation_lookup() -> dict[str, TechnologyGeneration]:
-    """Pre-fetch all technology generations into {slug: TechnologyGeneration}."""
-    return {t.slug: t for t in TechnologyGeneration.objects.all()}
-
-
-def _build_display_type_lookup() -> dict[str, DisplayType]:
-    """Pre-fetch all display types into {slug: DisplayType}."""
-    return {d.slug: d for d in DisplayType.objects.all()}
-
-
-def _build_display_subtype_lookup() -> dict[str, DisplaySubtype]:
-    """Pre-fetch all display subtypes into {slug: DisplaySubtype}."""
-    return {d.slug: d for d in DisplaySubtype.objects.all()}
-
-
-def _build_cabinet_lookup() -> dict[str, Cabinet]:
-    """Pre-fetch all cabinets into {slug: Cabinet}."""
-    return {c.slug: c for c in Cabinet.objects.all()}
-
-
-def _build_game_format_lookup() -> dict[str, GameFormat]:
-    """Pre-fetch all game formats into {slug: GameFormat}."""
-    return {g.slug: g for g in GameFormat.objects.all()}
-
-
-def _build_converted_from_lookup() -> dict[str, MachineModel]:
-    """Pre-fetch all machine models into {slug: MachineModel}."""
-    return {m.slug: m for m in MachineModel.objects.all()}
-
-
-def _resolve_slug_fk(value, lookup: dict[str, Any], label: str):
-    """Resolve a slug claim value to a model instance via a pre-fetched lookup."""
-    if not value:
-        return None
-    result = lookup.get(str(value))
-    if not result:
-        logger.warning("Unmatched %s claim slug: %r", label, value)
-    return result
-
-
-def _resolve_manufacturer_bulk(
-    value,
-    mfr_lookup: dict[str, Manufacturer],
-) -> Manufacturer | None:
-    """Resolve a manufacturer slug to a Manufacturer using pre-fetched dict."""
-    if value is None or value == "":
-        return None
-    result = mfr_lookup.get(str(value))
-    if not result:
-        logger.warning("Unmatched manufacturer claim slug: %r", value)
-    return result
-
-
-def _resolve_title_fk_bulk(value, group_lookup: dict[str, Title]) -> Title | None:
-    """Same logic as _resolve_title_fk() but uses pre-fetched dict."""
-    if value is None or value == "":
-        return None
-    title = group_lookup.get(str(value))
-    if not title:
-        logger.warning("Unmatched group claim value: %r", value)
-    return title
-
-
-# ------------------------------------------------------------------
-# Field defaults cache (used by bulk resolution)
-# ------------------------------------------------------------------
-
-_field_defaults: dict[str, Any] | None = None
-
-
-def _get_field_defaults() -> dict[str, Any]:
-    """Compute reset values for all DIRECT_FIELDS (cached after first call)."""
-    global _field_defaults
-    if _field_defaults is not None:
-        return _field_defaults
+def get_field_defaults(
+    model_class: type[models.Model],
+    direct_fields: dict[str, str],
+) -> dict[str, Any]:
+    """Compute reset values for direct fields by inspecting Django model metadata."""
     defaults: dict[str, Any] = {}
-    for attr in DIRECT_FIELDS.values():
-        field = MachineModel._meta.get_field(attr)
+    for attr in direct_fields.values():
+        field = model_class._meta.get_field(attr)
         if hasattr(field, "default") and field.default is not models.NOT_PROVIDED:
             defaults[attr] = (
                 field.default() if callable(field.default) else field.default
@@ -230,8 +170,7 @@ def _get_field_defaults() -> dict[str, Any]:
             defaults[attr] = None
         else:
             defaults[attr] = ""
-    _field_defaults = defaults
-    return _field_defaults
+    return defaults
 
 
 # ------------------------------------------------------------------

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -7,6 +7,7 @@ Includes both single-object and bulk variants for each relationship type.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 from django.db.models import Case, F, IntegerField, Value, When
 
@@ -30,16 +31,209 @@ logger = logging.getLogger(__name__)
 
 
 # ------------------------------------------------------------------
-# Single-object relationship resolvers
+# M2M relationship registry
+# ------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class M2MFieldSpec:
+    """Descriptor for a simple M2M relationship resolved from claims."""
+
+    field_name: str  # claim field_name: "theme", "tag", "gameplay_feature"
+    slug_key: str  # key in claim value dict: "theme_slug", "tag_slug", etc.
+    m2m_attr: str  # model attribute: "themes", "tags", "gameplay_features"
+    target_model: type  # Theme, Tag, GameplayFeature
+
+
+M2M_FIELDS: dict[str, M2MFieldSpec] = {
+    "theme": M2MFieldSpec("theme", "theme_slug", "themes", Theme),
+    "gameplay_feature": M2MFieldSpec(
+        "gameplay_feature",
+        "gameplay_feature_slug",
+        "gameplay_features",
+        GameplayFeature,
+    ),
+    "tag": M2MFieldSpec("tag", "tag_slug", "tags", Tag),
+}
+
+
+# ------------------------------------------------------------------
+# Generic M2M resolvers
+# ------------------------------------------------------------------
+
+
+def _resolve_m2m_single(obj, spec: M2MFieldSpec) -> None:
+    """Resolve M2M claims for a single object using the given spec."""
+    winners = _pick_relationship_winners(obj, spec.field_name)
+
+    desired_pks: set[int] = set()
+    for claim in winners.values():
+        val = claim.value
+        if not val.get("exists", True):
+            continue
+        target = spec.target_model.objects.filter(slug=val[spec.slug_key]).first()
+        if not target:
+            logger.warning(
+                "Unresolved %s slug %r in %s claim for %s",
+                spec.field_name,
+                val[spec.slug_key],
+                spec.field_name,
+                obj,
+            )
+            continue
+        desired_pks.add(target.pk)
+
+    getattr(obj, spec.m2m_attr).set(desired_pks)
+
+
+def _resolve_all_m2m(
+    spec: M2MFieldSpec,
+    all_models: list[MachineModel],
+    *,
+    model_ids: set[int] | None = None,
+) -> None:
+    """Bulk-resolve M2M claims into through-table rows for the given spec."""
+    from django.contrib.contenttypes.models import ContentType
+
+    ct = ContentType.objects.get_for_model(MachineModel)
+
+    # Pre-fetch slug→pk lookup.
+    slug_lookup: dict[str, int] = dict(
+        spec.target_model.objects.values_list("slug", "pk")
+    )
+
+    # Pre-fetch active claims with priority annotation.
+    claims_qs = Claim.objects.filter(
+        is_active=True, content_type=ct, field_name=spec.field_name
+    )
+    if model_ids is not None:
+        claims_qs = claims_qs.filter(object_id__in=model_ids)
+    claims = (
+        claims_qs.select_related("source", "user__profile")
+        .annotate(
+            effective_priority=Case(
+                When(source__isnull=False, then=F("source__priority")),
+                When(user__isnull=False, then=F("user__profile__priority")),
+                default=Value(0),
+                output_field=IntegerField(),
+            )
+        )
+        .order_by("object_id", "claim_key", "-effective_priority", "-created_at")
+    )
+
+    # Pick winner per (object_id, claim_key).
+    winners_by_model: dict[int, list[Claim]] = {}
+    seen: set[tuple[int, str]] = set()
+    for claim in claims:
+        key = (claim.object_id, claim.claim_key)
+        if key not in seen:
+            seen.add(key)
+            winners_by_model.setdefault(claim.object_id, []).append(claim)
+
+    # Desired PKs from winning claims.
+    desired_by_model: dict[int, set[int]] = {}
+    for model_id, claims_list in winners_by_model.items():
+        desired: set[int] = set()
+        for claim in claims_list:
+            val = claim.value
+            if not val.get("exists", True):
+                continue
+            target_pk = slug_lookup.get(val[spec.slug_key])
+            if target_pk is None:
+                logger.warning(
+                    "Unresolved %s slug %r in claim (model pk=%s)",
+                    spec.field_name,
+                    val[spec.slug_key],
+                    model_id,
+                )
+                continue
+            desired.add(target_pk)
+        desired_by_model[model_id] = desired
+
+    # Pre-fetch existing M2M through-table rows.
+    all_model_ids = model_ids if model_ids is not None else {pm.pk for pm in all_models}
+    through = getattr(MachineModel, spec.m2m_attr).through
+    target_col = spec.target_model._meta.model_name + "_id"
+
+    existing_by_model: dict[int, set[int]] = {}
+    for row in through.objects.filter(machinemodel_id__in=all_model_ids).values_list(
+        "machinemodel_id", target_col
+    ):
+        existing_by_model.setdefault(row[0], set()).add(row[1])
+
+    # Diff and apply.
+    to_create = []
+    to_delete_pks: list[int] = []
+
+    for model_id in all_model_ids:
+        desired = desired_by_model.get(model_id, set())
+        existing = existing_by_model.get(model_id, set())
+
+        for target_pk in desired - existing:
+            to_create.append(
+                through(machinemodel_id=model_id, **{target_col: target_pk})
+            )
+
+    # Build a lookup for deletions.
+    for row in through.objects.filter(machinemodel_id__in=all_model_ids).values_list(
+        "pk", "machinemodel_id", target_col
+    ):
+        pk, model_id, fk_id = row
+        desired = desired_by_model.get(model_id, set())
+        if fk_id not in desired:
+            to_delete_pks.append(pk)
+
+    if to_delete_pks:
+        through.objects.filter(pk__in=to_delete_pks).delete()
+    if to_create:
+        through.objects.bulk_create(to_create, batch_size=2000)
+
+
+# ------------------------------------------------------------------
+# Public M2M wrappers (single-object)
+# ------------------------------------------------------------------
+
+
+def resolve_themes(machine_model: MachineModel) -> None:
+    _resolve_m2m_single(machine_model, M2M_FIELDS["theme"])
+
+
+def resolve_gameplay_features(machine_model: MachineModel) -> None:
+    _resolve_m2m_single(machine_model, M2M_FIELDS["gameplay_feature"])
+
+
+def resolve_tags(machine_model: MachineModel) -> None:
+    _resolve_m2m_single(machine_model, M2M_FIELDS["tag"])
+
+
+# ------------------------------------------------------------------
+# Public M2M wrappers (bulk)
+# ------------------------------------------------------------------
+
+
+def resolve_all_themes(
+    all_models: list[MachineModel],
+    *,
+    model_ids: set[int] | None = None,
+) -> None:
+    _resolve_all_m2m(M2M_FIELDS["theme"], all_models, model_ids=model_ids)
+
+
+def _resolve_all_gameplay_features(all_models: list[MachineModel]) -> None:
+    _resolve_all_m2m(M2M_FIELDS["gameplay_feature"], all_models)
+
+
+def _resolve_all_tags(all_models: list[MachineModel]) -> None:
+    _resolve_all_m2m(M2M_FIELDS["tag"], all_models)
+
+
+# ------------------------------------------------------------------
+# Credits (compound identity — not amenable to generic M2M)
 # ------------------------------------------------------------------
 
 
 def resolve_credits(machine_model: MachineModel) -> None:
-    """Resolve credit claims into Credit rows for a single machine.
-
-    Picks the winning claim per claim_key. Where ``value["exists"]`` is
-    True, looks up the Person by slug and materializes a Credit.
-    """
+    """Resolve credit claims into Credit rows for a single machine."""
     winners = _pick_relationship_winners(machine_model, "credit")
 
     role_lookup: dict[str, int] = dict(CreditRole.objects.values_list("slug", "pk"))
@@ -52,8 +246,7 @@ def resolve_credits(machine_model: MachineModel) -> None:
             )
         return
 
-    # Desired credits from winning claims.
-    desired: set[tuple[int, int]] = set()  # (person_id, role_id)
+    desired: set[tuple[int, int]] = set()
     for claim in winners.values():
         val = claim.value
         if not val.get("exists", True):
@@ -76,10 +269,8 @@ def resolve_credits(machine_model: MachineModel) -> None:
             continue
         desired.add((person.pk, role_id))
 
-    # Existing credits.
     existing = set(machine_model.credits.values_list("person_id", "role_id"))
 
-    # Diff and apply.
     to_create = desired - existing
     to_delete = existing - desired
 
@@ -96,106 +287,16 @@ def resolve_credits(machine_model: MachineModel) -> None:
         )
 
 
-def resolve_themes(machine_model: MachineModel) -> None:
-    """Resolve theme claims into the M2M for a single machine.
-
-    Picks the winning claim per claim_key. Where ``value["exists"]`` is
-    True, looks up the Theme by slug and sets the M2M.
-    """
-    winners = _pick_relationship_winners(machine_model, "theme")
-
-    desired_pks: set[int] = set()
-    for claim in winners.values():
-        val = claim.value
-        if not val.get("exists", True):
-            continue
-        theme = Theme.objects.filter(slug=val["theme_slug"]).first()
-        if not theme:
-            logger.warning(
-                "Unresolved theme slug %r in theme claim for %s",
-                val["theme_slug"],
-                machine_model.name,
-            )
-            continue
-        desired_pks.add(theme.pk)
-
-    machine_model.themes.set(desired_pks)
-
-
-def resolve_gameplay_features(machine_model: MachineModel) -> None:
-    """Resolve gameplay feature claims into the M2M for a single machine.
-
-    Picks the winning claim per claim_key. Where ``value["exists"]`` is
-    True, looks up the GameplayFeature by slug and sets the M2M.
-    """
-    winners = _pick_relationship_winners(machine_model, "gameplay_feature")
-
-    desired_pks: set[int] = set()
-    for claim in winners.values():
-        val = claim.value
-        if not val.get("exists", True):
-            continue
-        feature = GameplayFeature.objects.filter(
-            slug=val["gameplay_feature_slug"]
-        ).first()
-        if not feature:
-            logger.warning(
-                "Unresolved gameplay feature slug %r in claim for %s",
-                val["gameplay_feature_slug"],
-                machine_model.name,
-            )
-            continue
-        desired_pks.add(feature.pk)
-
-    machine_model.gameplay_features.set(desired_pks)
-
-
-def resolve_tags(machine_model: MachineModel) -> None:
-    """Resolve tag claims into the M2M for a single machine.
-
-    Picks the winning claim per claim_key. Where ``value["exists"]`` is
-    True, looks up the Tag by slug and sets the M2M.
-    """
-    winners = _pick_relationship_winners(machine_model, "tag")
-
-    desired_pks: set[int] = set()
-    for claim in winners.values():
-        val = claim.value
-        if not val.get("exists", True):
-            continue
-        tag = Tag.objects.filter(slug=val["tag_slug"]).first()
-        if not tag:
-            logger.warning(
-                "Unresolved tag slug %r in tag claim for %s",
-                val["tag_slug"],
-                machine_model.name,
-            )
-            continue
-        desired_pks.add(tag.pk)
-
-    machine_model.tags.set(desired_pks)
-
-
-# ------------------------------------------------------------------
-# Bulk relationship resolvers
-# ------------------------------------------------------------------
-
-
 def resolve_all_credits(
     all_models: list[MachineModel],
     *,
     model_ids: set[int] | None = None,
 ) -> None:
-    """Bulk-resolve credit claims into Credit rows.
-
-    If *model_ids* is given, only claims and rows for those models are
-    queried.  Otherwise all models in *all_models* are processed.
-    """
+    """Bulk-resolve credit claims into Credit rows."""
     from django.contrib.contenttypes.models import ContentType
 
     ct = ContentType.objects.get_for_model(MachineModel)
 
-    # Pre-fetch person slug→pk and role slug→pk lookups.
     person_lookup: dict[str, int] = dict(Person.objects.values_list("slug", "pk"))
     role_lookup: dict[str, int] = dict(CreditRole.objects.values_list("slug", "pk"))
     if not role_lookup:
@@ -205,7 +306,6 @@ def resolve_all_credits(
         )
         return
 
-    # Pre-fetch active credit claims with priority annotation.
     credit_qs = Claim.objects.filter(
         is_active=True, content_type=ct, field_name="credit"
     )
@@ -224,7 +324,6 @@ def resolve_all_credits(
         .order_by("object_id", "claim_key", "-effective_priority", "-created_at")
     )
 
-    # Pick winner per (object_id, claim_key).
     winners_by_model: dict[int, list[Claim]] = {}
     seen: set[tuple[int, str]] = set()
     for claim in credit_claims:
@@ -233,7 +332,6 @@ def resolve_all_credits(
             seen.add(key)
             winners_by_model.setdefault(claim.object_id, []).append(claim)
 
-    # Desired credits from winning claims.
     desired_by_model: dict[int, set[tuple[int, int]]] = {}
     for model_id, claims_list in winners_by_model.items():
         desired: set[tuple[int, int]] = set()
@@ -260,14 +358,12 @@ def resolve_all_credits(
             desired.add((person_pk, role_pk))
         desired_by_model[model_id] = desired
 
-    # Pre-fetch existing Credit rows (model-linked only, not series credits).
     all_model_ids = model_ids if model_ids is not None else {pm.pk for pm in all_models}
     existing_by_model: dict[int, set[tuple[int, int]]] = {}
     dc_qs = Credit.objects.filter(model_id__in=all_model_ids)
     for dc in dc_qs.values_list("model_id", "person_id", "role_id"):
         existing_by_model.setdefault(dc[0], set()).add((dc[1], dc[2]))
 
-    # Diff and apply.
     to_create: list[Credit] = []
     to_delete_pks: list[int] = []
 
@@ -280,7 +376,6 @@ def resolve_all_credits(
                 Credit(model_id=model_id, person_id=person_id, role_id=role_id)
             )
 
-    # Build a lookup for deletions.
     for dc in Credit.objects.filter(model_id__in=all_model_ids).values_list(
         "pk", "model_id", "person_id", "role_id"
     ):
@@ -295,287 +390,8 @@ def resolve_all_credits(
         Credit.objects.bulk_create(to_create, batch_size=2000)
 
 
-def resolve_all_themes(
-    all_models: list[MachineModel],
-    *,
-    model_ids: set[int] | None = None,
-) -> None:
-    """Bulk-resolve theme claims into M2M rows.
-
-    If *model_ids* is given, only claims and rows for those models are
-    queried.  Otherwise all models in *all_models* are processed.
-    """
-    from django.contrib.contenttypes.models import ContentType
-
-    ct = ContentType.objects.get_for_model(MachineModel)
-
-    # Pre-fetch theme slug→pk lookup.
-    theme_lookup: dict[str, int] = dict(Theme.objects.values_list("slug", "pk"))
-
-    # Pre-fetch active theme claims with priority annotation.
-    theme_qs = Claim.objects.filter(is_active=True, content_type=ct, field_name="theme")
-    if model_ids is not None:
-        theme_qs = theme_qs.filter(object_id__in=model_ids)
-    theme_claims = (
-        theme_qs.select_related("source", "user__profile")
-        .annotate(
-            effective_priority=Case(
-                When(source__isnull=False, then=F("source__priority")),
-                When(user__isnull=False, then=F("user__profile__priority")),
-                default=Value(0),
-                output_field=IntegerField(),
-            )
-        )
-        .order_by("object_id", "claim_key", "-effective_priority", "-created_at")
-    )
-
-    # Pick winner per (object_id, claim_key).
-    winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
-    for claim in theme_claims:
-        key = (claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_model.setdefault(claim.object_id, []).append(claim)
-
-    # Desired themes from winning claims.
-    desired_by_model: dict[int, set[int]] = {}
-    for model_id, claims_list in winners_by_model.items():
-        desired: set[int] = set()
-        for claim in claims_list:
-            val = claim.value
-            if not val.get("exists", True):
-                continue
-            theme_pk = theme_lookup.get(val["theme_slug"])
-            if theme_pk is None:
-                logger.warning(
-                    "Unresolved theme slug %r in theme claim (model pk=%s)",
-                    val["theme_slug"],
-                    model_id,
-                )
-                continue
-            desired.add(theme_pk)
-        desired_by_model[model_id] = desired
-
-    # Pre-fetch existing M2M through-table rows.
-    all_model_ids = model_ids if model_ids is not None else {pm.pk for pm in all_models}
-    through = MachineModel.themes.through
-    existing_by_model: dict[int, set[int]] = {}
-    for row in through.objects.filter(machinemodel_id__in=all_model_ids).values_list(
-        "machinemodel_id", "theme_id"
-    ):
-        existing_by_model.setdefault(row[0], set()).add(row[1])
-
-    # Diff and apply.
-    to_create = []
-    to_delete_pks: list[int] = []
-
-    for model_id in all_model_ids:
-        desired = desired_by_model.get(model_id, set())
-        existing = existing_by_model.get(model_id, set())
-
-        for theme_pk in desired - existing:
-            to_create.append(through(machinemodel_id=model_id, theme_id=theme_pk))
-
-    # Build a lookup for deletions.
-    for row in through.objects.filter(machinemodel_id__in=all_model_ids).values_list(
-        "pk", "machinemodel_id", "theme_id"
-    ):
-        pk, model_id, theme_id = row
-        desired = desired_by_model.get(model_id, set())
-        if theme_id not in desired:
-            to_delete_pks.append(pk)
-
-    if to_delete_pks:
-        through.objects.filter(pk__in=to_delete_pks).delete()
-    if to_create:
-        through.objects.bulk_create(to_create, batch_size=2000)
-
-
-def _resolve_all_gameplay_features(all_models: list[MachineModel]) -> None:
-    """Bulk-resolve gameplay feature claims into M2M rows for all models.
-
-    Follows the same pattern as ``resolve_all_themes()``.
-    """
-    from django.contrib.contenttypes.models import ContentType
-
-    ct = ContentType.objects.get_for_model(MachineModel)
-
-    # Pre-fetch gameplay feature slug→pk lookup.
-    feature_lookup: dict[str, int] = dict(
-        GameplayFeature.objects.values_list("slug", "pk")
-    )
-
-    # Pre-fetch all active gameplay feature claims with priority annotation.
-    feature_claims = (
-        Claim.objects.filter(
-            is_active=True, content_type=ct, field_name="gameplay_feature"
-        )
-        .select_related("source", "user__profile")
-        .annotate(
-            effective_priority=Case(
-                When(source__isnull=False, then=F("source__priority")),
-                When(user__isnull=False, then=F("user__profile__priority")),
-                default=Value(0),
-                output_field=IntegerField(),
-            )
-        )
-        .order_by("object_id", "claim_key", "-effective_priority", "-created_at")
-    )
-
-    # Pick winner per (object_id, claim_key).
-    winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
-    for claim in feature_claims:
-        key = (claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_model.setdefault(claim.object_id, []).append(claim)
-
-    # Desired features from winning claims.
-    desired_by_model: dict[int, set[int]] = {}
-    for model_id, claims_list in winners_by_model.items():
-        desired: set[int] = set()
-        for claim in claims_list:
-            val = claim.value
-            if not val.get("exists", True):
-                continue
-            feature_pk = feature_lookup.get(val["gameplay_feature_slug"])
-            if feature_pk is None:
-                logger.warning(
-                    "Unresolved gameplay feature slug %r in claim (model pk=%s)",
-                    val["gameplay_feature_slug"],
-                    model_id,
-                )
-                continue
-            desired.add(feature_pk)
-        desired_by_model[model_id] = desired
-
-    # Pre-fetch existing M2M through-table rows.
-    through = MachineModel.gameplay_features.through
-    existing_by_model: dict[int, set[int]] = {}
-    for row in through.objects.values_list("machinemodel_id", "gameplayfeature_id"):
-        existing_by_model.setdefault(row[0], set()).add(row[1])
-
-    # Diff and apply for ALL models.
-    all_model_ids = {pm.pk for pm in all_models}
-    to_create = []
-    to_delete_pks: list[int] = []
-
-    for model_id in all_model_ids:
-        desired = desired_by_model.get(model_id, set())
-        existing = existing_by_model.get(model_id, set())
-
-        for feature_pk in desired - existing:
-            to_create.append(
-                through(machinemodel_id=model_id, gameplayfeature_id=feature_pk)
-            )
-
-    # Build a lookup for deletions.
-    for row in through.objects.filter(machinemodel_id__in=all_model_ids).values_list(
-        "pk", "machinemodel_id", "gameplayfeature_id"
-    ):
-        pk, model_id, feature_id = row
-        desired = desired_by_model.get(model_id, set())
-        if feature_id not in desired:
-            to_delete_pks.append(pk)
-
-    if to_delete_pks:
-        through.objects.filter(pk__in=to_delete_pks).delete()
-    if to_create:
-        through.objects.bulk_create(to_create, batch_size=2000)
-
-
-def _resolve_all_tags(all_models: list[MachineModel]) -> None:
-    """Bulk-resolve tag claims into M2M rows for all models.
-
-    Follows the same pattern as ``resolve_all_themes()``.
-    """
-    from django.contrib.contenttypes.models import ContentType
-
-    ct = ContentType.objects.get_for_model(MachineModel)
-
-    # Pre-fetch tag slug→pk lookup.
-    tag_lookup: dict[str, int] = dict(Tag.objects.values_list("slug", "pk"))
-
-    # Pre-fetch all active tag claims with priority annotation.
-    tag_claims = (
-        Claim.objects.filter(is_active=True, content_type=ct, field_name="tag")
-        .select_related("source", "user__profile")
-        .annotate(
-            effective_priority=Case(
-                When(source__isnull=False, then=F("source__priority")),
-                When(user__isnull=False, then=F("user__profile__priority")),
-                default=Value(0),
-                output_field=IntegerField(),
-            )
-        )
-        .order_by("object_id", "claim_key", "-effective_priority", "-created_at")
-    )
-
-    # Pick winner per (object_id, claim_key).
-    winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
-    for claim in tag_claims:
-        key = (claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_model.setdefault(claim.object_id, []).append(claim)
-
-    # Desired tags from winning claims.
-    desired_by_model: dict[int, set[int]] = {}
-    for model_id, claims_list in winners_by_model.items():
-        desired: set[int] = set()
-        for claim in claims_list:
-            val = claim.value
-            if not val.get("exists", True):
-                continue
-            tag_pk = tag_lookup.get(val["tag_slug"])
-            if tag_pk is None:
-                logger.warning(
-                    "Unresolved tag slug %r in tag claim (model pk=%s)",
-                    val["tag_slug"],
-                    model_id,
-                )
-                continue
-            desired.add(tag_pk)
-        desired_by_model[model_id] = desired
-
-    # Pre-fetch existing M2M through-table rows.
-    through = MachineModel.tags.through
-    existing_by_model: dict[int, set[int]] = {}
-    for row in through.objects.values_list("machinemodel_id", "tag_id"):
-        existing_by_model.setdefault(row[0], set()).add(row[1])
-
-    # Diff and apply for ALL models.
-    all_model_ids = {pm.pk for pm in all_models}
-    to_create = []
-    to_delete_pks: list[int] = []
-
-    for model_id in all_model_ids:
-        desired = desired_by_model.get(model_id, set())
-        existing = existing_by_model.get(model_id, set())
-
-        for tag_pk in desired - existing:
-            to_create.append(through(machinemodel_id=model_id, tag_id=tag_pk))
-
-    # Build a lookup for deletions.
-    for row in through.objects.filter(machinemodel_id__in=all_model_ids).values_list(
-        "pk", "machinemodel_id", "tag_id"
-    ):
-        pk, model_id, tag_id = row
-        desired = desired_by_model.get(model_id, set())
-        if tag_id not in desired:
-            to_delete_pks.append(pk)
-
-    if to_delete_pks:
-        through.objects.filter(pk__in=to_delete_pks).delete()
-    if to_create:
-        through.objects.bulk_create(to_create, batch_size=2000)
-
-
 # ------------------------------------------------------------------
-# Single-object abbreviation resolvers
+# Abbreviation resolvers (string values, dedup logic — not generic M2M)
 # ------------------------------------------------------------------
 
 
@@ -592,11 +408,9 @@ def resolve_title_abbreviations(title: Title) -> None:
 
     existing = set(title.abbreviations.values_list("value", flat=True))
 
-    # Create new abbreviations.
     for value in desired - existing:
         TitleAbbreviation.objects.create(title=title, value=value)
 
-    # Remove stale abbreviations.
     if stale := existing - desired:
         title.abbreviations.filter(value__in=stale).delete()
 
@@ -630,11 +444,6 @@ def resolve_model_abbreviations(machine_model: MachineModel) -> None:
         machine_model.abbreviations.filter(value__in=stale).delete()
 
 
-# ------------------------------------------------------------------
-# Bulk abbreviation resolvers
-# ------------------------------------------------------------------
-
-
 def resolve_all_title_abbreviations(
     all_titles: list[Title],
     *,
@@ -645,7 +454,6 @@ def resolve_all_title_abbreviations(
 
     ct = ContentType.objects.get_for_model(Title)
 
-    # Pre-fetch active abbreviation claims with priority annotation.
     abbr_qs = Claim.objects.filter(
         is_active=True, content_type=ct, field_name="abbreviation"
     )
@@ -664,7 +472,6 @@ def resolve_all_title_abbreviations(
         .order_by("object_id", "claim_key", "-effective_priority", "-created_at")
     )
 
-    # Pick winner per (object_id, claim_key).
     winners_by_title: dict[int, list[Claim]] = {}
     seen: set[tuple[int, str]] = set()
     for claim in abbr_claims:
@@ -673,7 +480,6 @@ def resolve_all_title_abbreviations(
             seen.add(key)
             winners_by_title.setdefault(claim.object_id, []).append(claim)
 
-    # Desired abbreviation values from winning claims.
     desired_by_title: dict[int, set[str]] = {}
     for title_id, claims_list in winners_by_title.items():
         desired: set[str] = set()
@@ -684,7 +490,6 @@ def resolve_all_title_abbreviations(
             desired.add(val["value"])
         desired_by_title[title_id] = desired
 
-    # Pre-fetch existing TitleAbbreviation rows.
     all_title_ids = title_ids if title_ids is not None else {t.pk for t in all_titles}
     existing_by_title: dict[int, set[str]] = {}
     for row in TitleAbbreviation.objects.filter(title_id__in=all_title_ids).values_list(
@@ -692,7 +497,6 @@ def resolve_all_title_abbreviations(
     ):
         existing_by_title.setdefault(row[0], set()).add(row[1])
 
-    # Diff and apply.
     to_create = []
     to_delete_pks: list[int] = []
 
@@ -703,7 +507,6 @@ def resolve_all_title_abbreviations(
         for value in desired - existing:
             to_create.append(TitleAbbreviation(title_id=title_id, value=value))
 
-    # Build a lookup for deletions.
     for row in TitleAbbreviation.objects.filter(title_id__in=all_title_ids).values_list(
         "pk", "title_id", "value"
     ):
@@ -722,7 +525,6 @@ def _get_title_abbrs_for_models(
     model_ids: set[int],
 ) -> dict[int, set[str]]:
     """Return {model_id: set(abbreviation_values)} from each model's title."""
-    # Get model_id -> title_id mapping.
     model_title_map = dict(
         MachineModel.objects.filter(pk__in=model_ids, title__isnull=False).values_list(
             "pk", "title_id"
@@ -731,7 +533,6 @@ def _get_title_abbrs_for_models(
     if not model_title_map:
         return {}
 
-    # Get title_id -> set of abbreviation values.
     title_ids = set(model_title_map.values())
     title_abbrs: dict[int, set[str]] = {}
     for title_id, value in TitleAbbreviation.objects.filter(
@@ -739,7 +540,6 @@ def _get_title_abbrs_for_models(
     ).values_list("title_id", "value"):
         title_abbrs.setdefault(title_id, set()).add(value)
 
-    # Map back to model_id.
     result: dict[int, set[str]] = {}
     for model_id, title_id in model_title_map.items():
         abbrs = title_abbrs.get(title_id)
@@ -758,7 +558,6 @@ def resolve_all_model_abbreviations(
 
     ct = ContentType.objects.get_for_model(MachineModel)
 
-    # Pre-fetch active abbreviation claims with priority annotation.
     abbr_qs = Claim.objects.filter(
         is_active=True, content_type=ct, field_name="abbreviation"
     )
@@ -777,7 +576,6 @@ def resolve_all_model_abbreviations(
         .order_by("object_id", "claim_key", "-effective_priority", "-created_at")
     )
 
-    # Pick winner per (object_id, claim_key).
     winners_by_model: dict[int, list[Claim]] = {}
     seen: set[tuple[int, str]] = set()
     for claim in abbr_claims:
@@ -786,7 +584,6 @@ def resolve_all_model_abbreviations(
             seen.add(key)
             winners_by_model.setdefault(claim.object_id, []).append(claim)
 
-    # Desired abbreviation values from winning claims.
     desired_by_model: dict[int, set[str]] = {}
     for model_id, claims_list in winners_by_model.items():
         desired: set[str] = set()
@@ -797,7 +594,6 @@ def resolve_all_model_abbreviations(
             desired.add(val["value"])
         desired_by_model[model_id] = desired
 
-    # Deduplicate: remove model abbreviations that already exist on the title.
     all_model_ids = model_ids if model_ids is not None else {pm.pk for pm in all_models}
     title_abbrs_by_model = _get_title_abbrs_for_models(all_model_ids)
     for model_id in list(desired_by_model):
@@ -805,14 +601,12 @@ def resolve_all_model_abbreviations(
         if title_abbrs:
             desired_by_model[model_id] -= title_abbrs
 
-    # Pre-fetch existing ModelAbbreviation rows.
     existing_by_model: dict[int, set[str]] = {}
     for row in ModelAbbreviation.objects.filter(
         machine_model_id__in=all_model_ids
     ).values_list("machine_model_id", "value"):
         existing_by_model.setdefault(row[0], set()).add(row[1])
 
-    # Diff and apply.
     to_create = []
     to_delete_pks: list[int] = []
 
@@ -823,7 +617,6 @@ def resolve_all_model_abbreviations(
         for value in desired - existing:
             to_create.append(ModelAbbreviation(machine_model_id=model_id, value=value))
 
-    # Build a lookup for deletions.
     for row in ModelAbbreviation.objects.filter(
         machine_model_id__in=all_model_ids
     ).values_list("pk", "machine_model_id", "value"):

--- a/backend/apps/catalog/tests/test_ingest_ipdb_titles.py
+++ b/backend/apps/catalog/tests/test_ingest_ipdb_titles.py
@@ -86,7 +86,7 @@ class TestGenerateIpdbTitles:
 
         source = Source.objects.get(slug="ipdb")
         claim = ipdb_only_model.claims.get(
-            source=source, field_name="group", is_active=True
+            source=source, field_name="title", is_active=True
         )
         assert claim.value == "ipdb:20"
         assert claim.needs_review is False
@@ -96,8 +96,8 @@ class TestGenerateIpdbTitles:
 
         assert not Title.objects.filter(opdb_id__startswith="ipdb:").exists()
 
-    def test_skips_model_with_existing_group_claim(self, ipdb_only_model, ipdb_source):
-        """Models that already have an active group claim should be skipped."""
+    def test_skips_model_with_existing_title_claim(self, ipdb_only_model, ipdb_source):
+        """Models that already have an active title claim should be skipped."""
         from django.contrib.contenttypes.models import ContentType
 
         ct = ContentType.objects.get_for_model(MachineModel)
@@ -105,8 +105,8 @@ class TestGenerateIpdbTitles:
             content_type=ct,
             object_id=ipdb_only_model.pk,
             source=ipdb_source,
-            field_name="group",
-            claim_key="group",
+            field_name="title",
+            claim_key="title",
             value="G9999",
         )
 
@@ -135,7 +135,7 @@ class TestGenerateIpdbTitles:
 
         source = Source.objects.get(slug="ipdb")
         claim = ipdb_model_matching_opdb.claims.get(
-            source=source, field_name="group", is_active=True
+            source=source, field_name="title", is_active=True
         )
         assert claim.needs_review is True
         assert "G1234" in claim.needs_review_notes

--- a/backend/apps/catalog/tests/test_ingest_opdb.py
+++ b/backend/apps/catalog/tests/test_ingest_opdb.py
@@ -129,16 +129,16 @@ class TestIngestOpdbGroups:
         assert mm.name == "Medieval Madness"
         assert list(mm.abbreviations.values_list("value", flat=True)) == ["MM"]
 
-    def test_group_claim_on_machine(self):
+    def test_title_claim_on_machine(self):
         pm = MachineModel.objects.get(opdb_id="G1111-MTest1")
         source = Source.objects.get(slug="opdb")
-        claim = pm.claims.get(source=source, field_name="group", is_active=True)
+        claim = pm.claims.get(source=source, field_name="title", is_active=True)
         assert claim.value == "G1111"
 
-    def test_group_claim_on_unmatched_machine(self):
+    def test_title_claim_on_unmatched_machine(self):
         pm = MachineModel.objects.get(opdb_id="G2222-MTest2")
         source = Source.objects.get(slug="opdb")
-        claim = pm.claims.get(source=source, field_name="group", is_active=True)
+        claim = pm.claims.get(source=source, field_name="title", is_active=True)
         assert claim.value == "G2222"
 
 
@@ -161,7 +161,7 @@ class TestIngestOpdbAliases:
         field_names = set(claims.values_list("field_name", flat=True))
         assert "name" in field_names
         assert "variant_features" in field_names
-        assert "group" in field_names
+        assert "title" in field_names
 
     def test_alias_features_claim(self):
         variant = MachineModel.objects.get(opdb_id="G1111-MTest1-AAlias")

--- a/backend/apps/catalog/tests/test_resolve.py
+++ b/backend/apps/catalog/tests/test_resolve.py
@@ -204,7 +204,7 @@ class TestResolveAll:
             Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=ipdb)
             Claim.objects.assert_claim(pm, "year", 1997, source=opdb)
             Claim.objects.assert_claim(pm, "manufacturer", "williams", source=ipdb)
-            Claim.objects.assert_claim(pm, "group", "G1111", source=opdb)
+            Claim.objects.assert_claim(pm, "title", "G1111", source=opdb)
             Claim.objects.assert_claim(
                 pm, "abbreviation", abbr_val, source=ipdb, claim_key=abbr_key
             )

--- a/backend/apps/catalog/tests/test_resolve_bulk.py
+++ b/backend/apps/catalog/tests/test_resolve_bulk.py
@@ -2,11 +2,11 @@
 
 import pytest
 
-from apps.catalog.models import Franchise, Manufacturer, Title
+from apps.catalog.models import Franchise, Manufacturer, Tag, Title
 from apps.catalog.resolve import (
     MANUFACTURER_DIRECT_FIELDS,
+    TAXONOMY_DIRECT_FIELDS,
     TITLE_DIRECT_FIELDS,
-    _MANUFACTURER_INT_FIELDS,
     _resolve_bulk,
     resolve_title,
 )
@@ -131,13 +131,28 @@ class TestResolveBulkManufacturer:
         _resolve_bulk(
             Manufacturer,
             MANUFACTURER_DIRECT_FIELDS,
-            int_fields=_MANUFACTURER_INT_FIELDS,
         )
 
         m.refresh_from_db()
         assert m.name == "Stern Pinball"
         assert m.founded_year == 1999
         assert m.country == "US"
+
+
+@pytest.mark.django_db
+class TestResolveBulkTaxonomy:
+    def test_malformed_int_claim_uses_default(self, opdb):
+        """Non-parseable integer on a non-null field should fall back to 0, not None."""
+        tag = Tag.objects.create(name="", slug="test-tag")
+
+        Claim.objects.assert_claim(tag, "name", "Test Tag", source=opdb)
+        Claim.objects.assert_claim(tag, "display_order", "abc", source=opdb)
+
+        _resolve_bulk(Tag, TAXONOMY_DIRECT_FIELDS, object_ids={tag.pk})
+
+        tag.refresh_from_db()
+        assert tag.name == "Test Tag"
+        assert tag.display_order == 0  # default, not None
 
 
 @pytest.mark.django_db

--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -119,7 +119,7 @@ def list_review_claims(request):
         subject = claim.subject
         subject_name = str(subject) if subject else "Unknown"
         subject_slug = getattr(subject, "slug", None)
-        if claim.field_name == "group":
+        if claim.field_name == "title":
             review_links, title_slug = _build_claim_review_context(claim)
         else:
             review_links, title_slug = [], None


### PR DESCRIPTION
## Summary

- Replace scattered if/elif chains and copy-pasted resolvers with declarative registries (`FK_FIELDS`, `M2M_FIELDS`, `DIRECT_FIELDS`) and generic resolution functions
- Rename claim `field_name` `"group"` → `"title"` everywhere (OPDB ingest translates at the boundary)
- Auto-derive type coercion from Django model field introspection instead of manual field sets
- Net reduction: **~520 lines across 18 files**; adding a new field now requires 1-2 file edits instead of 4-8

### Key changes

- `FK_FIELDS` registry with `FKFieldSpec` replaces 8 individual lookup builders and 6 FK resolvers
- `M2M_FIELDS` dict with `M2MFieldSpec` replaces 6 near-identical M2M resolvers
- `_coerce()` auto-detects field type via `model._meta` instead of `_INT_FIELDS`/`_DECIMAL_FIELDS`/`_BOOL_FIELDS` manual sets
- `_coerce()` respects field nullability on parse failure (fixes `IntegrityError` on non-null integer fields)
- `_apply_resolution()` collapsed from 13 parameters to 4
- Admin `CLAIM_FIELDS` and `_to_claim_value()` derived from registries

## Test plan

- [x] All 441 backend tests pass
- [x] ruff lint and format clean
- [x] Full ingestion (6826 models) completed successfully
- [x] Regression test added for malformed integer claim on non-null field

🤖 Generated with [Claude Code](https://claude.com/claude-code)