### PR TITLE
fix: use title slugs in claims and route OPDB variant_of through claims

### DIFF
--- a/backend/apps/catalog/management/commands/ingest_ipdb_titles.py
+++ b/backend/apps/catalog/management/commands/ingest_ipdb_titles.py
@@ -163,7 +163,7 @@ class Command(BaseCommand):
                     object_id=model.pk,
                     field_name="title",
                     claim_key="title",
-                    value=synthetic_id,
+                    value=slug,
                     needs_review=needs_review,
                     needs_review_notes=needs_review_notes,
                 )

--- a/backend/apps/catalog/management/commands/ingest_opdb.py
+++ b/backend/apps/catalog/management/commands/ingest_opdb.py
@@ -275,11 +275,9 @@ class Command(BaseCommand):
                     pm.opdb_id = opdb_id
                     by_opdb_id[opdb_id] = pm
                     promoted_update.append(pm)
-                # Clear variant_of if it was previously set (e.g. from a prior run).
-                if pm.variant_of_id is not None:
-                    pm.variant_of = None
-                    if pm not in promoted_update:
-                        promoted_update.append(pm)
+                # Stale variant_of claims from prior runs are swept by
+                # bulk_assert_claims(sweep_field="variant_of"); no direct
+                # model mutation needed here.
             else:
                 slug = generate_unique_slug(name, existing_slugs)
                 pm = MachineModel(name=name, opdb_id=opdb_id, slug=slug)
@@ -300,9 +298,7 @@ class Command(BaseCommand):
         if promoted_new:
             MachineModel.objects.bulk_create(promoted_new)
         if promoted_update:
-            MachineModel.objects.bulk_update(
-                promoted_update, ["opdb_id", "variant_of_id"]
-            )
+            MachineModel.objects.bulk_update(promoted_update, ["opdb_id"])
 
         if promoted_count:
             self.stdout.write(
@@ -347,6 +343,9 @@ class Command(BaseCommand):
             if not pm:
                 pm = by_opdb_id.get(opdb_id)
 
+            # Inject parent slug so _collect_claims can emit a variant_of claim.
+            rec["_variant_of_slug"] = parent.slug
+
             if pm:
                 alias_linked += 1
                 needs_update = False
@@ -356,18 +355,12 @@ class Command(BaseCommand):
                         pm.opdb_id = opdb_id
                         by_opdb_id[opdb_id] = pm
                         needs_update = True
-                # Link to parent.
-                if pm.variant_of_id != parent.pk:
-                    pm.variant_of = parent
-                    needs_update = True
                 if needs_update:
                     variant_models_needing_update.append(pm)
             else:
                 alias_created += 1
                 slug = generate_unique_slug(name, existing_slugs)
-                pm = MachineModel(
-                    name=name, opdb_id=opdb_id, variant_of=parent, slug=slug
-                )
+                pm = MachineModel(name=name, opdb_id=opdb_id, slug=slug)
                 new_variant_models.append(pm)
                 by_opdb_id[opdb_id] = pm
                 if ipdb_id:
@@ -378,9 +371,7 @@ class Command(BaseCommand):
         if new_variant_models:
             MachineModel.objects.bulk_create(new_variant_models)
         if variant_models_needing_update:
-            MachineModel.objects.bulk_update(
-                variant_models_needing_update, ["opdb_id", "variant_of_id"]
-            )
+            MachineModel.objects.bulk_update(variant_models_needing_update, ["opdb_id"])
 
         self.stdout.write(
             f"  Aliases — Linked: {alias_linked}, Created: {alias_created}, "
@@ -434,7 +425,20 @@ class Command(BaseCommand):
             self.stderr.write(f"  Failed IDs: {failed_ids}")
 
         # --- Bulk-assert all collected claims ---
-        claim_stats = Claim.objects.bulk_assert_claims(source, pending_claims)
+        # Sweep stale variant_of claims: if a model was previously a variant
+        # but is now standalone (e.g. promoted from non-physical group), the
+        # old variant_of claim must be deactivated.
+        variant_of_scope: set[tuple[int, int]] = set()
+        for pm, _rec in machine_models:
+            variant_of_scope.add((ct_id, pm.pk))
+        for pm, _rec in variant_models:
+            variant_of_scope.add((ct_id, pm.pk))
+        claim_stats = Claim.objects.bulk_assert_claims(
+            source,
+            pending_claims,
+            sweep_field="variant_of",
+            authoritative_scope=variant_of_scope,
+        )
         self.stdout.write(
             f"  Claims: {claim_stats['unchanged']} unchanged, "
             f"{claim_stats['created']} created, "
@@ -687,6 +691,11 @@ class Command(BaseCommand):
         opdb_features = rec.get("features")
         if opdb_features:
             _add("variant_features", opdb_features)
+
+        # variant_of: injected by Phase 1d alias processing as parent slug.
+        variant_of_slug = rec.get("_variant_of_slug")
+        if variant_of_slug:
+            _add("variant_of", variant_of_slug)
 
         for field in ("keywords", "description", "common_name", "images"):
             value = rec.get(field)

--- a/backend/apps/catalog/management/commands/ingest_opdb.py
+++ b/backend/apps/catalog/management/commands/ingest_opdb.py
@@ -559,6 +559,9 @@ class Command(BaseCommand):
             if not title:
                 continue
 
+            # Inject title slug for _collect_claims to emit slug-based claims.
+            rec["_title_slug"] = title.slug
+
             name = rec.get("name", "")
             short_name = rec.get("shortname") or ""
             touched_ids.add(title.pk)
@@ -718,8 +721,11 @@ class Command(BaseCommand):
                 )
             )
 
-        # Title claim (derived from opdb_id prefix).
+        # Title claim (derived from opdb_id prefix, emitted as slug).
         if opdb_id and groups_by_id:
             group_opdb_id = parse_opdb_group_id(opdb_id)
-            if group_opdb_id and group_opdb_id in groups_by_id:
-                _add("title", group_opdb_id)
+            group = groups_by_id.get(group_opdb_id) if group_opdb_id else None
+            if group:
+                title_slug = group.get("_title_slug")
+                if title_slug:
+                    _add("title", title_slug)

--- a/backend/apps/catalog/management/commands/ingest_pinbase_models.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_models.py
@@ -25,6 +25,7 @@ DEFAULT_PATH = Path(__file__).parents[5] / "data" / "models.json"
 # Fields stored as claim values (claim field_name → JSON key).
 CLAIM_FIELDS = {
     "name": "name",
+    "title": "title",
     "display_type": "display_type",
     "description": "description",
     "is_conversion": "is_conversion",

--- a/backend/apps/catalog/management/commands/ingest_pinbase_signs.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_signs.py
@@ -108,10 +108,10 @@ class Command(BaseCommand):
             pm.ipdb_id: pm for pm in MachineModel.objects.filter(ipdb_id__isnull=False)
         }
 
-        # Build model PK → Title lookup from active group claims.
+        # Build model PK → Title lookup from active title claims.
         # The title FK may not be populated yet (resolve_claims runs later),
-        # so we resolve the mapping from group claim values → Title opdb_ids.
-        titles_by_opdb_id = {t.opdb_id: t for t in Title.objects.all()}
+        # so we resolve the mapping from title claim values (slugs) → Titles.
+        titles_by_slug = {t.slug: t for t in Title.objects.all()}
         model_title: dict[int, Title] = {}
         group_claims = Claim.objects.filter(
             content_type_id=model_ct_id,
@@ -120,7 +120,7 @@ class Command(BaseCommand):
         ).values_list("object_id", "value")
         for obj_id, group_value in group_claims:
             if group_value:
-                title = titles_by_opdb_id.get(str(group_value))
+                title = titles_by_slug.get(str(group_value))
                 if title:
                     model_title[obj_id] = title
 

--- a/backend/apps/catalog/management/commands/ingest_pinbase_titles.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase_titles.py
@@ -61,6 +61,7 @@ class Command(BaseCommand):
 
         # Build lookups.
         titles_by_opdb_id = {t.opdb_id: t for t in Title.objects.all()}
+        titles_by_slug = {t.slug: t for t in Title.objects.all()}
         existing_slugs: set[str] = set(Title.objects.values_list("slug", flat=True))
         franchises_by_slug = {f.slug: f for f in Franchise.objects.all()}
         series_by_slug = {s.slug: s for s in Series.objects.all()}
@@ -68,15 +69,21 @@ class Command(BaseCommand):
         # Pass 1: create Titles that don't exist yet.
         new_titles: list[Title] = []
         for entry in entries:
-            opdb_group_id = entry["opdb_group_id"]
-            if opdb_group_id in titles_by_opdb_id:
+            opdb_group_id = entry.get("opdb_group_id")
+            slug = entry.get("slug")
+
+            # Match by opdb_group_id first, then by slug.
+            if opdb_group_id and opdb_group_id in titles_by_opdb_id:
                 continue
-            slug = entry.get("slug") or generate_unique_slug(
-                entry.get("name", ""), existing_slugs
-            )
+            if slug and slug in titles_by_slug:
+                continue
+
+            slug = slug or generate_unique_slug(entry.get("name", ""), existing_slugs)
+            # Use opdb_group_id if provided, otherwise a synthetic ID.
+            opdb_id = opdb_group_id or f"pinbase:{slug}"
             new_titles.append(
                 Title(
-                    opdb_id=opdb_group_id,
+                    opdb_id=opdb_id,
                     name=entry.get("name", ""),
                     slug=slug,
                 )
@@ -86,7 +93,10 @@ class Command(BaseCommand):
         titles_created = len(new_titles)
         if new_titles:
             Title.objects.bulk_create(new_titles)
-            titles_by_opdb_id = {t.opdb_id: t for t in Title.objects.all()}
+
+        # Re-fetch lookups after potential creation.
+        titles_by_opdb_id = {t.opdb_id: t for t in Title.objects.all()}
+        titles_by_slug = {t.slug: t for t in Title.objects.all()}
 
         membership_set = slug_set = skipped = 0
         pending_claims: list[Claim] = []
@@ -95,12 +105,19 @@ class Command(BaseCommand):
         touched_ids: set[int] = set()
 
         for entry in entries:
-            opdb_group_id = entry["opdb_group_id"]
+            opdb_group_id = entry.get("opdb_group_id")
+            slug = entry.get("slug")
 
-            title = titles_by_opdb_id.get(opdb_group_id)
+            # Look up by opdb_group_id first, then by slug.
+            title = None
+            if opdb_group_id:
+                title = titles_by_opdb_id.get(opdb_group_id)
+            if title is None and slug:
+                title = titles_by_slug.get(slug)
             if title is None:
                 logger.warning(
-                    "Title with opdb_id %r not found — skipping", opdb_group_id
+                    "Title %r not found — skipping",
+                    opdb_group_id or slug,
                 )
                 skipped += 1
                 continue

--- a/backend/apps/catalog/resolve/_helpers.py
+++ b/backend/apps/catalog/resolve/_helpers.py
@@ -58,7 +58,7 @@ class FKFieldSpec:
 
 
 FK_FIELDS: dict[str, FKFieldSpec] = {
-    "title": FKFieldSpec("title", Title, "opdb_id"),
+    "title": FKFieldSpec("title", Title, "slug"),
     "manufacturer": FKFieldSpec("manufacturer", Manufacturer, "slug"),
     "system": FKFieldSpec("system", System, "slug"),
     "technology_generation": FKFieldSpec(

--- a/backend/apps/catalog/tests/test_admin.py
+++ b/backend/apps/catalog/tests/test_admin.py
@@ -219,8 +219,10 @@ class TestMachineModelAdminClaims:
             object_id=pm.pk, field_name="manufacturer", is_active=True
         ).exists()
 
-    def test_title_fk_serialized_as_opdb_id(self, admin_request):
-        title = Title.objects.create(opdb_id="G5pe4", name="Medieval Madness")
+    def test_title_fk_serialized_as_slug(self, admin_request):
+        title = Title.objects.create(
+            opdb_id="G5pe4", name="Medieval Madness", slug="medieval-madness"
+        )
         pm = MachineModel.objects.create(name="Medieval Madness")
         pm.title = title
 
@@ -234,7 +236,7 @@ class TestMachineModelAdminClaims:
             field_name="title",
             is_active=True,
         )
-        assert claim.value == "G5pe4"
+        assert claim.value == "medieval-madness"
 
     def test_claim_field_variant_of_creates_claim(self, admin_request):
         parent = MachineModel.objects.create(name="Medieval Madness")

--- a/backend/apps/catalog/tests/test_ingest_ipdb_titles.py
+++ b/backend/apps/catalog/tests/test_ingest_ipdb_titles.py
@@ -88,7 +88,7 @@ class TestGenerateIpdbTitles:
         claim = ipdb_only_model.claims.get(
             source=source, field_name="title", is_active=True
         )
-        assert claim.value == "ipdb:20"
+        assert claim.value == "alien-poker"
         assert claim.needs_review is False
 
     def test_skips_opdb_models(self, opdb_model, ipdb_source):

--- a/backend/apps/catalog/tests/test_ingest_opdb.py
+++ b/backend/apps/catalog/tests/test_ingest_opdb.py
@@ -7,6 +7,7 @@ import pytest
 from django.core.management import call_command
 
 from apps.catalog.models import MachineModel, Title
+from apps.catalog.resolve import resolve_model
 from apps.provenance.models import Source
 
 FIXTURES = "apps/catalog/tests/fixtures"
@@ -152,6 +153,8 @@ class TestIngestOpdbAliases:
     def test_alias_linked_to_parent(self):
         parent = MachineModel.objects.get(opdb_id="G1111-MTest1")
         variant = MachineModel.objects.get(opdb_id="G1111-MTest1-AAlias")
+        resolve_model(variant)
+        variant.refresh_from_db()
         assert variant.variant_of == parent
 
     def test_alias_has_claims(self):
@@ -193,6 +196,8 @@ class TestIngestOpdbNonPhysical:
         """The remaining alias should point to the promoted model."""
         promoted = MachineModel.objects.get(opdb_id="G3333-MCombo-APrem")
         variant = MachineModel.objects.get(opdb_id="G3333-MCombo-ALE")
+        resolve_model(variant)
+        variant.refresh_from_db()
         assert variant.variant_of == promoted
 
     def test_non_physical_idempotent(self):
@@ -204,9 +209,13 @@ class TestIngestOpdbNonPhysical:
             groups=f"{FIXTURES}/opdb_groups_sample.json",
         )
         assert MachineModel.objects.count() == initial_count
-        # Verify relationships preserved.
+        # Verify relationships preserved after resolution.
         promoted = MachineModel.objects.get(opdb_id="G3333-MCombo-APrem")
         variant = MachineModel.objects.get(opdb_id="G3333-MCombo-ALE")
+        resolve_model(promoted)
+        resolve_model(variant)
+        promoted.refresh_from_db()
+        variant.refresh_from_db()
         assert promoted.variant_of is None
         assert variant.variant_of == promoted
 
@@ -239,6 +248,10 @@ class TestOpdbNonPhysicalHeuristics:
         call_command("ingest_opdb", opdb=path)
         le = MachineModel.objects.get(opdb_id="GTEST-MNP-ALE")
         ce = MachineModel.objects.get(opdb_id="GTEST-MNP-ACE")
+        resolve_model(le)
+        resolve_model(ce)
+        le.refresh_from_db()
+        ce.refresh_from_db()
         assert le.variant_of is None
         assert ce.variant_of == le
 
@@ -268,6 +281,10 @@ class TestOpdbNonPhysicalHeuristics:
         call_command("ingest_opdb", opdb=path)
         pe = MachineModel.objects.get(opdb_id="GTEST-MNP2-APE")
         ce = MachineModel.objects.get(opdb_id="GTEST-MNP2-ACE")
+        resolve_model(pe)
+        resolve_model(ce)
+        pe.refresh_from_db()
+        ce.refresh_from_db()
         assert pe.variant_of is None
         assert ce.variant_of == pe
 
@@ -297,6 +314,10 @@ class TestOpdbNonPhysicalHeuristics:
         call_command("ingest_opdb", opdb=path)
         std = MachineModel.objects.get(opdb_id="GTEST-MNP3-AStd")
         ce = MachineModel.objects.get(opdb_id="GTEST-MNP3-ACE")
+        resolve_model(std)
+        resolve_model(ce)
+        std.refresh_from_db()
+        ce.refresh_from_db()
         assert std.variant_of is None
         assert ce.variant_of == std
 
@@ -410,4 +431,159 @@ class TestOpdbAliasEdgeCases:
         call_command("ingest_opdb", opdb=path)
         parent = MachineModel.objects.get(opdb_id="GNEW-M1")
         alias = MachineModel.objects.get(opdb_id="GNEW-M1-AAlias")
+        resolve_model(alias)
+        alias.refresh_from_db()
         assert alias.variant_of == parent
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_run_opdb")
+class TestOpdbFKClaimGuards:
+    """Structural guard: every FK set on a model must be backed by an OPDB claim."""
+
+    # FK fields that _collect_claims emits for OPDB records.
+    OPDB_FK_FIELDS = [
+        "manufacturer",
+        "technology_generation",
+        "display_type",
+        "title",
+        "variant_of",
+    ]
+
+    def test_variant_of_claim_matches_resolved_fk(self):
+        """Every model with variant_of set must have a matching OPDB claim."""
+        source = Source.objects.get(slug="opdb")
+        for pm in MachineModel.objects.all():
+            resolve_model(pm)
+        for pm in MachineModel.objects.filter(variant_of__isnull=False).select_related(
+            "variant_of"
+        ):
+            claim = pm.claims.filter(
+                source=source, field_name="variant_of", is_active=True
+            ).first()
+            assert claim is not None, (
+                f"{pm.slug} has variant_of={pm.variant_of.slug} but no OPDB claim"
+            )
+            assert claim.value == pm.variant_of.slug, (
+                f"{pm.slug} variant_of claim value={claim.value} "
+                f"!= resolved FK slug={pm.variant_of.slug}"
+            )
+
+    @pytest.mark.parametrize("fk_field", OPDB_FK_FIELDS)
+    def test_fk_field_has_opdb_claim(self, fk_field):
+        """OPDB-authoritative models with an FK set must have a backing claim."""
+        source = Source.objects.get(slug="opdb")
+        # Scope to models that have an opdb_id (OPDB-authoritative).
+        fk_attr = f"{fk_field}_id"
+        models_with_fk = MachineModel.objects.filter(
+            opdb_id__isnull=False,
+            **{f"{fk_attr}__isnull": False},
+        )
+        for pm in models_with_fk:
+            assert pm.claims.filter(
+                source=source, field_name=fk_field, is_active=True
+            ).exists(), (
+                f"{pm.slug} (opdb_id={pm.opdb_id}) has {fk_field} set "
+                f"but no active OPDB claim"
+            )
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_run_opdb")
+class TestOpdbAliasVariantOfClaims:
+    """variant_of must go through the claims system so it survives resolution."""
+
+    def test_alias_variant_of_claim_exists(self):
+        """OPDB ingest should emit a variant_of claim for aliases."""
+        parent = MachineModel.objects.get(opdb_id="G1111-MTest1")
+        variant = MachineModel.objects.get(opdb_id="G1111-MTest1-AAlias")
+        source = Source.objects.get(slug="opdb")
+        claim = variant.claims.get(
+            source=source, field_name="variant_of", is_active=True
+        )
+        assert claim.value == parent.slug
+
+    def test_alias_variant_of_survives_resolution(self):
+        """variant_of must persist after resolve_model (claims-based resolution)."""
+        parent = MachineModel.objects.get(opdb_id="G1111-MTest1")
+        variant = MachineModel.objects.get(opdb_id="G1111-MTest1-AAlias")
+        resolve_model(variant)
+        variant.refresh_from_db()
+        assert variant.variant_of == parent
+
+    def test_nonphysical_variant_of_claim_exists(self):
+        """Remaining aliases in non-physical groups should have variant_of claims."""
+        promoted = MachineModel.objects.get(opdb_id="G3333-MCombo-APrem")
+        variant = MachineModel.objects.get(opdb_id="G3333-MCombo-ALE")
+        source = Source.objects.get(slug="opdb")
+        claim = variant.claims.get(
+            source=source, field_name="variant_of", is_active=True
+        )
+        assert claim.value == promoted.slug
+
+    def test_nonphysical_variant_of_survives_resolution(self):
+        """Non-physical group variant_of must persist after resolution."""
+        promoted = MachineModel.objects.get(opdb_id="G3333-MCombo-APrem")
+        variant = MachineModel.objects.get(opdb_id="G3333-MCombo-ALE")
+        resolve_model(variant)
+        variant.refresh_from_db()
+        assert variant.variant_of == promoted
+
+    def test_promoted_alias_no_variant_of_after_resolution(self):
+        """Promoted aliases should have no variant_of claim or FK after resolution."""
+        promoted = MachineModel.objects.get(opdb_id="G3333-MCombo-APrem")
+        source = Source.objects.get(slug="opdb")
+        assert not promoted.claims.filter(
+            source=source, field_name="variant_of", is_active=True
+        ).exists()
+        resolve_model(promoted)
+        promoted.refresh_from_db()
+        assert promoted.variant_of is None
+
+
+@pytest.mark.django_db
+class TestOpdbVariantOfSweep:
+    """Stale variant_of claims must be swept on rerun."""
+
+    def test_rerun_promotion_clears_stale_variant_of(self):
+        """When a parent becomes non-physical, alias gets promoted and variant_of is swept."""
+        # Run 1: physical parent + alias → alias is a variant.
+        path1 = _opdb_dump(
+            machines=[{"opdb_id": "GSWP-M1", "name": "Sweep Parent"}],
+            aliases=[
+                {
+                    "opdb_id": "GSWP-M1-APrem",
+                    "name": "Sweep (Premium)",
+                    "features": ["Premium edition"],
+                },
+            ],
+        )
+        call_command("ingest_opdb", opdb=path1)
+        variant = MachineModel.objects.get(opdb_id="GSWP-M1-APrem")
+        resolve_model(variant)
+        variant.refresh_from_db()
+        parent = MachineModel.objects.get(opdb_id="GSWP-M1")
+        assert variant.variant_of == parent
+
+        # Run 2: parent becomes non-physical → alias is promoted to standalone.
+        path2 = _opdb_dump(
+            machines=[
+                {
+                    "opdb_id": "GSWP-M1",
+                    "name": "Sweep (Premium/LE)",
+                    "physical_machine": 0,
+                },
+            ],
+            aliases=[
+                {
+                    "opdb_id": "GSWP-M1-APrem",
+                    "name": "Sweep (Premium)",
+                    "features": ["Premium edition"],
+                },
+            ],
+        )
+        call_command("ingest_opdb", opdb=path2)
+        variant.refresh_from_db()
+        resolve_model(variant)
+        variant.refresh_from_db()
+        assert variant.variant_of is None

--- a/backend/apps/catalog/tests/test_ingest_opdb.py
+++ b/backend/apps/catalog/tests/test_ingest_opdb.py
@@ -134,13 +134,13 @@ class TestIngestOpdbGroups:
         pm = MachineModel.objects.get(opdb_id="G1111-MTest1")
         source = Source.objects.get(slug="opdb")
         claim = pm.claims.get(source=source, field_name="title", is_active=True)
-        assert claim.value == "G1111"
+        assert claim.value == "medieval-madness"
 
     def test_title_claim_on_unmatched_machine(self):
         pm = MachineModel.objects.get(opdb_id="G2222-MTest2")
         source = Source.objects.get(slug="opdb")
         claim = pm.claims.get(source=source, field_name="title", is_active=True)
-        assert claim.value == "G2222"
+        assert claim.value == "stern-exclusive-game"
 
 
 @pytest.mark.django_db

--- a/backend/apps/catalog/tests/test_ingest_pinbase_models.py
+++ b/backend/apps/catalog/tests/test_ingest_pinbase_models.py
@@ -6,7 +6,7 @@ import tempfile
 import pytest
 from django.core.management import call_command
 
-from apps.catalog.models import MachineModel
+from apps.catalog.models import MachineModel, Title
 from apps.catalog.resolve import resolve_model
 from apps.provenance.models import Claim, Source
 
@@ -368,3 +368,49 @@ class TestIngestPinbaseModels:
         assert not mm.claims.filter(
             source=source, field_name="converted_from", is_active=True
         ).exists()
+
+    def test_title_claim(self, db):
+        """title asserts a claim with the slug value."""
+        Title.objects.create(name="Test Title", slug="test-title", opdb_id="Gtest")
+        mm = MachineModel.objects.create(
+            name="Test Model", opdb_id="Gtest-Mtest", slug="test-model"
+        )
+        path = _write_models_json(
+            [
+                {
+                    "slug": "test-model",
+                    "opdb_id": "Gtest-Mtest",
+                    "title": "test-title",
+                },
+            ]
+        )
+
+        call_command("ingest_pinbase_models", path=path)
+
+        source = Source.objects.get(slug="pinbase")
+        claim = mm.claims.get(source=source, field_name="title", is_active=True)
+        assert claim.value == "test-title"
+
+    def test_title_resolves(self, db):
+        """title slug claim resolves to FK on model."""
+        title = Title.objects.create(
+            name="Test Title", slug="test-title", opdb_id="Gtest"
+        )
+        mm = MachineModel.objects.create(
+            name="Test Model", opdb_id="Gtest-Mtest", slug="test-model"
+        )
+        path = _write_models_json(
+            [
+                {
+                    "slug": "test-model",
+                    "opdb_id": "Gtest-Mtest",
+                    "title": "test-title",
+                },
+            ]
+        )
+
+        call_command("ingest_pinbase_models", path=path)
+        resolve_model(mm)
+        mm.refresh_from_db()
+
+        assert mm.title == title

--- a/backend/apps/catalog/tests/test_ingest_pinbase_signs.py
+++ b/backend/apps/catalog/tests/test_ingest_pinbase_signs.py
@@ -1,0 +1,90 @@
+"""Tests for the ingest_pinbase_signs command."""
+
+import csv
+import tempfile
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+
+from apps.catalog.models import MachineModel, Title
+from apps.provenance.models import Claim, Source
+
+
+def _write_csv(rows: list[dict]) -> str:
+    """Write rows to a temp CSV and return the path."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False, newline="")
+    writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+    writer.writeheader()
+    writer.writerows(rows)
+    f.close()
+    return f.name
+
+
+@pytest.mark.django_db
+class TestSignsTitleLookup:
+    def test_description_hoisted_to_title_via_slug_claim(self, db):
+        """Title description is hoisted when model→title claim uses slug."""
+        title = Title.objects.create(
+            name="Alien Poker", slug="alien-poker", opdb_id="ipdb:20"
+        )
+        mm = MachineModel.objects.create(
+            name="Alien Poker", slug="alien-poker-model", ipdb_id=20
+        )
+
+        # Create a slug-based title claim (as all sources now emit).
+        ct = ContentType.objects.get_for_model(MachineModel)
+        source, _ = Source.objects.update_or_create(
+            slug="ipdb",
+            defaults={
+                "name": "IPDB",
+                "source_type": "database",
+                "priority": 100,
+            },
+        )
+        Claim.objects.bulk_assert_claims(
+            source,
+            [
+                Claim(
+                    content_type_id=ct.pk,
+                    object_id=mm.pk,
+                    field_name="title",
+                    claim_key="title",
+                    value="alien-poker",
+                )
+            ],
+        )
+
+        csv_path = _write_csv(
+            [
+                {
+                    "IPDBid": "20",
+                    "Title": "Alien Poker",
+                    "Year": "",
+                    "Month": "",
+                    "Manufacturer": "",
+                    "Address": "",
+                    "Produced": "",
+                    "MainText": "A classic 1980 solid-state pinball machine.",
+                    "Sources/Notes": "",
+                    "Heading1": "",
+                    "Info1": "",
+                    "Heading2": "",
+                    "Info2": "",
+                    "Heading3": "",
+                    "Info3": "",
+                }
+            ]
+        )
+
+        call_command("ingest_pinbase_signs", csv=csv_path)
+
+        # The MainText should be hoisted as a description claim on the Title.
+        title_ct = ContentType.objects.get_for_model(Title)
+        desc_claim = Claim.objects.get(
+            content_type_id=title_ct.pk,
+            object_id=title.pk,
+            field_name="description",
+            is_active=True,
+        )
+        assert desc_claim.value == "A classic 1980 solid-state pinball machine."

--- a/data/explore/02_staging.sql
+++ b/data/explore/02_staging.sql
@@ -345,7 +345,7 @@ SELECT
   m.player_count,
   -- Taxonomy: pinbase > OPDB > IPDB
   m.opdb_tech_gen_slug AS technology_generation_slug,
-  COALESCE(pm.display_type_slug, m.opdb_display_type_slug) AS display_type_slug,
+  COALESCE(pm.display_type, m.opdb_display_type_slug) AS display_type_slug,
   m.opdb_system_slug AS system_slug,
   -- Pinbase editorial claims
   COALESCE(pm.is_conversion, false) AS is_conversion,

--- a/data/explore/04_checks.sql
+++ b/data/explore/04_checks.sql
@@ -47,7 +47,7 @@ INSERT INTO _violations
 SELECT 'orphan_pinbase_title', pt.opdb_group_id
 FROM pinbase_titles AS pt
 LEFT JOIN opdb_groups AS og ON pt.opdb_group_id = og.opdb_id
-WHERE og.opdb_id IS NULL;
+WHERE pt.opdb_group_id IS NOT NULL AND og.opdb_id IS NULL;
 
 -- Pinbase title franchise_slug references nonexistent franchise
 INSERT INTO _violations
@@ -91,6 +91,28 @@ SELECT 'chained_variant_of', a.slug || ' -> ' || a.variant_of || ' -> ' || b.var
 FROM pinbase_models AS a
 JOIN pinbase_models AS b ON a.variant_of = b.slug
 WHERE b.variant_of IS NOT NULL;
+
+-- Pinbase model title references nonexistent title slug
+INSERT INTO _violations
+SELECT 'orphan_model_title', pm.slug || ' -> ' || pm.title
+FROM pinbase_models AS pm
+WHERE pm.title IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM pinbase_titles AS pt WHERE pt.slug = pm.title
+  );
+
+-- Duplicate slugs in pinbase_titles
+INSERT INTO _violations
+SELECT 'duplicate_title_slug', slug
+FROM pinbase_titles
+GROUP BY slug HAVING count(*) > 1;
+
+-- Duplicate opdb_group_ids in pinbase_titles
+INSERT INTO _violations
+SELECT 'duplicate_title_opdb_group_id', opdb_group_id
+FROM pinbase_titles
+WHERE opdb_group_id IS NOT NULL
+GROUP BY opdb_group_id HAVING count(*) > 1;
 
 -- Pinbase model references a combo_label (physical_machine=0)
 INSERT INTO _violations

--- a/data/franchises.json
+++ b/data/franchises.json
@@ -2,621 +2,626 @@
   {
     "slug": "24",
     "name": "24",
-    "description": "Pinball adaptation of the 24 television series, produced by Stern (2009)."
+    "description": "Pinball machines based on the 24 television series."
   },
   {
     "slug": "ac-dc",
     "name": "AC/DC",
-    "description": "Pinball machines themed around the rock band AC/DC, produced by Stern (2012–2018)."
+    "description": "Pinball machines themed around the rock band AC/DC."
   },
   {
     "slug": "aerosmith",
     "name": "Aerosmith",
-    "description": "Pinball machines themed around the rock band Aerosmith, produced by Stern (2017)."
+    "description": "Pinball machines themed around the rock band Aerosmith."
   },
   {
     "slug": "alice-cooper",
     "name": "Alice Cooper",
-    "description": "Pinball themed around rock musician Alice Cooper, produced by Spooky Pinball (2018)."
+    "description": "Pinball machines themed around rock musician Alice Cooper."
   },
   {
     "slug": "alien",
     "name": "Alien",
-    "description": "Pinball adaptations of the Alien film franchise, produced by Heighway Pinball (2017) and Pinball Brothers (2021)."
+    "description": "Pinball machines based on the Alien film franchise."
   },
   {
     "slug": "apollo-13",
     "name": "Apollo 13",
-    "description": "Pinball adaptation of the Apollo 13 film, produced by Sega (1995)."
+    "description": "Pinball machines based on the Apollo 13 film."
   },
   {
     "slug": "austin-powers",
     "name": "Austin Powers",
-    "description": "Pinball adaptation of the Austin Powers film franchise, produced by Stern (2001)."
+    "description": "Pinball machines based on the Austin Powers film franchise."
   },
   {
     "slug": "avatar",
     "name": "Avatar",
-    "description": "Pinball adaptation of James Cameron's Avatar, produced by Stern (2010)."
+    "description": "Pinball machines based on James Cameron's Avatar."
   },
   {
     "slug": "back-to-the-future",
     "name": "Back to the Future",
-    "description": "Pinball adaptation of the Back to the Future film franchise, produced by Data East (1990)."
+    "description": "Pinball machines based on the Back to the Future film franchise."
   },
   {
     "slug": "barb-wire",
     "name": "Barb Wire",
-    "description": "Pinball adaptation of the Barb Wire film, produced by Gottlieb (1996)."
+    "description": "Pinball machines based on the Barb Wire film."
   },
   {
     "slug": "batman",
     "name": "Batman",
-    "description": "Pinball adaptations of the Batman franchise, produced by Data East (1991), Sega (1995), and Stern (2008, 2016)."
+    "description": "Pinball machines based on the Batman franchise."
   },
   {
     "slug": "baywatch",
     "name": "Baywatch",
-    "description": "Pinball adaptation of the Baywatch television series, produced by Sega (1995)."
+    "description": "Pinball machines based on the Baywatch television series."
   },
   {
     "slug": "big-buck-hunter",
     "name": "Big Buck Hunter",
-    "description": "Pinball adaptation of the Big Buck Hunter arcade game, produced by Stern (2010)."
+    "description": "Pinball machines based on the Big Buck Hunter arcade game."
   },
   {
     "slug": "black-velvet",
     "name": "Black Velvet",
-    "description": "Pinball machine themed around the Black Velvet whiskey brand, produced by Game Plan (1978)."
+    "description": "Pinball machines themed around the Black Velvet whiskey brand."
   },
   {
     "slug": "camel",
     "name": "Camel",
-    "description": "Pinball machine themed around the Camel cigarette brand, produced by Premier Technology (1990)."
+    "description": "Pinball machines themed around the Camel cigarette brand."
   },
   {
     "slug": "charlies-angels",
     "name": "Charlie's Angels",
-    "description": "Pinball adaptation of the Charlie's Angels television series, produced by Gottlieb (1978)."
+    "description": "Pinball machines based on the Charlie's Angels television series."
   },
   {
     "slug": "close-encounters",
     "name": "Close Encounters of the Third Kind",
-    "description": "Pinball adaptation of Close Encounters of the Third Kind, produced by Gottlieb (1978)."
+    "description": "Pinball machines based on Close Encounters of the Third Kind."
   },
   {
     "slug": "congo",
     "name": "Congo",
-    "description": "Pinball adaptation of the Congo film, produced by Williams (1995)."
+    "description": "Pinball machines based on the Congo film."
   },
   {
     "slug": "csi",
     "name": "CSI",
-    "description": "Pinball adaptation of the CSI: Crime Scene Investigation television series, produced by Stern (2008)."
+    "description": "Pinball machines based on the CSI: Crime Scene Investigation television series."
   },
   {
     "slug": "deadpool",
     "name": "Deadpool",
-    "description": "Pinball adaptation of Marvel's Deadpool, produced by Stern (2018)."
+    "description": "Pinball machines based on Marvel's Deadpool."
   },
   {
     "slug": "demolition-man",
     "name": "Demolition Man",
-    "description": "Pinball adaptation of the Demolition Man film, produced by Williams (1994)."
+    "description": "Pinball machines based on the Demolition Man film."
   },
   {
     "slug": "dirty-harry",
     "name": "Dirty Harry",
-    "description": "Pinball adaptation of the Dirty Harry film franchise, produced by Williams (1995)."
+    "description": "Pinball machines based on the Dirty Harry film franchise."
   },
   {
     "slug": "doctor-who",
     "name": "Doctor Who",
-    "description": "Pinball adaptation of the Doctor Who television series, produced by Bally (1992)."
+    "description": "Pinball machines based on the Doctor Who television series."
   },
   {
     "slug": "dolly-parton",
     "name": "Dolly Parton",
-    "description": "Pinball machine themed around Dolly Parton, produced by Bally (1979)."
+    "description": "Pinball machines themed around Dolly Parton."
   },
   {
     "slug": "dominos",
     "name": "Domino's",
-    "description": "Pinball machine themed around the Domino's Pizza brand, produced by Bally (1993)."
+    "description": "Pinball machines themed around the Domino's Pizza brand."
   },
   {
     "slug": "dracula",
     "name": "Dracula",
-    "description": "Pinball adaptation of Bram Stoker's Dracula, produced by Williams (1993)."
+    "description": "Pinball machines based on the Dracula literary and film franchise."
   },
   {
     "slug": "dune",
     "name": "Dune",
-    "description": "Pinball adaptation of the Dune franchise, produced by Gottlieb (1984)."
+    "description": "Pinball machines based on the Dune franchise."
   },
   {
     "slug": "elton-john",
     "name": "Elton John",
-    "description": "Pinball themed around musician Elton John, produced by Bally (1976)."
+    "description": "Pinball machines themed around musician Elton John."
   },
   {
     "slug": "elvira",
     "name": "Elvira",
-    "description": "Pinball machines featuring Elvira, Mistress of the Dark, produced by Bally (1989, 1996) and Stern (2019)."
+    "description": "Pinball machines featuring Elvira, Mistress of the Dark."
   },
   {
     "slug": "elvis",
     "name": "Elvis",
-    "description": "Pinball machines themed around Elvis Presley, produced by Stern (2004)."
+    "description": "Pinball machines themed around Elvis Presley."
   },
   {
     "slug": "evel-knievel",
     "name": "Evel Knievel",
-    "description": "Pinball machine themed around stunt performer Evel Knievel, produced by Bally (1977)."
+    "description": "Pinball machines themed around stunt performer Evel Knievel."
   },
   {
     "slug": "family-guy",
     "name": "Family Guy",
-    "description": "Pinball adaptation of the Family Guy animated series, produced by Stern (2007)."
+    "description": "Pinball machines based on the Family Guy animated series."
   },
   {
     "slug": "flash-gordon",
     "name": "Flash Gordon",
-    "description": "Pinball adaptation of Flash Gordon, produced by Bally (1981)."
+    "description": "Pinball machines based on the Flash Gordon franchise."
   },
   {
     "slug": "frankenstein",
     "name": "Frankenstein",
-    "description": "Pinball adaptation of Mary Shelley's Frankenstein, produced by Sega (1995)."
+    "description": "Pinball machines based on the Frankenstein literary and film franchise."
   },
   {
     "slug": "game-of-thrones",
     "name": "Game of Thrones",
-    "description": "Pinball adaptation of the Game of Thrones television series, produced by Stern (2015)."
+    "description": "Pinball machines based on the Game of Thrones television series."
   },
   {
     "slug": "ghostbusters",
     "name": "Ghostbusters",
-    "description": "Pinball adaptations of the Ghostbusters franchise, produced by Stern (2016)."
+    "description": "Pinball machines based on the Ghostbusters franchise."
   },
   {
     "slug": "gilligans-island",
     "name": "Gilligan's Island",
-    "description": "Pinball adaptation of the Gilligan's Island television series, produced by Bally (1991)."
+    "description": "Pinball machines based on the Gilligan's Island television series."
   },
   {
     "slug": "godzilla",
     "name": "Godzilla",
-    "description": "Pinball adaptations of the Godzilla franchise, produced by Sega (1998) and Stern (2021)."
+    "description": "Pinball machines based on the Godzilla franchise."
   },
   {
     "slug": "guardians-of-the-galaxy",
     "name": "Guardians of the Galaxy",
-    "description": "Pinball adaptation of Marvel's Guardians of the Galaxy, produced by Stern (2017)."
+    "description": "Pinball machines based on Marvel's Guardians of the Galaxy."
   },
   {
     "slug": "guns-n-roses",
     "name": "Guns N' Roses",
-    "description": "Pinball machines themed around the rock band Guns N' Roses, produced by Data East (1994) and Jersey Jack Pinball (2021)."
+    "description": "Pinball machines themed around the rock band Guns N' Roses."
   },
   {
     "slug": "harlem-globetrotters",
     "name": "Harlem Globetrotters",
-    "description": "Pinball machine themed around the Harlem Globetrotters, produced by Bally (1979)."
+    "description": "Pinball machines themed around the Harlem Globetrotters."
   },
   {
     "slug": "harley-davidson",
     "name": "Harley Davidson",
-    "description": "Pinball machines themed around the Harley-Davidson motorcycle brand, produced by Bally in 1991 and Stern across multiple editions from 1999–2004."
+    "description": "Pinball machines themed around the Harley-Davidson motorcycle brand."
   },
   {
     "slug": "heavy-metal",
     "name": "Heavy Metal",
-    "description": "Pinball adaptation of the Heavy Metal franchise, produced by Stern (2020)."
+    "description": "Pinball machines based on the Heavy Metal franchise."
   },
   {
     "slug": "hook",
     "name": "Hook",
-    "description": "Pinball adaptation of the Hook film, produced by Data East (1992)."
+    "description": "Pinball machines based on the Hook film."
   },
   {
     "slug": "hot-wheels",
     "name": "Hot Wheels",
-    "description": "Pinball machine themed around the Hot Wheels brand, produced by American Pinball (2020)."
+    "description": "Pinball machines themed around the Hot Wheels brand."
   },
   {
     "slug": "independence-day",
     "name": "Independence Day",
-    "description": "Pinball adaptation of the Independence Day film, produced by Sega (1996)."
+    "description": "Pinball machines based on the Independence Day film."
   },
   {
     "slug": "indiana-jones",
     "name": "Indiana Jones",
-    "description": "Pinball adaptations of the Indiana Jones film franchise, produced by Williams in 1993 and Stern in 2008."
+    "description": "Pinball machines based on the Indiana Jones film franchise."
   },
   {
     "slug": "iron-maiden",
     "name": "Iron Maiden",
-    "description": "Pinball themed around the rock band Iron Maiden, produced by Stern (2018)."
+    "description": "Pinball machines themed around the rock band Iron Maiden."
   },
   {
     "slug": "iron-man",
     "name": "Iron Man",
-    "description": "Pinball adaptation of Marvel's Iron Man, produced by Stern (2010)."
+    "description": "Pinball machines based on Marvel's Iron Man."
   },
   {
     "slug": "james-bond",
     "name": "James Bond",
-    "description": "Pinball adaptations of the James Bond franchise, produced by Gottlieb (1980, 1995), Sega (1996), and Stern (2022)."
+    "description": "Pinball machines based on the James Bond franchise."
   },
   {
     "slug": "johnny-mnemonic",
     "name": "Johnny Mnemonic",
-    "description": "Pinball adaptation of the Johnny Mnemonic film, produced by Williams (1995)."
+    "description": "Pinball machines based on the Johnny Mnemonic film."
   },
   {
     "slug": "judge-dredd",
     "name": "Judge Dredd",
-    "description": "Pinball adaptation of the Judge Dredd comic franchise, produced by Bally (1993)."
+    "description": "Pinball machines based on the Judge Dredd comic franchise."
   },
   {
     "slug": "jurassic-park",
     "name": "Jurassic Park",
-    "description": "Pinball adaptations of the Jurassic Park franchise, produced by Data East in 1993, Sega in 1997, and Stern in 2019."
+    "description": "Pinball machines based on the Jurassic Park franchise."
   },
   {
     "slug": "kiss",
     "name": "KISS",
-    "description": "Pinball machines based on the rock band KISS, produced by Bally in 1979 and Stern in 2015."
+    "description": "Pinball machines themed around the rock band KISS."
   },
   {
     "slug": "last-action-hero",
     "name": "Last Action Hero",
-    "description": "Pinball adaptation of the Last Action Hero film, produced by Data East (1993)."
+    "description": "Pinball machines based on the Last Action Hero film."
   },
   {
     "slug": "led-zeppelin",
     "name": "Led Zeppelin",
-    "description": "Pinball themed around the rock band Led Zeppelin, produced by Stern (2020)."
+    "description": "Pinball machines themed around the rock band Led Zeppelin."
   },
   {
     "slug": "lethal-weapon",
     "name": "Lethal Weapon",
-    "description": "Pinball adaptation of the Lethal Weapon film franchise, produced by Data East (1992)."
+    "description": "Pinball machines based on the Lethal Weapon film franchise."
   },
   {
     "slug": "looney-tunes",
     "name": "Looney Tunes",
-    "description": "Pinball machines featuring Looney Tunes characters, produced by Bally (1989) and Atari (1979)."
+    "description": "Pinball machines featuring Looney Tunes characters."
   },
   {
     "slug": "lord-of-the-rings",
     "name": "Lord of the Rings",
-    "description": "Pinball adaptations of the Lord of the Rings and Hobbit franchises, produced by Stern (2003) and Jersey Jack Pinball (2016)."
+    "description": "Pinball machines based on the Lord of the Rings and Hobbit franchises."
   },
   {
     "slug": "lost-in-space",
     "name": "Lost in Space",
-    "description": "Pinball adaptation of the Lost in Space television series, produced by Sega (1998)."
+    "description": "Pinball machines based on the Lost in Space franchise."
   },
   {
     "slug": "maverick",
     "name": "Maverick",
-    "description": "Pinball adaptation of the Maverick film, produced by Data East (1994)."
+    "description": "Pinball machines based on the Maverick film."
   },
   {
     "slug": "metallica",
     "name": "Metallica",
-    "description": "Pinball themed around the rock band Metallica, produced by Stern (2013)."
+    "description": "Pinball machines themed around the rock band Metallica."
   },
   {
     "slug": "monopoly",
     "name": "Monopoly",
-    "description": "Pinball adaptation of the Monopoly board game, produced by Stern (2001)."
+    "description": "Pinball machines based on the Monopoly board game."
   },
   {
     "slug": "muhammad-ali",
     "name": "Muhammad Ali",
-    "description": "Pinball machine themed around boxer Muhammad Ali, produced by Stern Electronics (1980)."
+    "description": "Pinball machines themed around boxer Muhammad Ali."
   },
   {
     "slug": "mustang",
     "name": "Mustang",
-    "description": "Pinball machine themed around the Ford Mustang, produced by Stern (2014)."
+    "description": "Pinball machines themed around the Ford Mustang."
   },
   {
     "slug": "nascar",
     "name": "NASCAR",
-    "description": "Pinball machine themed around the NASCAR racing series, produced by Stern (2005)."
+    "description": "Pinball machines themed around the NASCAR racing series."
   },
   {
     "slug": "nba",
     "name": "NBA",
-    "description": "Pinball machines themed around the NBA, produced by Stern (1997, 2009)."
+    "description": "Pinball machines themed around the NBA."
   },
   {
     "slug": "nightmare-on-elm-street",
     "name": "A Nightmare on Elm Street",
-    "description": "Pinball adaptation of A Nightmare on Elm Street, produced by Gottlieb (1994)."
+    "description": "Pinball machines based on the A Nightmare on Elm Street film franchise."
   },
   {
     "slug": "no-fear",
     "name": "No Fear",
-    "description": "Pinball machine themed around the No Fear brand, produced by Williams (1995)."
+    "description": "Pinball machines themed around the No Fear brand."
   },
   {
     "slug": "pabst-blue-ribbon",
     "name": "Pabst Blue Ribbon",
-    "description": "Pinball machine themed around Pabst Blue Ribbon, produced by Stern (2015–2018)."
+    "description": "Pinball machines themed around the Pabst Blue Ribbon beer brand."
   },
   {
     "slug": "pirates-of-the-caribbean",
     "name": "Pirates of the Caribbean",
-    "description": "Pinball adaptations of the Pirates of the Caribbean film franchise, produced by Stern in 2006 and Jersey Jack Pinball in 2018."
+    "description": "Pinball machines based on the Pirates of the Caribbean franchise."
   },
   {
     "slug": "playboy",
     "name": "Playboy",
-    "description": "Pinball machines themed around the Playboy brand, produced by Rally (1967), Bally (1978, 2002), and Stern (2002)."
+    "description": "Pinball machines themed around the Playboy brand."
   },
   {
     "slug": "popeye",
     "name": "Popeye",
-    "description": "Pinball adaptation of the Popeye franchise, produced by Bally (1994)."
+    "description": "Pinball machines based on the Popeye franchise."
   },
   {
     "slug": "rick-and-morty",
     "name": "Rick and Morty",
-    "description": "Pinball adaptation of the Rick and Morty animated series, produced by Spooky Pinball (2020)."
+    "description": "Pinball machines based on the Rick and Morty animated series."
   },
   {
     "slug": "ripleys-believe-it-or-not",
     "name": "Ripley's Believe It or Not!",
-    "description": "Pinball adaptation of the Ripley's Believe It or Not! brand, produced by Stern (2004)."
+    "description": "Pinball machines based on the Ripley's Believe It or Not! brand."
   },
   {
     "slug": "rob-zombie",
     "name": "Rob Zombie",
-    "description": "Pinball themed around musician Rob Zombie, produced by Spooky Pinball (2016)."
+    "description": "Pinball machines themed around musician Rob Zombie."
   },
   {
     "slug": "robocop",
     "name": "RoboCop",
-    "description": "Pinball adaptation of the RoboCop film franchise, produced by Data East (1989)."
+    "description": "Pinball machines based on the RoboCop film franchise."
   },
   {
     "slug": "rocky",
     "name": "Rocky",
-    "description": "Pinball adaptation of the Rocky film franchise, produced by Gottlieb (1982)."
+    "description": "Pinball machines based on the Rocky film franchise."
   },
   {
     "slug": "rocky-and-bullwinkle",
     "name": "Rocky and Bullwinkle",
-    "description": "Pinball adaptation of The Adventures of Rocky and Bullwinkle, produced by Data East (1993)."
+    "description": "Pinball machines based on The Adventures of Rocky and Bullwinkle."
   },
   {
     "slug": "rollercoaster-tycoon",
     "name": "RollerCoaster Tycoon",
-    "description": "Pinball adaptation of the RollerCoaster Tycoon video game, produced by Stern (2002)."
+    "description": "Pinball machines based on the RollerCoaster Tycoon video game."
   },
   {
     "slug": "rollergames",
     "name": "Rollergames",
-    "description": "Pinball adaptation of the Rollergames television series, produced by Williams (1990)."
+    "description": "Pinball machines based on the Rollergames television series."
   },
   {
     "slug": "rush",
     "name": "Rush",
-    "description": "Pinball themed around the rock band Rush, produced by Stern (2022)."
+    "description": "Pinball machines themed around the rock band Rush."
   },
   {
     "slug": "shaq",
     "name": "Shaq",
-    "description": "Pinball machine themed around Shaquille O'Neal, produced by Gottlieb (1995)."
+    "description": "Pinball machines themed around Shaquille O'Neal."
+  },
+  {
+    "slug": "shrek",
+    "name": "Shrek",
+    "description": "Pinball machines based on the Shrek animated film franchise."
   },
   {
     "slug": "south-park",
     "name": "South Park",
-    "description": "Pinball adaptation of the South Park animated series, produced by Sega (1999)."
+    "description": "Pinball machines based on the South Park animated series."
   },
   {
     "slug": "space-jam",
     "name": "Space Jam",
-    "description": "Pinball adaptation of the Space Jam film, produced by Sega (1996)."
+    "description": "Pinball machines based on the Space Jam film franchise."
   },
   {
     "slug": "spider-man",
     "name": "Spider-Man",
-    "description": "Pinball adaptations of the Spider-Man franchise, produced by Gottlieb in 1980 and Stern in 2007."
+    "description": "Pinball machines based on the Spider-Man franchise."
   },
   {
     "slug": "star-trek",
     "name": "Star Trek",
-    "description": "Pinball adaptations of the Star Trek franchise across four decades, produced by Bally (1979), Data East (1991), Williams (1993), and Stern (2013)."
+    "description": "Pinball machines based on the Star Trek franchise."
   },
   {
     "slug": "star-wars",
     "name": "Star Wars",
-    "description": "Pinball adaptations of the Star Wars franchise, produced by Hankin (1980), Sonic (1987), Data East (1992), Sega (1997), Williams (1999), and Stern (2017–2025)."
+    "description": "Pinball machines based on the Star Wars franchise."
   },
   {
     "slug": "stargate",
     "name": "Stargate",
-    "description": "Pinball adaptation of the Stargate film, produced by Gottlieb (1995)."
+    "description": "Pinball machines based on the Stargate franchise."
   },
   {
     "slug": "starship-troopers",
     "name": "Starship Troopers",
-    "description": "Pinball adaptation of the Starship Troopers film, produced by Sega (1997)."
+    "description": "Pinball machines based on the Starship Troopers film franchise."
   },
   {
     "slug": "stranger-things",
     "name": "Stranger Things",
-    "description": "Pinball adaptation of the Stranger Things television series, produced by Stern (2019)."
+    "description": "Pinball machines based on the Stranger Things television series."
   },
   {
     "slug": "super-mario-bros",
     "name": "Super Mario Bros.",
-    "description": "Pinball adaptation of Super Mario Bros., produced by Gottlieb (1992)."
+    "description": "Pinball machines based on the Super Mario Bros. video game franchise."
   },
   {
     "slug": "superman",
     "name": "Superman",
-    "description": "Pinball adaptations of the Superman franchise, produced by Atari (1979) and Stern (2024)."
+    "description": "Pinball machines based on the Superman franchise."
   },
   {
     "slug": "tales-from-the-crypt",
     "name": "Tales from the Crypt",
-    "description": "Pinball adaptation of Tales from the Crypt, produced by Data East (1993)."
+    "description": "Pinball machines based on the Tales from the Crypt franchise."
   },
   {
     "slug": "ted-nugent",
     "name": "Ted Nugent",
-    "description": "Pinball themed around musician Ted Nugent, produced by Stern Electronics (1978)."
+    "description": "Pinball machines themed around musician Ted Nugent."
   },
   {
     "slug": "teenage-mutant-ninja-turtles",
     "name": "Teenage Mutant Ninja Turtles",
-    "description": "Pinball adaptation of the Teenage Mutant Ninja Turtles franchise, produced by Stern (2020)."
+    "description": "Pinball machines based on the Teenage Mutant Ninja Turtles franchise."
   },
   {
     "slug": "terminator",
     "name": "Terminator",
-    "description": "Pinball adaptations of the Terminator film franchise, produced by Williams (T2, 1991) and Stern (T3, 2003)."
+    "description": "Pinball machines based on the Terminator film franchise."
   },
   {
     "slug": "the-addams-family",
     "name": "The Addams Family",
-    "description": "Pinball adaptations of The Addams Family franchise, produced by Bally (1992)."
+    "description": "Pinball machines based on The Addams Family franchise."
   },
   {
     "slug": "the-avengers",
     "name": "The Avengers",
-    "description": "Pinball adaptations of the Avengers franchise, produced by Stern (2012, 2020)."
+    "description": "Pinball machines based on Marvel's Avengers franchise."
   },
   {
     "slug": "the-beatles",
     "name": "The Beatles",
-    "description": "Pinball machines themed around The Beatles, produced by Stern (2018)."
+    "description": "Pinball machines themed around The Beatles."
   },
   {
     "slug": "the-big-lebowski",
     "name": "The Big Lebowski",
-    "description": "Pinball adaptation of The Big Lebowski film, produced by Dutch Pinball (2016)."
+    "description": "Pinball machines based on The Big Lebowski film."
   },
   {
     "slug": "the-flintstones",
     "name": "The Flintstones",
-    "description": "Pinball adaptations of The Flintstones animated series, produced by Williams (1994) and Hanna-Barbera licensees."
+    "description": "Pinball machines based on The Flintstones animated series."
   },
   {
     "slug": "the-incredible-hulk",
     "name": "The Incredible Hulk",
-    "description": "Pinball adaptation of Marvel's The Incredible Hulk, produced by Gottlieb (1979)."
+    "description": "Pinball machines based on Marvel's The Incredible Hulk."
   },
   {
     "slug": "the-jetsons",
     "name": "The Jetsons",
-    "description": "Pinball adaptation of The Jetsons animated series, produced by The Pinball Company (2017)."
+    "description": "Pinball machines based on The Jetsons animated series."
   },
   {
     "slug": "the-munsters",
     "name": "The Munsters",
-    "description": "Pinball adaptation of The Munsters television series, produced by Stern (2019)."
+    "description": "Pinball machines based on The Munsters television series."
   },
   {
     "slug": "the-rolling-stones",
     "name": "The Rolling Stones",
-    "description": "Pinball machines themed around the rock band The Rolling Stones, produced by Bally (1980) and Stern (2011)."
+    "description": "Pinball machines themed around the rock band The Rolling Stones."
   },
   {
     "slug": "the-shadow",
     "name": "The Shadow",
-    "description": "Pinball adaptation of The Shadow, produced by Bally (1994)."
+    "description": "Pinball machines based on The Shadow franchise."
   },
   {
     "slug": "the-simpsons",
     "name": "The Simpsons",
-    "description": "Pinball adaptations of The Simpsons animated series, produced by Data East (1990) and Stern (2003)."
+    "description": "Pinball machines based on The Simpsons animated series."
   },
   {
     "slug": "the-sopranos",
     "name": "The Sopranos",
-    "description": "Pinball adaptation of The Sopranos television series, produced by Stern (2005)."
+    "description": "Pinball machines based on The Sopranos television series."
   },
   {
     "slug": "the-walking-dead",
     "name": "The Walking Dead",
-    "description": "Pinball adaptation of The Walking Dead franchise, produced by Stern (2014)."
+    "description": "Pinball machines based on The Walking Dead franchise."
   },
   {
     "slug": "the-who",
     "name": "The Who",
-    "description": "Pinball machines themed around The Who, produced by Bally (1975) and Data East (1994)."
+    "description": "Pinball machines themed around the rock band The Who."
   },
   {
     "slug": "the-wizard-of-oz",
     "name": "The Wizard of Oz",
-    "description": "Pinball adaptations of The Wizard of Oz, produced by Jersey Jack Pinball (2013)."
+    "description": "Pinball machines based on The Wizard of Oz."
   },
   {
     "slug": "the-x-files",
     "name": "The X-Files",
-    "description": "Pinball adaptation of The X-Files television series, produced by Sega (1997)."
+    "description": "Pinball machines based on The X-Files television series."
   },
   {
     "slug": "transformers",
     "name": "Transformers",
-    "description": "Pinball adaptations of the Transformers franchise, produced by Stern (2011–2012)."
+    "description": "Pinball machines based on the Transformers franchise."
   },
   {
     "slug": "tron",
     "name": "TRON",
-    "description": "Pinball adaptation of the TRON franchise, produced by Stern (2011)."
+    "description": "Pinball machines based on the TRON franchise."
   },
   {
     "slug": "twilight-zone",
     "name": "Twilight Zone",
-    "description": "Pinball adaptation of The Twilight Zone television series, produced by Bally (1993)."
+    "description": "Pinball machines based on The Twilight Zone television series."
   },
   {
     "slug": "twister",
     "name": "Twister",
-    "description": "Pinball adaptation of the Twister film, produced by Sega (1996)."
+    "description": "Pinball machines based on the Twister film."
   },
   {
     "slug": "universal-monsters",
     "name": "Universal Monsters",
-    "description": "Pinball machines featuring Universal Studios classic monsters, produced by Bally (1992, 1998)."
+    "description": "Pinball machines featuring Universal Studios classic monsters."
   },
   {
     "slug": "waterworld",
     "name": "Waterworld",
-    "description": "Pinball adaptation of the Waterworld film, produced by Gottlieb (1995)."
+    "description": "Pinball machines based on the Waterworld film."
   },
   {
     "slug": "wheel-of-fortune",
     "name": "Wheel of Fortune",
-    "description": "Pinball adaptation of the Wheel of Fortune game show, produced by Stern (2007)."
+    "description": "Pinball machines based on the Wheel of Fortune game show."
   },
   {
     "slug": "willy-wonka",
     "name": "Willy Wonka",
-    "description": "Pinball adaptation of Willy Wonka & The Chocolate Factory, produced by Jersey Jack Pinball (2019)."
+    "description": "Pinball machines based on the Willy Wonka franchise."
   },
   {
     "slug": "world-poker-tour",
     "name": "World Poker Tour",
-    "description": "Pinball adaptation of the World Poker Tour, produced by Stern (2006)."
+    "description": "Pinball machines based on the World Poker Tour."
   },
   {
     "slug": "wwf",
     "name": "WWF",
-    "description": "Pinball adaptation of the WWF professional wrestling franchise, produced by Data East (1994)."
+    "description": "Pinball machines based on the WWF professional wrestling franchise."
   },
   {
     "slug": "x-men",
     "name": "X-Men",
-    "description": "Pinball adaptations of Marvel's X-Men, produced by Stern (2012)."
+    "description": "Pinball machines based on Marvel's X-Men."
   }
 ]

--- a/data/models.json
+++ b/data/models.json
@@ -130,8 +130,15 @@
   {
     "slug": "black-knight-sword-of-rage-limited-edition",
     "name": "Black Knight: Sword of Rage (Limited Edition)",
+    "variant_of": "black-knight-sword-of-rage-premium",
     "opdb_id": "GD7Ld-MBRP4-A1e4P",
     "ipdb_id": 6569
+  },
+  {
+    "slug": "black-knight-sword-of-rage-premium",
+    "name": "Black Knight: Sword of Rage (Premium)",
+    "opdb_id": "GD7Ld-MBRP4",
+    "ipdb_id": 6568
   },
   {
     "slug": "blood-bank-billiards",
@@ -330,12 +337,14 @@
   {
     "slug": "dialed-in-collectors-edition",
     "name": "Dialed In! (Collector's Edition)",
+    "variant_of": "dialed-in-standard-edition",
     "opdb_id": "G4X2l-MYepl-ARXxn",
     "ipdb_id": 6352
   },
   {
     "slug": "dialed-in-limited-edition",
     "name": "Dialed In! (Limited Edition)",
+    "variant_of": "dialed-in-standard-edition",
     "opdb_id": "G4X2l-MYepl-A1WXy",
     "ipdb_id": 6351
   },
@@ -391,6 +400,11 @@
     "name": "Eight Ball",
     "opdb_id": "GrN7J-MJ78q",
     "ipdb_id": 760
+  },
+  {
+    "slug": "eight-ball-deluxe",
+    "opdb_id": "G5KXk-MLB9V",
+    "ipdb_id": 762
   },
   {
     "slug": "eight-ball-deluxe-limited-edition",
@@ -530,8 +544,14 @@
     "opdb_id": "G5Dz7-MdEod-AR8Nb"
   },
   {
+    "slug": "galactic-tank-force-classic",
+    "name": "Galactic Tank Force (Classic)",
+    "opdb_id": "Gj6PZ-Mb5z6"
+  },
+  {
     "slug": "galactic-tank-force-limited-edition",
     "name": "Galactic Tank Force (Limited Edition)",
+    "variant_of": "galactic-tank-force-classic",
     "opdb_id": "Gj6PZ-Mb5z6-A9Lbd"
   },
   {
@@ -648,6 +668,7 @@
   {
     "slug": "halloween-collectors-edition",
     "name": "Halloween (Collector's Edition)",
+    "variant_of": "halloween-standard-edition",
     "opdb_id": "Gj66Z-Mp4BN-A9Y6n"
   },
   {
@@ -927,6 +948,7 @@
   {
     "slug": "looney-tunes-collectors-edition",
     "name": "Looney Tunes (Collector's Edition)",
+    "variant_of": "looney-tunes-standard-edition",
     "opdb_id": "GJ2K0-M85re-A1qdn"
   },
   {
@@ -1086,6 +1108,7 @@
   {
     "slug": "pirates-of-the-caribbean-limited-edition",
     "name": "Pirates of the Caribbean (Limited Edition)",
+    "variant_of": "pirates-of-the-caribbean-standard-edition",
     "opdb_id": "GRbPY-MePOP-A9pVl",
     "ipdb_id": 6493
   },
@@ -1226,6 +1249,7 @@
   {
     "slug": "scooby-doo-collectors-edition",
     "name": "Scooby-Doo (Collector's Edition)",
+    "variant_of": "scooby-doo-standard-edition",
     "opdb_id": "GllPz-MBRrV-A9vWL"
   },
   {
@@ -1236,10 +1260,10 @@
   {
     "slug": "screech",
     "name": "Screech",
-    "description": "OPDB incorrectly lists display as DMD; Screech is a 1976 Inder EM with a digital score display fitted over factory-installed reels — the player-visible display is what matters for classification",
-    "display_type": "alphanumeric",
     "opdb_id": "GPBBv-ME0x0",
-    "ipdb_id": 3939
+    "ipdb_id": 3939,
+    "description": "OPDB incorrectly lists display as DMD; Screech is a 1976 Inder EM with a digital score display fitted over factory-installed reels — the player-visible display is what matters for classification",
+    "display_type": "alphanumeric"
   },
   {
     "slug": "sexy-girl",
@@ -1443,6 +1467,7 @@
   {
     "slug": "sure-shot",
     "name": "Sure Shot",
+    "variant_of": "eight-ball-deluxe",
     "opdb_id": "G5KXk-MLB9V-AOjJb",
     "ipdb_id": 4574
   },
@@ -1484,6 +1509,7 @@
   {
     "slug": "the-avengers-hulk-limited-edition",
     "name": "The Avengers Hulk (Limited Edition)",
+    "variant_of": "the-avengers-limited-edition",
     "opdb_id": "GRzNR-MyNq8-A1oeR",
     "ipdb_id": 5941
   },
@@ -1519,6 +1545,7 @@
   {
     "slug": "the-hobbit-limited-edition",
     "name": "The Hobbit (Limited Edition)",
+    "variant_of": "the-hobbit-standard-edition",
     "opdb_id": "G5bYr-MLezO-A9dNe"
   },
   {
@@ -1561,13 +1588,20 @@
     "ipdb_id": 6565
   },
   {
+    "slug": "the-princess-bride",
+    "name": "The Princess Bride",
+    "opdb_id": "GkBnQ-MBRxV"
+  },
+  {
     "slug": "the-princess-bride-collectors-edition",
     "name": "The Princess Bride (Collector's Edition)",
+    "variant_of": "the-princess-bride",
     "opdb_id": "GkBnQ-MBRxV-A96qp"
   },
   {
     "slug": "the-princess-bride-limited-edition",
     "name": "The Princess Bride (Limited Edition)",
+    "variant_of": "the-princess-bride",
     "opdb_id": "GkBnQ-MBRxV-ARB7b"
   },
   {
@@ -1579,6 +1613,7 @@
   {
     "slug": "the-texas-chainsaw-massacre-collectors-edition",
     "name": "The Texas Chainsaw Massacre (Collector's Edition)",
+    "variant_of": "the-texas-chainsaw-massacre-standard-edition",
     "opdb_id": "G0lkp-MZeqp-AOdky"
   },
   {
@@ -1623,6 +1658,7 @@
   {
     "slug": "the-wizard-of-oz-limited-edition",
     "name": "The Wizard of Oz (Limited Edition)",
+    "variant_of": "the-wizard-of-oz-standard-edition",
     "opdb_id": "G4xyR-MJ2v0-AOPQQ"
   },
   {
@@ -1653,8 +1689,14 @@
     "ipdb_id": 3904
   },
   {
+    "slug": "total-nuclear-annihilation",
+    "opdb_id": "GRD79-M0odk",
+    "ipdb_id": 6444
+  },
+  {
     "slug": "total-nuclear-annihilation-collectors-edition",
     "name": "Total Nuclear Annihilation (Collector's Edition)",
+    "variant_of": "total-nuclear-annihilation",
     "opdb_id": "GRD79-M0odk-AObBw"
   },
   {
@@ -1673,12 +1715,14 @@
   {
     "slug": "transformers-autobot-crimson-limited-edition",
     "name": "Transformers Autobot Crimson (Limited Edition)",
+    "variant_of": "transformers-limited-edition",
     "opdb_id": "GRnPz-Mx0XO-AOxV9",
     "ipdb_id": 5754
   },
   {
     "slug": "transformers-decepticon-violet-limited-edition",
     "name": "Transformers Decepticon Violet (Limited Edition)",
+    "variant_of": "transformers-limited-edition",
     "opdb_id": "GRnPz-Mx0XO-ARzL1",
     "ipdb_id": 5755
   },
@@ -1697,6 +1741,7 @@
   {
     "slug": "ultraman-kaiju-rumble-collectors-edition",
     "name": "Ultraman: Kaiju Rumble (Collector's Edition)",
+    "variant_of": "ultraman-kaiju-rumble-standard-edition",
     "opdb_id": "GBLLd-MdEON-A9QJL"
   },
   {
@@ -1718,8 +1763,13 @@
     "ipdb_id": 7065
   },
   {
+    "slug": "weird-als-museum-of-natural-hilarity",
+    "opdb_id": "GN6WW-MnKPq"
+  },
+  {
     "slug": "weird-als-museum-of-natural-hilarity-limited-edition",
     "name": "Weird Al's Museum of Natural Hilarity (Limited Edition)",
+    "variant_of": "weird-als-museum-of-natural-hilarity",
     "opdb_id": "GN6WW-MnKPq-AOPQq"
   },
   {
@@ -1767,6 +1817,7 @@
   {
     "slug": "willy-wonka-and-the-chocolate-factory-collectors-edition",
     "name": "Willy Wonka & The Chocolate Factory (Collector's Edition)",
+    "variant_of": "willy-wonka-and-the-chocolate-factory-limited-edition",
     "opdb_id": "GYWBZ-MW9B0-A9jqd",
     "ipdb_id": 6649
   },
@@ -1803,6 +1854,7 @@
   {
     "slug": "x-men-magneto-limited-edition",
     "name": "X-Men Magneto (Limited Edition)",
+    "variant_of": "x-men-limited-edition",
     "opdb_id": "Grj6X-MJNV1-AOwN1",
     "ipdb_id": 5823
   },
@@ -1815,6 +1867,7 @@
   {
     "slug": "x-men-wolverine-limited-edition",
     "name": "X-Men Wolverine (Limited Edition)",
+    "variant_of": "x-men-limited-edition",
     "opdb_id": "Grj6X-MJNV1-AO209",
     "ipdb_id": 5824
   },

--- a/data/models.json
+++ b/data/models.json
@@ -2,6 +2,7 @@
   {
     "slug": "301bullseye",
     "name": "301/Bullseye",
+    "title": "301bullseye",
     "is_conversion": true,
     "opdb_id": "G4kE2-MBRzN",
     "ipdb_id": 403
@@ -9,52 +10,63 @@
   {
     "slug": "abba-collectors-edition",
     "name": "ABBA (Collector's Edition)",
+    "title": "abba",
     "opdb_id": "Ge1py-MkPj1-AOppL"
   },
   {
     "slug": "abba-limited-edition",
     "name": "ABBA (Limited Edition)",
+    "title": "abba",
     "variant_of": "abba-collectors-edition",
     "opdb_id": "Ge1py-MkPj1-A1XDN"
   },
   {
     "slug": "ac-dc-limited-edition",
     "name": "AC/DC (Limited Edition)",
+    "title": "ac-dc",
     "variant_of": "ac-dc-premium",
     "opdb_id": "G43W4-MrRpw",
     "ipdb_id": 5777
   },
   {
     "slug": "ac-dc-premium",
+    "name": "AC/DC (Premium)",
+    "title": "ac-dc",
     "opdb_id": "G43W4-MXrPx",
     "ipdb_id": 5775
   },
   {
     "slug": "aerosmith-limited-edition",
     "name": "Aerosmith (Limited Edition)",
+    "title": "aerosmith",
     "variant_of": "aerosmith-premium",
     "opdb_id": "Gr16e-M5Rbv",
     "ipdb_id": 6372
   },
   {
     "slug": "aerosmith-premium",
+    "name": "Aerosmith (Premium)",
+    "title": "aerosmith",
     "opdb_id": "Gr16e-Mq1k3",
     "ipdb_id": 6371
   },
   {
     "slug": "aerosmith-pro",
     "name": "Aerosmith (Pro)",
+    "title": "aerosmith",
     "opdb_id": "Gr16e-MnKEX",
     "ipdb_id": 6370
   },
   {
     "slug": "alien-limited-edition",
     "name": "Alien (Limited Edition)",
+    "title": "alien",
     "opdb_id": "G4PBO-MYep0"
   },
   {
     "slug": "amazon-hunt-iii",
     "name": "Amazon Hunt III",
+    "title": "bone-busters-inc",
     "is_conversion": true,
     "converted_from": "bone-busters-inc",
     "opdb_id": "G5Lk0-MDeVZ",
@@ -63,17 +75,20 @@
   {
     "slug": "avatar-the-battle-for-pandora-collectors-edition",
     "name": "Avatar: The Battle for Pandora (Collector's Edition)",
+    "title": "avatar-the-battle-for-pandora",
     "variant_of": "avatar-the-battle-for-pandora-limited-edition",
     "opdb_id": "GbPxB-MkPol-A9j2b"
   },
   {
     "slug": "avatar-the-battle-for-pandora-limited-edition",
     "name": "Avatar: The Battle for Pandora (Limited Edition)",
+    "title": "avatar-the-battle-for-pandora",
     "opdb_id": "GbPxB-MkPol-A93vd"
   },
   {
     "slug": "avengers-infinity-quest-limited-edition",
     "name": "Avengers: Infinity Quest (Limited Edition)",
+    "title": "avengers-infinity-quest",
     "variant_of": "avengers-infinity-quest-premium",
     "opdb_id": "Gj66P-MXr0E-ARkqN",
     "ipdb_id": 6756
@@ -81,35 +96,42 @@
   {
     "slug": "avengers-infinity-quest-premium",
     "name": "Avengers: Infinity Quest (Premium)",
+    "title": "avengers-infinity-quest",
     "opdb_id": "Gj66P-MXr0E-A1nx0",
     "ipdb_id": 6755
   },
   {
     "slug": "barry-os-barbecue-challenge-collectors-edition",
     "name": "Barry O's Barbecue Challenge (Collector's Edition)",
+    "title": "barry-os-barbeque-challenge",
     "opdb_id": "GK1Kv-ME0E0-A9PJq"
   },
   {
     "slug": "barry-os-barbecue-challenge-limited-edition",
     "name": "Barry O's Barbecue Challenge (Limited Edition)",
+    "title": "barry-os-barbeque-challenge",
     "variant_of": "barry-os-barbecue-challenge-collectors-edition",
     "opdb_id": "GK1Kv-ME0E0-AO7ZV"
   },
   {
     "slug": "batman-66-limited-edition",
     "name": "Batman 66 (Limited Edition)",
+    "title": "batman-66",
     "variant_of": "batman-66-premium",
     "opdb_id": "GRoz4-MrRPw",
     "ipdb_id": 6355
   },
   {
     "slug": "batman-66-premium",
+    "name": "Batman 66 (Premium)",
+    "title": "batman-66",
     "opdb_id": "GRoz4-MjBV6",
     "ipdb_id": 6354
   },
   {
     "slug": "big-dryvers",
     "name": "Big Dryvers",
+    "title": "space-orbit",
     "is_conversion": true,
     "converted_from": "space-orbit",
     "opdb_id": "G43WO-MJYYV",
@@ -118,18 +140,21 @@
   {
     "slug": "bird-watcher",
     "name": "Bird Watcher",
+    "title": "bird-watcher",
     "is_conversion": true,
     "opdb_id": "GX2zO-M5Rr4"
   },
   {
     "slug": "black-knight-limited-edition",
     "name": "Black Knight (Limited Edition)",
+    "title": "black-knight",
     "opdb_id": "GrO7w-MDR9W",
     "ipdb_id": 3799
   },
   {
     "slug": "black-knight-sword-of-rage-limited-edition",
     "name": "Black Knight: Sword of Rage (Limited Edition)",
+    "title": "black-knight-sword-of-rage",
     "variant_of": "black-knight-sword-of-rage-premium",
     "opdb_id": "GD7Ld-MBRP4-A1e4P",
     "ipdb_id": 6569
@@ -137,36 +162,42 @@
   {
     "slug": "black-knight-sword-of-rage-premium",
     "name": "Black Knight: Sword of Rage (Premium)",
+    "title": "black-knight-sword-of-rage",
     "opdb_id": "GD7Ld-MBRP4",
     "ipdb_id": 6568
   },
   {
     "slug": "blood-bank-billiards",
     "name": "Blood Bank Billiards",
+    "title": "blood-bank-billiards",
     "is_conversion": true,
     "opdb_id": "GPBzy-Mo1KX"
   },
   {
     "slug": "bobby-orrs-power-play",
     "name": "Bobby Orr's Power Play",
+    "title": "bobby-orrs-power-play",
     "opdb_id": "G4en0-MJ5vB",
     "ipdb_id": 1858
   },
   {
     "slug": "bone-busters-inc",
     "name": "Bone Busters Inc.",
+    "title": "bone-busters-inc",
     "opdb_id": "G5Lk0-MQjl3",
     "ipdb_id": 347
   },
   {
     "slug": "bride-of-pinbot",
     "name": "Bride of Pinbot",
+    "title": "bride-of-pinbot",
     "opdb_id": "GRpee-MePdR",
     "ipdb_id": 1502
   },
   {
     "slug": "bride-of-pinbot-20",
     "name": "Bride of Pinbot 2.0",
+    "title": "bride-of-pinbot",
     "is_conversion": true,
     "converted_from": "bride-of-pinbot",
     "opdb_id": "GRpee-MJkyr",
@@ -175,6 +206,7 @@
   {
     "slug": "buck-rogers",
     "name": "Buck Rogers",
+    "title": "tiger",
     "is_conversion": true,
     "converted_from": "tiger",
     "opdb_id": "GRw8o-MDxjq",
@@ -183,12 +215,14 @@
   {
     "slug": "cactus-canyon",
     "name": "Cactus Canyon",
+    "title": "cactus-canyon-remake",
     "opdb_id": "G4835-Mb5eO",
     "ipdb_id": 4445
   },
   {
     "slug": "cactus-canyon-continued",
     "name": "Cactus Canyon Continued",
+    "title": "cactus-canyon-remake",
     "is_conversion": true,
     "converted_from": "cactus-canyon",
     "opdb_id": "G4835-M2YEn"
@@ -196,6 +230,7 @@
   {
     "slug": "cactus-canyon-lyman-upgrade",
     "name": "Cactus Canyon (Lyman Upgrade)",
+    "title": "cactus-canyon-remake",
     "variant_of": "cactus-canyon-remake-special-edition",
     "is_conversion": true,
     "converted_from": "cactus-canyon-remake-special-edition",
@@ -204,29 +239,34 @@
   {
     "slug": "cactus-canyon-remake-limited-edition",
     "name": "Cactus Canyon (Remake Limited Edition)",
+    "title": "cactus-canyon-remake",
     "variant_of": "cactus-canyon-remake-special-edition",
     "opdb_id": "G4835-M2YPK-A9ylv"
   },
   {
     "slug": "cactus-canyon-remake-special-edition",
     "name": "Cactus Canyon (Remake Special Edition)",
+    "title": "cactus-canyon-remake",
     "opdb_id": "G4835-M2YPK-AR5ln"
   },
   {
     "slug": "centaur",
     "name": "Centaur",
+    "title": "centaur",
     "opdb_id": "GrX7q-MLWkn",
     "ipdb_id": 476
   },
   {
     "slug": "central-park",
     "name": "Central Park",
+    "title": "central-park",
     "opdb_id": "GRpYQ-MRj0O",
     "ipdb_id": 481
   },
   {
     "slug": "challenger",
     "name": "Challenger",
+    "title": "eight-ball",
     "is_conversion": true,
     "converted_from": "eight-ball",
     "opdb_id": "GrN7J-MDlYZ",
@@ -235,6 +275,7 @@
   {
     "slug": "challenger-ii",
     "name": "Challenger II",
+    "title": "evel-knievel",
     "is_conversion": true,
     "converted_from": "evel-knievel",
     "opdb_id": "G59wx-MLnZ3-A1lJd",
@@ -243,6 +284,7 @@
   {
     "slug": "challenger-iii",
     "name": "Challenger III",
+    "title": "bobby-orrs-power-play",
     "is_conversion": true,
     "converted_from": "bobby-orrs-power-play",
     "opdb_id": "G4en0-MJ5vB-ARevr",
@@ -251,6 +293,7 @@
   {
     "slug": "challenger-iv",
     "name": "Challenger IV",
+    "title": "strikes-and-spares",
     "is_conversion": true,
     "converted_from": "strikes-and-spares",
     "opdb_id": "GrleW-MYeod-AO3dY",
@@ -259,6 +302,7 @@
   {
     "slug": "challenger-v",
     "name": "Challenger V",
+    "title": "star-trek-bally",
     "is_conversion": true,
     "converted_from": "star-trek",
     "opdb_id": "GRVnd-MQZzx-AOjJv",
@@ -267,6 +311,7 @@
   {
     "slug": "city-ship",
     "name": "City Ship",
+    "title": "super-spin",
     "is_conversion": true,
     "converted_from": "super-spin",
     "opdb_id": "G4qzZ-MQpoP-A9pdL",
@@ -275,6 +320,7 @@
   {
     "slug": "cleopatra",
     "name": "Cleopatra",
+    "title": "play-pool",
     "is_conversion": true,
     "converted_from": "play-pool",
     "opdb_id": "G5n1Q-MQPRP",
@@ -283,6 +329,7 @@
   {
     "slug": "coney-island",
     "name": "Coney Island",
+    "title": "lady-robin-hood",
     "is_conversion": true,
     "converted_from": "lady-robin-hood",
     "opdb_id": "GRVL2-MLl9Y-A1Zx2",
@@ -291,6 +338,7 @@
   {
     "slug": "cosmodrome",
     "name": "Cosmodrome",
+    "title": "cosmodrome",
     "is_conversion": true,
     "opdb_id": "G509D-MnKVN",
     "ipdb_id": 3696
@@ -298,12 +346,14 @@
   {
     "slug": "cybernaut",
     "name": "Cybernaut",
+    "title": "cybernaut",
     "opdb_id": "GR69j-MW93o",
     "ipdb_id": 614
   },
   {
     "slug": "dark-rider",
     "name": "Dark Rider",
+    "title": "star-trek-bally",
     "is_conversion": true,
     "converted_from": "star-trek",
     "opdb_id": "GRVnd-MLbOx",
@@ -312,24 +362,29 @@
   {
     "slug": "deadpool-limited-edition",
     "name": "Deadpool (Limited Edition)",
+    "title": "deadpool",
     "variant_of": "deadpool-premium",
     "opdb_id": "G6lnq-M6153",
     "ipdb_id": 6560
   },
   {
     "slug": "deadpool-premium",
+    "name": "Deadpool (Premium)",
+    "title": "deadpool",
     "opdb_id": "G6lnq-MRj7Z",
     "ipdb_id": 6559
   },
   {
     "slug": "demolition-man",
     "name": "Demolition Man",
+    "title": "demolition-man",
     "opdb_id": "G5bv3-MLW68",
     "ipdb_id": 662
   },
   {
     "slug": "demolition-man-on-steroids",
     "name": "Demolition Man on Steroids",
+    "title": "demolition-man",
     "is_conversion": true,
     "converted_from": "demolition-man",
     "opdb_id": "G5bv3-MePXV"
@@ -337,6 +392,7 @@
   {
     "slug": "dialed-in-collectors-edition",
     "name": "Dialed In! (Collector's Edition)",
+    "title": "dialed-in",
     "variant_of": "dialed-in-standard-edition",
     "opdb_id": "G4X2l-MYepl-ARXxn",
     "ipdb_id": 6352
@@ -344,6 +400,7 @@
   {
     "slug": "dialed-in-limited-edition",
     "name": "Dialed In! (Limited Edition)",
+    "title": "dialed-in",
     "variant_of": "dialed-in-standard-edition",
     "opdb_id": "G4X2l-MYepl-A1WXy",
     "ipdb_id": 6351
@@ -351,93 +408,110 @@
   {
     "slug": "dialed-in-standard-edition",
     "name": "Dialed In! (Standard Edition)",
+    "title": "dialed-in",
     "opdb_id": "G4X2l-MYepl",
     "ipdb_id": 6350
   },
   {
     "slug": "disney-tron-legacy-limited-edition",
     "name": "Disney TRON: Legacy (Limited Edition)",
+    "title": "tron",
     "opdb_id": "GrkL5-MJoNN",
     "ipdb_id": 5707
   },
   {
     "slug": "drained",
     "name": "Drained",
+    "title": "drained",
     "is_conversion": true,
     "opdb_id": "GyVb1-MYeq1"
   },
   {
     "slug": "drained-bite-sized",
     "name": "Drained Bite-Sized",
+    "title": "drained-bite-sized",
     "is_conversion": true,
     "opdb_id": "GbPv6-MVKq8"
   },
   {
     "slug": "dungeon-door-defender",
     "name": "Dungeon Door Defender",
+    "title": "dungeon-door-defender",
     "is_conversion": true,
     "opdb_id": "G7Zyb-MvB5k"
   },
   {
     "slug": "dungeons-and-dragons-the-tyrants-eye-limited-edition",
     "name": "Dungeons & Dragons: The Tyrant's Eye (Limited Edition)",
+    "title": "dungeons-dragons-the-tyrants-eye",
     "variant_of": "dungeons-and-dragons-the-tyrants-eye-premium",
     "opdb_id": "GK1Ej-MePok-A1zKx"
   },
   {
     "slug": "dungeons-and-dragons-the-tyrants-eye-premium",
     "name": "Dungeons & Dragons: The Tyrant's Eye (Premium)",
+    "title": "dungeons-dragons-the-tyrants-eye",
     "opdb_id": "GK1Ej-MePok-A9VWD"
   },
   {
     "slug": "earthshaker",
     "name": "Earthshaker",
+    "title": "earthshaker",
     "opdb_id": "GRw0r-Mp42p",
     "ipdb_id": 753
   },
   {
     "slug": "eight-ball",
     "name": "Eight Ball",
+    "title": "eight-ball",
     "opdb_id": "GrN7J-MJ78q",
     "ipdb_id": 760
   },
   {
     "slug": "eight-ball-deluxe",
+    "name": "Eight Ball Deluxe",
+    "title": "eight-ball-deluxe",
     "opdb_id": "G5KXk-MLB9V",
     "ipdb_id": 762
   },
   {
     "slug": "eight-ball-deluxe-limited-edition",
     "name": "Eight Ball Deluxe (Limited Edition)",
+    "title": "eight-ball-deluxe",
     "opdb_id": "G5KXk-MLqNz",
     "ipdb_id": 763
   },
   {
     "slug": "elton-john-collectors-edition",
     "name": "Elton John (Collector's Edition)",
+    "title": "elton-john",
     "variant_of": "elton-john-platinum-edition",
     "opdb_id": "G2LWd-M4o3Y-AOwoL"
   },
   {
     "slug": "elton-john-platinum-edition",
     "name": "Elton John (Platinum Edition)",
+    "title": "elton-john",
     "opdb_id": "G2LWd-M4o3Y-A1e22"
   },
   {
     "slug": "elviras-house-of-horrors-40th-anniversary",
     "name": "Elvira's House of Horrors (40th Anniversary)",
+    "title": "elviras-house-of-horrors",
     "variant_of": "elviras-house-of-horrors-premium",
     "opdb_id": "GZVOd-MwNxZ-A1lvp"
   },
   {
     "slug": "elviras-house-of-horrors-blood-red-kiss",
     "name": "Elvira's House of Horrors (Blood Red Kiss)",
+    "title": "elviras-house-of-horrors",
     "variant_of": "elviras-house-of-horrors-premium",
     "opdb_id": "GZVOd-MwNxZ-AO25N"
   },
   {
     "slug": "elviras-house-of-horrors-limited-edition",
     "name": "Elvira's House of Horrors (Limited Edition)",
+    "title": "elviras-house-of-horrors",
     "variant_of": "elviras-house-of-horrors-premium",
     "opdb_id": "GZVOd-MwNxZ-AR8vV",
     "ipdb_id": 6597
@@ -445,12 +519,14 @@
   {
     "slug": "elviras-house-of-horrors-premium",
     "name": "Elvira's House of Horrors (Premium)",
+    "title": "elviras-house-of-horrors",
     "opdb_id": "GZVOd-MwNxZ-AOLoy",
     "ipdb_id": 6596
   },
   {
     "slug": "elviras-house-of-horrors-signature-edition",
     "name": "Elvira's House of Horrors (Signature Edition)",
+    "title": "elviras-house-of-horrors",
     "variant_of": "elviras-house-of-horrors-premium",
     "opdb_id": "GZVOd-MwNxZ-ARove",
     "ipdb_id": 6598
@@ -458,29 +534,41 @@
   {
     "slug": "escape-from-the-megaverse",
     "name": "Escape From The Megaverse",
+    "title": "escape-from-the-megaverse",
     "is_conversion": true,
     "opdb_id": "G0lop-M4oEY"
   },
   {
     "slug": "evel-knievel",
     "name": "Evel Knievel",
+    "title": "evel-knievel",
     "opdb_id": "G59wx-MLnZ3",
     "ipdb_id": 4499
   },
   {
     "slug": "evel-knievel-em",
     "name": "Evel Knievel (EM)",
+    "title": "evel-knievel",
     "opdb_id": "G59wx-MLBX4",
     "ipdb_id": 793
   },
   {
     "slug": "evil-dead-collectors-edition",
     "name": "Evil Dead (Collector's Edition)",
+    "title": "evil-dead",
     "opdb_id": "GYWvw-MKNP4"
+  },
+  {
+    "slug": "family-guy",
+    "name": "Family Guy",
+    "title": "family-guy",
+    "opdb_id": "G5LW9-MQ6N5",
+    "ipdb_id": 5219
   },
   {
     "slug": "fantasy",
     "name": "Fantasy",
+    "title": "centaur",
     "is_conversion": true,
     "converted_from": "centaur",
     "opdb_id": "GrX7q-MJop6",
@@ -489,6 +577,7 @@
   {
     "slug": "flesh-and-blood",
     "name": "Flesh and Blood",
+    "title": "pinball-champ-82",
     "is_conversion": true,
     "converted_from": "pinball-champ-82",
     "opdb_id": "GrPdq-MnKwO",
@@ -497,12 +586,14 @@
   {
     "slug": "flipper-foxtrot-rhythm-explosion",
     "name": "Flipper Foxtrot Rhythm Explosion",
+    "title": "flipper-foxtrot-rhythm-explosion",
     "is_conversion": true,
     "opdb_id": "G9z10-M2Y1K"
   },
   {
     "slug": "fly-high",
     "name": "Fly High",
+    "title": "star-ship",
     "is_conversion": true,
     "converted_from": "star-ship",
     "opdb_id": "GRLXd-MDbdq",
@@ -511,23 +602,27 @@
   {
     "slug": "foo-fighters-limited-edition",
     "name": "Foo Fighters (Limited Edition)",
+    "title": "foo-fighters",
     "variant_of": "foo-fighters-premium",
     "opdb_id": "GpeoL-MkPz1-A944p"
   },
   {
     "slug": "foo-fighters-premium",
     "name": "Foo Fighters (Premium)",
+    "title": "foo-fighters",
     "opdb_id": "GpeoL-MkPz1-A9Qlw"
   },
   {
     "slug": "funhouse",
     "name": "Funhouse",
+    "title": "funhouse",
     "opdb_id": "G5Dz7-Mq139",
     "ipdb_id": 966
   },
   {
     "slug": "funhouse-20-rudys-nightmare",
     "name": "Funhouse 2.0 (Rudy's Nightmare)",
+    "title": "funhouse",
     "is_conversion": true,
     "converted_from": "funhouse",
     "opdb_id": "G5Dz7-Mz2e1"
@@ -535,34 +630,40 @@
   {
     "slug": "funhouse-remake-collectors-edition",
     "name": "Funhouse (Remake Collector's Edition)",
+    "title": "funhouse",
     "opdb_id": "G5Dz7-MdEod-AOL3d"
   },
   {
     "slug": "funhouse-remake-limited-edition",
     "name": "Funhouse (Remake Limited Edition)",
+    "title": "funhouse",
     "variant_of": "funhouse-remake-collectors-edition",
     "opdb_id": "G5Dz7-MdEod-AR8Nb"
   },
   {
     "slug": "galactic-tank-force-classic",
     "name": "Galactic Tank Force (Classic)",
+    "title": "galactic-tank-force",
     "opdb_id": "Gj6PZ-Mb5z6"
   },
   {
     "slug": "galactic-tank-force-limited-edition",
     "name": "Galactic Tank Force (Limited Edition)",
+    "title": "galactic-tank-force",
     "variant_of": "galactic-tank-force-classic",
     "opdb_id": "Gj6PZ-Mb5z6-A9Lbd"
   },
   {
     "slug": "gamatron",
     "name": "Gamatron",
+    "title": "gamatron",
     "opdb_id": "GRo6e-MDB2x",
     "ipdb_id": 3116
   },
   {
     "slug": "gamatron-2",
     "name": "Gamatron",
+    "title": "gamatron",
     "is_conversion": true,
     "converted_from": "gamatron",
     "opdb_id": "GRo6e-MQPov",
@@ -571,42 +672,51 @@
   {
     "slug": "game-of-thrones-limited-edition",
     "name": "Game of Thrones (Limited Edition)",
+    "title": "game-of-thrones",
     "variant_of": "game-of-thrones-premium",
     "opdb_id": "G41d5-M9REd",
     "ipdb_id": 6309
   },
   {
     "slug": "game-of-thrones-premium",
+    "name": "Game of Thrones (Premium)",
+    "title": "game-of-thrones",
     "opdb_id": "G41d5-M0ovk",
     "ipdb_id": 6308
   },
   {
     "slug": "genie",
     "name": "Genie",
+    "title": "genie",
     "opdb_id": "GRBKZ-ML8Oe",
     "ipdb_id": 997
   },
   {
     "slug": "ghostbusters-limited-edition",
     "name": "Ghostbusters (Limited Edition)",
+    "title": "ghostbusters",
     "variant_of": "ghostbusters-premium",
     "opdb_id": "GR9Nr-MVKol",
     "ipdb_id": 6334
   },
   {
     "slug": "ghostbusters-premium",
+    "name": "Ghostbusters (Premium)",
+    "title": "ghostbusters",
     "opdb_id": "GR9Nr-M5RxE",
     "ipdb_id": 6333
   },
   {
     "slug": "godzilla-70th-anniversary",
     "name": "Godzilla (70th Anniversary)",
+    "title": "godzilla-stern",
     "variant_of": "godzilla-premium",
     "opdb_id": "GweeP-Ml9pZ-AOvNL"
   },
   {
     "slug": "godzilla-limited-edition",
     "name": "Godzilla (Limited Edition)",
+    "title": "godzilla-stern",
     "variant_of": "godzilla-premium",
     "opdb_id": "GweeP-Ml9pZ-A9vXB",
     "ipdb_id": 6843
@@ -614,111 +724,131 @@
   {
     "slug": "godzilla-premium",
     "name": "Godzilla (Premium)",
+    "title": "godzilla-stern",
     "opdb_id": "GweeP-Ml9pZ-ARZoY",
     "ipdb_id": 6842
   },
   {
     "slug": "golden-arrow",
     "name": "Golden Arrow",
+    "title": "golden-arrow",
     "opdb_id": "G5WPp-MDBx9",
     "ipdb_id": 1044
   },
   {
     "slug": "grand-slam-rally",
     "name": "Grand Slam Rally",
+    "title": "grand-slam-rally",
     "is_conversion": true,
     "opdb_id": "GoEEx-MjB52"
   },
   {
     "slug": "guardians-of-the-galaxy-limited-edition",
     "name": "Guardians of the Galaxy (Limited Edition)",
+    "title": "guardians-of-the-galaxy",
     "variant_of": "guardians-of-the-galaxy-premium",
     "opdb_id": "GRWvz-MP37P",
     "ipdb_id": 6476
   },
   {
     "slug": "guardians-of-the-galaxy-premium",
+    "name": "Guardians of the Galaxy (Premium)",
+    "title": "guardians-of-the-galaxy",
     "opdb_id": "GRWvz-Mx0eb",
     "ipdb_id": 6475
   },
   {
     "slug": "guardians-of-the-galaxy-pro",
     "name": "Guardians of the Galaxy (Pro)",
+    "title": "guardians-of-the-galaxy",
     "opdb_id": "GRWvz-Mp4yl",
     "ipdb_id": 6474
   },
   {
     "slug": "guns-n-roses-collectors-edition",
     "name": "Guns N' Roses (Collector's Edition)",
+    "title": "guns-n-roses-jersey-jack-pinball",
     "opdb_id": "GqZZ1-MZeoE",
     "ipdb_id": 6766
   },
   {
     "slug": "guns-n-roses-limited-edition",
     "name": "Guns N' Roses (Limited Edition)",
+    "title": "guns-n-roses-jersey-jack-pinball",
     "opdb_id": "GqZZ1-M85y9",
     "ipdb_id": 6765
   },
   {
     "slug": "guns-n-roses-standard-edition",
     "name": "Guns N' Roses (Standard Edition)",
+    "title": "guns-n-roses-jersey-jack-pinball",
     "opdb_id": "GqZZ1-M1r5Y",
     "ipdb_id": 6764
   },
   {
     "slug": "halloween-collectors-edition",
     "name": "Halloween (Collector's Edition)",
+    "title": "halloween",
     "variant_of": "halloween-standard-edition",
     "opdb_id": "Gj66Z-Mp4BN-A9Y6n"
   },
   {
     "slug": "halloween-standard-edition",
     "name": "Halloween (Standard Edition)",
+    "title": "halloween",
     "opdb_id": "Gj66Z-Mp4BN"
   },
   {
     "slug": "harlem-globetrotters-on-tour",
     "name": "Harlem Globetrotters On Tour",
+    "title": "harlem-globetrotters",
     "opdb_id": "GRnwQ-M9R5d",
     "ipdb_id": 1125
   },
   {
     "slug": "harry-potter-arcade-edition",
     "name": "Harry Potter (Arcade Edition)",
+    "title": "harry-potter",
     "variant_of": "harry-potter-wizard-edition",
     "opdb_id": "GWyBj-MdEbK-A9dEy"
   },
   {
     "slug": "harry-potter-collectors-edition",
     "name": "Harry Potter (Collector's Edition)",
+    "title": "harry-potter",
     "variant_of": "harry-potter-wizard-edition",
     "opdb_id": "GWyBj-MdEbK-AOPdq"
   },
   {
     "slug": "harry-potter-wizard-edition",
     "name": "Harry Potter (Wizard Edition)",
+    "title": "harry-potter",
     "opdb_id": "GWyBj-MdEbK-A973V"
   },
   {
     "slug": "high-speed",
     "name": "High Speed",
+    "title": "high-speed",
     "opdb_id": "GRvzd-MLxV8",
     "ipdb_id": 1176
   },
   {
     "slug": "holden-heritage",
     "name": "Holden Heritage",
+    "title": "peter-brock-holden",
     "opdb_id": "Ge1O1-MYeEB-A92WN"
   },
   {
     "slug": "hoopin-it-up",
     "name": "Hoopin' It Up",
+    "title": "hoopin-it-up",
     "is_conversion": true,
     "opdb_id": "G188W-MnK95"
   },
   {
     "slug": "horror",
     "name": "Horror",
+    "title": "space-shuttle",
     "is_conversion": true,
     "converted_from": "space-shuttle",
     "opdb_id": "G4jyz-M5REB",
@@ -727,12 +857,14 @@
   {
     "slug": "ice-fever",
     "name": "Ice Fever",
+    "title": "ice-fever",
     "opdb_id": "G43DV-MQYKB",
     "ipdb_id": 1260
   },
   {
     "slug": "ice-mania",
     "name": "Ice Mania",
+    "title": "ice-fever",
     "is_conversion": true,
     "converted_from": "ice-fever",
     "opdb_id": "G43DV-MBREl",
@@ -741,24 +873,29 @@
   {
     "slug": "iron-maiden-legacy-of-the-beast-limited-edition",
     "name": "Iron Maiden: Legacy of the Beast (Limited Edition)",
+    "title": "iron-maiden",
     "variant_of": "iron-maiden-legacy-of-the-beast-premium",
     "opdb_id": "G4dOQ-MW970",
     "ipdb_id": 6557
   },
   {
     "slug": "iron-maiden-legacy-of-the-beast-premium",
+    "name": "Iron Maiden: Legacy of the Beast (Premium)",
+    "title": "iron-maiden",
     "opdb_id": "G4dOQ-MkPxr",
     "ipdb_id": 6556
   },
   {
     "slug": "iron-maiden-legacy-of-the-beast-pro",
     "name": "Iron Maiden: Legacy of the Beast (Pro)",
+    "title": "iron-maiden",
     "opdb_id": "G4dOQ-MyNbb",
     "ipdb_id": 6555
   },
   {
     "slug": "james-bond-007-limited-edition",
     "name": "James Bond 007 (Limited Edition)",
+    "title": "james-bond-007",
     "variant_of": "james-bond-007-premium",
     "opdb_id": "GQKyP-MP3OK-A1KoX",
     "ipdb_id": 6898
@@ -766,52 +903,61 @@
   {
     "slug": "james-bond-007-premium",
     "name": "James Bond 007 (Premium)",
+    "title": "james-bond-007",
     "opdb_id": "GQKyP-MP3OK-AOEEx",
     "ipdb_id": 6897
   },
   {
     "slug": "james-camerons-avatar-limited-edition",
     "name": "James Cameron's Avatar (Limited Edition)",
+    "title": "avatar",
     "opdb_id": "GrZBr-MyNZz",
     "ipdb_id": 5653
   },
   {
     "slug": "jaws-50th-anniversary",
     "name": "JAWS (50th Anniversary)",
+    "title": "jaws",
     "variant_of": "jaws-premium",
     "opdb_id": "GLWll-M1r8O-A1KkX"
   },
   {
     "slug": "jaws-limited-edition",
     "name": "JAWS (Limited Edition)",
+    "title": "jaws",
     "variant_of": "jaws-premium",
     "opdb_id": "GLWll-M1r8O-A1kx7"
   },
   {
     "slug": "jaws-premium",
     "name": "JAWS (Premium)",
+    "title": "jaws",
     "opdb_id": "GLWll-M1r8O-ARnV7"
   },
   {
     "slug": "john-wick-limited-edition",
     "name": "John Wick (Limited Edition)",
+    "title": "john-wick",
     "variant_of": "john-wick-premium",
     "opdb_id": "GQK1P-Ml95Z-A9bjw"
   },
   {
     "slug": "john-wick-premium",
     "name": "John Wick (Premium)",
+    "title": "john-wick",
     "opdb_id": "GQK1P-Ml95Z-AOY43"
   },
   {
     "slug": "jurassic-park-30th-anniversary",
     "name": "Jurassic Park (30th Anniversary)",
+    "title": "jurassic-park-stern",
     "variant_of": "jurassic-park-premium",
     "opdb_id": "GK17D-MKNKd-AOxoz"
   },
   {
     "slug": "jurassic-park-limited-edition",
     "name": "Jurassic Park (Limited Edition)",
+    "title": "jurassic-park-stern",
     "variant_of": "jurassic-park-premium",
     "opdb_id": "GK17D-MKNKd-AOyKv",
     "ipdb_id": 6575
@@ -819,12 +965,14 @@
   {
     "slug": "jurassic-park-premium",
     "name": "Jurassic Park (Premium)",
+    "title": "jurassic-park-stern",
     "opdb_id": "GK17D-MKNKd-A15Yn",
     "ipdb_id": 6574
   },
   {
     "slug": "king",
     "name": "King",
+    "title": "king",
     "is_conversion": true,
     "opdb_id": "G4XjW-MLXXy",
     "ipdb_id": 3625
@@ -832,35 +980,42 @@
   {
     "slug": "king-kong-myth-of-terror-island-limited-edition",
     "name": "King Kong: Myth of Terror Island (Limited Edition)",
+    "title": "king-kong-myth-of-terror-island",
     "variant_of": "king-kong-myth-of-terror-island-premium",
     "opdb_id": "GEL0V-MyN8E-ARq7n"
   },
   {
     "slug": "king-kong-myth-of-terror-island-premium",
     "name": "King Kong: Myth of Terror Island (Premium)",
+    "title": "king-kong-myth-of-terror-island",
     "opdb_id": "GEL0V-MyN8E-A1Dkr"
   },
   {
     "slug": "kings-of-steel",
     "name": "Kings of Steel",
+    "title": "kings-of-steel",
     "opdb_id": "GR67j-M7ZYy",
     "ipdb_id": 1382
   },
   {
     "slug": "kiss-limited-edition",
     "name": "KISS (Limited Edition)",
+    "title": "kiss-stern",
     "variant_of": "kiss-premium",
     "opdb_id": "G4qX5-Ml9jb",
     "ipdb_id": 6267
   },
   {
     "slug": "kiss-premium",
+    "name": "KISS (Premium)",
+    "title": "kiss-stern",
     "opdb_id": "G4qX5-MJN17",
     "ipdb_id": 6266
   },
   {
     "slug": "la-retata",
     "name": "La Retata",
+    "title": "high-speed",
     "is_conversion": true,
     "converted_from": "high-speed",
     "opdb_id": "GRvzd-MD0r9",
@@ -869,6 +1024,7 @@
   {
     "slug": "lady-death",
     "name": "Lady Death",
+    "title": "mata-hari-em",
     "is_conversion": true,
     "converted_from": "mata-hari-em",
     "opdb_id": "G417e-MJkoe",
@@ -877,18 +1033,21 @@
   {
     "slug": "lady-robin-hood",
     "name": "Lady Robin Hood",
+    "title": "lady-robin-hood",
     "opdb_id": "GRVL2-MLl9Y",
     "ipdb_id": 1406
   },
   {
     "slug": "lawman",
     "name": "Lawman",
+    "title": "lawman",
     "opdb_id": "GrEXx-MDlq0",
     "ipdb_id": 1419
   },
   {
     "slug": "le-grande-8",
     "name": "Le Grande 8",
+    "title": "panthera",
     "is_conversion": true,
     "converted_from": "panthera",
     "opdb_id": "G5bQq-MkPW7",
@@ -897,6 +1056,7 @@
   {
     "slug": "led-zeppelin-limited-edition",
     "name": "Led Zeppelin (Limited Edition)",
+    "title": "led-zeppelin",
     "variant_of": "led-zeppelin-premium",
     "opdb_id": "Gweel-ME0pP-AR0N5",
     "ipdb_id": 6762
@@ -904,35 +1064,41 @@
   {
     "slug": "led-zeppelin-premium",
     "name": "Led Zeppelin (Premium)",
+    "title": "led-zeppelin",
     "opdb_id": "Gweel-ME0pP-ARqVK",
     "ipdb_id": 6761
   },
   {
     "slug": "legends-of-valhalla-classic",
     "name": "Legends of Valhalla (Classic)",
+    "title": "legends-of-valhalla",
     "opdb_id": "GWyyq-MwNK5-AReoP"
   },
   {
     "slug": "legends-of-valhalla-deluxe",
     "name": "Legends of Valhalla (Deluxe)",
+    "title": "legends-of-valhalla",
     "variant_of": "legends-of-valhalla-classic",
     "opdb_id": "GWyyq-MwNK5-AO3QJ"
   },
   {
     "slug": "legends-of-valhalla-deluxe-limited-edition",
     "name": "Legends of Valhalla (Deluxe Limited Edition)",
+    "title": "legends-of-valhalla",
     "variant_of": "legends-of-valhalla-classic",
     "opdb_id": "GWyyq-MwNK5-AObnw"
   },
   {
     "slug": "legends-of-wrestlemania-limited-edition",
     "name": "Legends of Wrestlemania (Limited Edition)",
+    "title": "wrestlemania",
     "opdb_id": "GR6Or-MKNYR",
     "ipdb_id": 6216
   },
   {
     "slug": "lexy-lightspeed-secret-agent-showdown",
     "name": "Lexy Lightspeed - Secret Agent Showdown",
+    "title": "lexy-lightspeed-secret-agent-showdown",
     "is_conversion": true,
     "opdb_id": "GpeeL-MYez0",
     "ipdb_id": 6453
@@ -940,6 +1106,7 @@
   {
     "slug": "lhexagone",
     "name": "L'Hexagone",
+    "title": "genie",
     "is_conversion": true,
     "converted_from": "genie",
     "opdb_id": "GRBKZ-MyNN8",
@@ -948,23 +1115,27 @@
   {
     "slug": "looney-tunes-collectors-edition",
     "name": "Looney Tunes (Collector's Edition)",
+    "title": "looney-tunes",
     "variant_of": "looney-tunes-standard-edition",
     "opdb_id": "GJ2K0-M85re-A1qdn"
   },
   {
     "slug": "looney-tunes-standard-edition",
     "name": "Looney Tunes (Standard Edition)",
+    "title": "looney-tunes",
     "opdb_id": "GJ2K0-M85re"
   },
   {
     "slug": "lord-of-the-rings-limited-edition",
     "name": "Lord of the Rings (Limited Edition)",
+    "title": "lord-of-the-rings",
     "opdb_id": "GrqZX-MDEPd",
     "ipdb_id": 5558
   },
   {
     "slug": "lovers",
     "name": "Lovers",
+    "title": "sky-dive",
     "is_conversion": true,
     "converted_from": "sky-dive",
     "opdb_id": "G4xlK-MJp6z",
@@ -973,6 +1144,7 @@
   {
     "slug": "mac-jungle",
     "name": "Mac Jungle",
+    "title": "macs-galaxy",
     "is_conversion": true,
     "converted_from": "macs-galaxy",
     "opdb_id": "G4Z6n-MDq43",
@@ -981,12 +1153,14 @@
   {
     "slug": "macs-galaxy",
     "name": "Mac's Galaxy",
+    "title": "macs-galaxy",
     "opdb_id": "G4Z6n-MQweZ",
     "ipdb_id": 3455
   },
   {
     "slug": "magic-picture-pin",
     "name": "Magic Picture Pin",
+    "title": "silverball-mania",
     "is_conversion": true,
     "converted_from": "silverball-mania",
     "opdb_id": "GRD2P-MQknK",
@@ -995,35 +1169,42 @@
   {
     "slug": "mata-hari-em",
     "name": "Mata Hari (EM)",
+    "title": "mata-hari-em",
     "opdb_id": "G417e-Ml9ZE",
     "ipdb_id": 1557
   },
   {
     "slug": "metallica-master-of-puppets-limited-edition",
     "name": "Metallica Master of Puppets (Limited Edition)",
+    "title": "metallica",
     "variant_of": "metallica-premium",
     "opdb_id": "GRBE4-MOE4l",
     "ipdb_id": 6031
   },
   {
     "slug": "metallica-premium",
+    "name": "Metallica (Premium)",
+    "title": "metallica",
     "opdb_id": "GRBE4-MJ9rE",
     "ipdb_id": 6029
   },
   {
     "slug": "metallica-remastered-limited-edition",
     "name": "Metallica Remastered (Limited Edition)",
+    "title": "metallica-remastered",
     "variant_of": "metallica-remastered-premium",
     "opdb_id": "GO0q3-MOEy8-ARrPz"
   },
   {
     "slug": "metallica-remastered-premium",
     "name": "Metallica Remastered (Premium)",
+    "title": "metallica-remastered",
     "opdb_id": "GO0q3-MOEy8-ARol7"
   },
   {
     "slug": "metallica-retheme",
     "name": "Metallica (Retheme)",
+    "title": "earthshaker",
     "is_conversion": true,
     "converted_from": "earthshaker",
     "opdb_id": "GRw0r-Mo1V7",
@@ -1032,18 +1213,22 @@
   {
     "slug": "mustang-limited-edition",
     "name": "Mustang (Limited Edition)",
+    "title": "mustang",
     "variant_of": "mustang-premium",
     "opdb_id": "GrPOR-MLq5x",
     "ipdb_id": 6100
   },
   {
     "slug": "mustang-premium",
+    "name": "Mustang (Premium)",
+    "title": "mustang",
     "opdb_id": "GrPOR-M61Pw",
     "ipdb_id": 6099
   },
   {
     "slug": "new-wave",
     "name": "New Wave",
+    "title": "new-wave",
     "is_conversion": true,
     "opdb_id": "GRB8Z-MQKXV",
     "ipdb_id": 3482
@@ -1051,35 +1236,41 @@
   {
     "slug": "ninja-eclipse-arcade-edition",
     "name": "Ninja Eclipse (Arcade Edition)",
+    "title": "ninja-eclipse",
     "opdb_id": "GZVXY-MyNOq-A1NeE"
   },
   {
     "slug": "ninja-eclipse-first-edition",
     "name": "Ninja Eclipse (First Edition)",
+    "title": "ninja-eclipse",
     "variant_of": "ninja-eclipse-arcade-edition",
     "opdb_id": "GZVXY-MyNOq-ARWE8"
   },
   {
     "slug": "panthera",
     "name": "Panthera",
+    "title": "panthera",
     "opdb_id": "G5bQq-MQ4ob",
     "ipdb_id": 1745
   },
   {
     "slug": "peter-brock-king-of-the-mountain-torana",
     "name": "Peter Brock: King Of The Mountain (Torana)",
+    "title": "peter-brock-holden",
     "variant_of": "holden-heritage",
     "opdb_id": "Ge1O1-MYeEB-A9xwz"
   },
   {
     "slug": "peter-brock-king-of-the-mountain-vk-commodore",
     "name": "Peter Brock: King Of The Mountain (VK Commodore)",
+    "title": "peter-brock-holden",
     "variant_of": "holden-heritage",
     "opdb_id": "Ge1O1-MYeEB-A9wWL"
   },
   {
     "slug": "pin-ball-pool",
     "name": "Pin Ball Pool",
+    "title": "eight-ball-deluxe",
     "is_conversion": true,
     "converted_from": "sure-shot",
     "opdb_id": "G5KXk-MJpvO",
@@ -1088,6 +1279,7 @@
   {
     "slug": "pinball",
     "name": "Pinball",
+    "title": "pinball-champ-82",
     "is_conversion": true,
     "converted_from": "pinball-champ-82",
     "opdb_id": "GrPdq-MLONx",
@@ -1096,18 +1288,21 @@
   {
     "slug": "pinball-champ-82",
     "name": "Pinball Champ '82",
+    "title": "pinball-champ-82",
     "opdb_id": "GrPdq-MQYkJ",
     "ipdb_id": 1794
   },
   {
     "slug": "pirates-of-the-caribbean-collectors-edition",
     "name": "Pirates of the Caribbean (Collector's Edition)",
+    "title": "pirates-of-the-caribbean-jersey-jack-pinball",
     "opdb_id": "GRbPY-MBR24",
     "ipdb_id": 6494
   },
   {
     "slug": "pirates-of-the-caribbean-limited-edition",
     "name": "Pirates of the Caribbean (Limited Edition)",
+    "title": "pirates-of-the-caribbean-jersey-jack-pinball",
     "variant_of": "pirates-of-the-caribbean-standard-edition",
     "opdb_id": "GRbPY-MePOP-A9pVl",
     "ipdb_id": 6493
@@ -1115,57 +1310,67 @@
   {
     "slug": "pirates-of-the-caribbean-standard-edition",
     "name": "Pirates of the Caribbean (Standard Edition)",
+    "title": "pirates-of-the-caribbean-jersey-jack-pinball",
     "opdb_id": "GRbPY-MePOP",
     "ipdb_id": 6492
   },
   {
     "slug": "play-pool",
     "name": "Play Pool",
+    "title": "play-pool",
     "opdb_id": "G5n1Q-MXrnx",
     "ipdb_id": 1819
   },
   {
     "slug": "playboy",
     "name": "Playboy",
+    "title": "playboy-arkon",
     "opdb_id": "GrkOB-MJVvl",
     "ipdb_id": 1823
   },
   {
     "slug": "pokemon-limited-edition",
     "name": "Pokémon (Limited Edition)",
+    "title": "pokemon",
     "variant_of": "pokemon-premium",
     "opdb_id": "GV8wB-MRjKd-ARz2r"
   },
   {
     "slug": "pokemon-premium",
     "name": "Pokémon (Premium)",
+    "title": "pokemon",
     "opdb_id": "GV8wB-MRjKd-AOVy7"
   },
   {
     "slug": "pulp-fiction-limited-edition",
     "name": "Pulp Fiction (Limited Edition)",
+    "title": "pulp-fiction",
     "variant_of": "pulp-fiction-special-edition",
     "opdb_id": "GoEkx-MdEzN-AR50E"
   },
   {
     "slug": "pulp-fiction-special-edition",
     "name": "Pulp Fiction (Special Edition)",
+    "title": "pulp-fiction",
     "opdb_id": "GoEkx-MdEzN-ARJQz"
   },
   {
     "slug": "queen-collectors-edition",
     "name": "Queen (Collector's Edition)",
+    "title": "queen",
     "opdb_id": "GELkO-Ml9zZ-AO3yd"
   },
   {
     "slug": "queen-limited-edition",
     "name": "Queen (Limited Edition)",
+    "title": "queen",
     "variant_of": "queen-collectors-edition",
     "opdb_id": "GELkO-Ml9zZ-AOjEb"
   },
   {
     "slug": "race-stars",
     "name": "Race Stars",
+    "title": "evel-knievel",
     "is_conversion": true,
     "converted_from": "evel-knievel-em",
     "opdb_id": "G59wx-MXrdl",
@@ -1174,18 +1379,21 @@
   {
     "slug": "ranger-in-the-ruins",
     "name": "Ranger in the Ruins",
+    "title": "ranger-in-the-ruins",
     "is_conversion": true,
     "opdb_id": "GLWWV-Mb5Xx"
   },
   {
     "slug": "rick-and-morty-standard-edition",
     "name": "Rick and Morty (Standard Edition)",
+    "title": "rick-and-morty",
     "opdb_id": "GQKb2-MYek0",
     "ipdb_id": 6640
   },
   {
     "slug": "road-racer",
     "name": "Road Racer",
+    "title": "evel-knievel",
     "is_conversion": true,
     "converted_from": "evel-knievel-em",
     "opdb_id": "G59wx-MJ92p",
@@ -1194,24 +1402,28 @@
   {
     "slug": "rob-zombies-spookshow-international-limited-edition",
     "name": "Rob Zombie's Spookshow International (Limited Edition)",
+    "title": "rob-zombie",
     "opdb_id": "G5pp2-MBRK4",
     "ipdb_id": 6417
   },
   {
     "slug": "rob-zombies-spookshow-international-standard-edition",
     "name": "Rob Zombie's Spookshow International (Standard Edition)",
+    "title": "rob-zombie",
     "opdb_id": "G5pp2-ME0eP",
     "ipdb_id": 6416
   },
   {
     "slug": "rock-star",
     "name": "Rock Star",
+    "title": "rock-star",
     "opdb_id": "GRbD8-MLWx0",
     "ipdb_id": 1983
   },
   {
     "slug": "rocky-girl",
     "name": "Rocky Girl",
+    "title": "rock-star",
     "is_conversion": true,
     "converted_from": "rock-star",
     "opdb_id": "GRbD8-M9Rqz",
@@ -1220,6 +1432,7 @@
   {
     "slug": "rush-limited-edition",
     "name": "Rush (Limited Edition)",
+    "title": "rush",
     "variant_of": "rush-premium",
     "opdb_id": "G2Lkd-M0ope-A97xV",
     "ipdb_id": 6846
@@ -1227,12 +1440,14 @@
   {
     "slug": "rush-premium",
     "name": "Rush (Premium)",
+    "title": "rush",
     "opdb_id": "G2Lkd-M0ope-A9dNy",
     "ipdb_id": 6845
   },
   {
     "slug": "sahara-love",
     "name": "Sahara Love",
+    "title": "sinbad",
     "is_conversion": true,
     "converted_from": "sinbad",
     "opdb_id": "G4xqN-MDvw2",
@@ -1241,6 +1456,7 @@
   {
     "slug": "saturn-2",
     "name": "Saturn 2",
+    "title": "spy-hunter",
     "is_conversion": true,
     "converted_from": "spy-hunter",
     "opdb_id": "GRwl7-MDBRl",
@@ -1249,25 +1465,29 @@
   {
     "slug": "scooby-doo-collectors-edition",
     "name": "Scooby-Doo (Collector's Edition)",
+    "title": "scooby-doo",
     "variant_of": "scooby-doo-standard-edition",
     "opdb_id": "GllPz-MBRrV-A9vWL"
   },
   {
     "slug": "scooby-doo-standard-edition",
     "name": "Scooby-Doo (Standard Edition)",
+    "title": "scooby-doo",
     "opdb_id": "GllPz-MBRrV"
   },
   {
     "slug": "screech",
     "name": "Screech",
-    "opdb_id": "GPBBv-ME0x0",
-    "ipdb_id": 3939,
+    "title": "screech",
     "description": "OPDB incorrectly lists display as DMD; Screech is a 1976 Inder EM with a digital score display fitted over factory-installed reels — the player-visible display is what matters for classification",
-    "display_type": "alphanumeric"
+    "display_type": "alphanumeric",
+    "opdb_id": "GPBBv-ME0x0",
+    "ipdb_id": 3939
   },
   {
     "slug": "sexy-girl",
     "name": "Sexy Girl",
+    "title": "playboy-arkon",
     "is_conversion": true,
     "converted_from": "playboy",
     "opdb_id": "GrkOB-MD00x",
@@ -1276,32 +1496,44 @@
   {
     "slug": "sexy-girl-delux",
     "name": "Sexy Girl (Delux)",
+    "title": "silverball-mania",
     "is_conversion": true,
     "converted_from": "silverball-mania",
     "opdb_id": "GRD2P-Mx03K",
     "ipdb_id": 4423
   },
   {
+    "slug": "shrek",
+    "name": "Shrek",
+    "title": "shrek",
+    "opdb_id": "G5LW9-ML371",
+    "ipdb_id": 5301
+  },
+  {
     "slug": "silver-falls",
     "name": "Silver Falls",
+    "title": "silver-falls",
     "is_conversion": true,
     "opdb_id": "GWyyZ-Mq1yv"
   },
   {
     "slug": "silverball-mania",
     "name": "Silverball Mania",
+    "title": "silverball-mania",
     "opdb_id": "GRD2P-MDX5b",
     "ipdb_id": 2156
   },
   {
     "slug": "sinbad",
     "name": "Sinbad",
+    "title": "sinbad",
     "opdb_id": "G4xqN-MD1Rj",
     "ipdb_id": 2159
   },
   {
     "slug": "sisters",
     "name": "Sisters",
+    "title": "golden-arrow",
     "is_conversion": true,
     "converted_from": "golden-arrow",
     "opdb_id": "G5WPp-MLyZJ",
@@ -1310,12 +1542,14 @@
   {
     "slug": "sky-dive",
     "name": "Sky Dive",
+    "title": "sky-dive",
     "opdb_id": "G4xlK-MOEr1",
     "ipdb_id": 2192
   },
   {
     "slug": "sky-warrior",
     "name": "Sky Warrior",
+    "title": "sky-warrior",
     "is_conversion": true,
     "opdb_id": "Gr3VN-MJ5qB",
     "ipdb_id": 3905
@@ -1323,12 +1557,14 @@
   {
     "slug": "sorcerers-apprentice",
     "name": "Sorcerer's Apprentice",
+    "title": "sorcerers-apprentice",
     "is_conversion": true,
     "opdb_id": "G8llL-MyNwq"
   },
   {
     "slug": "space-hawks",
     "name": "Space Hawks",
+    "title": "cybernaut",
     "is_conversion": true,
     "converted_from": "cybernaut",
     "opdb_id": "GR69j-MdEEB",
@@ -1337,12 +1573,14 @@
   {
     "slug": "space-orbit",
     "name": "Space Orbit",
+    "title": "space-orbit",
     "opdb_id": "G43WO-M1rdV",
     "ipdb_id": 2255
   },
   {
     "slug": "space-rider",
     "name": "Space Rider",
+    "title": "harlem-globetrotters",
     "is_conversion": true,
     "converted_from": "harlem-globetrotters-on-tour",
     "opdb_id": "GRnwQ-MLyWb",
@@ -1351,12 +1589,14 @@
   {
     "slug": "space-shuttle",
     "name": "Space Shuttle",
+    "title": "space-shuttle",
     "opdb_id": "G4jyz-MDyYE",
     "ipdb_id": 3263
   },
   {
     "slug": "space-wars",
     "name": "Space Wars",
+    "title": "eight-ball",
     "is_conversion": true,
     "converted_from": "eight-ball",
     "opdb_id": "GrN7J-MQjXy",
@@ -1365,6 +1605,7 @@
   {
     "slug": "spider",
     "name": "Spider",
+    "title": "central-park",
     "is_conversion": true,
     "converted_from": "central-park",
     "opdb_id": "GRpYQ-MkPd9",
@@ -1373,59 +1614,71 @@
   {
     "slug": "spy-hunter",
     "name": "Spy Hunter",
+    "title": "spy-hunter",
     "opdb_id": "GRwl7-MJ45o",
     "ipdb_id": 2328
   },
   {
     "slug": "star-ship",
     "name": "Star Ship",
+    "title": "star-ship",
     "opdb_id": "GRLXd-M4oxP",
     "ipdb_id": 3498
   },
   {
     "slug": "star-trek",
     "name": "Star Trek",
+    "title": "star-trek-bally",
     "opdb_id": "GRVnd-MQZzx",
     "ipdb_id": 2355
   },
   {
     "slug": "star-trek-limited-edition",
     "name": "Star Trek (Limited Edition)",
+    "title": "star-trek-stern",
     "variant_of": "star-trek-premium",
     "opdb_id": "Gryw4-MNEKn",
     "ipdb_id": 6046
   },
   {
     "slug": "star-trek-premium",
+    "name": "Star Trek (Premium)",
+    "title": "star-trek-stern",
     "opdb_id": "Gryw4-MRj4O",
     "ipdb_id": 6045
   },
   {
     "slug": "star-wars-fall-of-the-empire-limited-edition",
     "name": "Star Wars: Fall of the Empire (Limited Edition)",
+    "title": "star-wars-fall-of-the-empire",
     "variant_of": "star-wars-fall-of-the-empire-premium",
     "opdb_id": "Gxv81-Mo1rp-A9Qew"
   },
   {
     "slug": "star-wars-fall-of-the-empire-premium",
     "name": "Star Wars: Fall of the Empire (Premium)",
+    "title": "star-wars-fall-of-the-empire",
     "opdb_id": "Gxv81-Mo1rp-A9vrL"
   },
   {
     "slug": "star-wars-limited-edition",
     "name": "Star Wars (Limited Edition)",
+    "title": "star-wars-stern",
     "variant_of": "star-wars-premium",
     "opdb_id": "G5vLR-MZebq",
     "ipdb_id": 6430
   },
   {
     "slug": "star-wars-premium",
+    "name": "Star Wars (Premium)",
+    "title": "star-wars-stern",
     "opdb_id": "G5vLR-ME049",
     "ipdb_id": 6429
   },
   {
     "slug": "stellar-airship",
     "name": "Stellar Airship",
+    "title": "eight-ball",
     "is_conversion": true,
     "converted_from": "eight-ball",
     "opdb_id": "GrN7J-MQj62",
@@ -1434,6 +1687,7 @@
   {
     "slug": "stranger-things-limited-edition",
     "name": "Stranger Things (Limited Edition)",
+    "title": "stranger-things",
     "variant_of": "stranger-things-premium",
     "opdb_id": "Gzy89-M0oPy-A9xXV",
     "ipdb_id": 6644
@@ -1441,18 +1695,21 @@
   {
     "slug": "stranger-things-premium",
     "name": "Stranger Things (Premium)",
+    "title": "stranger-things",
     "opdb_id": "Gzy89-M0oPy-A1zrL",
     "ipdb_id": 6643
   },
   {
     "slug": "strikes-and-spares",
     "name": "Strikes and Spares",
+    "title": "strikes-and-spares",
     "opdb_id": "GrleW-MYeod",
     "ipdb_id": 2406
   },
   {
     "slug": "super-bowl",
     "name": "Super Bowl",
+    "title": "xs-os",
     "is_conversion": true,
     "converted_from": "xs-os",
     "opdb_id": "GRpWD-MQork",
@@ -1461,12 +1718,14 @@
   {
     "slug": "super-spin",
     "name": "Super Spin",
+    "title": "super-spin",
     "opdb_id": "G4qzZ-MQpoP",
     "ipdb_id": 2445
   },
   {
     "slug": "sure-shot",
     "name": "Sure Shot",
+    "title": "eight-ball-deluxe",
     "variant_of": "eight-ball-deluxe",
     "opdb_id": "G5KXk-MLB9V-AOjJb",
     "ipdb_id": 4574
@@ -1474,12 +1733,14 @@
   {
     "slug": "tag-team-pinball",
     "name": "Tag-Team Pinball",
+    "title": "tag-team-pinball",
     "opdb_id": "G5Yyo-ML3Wo",
     "ipdb_id": 2489
   },
   {
     "slug": "tag-team-pinball-2",
     "name": "Tag-Team Pinball",
+    "title": "tag-team-pinball",
     "is_conversion": true,
     "converted_from": "tag-team-pinball",
     "opdb_id": "G5Yyo-MQdNz",
@@ -1488,6 +1749,7 @@
   {
     "slug": "take-a-card",
     "name": "Take A Card",
+    "title": "lawman",
     "is_conversion": true,
     "converted_from": "lawman",
     "opdb_id": "GrEXx-MJ5Yv",
@@ -1496,6 +1758,7 @@
   {
     "slug": "teenage-mutant-ninja-turtles-limited-edition",
     "name": "Teenage Mutant Ninja Turtles (Limited Edition)",
+    "title": "teenage-mutant-ninja-turtles",
     "variant_of": "teenage-mutant-ninja-turtles-premium",
     "opdb_id": "Gd2Xb-MRjpZ-A92v0",
     "ipdb_id": 6732
@@ -1503,60 +1766,71 @@
   {
     "slug": "teenage-mutant-ninja-turtles-premium",
     "name": "Teenage Mutant Ninja Turtles (Premium)",
+    "title": "teenage-mutant-ninja-turtles",
     "opdb_id": "Gd2Xb-MRjpZ-A9wqN",
     "ipdb_id": 6731
   },
   {
     "slug": "the-avengers-hulk-limited-edition",
     "name": "The Avengers Hulk (Limited Edition)",
-    "variant_of": "the-avengers-limited-edition",
+    "title": "the-avengers",
+    "variant_of": "the-avengers-premium",
     "opdb_id": "GRzNR-MyNq8-A1oeR",
     "ipdb_id": 5941
   },
   {
     "slug": "the-avengers-limited-edition",
     "name": "The Avengers (Limited Edition)",
+    "title": "the-avengers",
     "variant_of": "the-avengers-premium",
     "opdb_id": "GRzNR-MyNq8",
     "ipdb_id": 5940
   },
   {
     "slug": "the-avengers-premium",
+    "name": "The Avengers (Premium)",
+    "title": "the-avengers",
     "opdb_id": "GRzNR-Mz2WY",
     "ipdb_id": 5939
   },
   {
     "slug": "the-avengers-pro",
     "name": "The Avengers (Pro)",
+    "title": "the-avengers",
     "opdb_id": "GRzNR-MLlEj",
     "ipdb_id": 5938
   },
   {
     "slug": "the-godfather-collectors-edition",
     "name": "The Godfather (Collector's Edition)",
+    "title": "the-godfather",
     "variant_of": "the-godfather-limited-edition",
     "opdb_id": "Gd2ox-MW9qj-A1loo"
   },
   {
     "slug": "the-godfather-limited-edition",
     "name": "The Godfather (Limited Edition)",
+    "title": "the-godfather",
     "opdb_id": "Gd2ox-MW9qj-AReW2"
   },
   {
     "slug": "the-hobbit-limited-edition",
     "name": "The Hobbit (Limited Edition)",
+    "title": "the-hobbit",
     "variant_of": "the-hobbit-standard-edition",
     "opdb_id": "G5bYr-MLezO-A9dNe"
   },
   {
     "slug": "the-hobbit-standard-edition",
     "name": "The Hobbit (Standard Edition)",
+    "title": "the-hobbit",
     "opdb_id": "G5bYr-MLezO",
     "ipdb_id": 6222
   },
   {
     "slug": "the-hunter",
     "name": "The Hunter",
+    "title": "the-hunter",
     "is_conversion": true,
     "opdb_id": "G4Od9-MDlpK",
     "ipdb_id": 3733
@@ -1564,6 +1838,7 @@
   {
     "slug": "the-mandalorian-limited-edition",
     "name": "The Mandalorian (Limited Edition)",
+    "title": "the-mandalorian",
     "variant_of": "the-mandalorian-premium",
     "opdb_id": "GBLLP-MW900-A1KoQ",
     "ipdb_id": 6830
@@ -1571,12 +1846,14 @@
   {
     "slug": "the-mandalorian-premium",
     "name": "The Mandalorian (Premium)",
+    "title": "the-mandalorian",
     "opdb_id": "GBLLP-MW900-AOEEN",
     "ipdb_id": 6829
   },
   {
     "slug": "the-munsters-limited-edition",
     "name": "The Munsters (Limited Edition)",
+    "title": "the-munsters",
     "variant_of": "the-munsters-premium",
     "opdb_id": "GbPde-Mp43l-AO4Do",
     "ipdb_id": 6566
@@ -1584,98 +1861,116 @@
   {
     "slug": "the-munsters-premium",
     "name": "The Munsters (Premium)",
+    "title": "the-munsters",
     "opdb_id": "GbPde-Mp43l-AOQwL",
     "ipdb_id": 6565
   },
   {
     "slug": "the-princess-bride",
     "name": "The Princess Bride",
+    "title": "the-princess-bride",
     "opdb_id": "GkBnQ-MBRxV"
   },
   {
     "slug": "the-princess-bride-collectors-edition",
     "name": "The Princess Bride (Collector's Edition)",
+    "title": "the-princess-bride",
     "variant_of": "the-princess-bride",
     "opdb_id": "GkBnQ-MBRxV-A96qp"
   },
   {
     "slug": "the-princess-bride-limited-edition",
     "name": "The Princess Bride (Limited Edition)",
+    "title": "the-princess-bride",
     "variant_of": "the-princess-bride",
     "opdb_id": "GkBnQ-MBRxV-ARB7b"
   },
   {
     "slug": "the-rolling-stones-limited-edition",
     "name": "The Rolling Stones (Limited Edition)",
+    "title": "the-rolling-stones",
     "opdb_id": "GredR-Mb5jN",
     "ipdb_id": 5708
   },
   {
     "slug": "the-texas-chainsaw-massacre-collectors-edition",
     "name": "The Texas Chainsaw Massacre (Collector's Edition)",
+    "title": "the-texas-chainsaw-massacre",
     "variant_of": "the-texas-chainsaw-massacre-standard-edition",
     "opdb_id": "G0lkp-MZeqp-AOdky"
   },
   {
     "slug": "the-texas-chainsaw-massacre-standard-edition",
     "name": "The Texas Chainsaw Massacre (Standard Edition)",
+    "title": "the-texas-chainsaw-massacre",
     "opdb_id": "G0lkp-MZeqp"
   },
   {
     "slug": "the-uncanny-x-men-limited-edition",
     "name": "The Uncanny X-Men (Limited Edition)",
+    "title": "the-uncanny-x-men",
     "variant_of": "the-uncanny-x-men-premium",
     "opdb_id": "G7ZEz-MyN3K-ARl3o"
   },
   {
     "slug": "the-uncanny-x-men-premium",
     "name": "The Uncanny X-Men (Premium)",
+    "title": "the-uncanny-x-men",
     "opdb_id": "G7ZEz-MyN3K-AO4qp"
   },
   {
     "slug": "the-walking-dead-limited-edition",
     "name": "The Walking Dead (Limited Edition)",
+    "title": "the-walking-dead",
     "variant_of": "the-walking-dead-premium",
     "opdb_id": "G5nz5-MP3r1",
     "ipdb_id": 6156
   },
   {
     "slug": "the-walking-dead-premium",
+    "name": "The Walking Dead (Premium)",
+    "title": "the-walking-dead",
     "opdb_id": "G5nz5-M7Z94",
     "ipdb_id": 6201
   },
   {
     "slug": "the-walking-dead-remastered-limited-edition",
     "name": "The Walking Dead Remastered (Limited Edition)",
+    "title": "the-walking-dead-remastered",
     "variant_of": "the-walking-dead-remastered-premium",
     "opdb_id": "Gj6DE-MePEz-AR5Pz"
   },
   {
     "slug": "the-walking-dead-remastered-premium",
     "name": "The Walking Dead Remastered (Premium)",
+    "title": "the-walking-dead-remastered",
     "opdb_id": "Gj6DE-MePEz-ARJ35"
   },
   {
     "slug": "the-wizard-of-oz-limited-edition",
     "name": "The Wizard of Oz (Limited Edition)",
+    "title": "the-wizard-of-oz",
     "variant_of": "the-wizard-of-oz-standard-edition",
     "opdb_id": "G4xyR-MJ2v0-AOPQQ"
   },
   {
     "slug": "the-wizard-of-oz-standard-edition",
     "name": "The Wizard of Oz (Standard Edition)",
+    "title": "the-wizard-of-oz",
     "opdb_id": "G4xyR-MJ2v0",
     "ipdb_id": 5800
   },
   {
     "slug": "tiger",
     "name": "Tiger",
+    "title": "tiger",
     "opdb_id": "GRw8o-Mz2lw",
     "ipdb_id": 2560
   },
   {
     "slug": "tiger-rag",
     "name": "Tiger Rag",
+    "title": "kings-of-steel",
     "is_conversion": true,
     "converted_from": "kings-of-steel",
     "opdb_id": "GR67j-MLqwr",
@@ -1684,24 +1979,29 @@
   {
     "slug": "tiger-woman",
     "name": "Tiger Woman",
+    "title": "tiger-woman",
     "is_conversion": true,
     "opdb_id": "G4eEJ-M61q0",
     "ipdb_id": 3904
   },
   {
     "slug": "total-nuclear-annihilation",
+    "name": "Total Nuclear Annihilation",
+    "title": "total-nuclear-annihilation",
     "opdb_id": "GRD79-M0odk",
     "ipdb_id": 6444
   },
   {
     "slug": "total-nuclear-annihilation-collectors-edition",
     "name": "Total Nuclear Annihilation (Collector's Edition)",
+    "title": "total-nuclear-annihilation",
     "variant_of": "total-nuclear-annihilation",
     "opdb_id": "GRD79-M0odk-AObBw"
   },
   {
     "slug": "toy-story-4-collectors-edition",
     "name": "Toy Story 4 (Collector's Edition)",
+    "title": "toy-story-4",
     "variant_of": "toy-story-4-limited-edition",
     "opdb_id": "GJ2o0-MrRye-AO62p",
     "ipdb_id": 6951
@@ -1709,12 +2009,14 @@
   {
     "slug": "toy-story-4-limited-edition",
     "name": "Toy Story 4 (Limited Edition)",
+    "title": "toy-story-4",
     "opdb_id": "GJ2o0-MrRye-ARNwE",
     "ipdb_id": 6950
   },
   {
     "slug": "transformers-autobot-crimson-limited-edition",
     "name": "Transformers Autobot Crimson (Limited Edition)",
+    "title": "transformers",
     "variant_of": "transformers-limited-edition",
     "opdb_id": "GRnPz-Mx0XO-AOxV9",
     "ipdb_id": 5754
@@ -1722,6 +2024,7 @@
   {
     "slug": "transformers-decepticon-violet-limited-edition",
     "name": "Transformers Decepticon Violet (Limited Edition)",
+    "title": "transformers",
     "variant_of": "transformers-limited-edition",
     "opdb_id": "GRnPz-Mx0XO-ARzL1",
     "ipdb_id": 5755
@@ -1729,29 +2032,34 @@
   {
     "slug": "transformers-limited-edition",
     "name": "Transformers (Limited Edition)",
+    "title": "transformers",
     "opdb_id": "GRnPz-Mx0XO",
     "ipdb_id": 5753
   },
   {
     "slug": "transformers-pro",
     "name": "Transformers (Pro)",
+    "title": "transformers",
     "opdb_id": "GRnPz-MLBzV",
     "ipdb_id": 5709
   },
   {
     "slug": "ultraman-kaiju-rumble-collectors-edition",
     "name": "Ultraman: Kaiju Rumble (Collector's Edition)",
+    "title": "ultraman-kaiju-rumble",
     "variant_of": "ultraman-kaiju-rumble-standard-edition",
     "opdb_id": "GBLLd-MdEON-A9QJL"
   },
   {
     "slug": "ultraman-kaiju-rumble-standard-edition",
     "name": "Ultraman: Kaiju Rumble (Standard Edition)",
+    "title": "ultraman-kaiju-rumble",
     "opdb_id": "GBLLd-MdEON"
   },
   {
     "slug": "venom-limited-edition",
     "name": "Venom (Limited Edition)",
+    "title": "venom",
     "variant_of": "venom-premium",
     "opdb_id": "G3EBl-MRj6e-ARzbx",
     "ipdb_id": 7066
@@ -1759,28 +2067,34 @@
   {
     "slug": "venom-premium",
     "name": "Venom (Premium)",
+    "title": "venom",
     "opdb_id": "G3EBl-MRj6e-AOVkD",
     "ipdb_id": 7065
   },
   {
     "slug": "weird-als-museum-of-natural-hilarity",
+    "name": "Weird Al's Museum of Natural Hilarity",
+    "title": "weird-als-museum-of-natural-hilarity",
     "opdb_id": "GN6WW-MnKPq"
   },
   {
     "slug": "weird-als-museum-of-natural-hilarity-limited-edition",
     "name": "Weird Al's Museum of Natural Hilarity (Limited Edition)",
+    "title": "weird-als-museum-of-natural-hilarity",
     "variant_of": "weird-als-museum-of-natural-hilarity",
     "opdb_id": "GN6WW-MnKPq-AOPQq"
   },
   {
     "slug": "whirlwind",
     "name": "Whirlwind",
+    "title": "whirlwind",
     "opdb_id": "GrE7e-MQ9N1",
     "ipdb_id": 2765
   },
   {
     "slug": "whirlwind-20",
     "name": "Whirlwind 2.0",
+    "title": "whirlwind",
     "is_conversion": true,
     "converted_from": "whirlwind",
     "opdb_id": "GrE7e-MnKzq"
@@ -1788,6 +2102,7 @@
   {
     "slug": "white-shark",
     "name": "White Shark",
+    "title": "cosmodrome",
     "is_conversion": true,
     "opdb_id": "G509D-M9RzK",
     "ipdb_id": 3555
@@ -1795,12 +2110,14 @@
   {
     "slug": "whoa-nellie-big-juicy-melons",
     "name": "Whoa Nellie! Big Juicy Melons",
+    "title": "pabst-blue-ribbon",
     "opdb_id": "GRYX4-MLqqx",
     "ipdb_id": 6252
   },
   {
     "slug": "whoa-nellie-big-juicy-melons-2",
     "name": "Whoa Nellie! Big Juicy Melons",
+    "title": "pabst-blue-ribbon",
     "is_conversion": true,
     "converted_from": "whoa-nellie-big-juicy-melons",
     "opdb_id": "GRYX4-MLRe3",
@@ -1809,6 +2126,7 @@
   {
     "slug": "wild-schutz",
     "name": "Wild Schutz",
+    "title": "strikes-and-spares",
     "is_conversion": true,
     "converted_from": "strikes-and-spares",
     "opdb_id": "GrleW-ME0op",
@@ -1817,6 +2135,7 @@
   {
     "slug": "willy-wonka-and-the-chocolate-factory-collectors-edition",
     "name": "Willy Wonka & The Chocolate Factory (Collector's Edition)",
+    "title": "willy-wonka",
     "variant_of": "willy-wonka-and-the-chocolate-factory-limited-edition",
     "opdb_id": "GYWBZ-MW9B0-A9jqd",
     "ipdb_id": 6649
@@ -1824,18 +2143,21 @@
   {
     "slug": "willy-wonka-and-the-chocolate-factory-limited-edition",
     "name": "Willy Wonka & The Chocolate Factory (Limited Edition)",
+    "title": "willy-wonka",
     "opdb_id": "GYWBZ-MW9B0",
     "ipdb_id": 6648
   },
   {
     "slug": "willy-wonka-standard-edition",
     "name": "Willy Wonka & The Chocolate Factory (Standard Edition)",
+    "title": "willy-wonka",
     "opdb_id": "GYWBZ-MkPrr",
     "ipdb_id": 6647
   },
   {
     "slug": "world-defender",
     "name": "World Defender",
+    "title": "world-defender",
     "is_conversion": true,
     "opdb_id": "GR9NQ-MRjop",
     "ipdb_id": 3519
@@ -1843,17 +2165,20 @@
   {
     "slug": "wrestlemania-pro",
     "name": "WrestleMania (Pro)",
+    "title": "wrestlemania",
     "opdb_id": "GR6Or-MwNex",
     "ipdb_id": 6215
   },
   {
     "slug": "x-men-limited-edition",
     "name": "X-Men (Limited Edition)",
+    "title": "x-men",
     "opdb_id": "Grj6X-MJNV1"
   },
   {
     "slug": "x-men-magneto-limited-edition",
     "name": "X-Men Magneto (Limited Edition)",
+    "title": "x-men",
     "variant_of": "x-men-limited-edition",
     "opdb_id": "Grj6X-MJNV1-AOwN1",
     "ipdb_id": 5823
@@ -1861,12 +2186,14 @@
   {
     "slug": "x-men-pro",
     "name": "X-Men (Pro)",
+    "title": "x-men",
     "opdb_id": "Grj6X-MJwj5",
     "ipdb_id": 5822
   },
   {
     "slug": "x-men-wolverine-limited-edition",
     "name": "X-Men Wolverine (Limited Edition)",
+    "title": "x-men",
     "variant_of": "x-men-limited-edition",
     "opdb_id": "Grj6X-MJNV1-AO209",
     "ipdb_id": 5824
@@ -1874,6 +2201,7 @@
   {
     "slug": "xs-os",
     "name": "X's & O's",
+    "title": "xs-os",
     "opdb_id": "GRpWD-MNEPl",
     "ipdb_id": 2822
   }

--- a/data/schemas/models.schema.json
+++ b/data/schemas/models.schema.json
@@ -9,6 +9,11 @@
     "properties": {
       "slug": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
       "name": { "type": "string", "minLength": 1 },
+      "title": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+        "description": "Slug of the title this model belongs to (references titles.json)"
+      },
       "description": { "type": "string" },
       "display_type": {
         "type": "string",
@@ -37,7 +42,7 @@
         "description": "Internet Pinball Database identifier"
       }
     },
-    "required": ["opdb_id"],
+    "required": ["slug", "name", "title", "opdb_id"],
     "additionalProperties": false
   }
 }

--- a/data/schemas/titles.schema.json
+++ b/data/schemas/titles.schema.json
@@ -27,7 +27,7 @@
         "uniqueItems": true
       }
     },
-    "required": ["opdb_group_id"],
+    "required": ["slug", "name"],
     "additionalProperties": false
   }
 }

--- a/data/titles.json
+++ b/data/titles.json
@@ -11,6 +11,11 @@
     "opdb_group_id": "G4kE2"
   },
   {
+    "slug": "abba",
+    "name": "ABBA",
+    "opdb_group_id": "Ge1py"
+  },
+  {
     "slug": "ac-dc",
     "name": "AC/DC",
     "opdb_group_id": "G43W4",
@@ -68,6 +73,11 @@
     "franchise_slug": "avatar"
   },
   {
+    "slug": "avatar-the-battle-for-pandora",
+    "name": "Avatar: The Battle for Pandora",
+    "opdb_group_id": "GbPxB"
+  },
+  {
     "slug": "avengers-infinity-quest",
     "name": "Avengers: Infinity Quest",
     "opdb_group_id": "Gj66P",
@@ -93,6 +103,11 @@
     "abbreviations": [
       "BW"
     ]
+  },
+  {
+    "slug": "barry-os-barbeque-challenge",
+    "name": "Barry O's Barbeque Challenge",
+    "opdb_group_id": "GK1Kv"
   },
   {
     "slug": "batman",
@@ -234,6 +249,15 @@
     "franchise_slug": "camel"
   },
   {
+    "slug": "captain-fantastic-and-the-brown-dirt-cowboy",
+    "name": "Captain Fantastic and the Brown Dirt Cowboy",
+    "opdb_group_id": "GRveZ",
+    "franchise_slug": "elton-john",
+    "abbreviations": [
+      "CF"
+    ]
+  },
+  {
     "slug": "centaur",
     "name": "Centaur",
     "opdb_group_id": "GrX7q"
@@ -317,6 +341,11 @@
     ]
   },
   {
+    "slug": "dialed-in",
+    "name": "Dialed In!",
+    "opdb_group_id": "G4X2l"
+  },
+  {
     "slug": "dirty-harry",
     "name": "Dirty Harry",
     "opdb_group_id": "GrJ2Z",
@@ -380,6 +409,11 @@
     "opdb_group_id": "G7Zyb"
   },
   {
+    "slug": "dungeons-dragons-the-tyrants-eye",
+    "name": "Dungeons & Dragons: The Tyrant's Eye",
+    "opdb_group_id": "GK1Ej"
+  },
+  {
     "slug": "earthshaker",
     "name": "Earthshaker",
     "opdb_group_id": "GRw0r"
@@ -413,12 +447,8 @@
   },
   {
     "slug": "elton-john",
-    "name": "Captain Fantastic and the Brown Dirt Cowboy",
-    "opdb_group_id": "GRveZ",
-    "franchise_slug": "elton-john",
-    "abbreviations": [
-      "CF"
-    ]
+    "name": "Elton John",
+    "opdb_group_id": "G2LWd"
   },
   {
     "slug": "elvira-and-the-party-monsters",
@@ -468,9 +498,13 @@
   },
   {
     "slug": "family-guy",
-    "name": "Family Guy / Shrek",
-    "opdb_group_id": "G5LW9",
+    "name": "Family Guy",
     "franchise_slug": "family-guy"
+  },
+  {
+    "slug": "shrek",
+    "name": "Shrek",
+    "franchise_slug": "shrek"
   },
   {
     "slug": "flash-gordon",
@@ -487,6 +521,11 @@
     "opdb_group_id": "G9z10"
   },
   {
+    "slug": "foo-fighters",
+    "name": "Foo Fighters",
+    "opdb_group_id": "GpeoL"
+  },
+  {
     "slug": "frankenstein",
     "name": "Mary Shelley's Frankenstein",
     "opdb_group_id": "GRB7E",
@@ -499,6 +538,11 @@
     "slug": "funhouse",
     "name": "Funhouse",
     "opdb_group_id": "G5Dz7"
+  },
+  {
+    "slug": "galactic-tank-force",
+    "name": "Galactic Tank Force",
+    "opdb_group_id": "Gj6PZ"
   },
   {
     "slug": "gamatron",
@@ -596,6 +640,11 @@
     ]
   },
   {
+    "slug": "halloween",
+    "name": "Halloween",
+    "opdb_group_id": "Gj66Z"
+  },
+  {
     "slug": "harlem-globetrotters",
     "name": "Harlem Globetrotters On Tour",
     "opdb_group_id": "GRnwQ",
@@ -618,6 +667,11 @@
     "abbreviations": [
       "HD"
     ]
+  },
+  {
+    "slug": "harry-potter",
+    "name": "Harry Potter",
+    "opdb_group_id": "GWyBj"
   },
   {
     "slug": "heavy-metal",
@@ -735,6 +789,16 @@
     ]
   },
   {
+    "slug": "jaws",
+    "name": "JAWS",
+    "opdb_group_id": "GLWll"
+  },
+  {
+    "slug": "john-wick",
+    "name": "John Wick",
+    "opdb_group_id": "GQK1P"
+  },
+  {
     "slug": "johnny-mnemonic",
     "name": "Johnny Mnemonic",
     "opdb_group_id": "GR6W8",
@@ -785,6 +849,11 @@
     "opdb_group_id": "G4XjW"
   },
   {
+    "slug": "king-kong-myth-of-terror-island",
+    "name": "King Kong: Myth of Terror Island",
+    "opdb_group_id": "GEL0V"
+  },
+  {
     "slug": "kings-of-steel",
     "name": "Kings of Steel",
     "opdb_group_id": "GR67j"
@@ -830,6 +899,11 @@
     ]
   },
   {
+    "slug": "legends-of-valhalla",
+    "name": "Legends of Valhalla",
+    "opdb_group_id": "GWyyq"
+  },
+  {
     "slug": "lethal-weapon",
     "name": "Lethal Weapon 3",
     "opdb_group_id": "GRokL",
@@ -842,6 +916,11 @@
     "slug": "lexy-lightspeed-secret-agent-showdown",
     "name": "Lexy Lightspeed - Secret Agent Showdown",
     "opdb_group_id": "GpeeL"
+  },
+  {
+    "slug": "looney-tunes",
+    "name": "Looney Tunes",
+    "opdb_group_id": "GJ2K0"
   },
   {
     "slug": "lord-of-the-rings",
@@ -896,6 +975,11 @@
     "abbreviations": [
       "MET"
     ]
+  },
+  {
+    "slug": "metallica-remastered",
+    "name": "Metallica Remastered",
+    "opdb_group_id": "GO0q3"
   },
   {
     "slug": "monopoly",
@@ -963,6 +1047,11 @@
     ]
   },
   {
+    "slug": "ninja-eclipse",
+    "name": "Ninja Eclipse",
+    "opdb_group_id": "GZVXY"
+  },
+  {
     "slug": "no-fear",
     "name": "No Fear: Dangerous Sports",
     "opdb_group_id": "Gr2Y2",
@@ -981,6 +1070,11 @@
     "slug": "panthera",
     "name": "Panthera",
     "opdb_group_id": "G5bQq"
+  },
+  {
+    "slug": "peter-brock-holden",
+    "name": "Peter Brock / Holden",
+    "opdb_group_id": "Ge1O1"
   },
   {
     "slug": "pinball-champ-82",
@@ -1047,6 +1141,11 @@
     ]
   },
   {
+    "slug": "pokemon",
+    "name": "Pokémon",
+    "opdb_group_id": "GV8wB"
+  },
+  {
     "slug": "popeye",
     "name": "Popeye Saves the Earth",
     "opdb_group_id": "GR0lW",
@@ -1054,6 +1153,16 @@
     "abbreviations": [
       "PSTE"
     ]
+  },
+  {
+    "slug": "pulp-fiction",
+    "name": "Pulp Fiction",
+    "opdb_group_id": "GoEkx"
+  },
+  {
+    "slug": "queen",
+    "name": "Queen",
+    "opdb_group_id": "GELkO"
   },
   {
     "slug": "ranger-in-the-ruins",
@@ -1160,6 +1269,16 @@
     "abbreviations": [
       "SS"
     ]
+  },
+  {
+    "slug": "scooby-doo",
+    "name": "Scooby Doo",
+    "opdb_group_id": "GllPz"
+  },
+  {
+    "slug": "screech",
+    "name": "Screech",
+    "opdb_group_id": "GPBBv"
   },
   {
     "slug": "shaq",
@@ -1515,6 +1634,11 @@
     ]
   },
   {
+    "slug": "the-godfather",
+    "name": "The Godfather",
+    "opdb_group_id": "Gd2ox"
+  },
+  {
     "slug": "the-hobbit",
     "name": "The Hobbit",
     "opdb_group_id": "G5bYr",
@@ -1565,6 +1689,11 @@
     "franchise_slug": "the-munsters"
   },
   {
+    "slug": "the-princess-bride",
+    "name": "The Princess Bride",
+    "opdb_group_id": "GkBnQ"
+  },
+  {
     "slug": "the-rolling-stones",
     "name": "The Rolling Stones",
     "opdb_group_id": "GredR",
@@ -1612,6 +1741,11 @@
     ]
   },
   {
+    "slug": "the-uncanny-x-men",
+    "name": "The Uncanny X-Men",
+    "opdb_group_id": "G7ZEz"
+  },
+  {
     "slug": "the-walking-dead",
     "name": "The Walking Dead",
     "opdb_group_id": "G5nz5",
@@ -1619,6 +1753,11 @@
     "abbreviations": [
       "TWD"
     ]
+  },
+  {
+    "slug": "the-walking-dead-remastered",
+    "name": "The Walking Dead Remastered",
+    "opdb_group_id": "Gj6DE"
   },
   {
     "slug": "the-whos-tommy-pinball-wizard",
@@ -1656,6 +1795,16 @@
     "slug": "tiger-woman",
     "name": "Tiger Woman",
     "opdb_group_id": "G4eEJ"
+  },
+  {
+    "slug": "total-nuclear-annihilation",
+    "name": "Total Nuclear Annihilation",
+    "opdb_group_id": "GRD79"
+  },
+  {
+    "slug": "toy-story-4",
+    "name": "Toy Story 4",
+    "opdb_group_id": "GJ2o0"
   },
   {
     "slug": "transformers",
@@ -1717,6 +1866,11 @@
     ]
   },
   {
+    "slug": "weird-als-museum-of-natural-hilarity",
+    "name": "Weird Al's Museum of Natural Hilarity",
+    "opdb_group_id": "GN6WW"
+  },
+  {
     "slug": "wheel-of-fortune",
     "name": "Wheel of Fortune",
     "opdb_group_id": "G417d",
@@ -1758,6 +1912,11 @@
     "abbreviations": [
       "WPT"
     ]
+  },
+  {
+    "slug": "wrestlemania",
+    "name": "WrestleMania",
+    "opdb_group_id": "GR6Or"
   },
   {
     "slug": "wwf",


### PR DESCRIPTION
## Summary
- **Route OPDB `variant_of` through the claims system** instead of setting the FK directly, consistent with the "all fields are claims" architecture
- **Switch title claims from OPDB group IDs to slugs**, making them consistent with other FK claims (manufacturer, system, etc.) and enabling titles without OPDB IDs
- **Simplify franchise descriptions** by removing manufacturer names and production years so they stay accurate as new machines are added

## Details
- All ingest commands now emit slug-based title claims
- `resolve_claims` looks up Title by `slug` instead of `opdb_id`
- `models.json` gains explicit `title` fields (slug references)
- `titles.json` supports entries without `opdb_group_id`
- New validation checks in `04_checks.sql` (orphan model titles, duplicate slugs)
- New `test_ingest_pinbase_signs.py` test module

## Test plan
- [x] All backend tests pass (pre-commit hooks run full suite)
- [x] JSON schema validation passes
- [x] `ruff format` and `ruff check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)