### PR TITLE
fix: split OPDB groups and show franchise in sidebar

### DIFF
--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -82,6 +82,7 @@ class TitleDetailSchema(Schema):
     needs_review_notes: str = ""
     review_links: list[ReviewLinkSchema] = []
     hero_image_url: Optional[str] = None
+    franchise: Optional[FacetRef] = None
     machines: list[TitleMachineSchema]
     series: list[SeriesRefSchema] = []
     credits: list[CreditSchema] = []
@@ -369,6 +370,11 @@ def _serialize_title_detail(title) -> dict:
         "needs_review_notes": title.needs_review_notes,
         "review_links": review_links,
         "hero_image_url": hero_image_url,
+        "franchise": (
+            {"slug": title.franchise.slug, "name": title.franchise.name}
+            if title.franchise
+            else None
+        ),
         "machines": machines,
         "series": series,
         "credits": credits,

--- a/backend/apps/catalog/management/commands/ingest_all.py
+++ b/backend/apps/catalog/management/commands/ingest_all.py
@@ -88,6 +88,7 @@ class Command(BaseCommand):
                         "groups": opdb_groups,
                         "changelog": opdb_changelog,
                         "models": "../data/models.json",
+                        "titles": "../data/titles.json",
                     }
                 elif step == "ingest_pinbase_signs":
                     kwargs = {"csv": csv_path}

--- a/backend/apps/catalog/management/commands/ingest_opdb.py
+++ b/backend/apps/catalog/management/commands/ingest_opdb.py
@@ -83,12 +83,18 @@ class Command(BaseCommand):
             default="",
             help="Path to models.json (supplements ipdb_id cross-references).",
         )
+        parser.add_argument(
+            "--titles",
+            default="",
+            help="Path to titles.json (split_from_opdb_group entries skip group creation).",
+        )
 
     def handle(self, *args, **options):
         opdb_path = options["opdb"]
         groups_path = options["groups"]
         changelog_path = options["changelog"]
         models_path = options["models"]
+        titles_path = options["titles"]
 
         from django.contrib.contenttypes.models import ContentType
 
@@ -117,10 +123,19 @@ class Command(BaseCommand):
         if changelog_path:
             self._process_changelog(changelog_path)
 
+        # --- Build skip set from titles.json split_from_opdb_group entries ---
+        split_group_ids: set[str] = set()
+        if titles_path:
+            with open(titles_path) as f:
+                for entry in json.load(f):
+                    gid = entry.get("split_from_opdb_group")
+                    if gid:
+                        split_group_ids.add(gid)
+
         # --- Titles pre-loading ---
         groups_by_id: dict[str, dict] = {}
         if groups_path:
-            groups_by_id = self._load_titles(groups_path, source)
+            groups_by_id = self._load_titles(groups_path, source, split_group_ids)
 
         # --- Supplemental ipdb_id cross-references from models.json ---
         ipdb_id_supplement: dict[str, int] = {}
@@ -499,8 +514,16 @@ class Command(BaseCommand):
     # Groups
     # ------------------------------------------------------------------
 
-    def _load_titles(self, path: str, source: Source) -> dict[str, dict]:
+    def _load_titles(
+        self,
+        path: str,
+        source: Source,
+        split_group_ids: set[str] | None = None,
+    ) -> dict[str, dict]:
         """Load groups JSON, create Title records, and assert name/short_name claims.
+
+        Groups in *split_group_ids* are skipped — they have been split into
+        separate titles in titles.json.
 
         Returns a dict mapping group opdb_id → group record for later lookup.
         """
@@ -513,12 +536,18 @@ class Command(BaseCommand):
 
         ct_id = ContentType.objects.get_for_model(Title).pk
 
-        # Build lookup of raw group data.
+        # Build lookup of raw group data, skipping split groups.
+        _skip = split_group_ids or set()
         groups_by_id: dict[str, dict] = {}
+        skipped_splits = 0
         for rec in data:
             opdb_id = rec.get("opdb_id")
-            if opdb_id:
-                groups_by_id[opdb_id] = rec
+            if not opdb_id:
+                continue
+            if opdb_id in _skip:
+                skipped_splits += 1
+                continue
+            groups_by_id[opdb_id] = rec
 
         # Pre-fetch existing titles.
         existing_titles: dict[str, Title] = {t.opdb_id: t for t in Title.objects.all()}
@@ -607,7 +636,10 @@ class Command(BaseCommand):
             list(Title.objects.all()), title_ids=touched_ids
         )
 
-        self.stdout.write(f"  Titles: {titles_created} created, {unchanged} unchanged")
+        self.stdout.write(
+            f"  Titles: {titles_created} created, {unchanged} unchanged"
+            + (f", {skipped_splits} split groups skipped" if skipped_splits else "")
+        )
         self.stdout.write(
             f"  Title claims: {claim_stats['created']} created, "
             f"{claim_stats['unchanged']} unchanged"

--- a/data/schemas/titles.schema.json
+++ b/data/schemas/titles.schema.json
@@ -21,6 +21,10 @@
         "type": "string",
         "description": "References a slug in series.json"
       },
+      "split_from_opdb_group": {
+        "type": "string",
+        "description": "OPDB group ID that this title was split from; prevents the OPDB ingester from creating the combined group title"
+      },
       "abbreviations": {
         "type": "array",
         "items": { "type": "string", "minLength": 1 },

--- a/data/titles.json
+++ b/data/titles.json
@@ -499,12 +499,14 @@
   {
     "slug": "family-guy",
     "name": "Family Guy",
-    "franchise_slug": "family-guy"
+    "franchise_slug": "family-guy",
+    "split_from_opdb_group": "G5LW9"
   },
   {
     "slug": "shrek",
     "name": "Shrek",
-    "franchise_slug": "shrek"
+    "franchise_slug": "shrek",
+    "split_from_opdb_group": "G5LW9"
   },
   {
     "slug": "flash-gordon",

--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -137,12 +137,6 @@
 							<a href={resolve(`/systems/${model.system_slug}`)}>{model.system_name}</a>
 						</dd>
 					{/if}
-					{#if model.franchise}
-						<dt>Franchise</dt>
-						<dd>
-							<a href={resolve(`/franchises/${model.franchise.slug}`)}>{model.franchise.name}</a>
-						</dd>
-					{/if}
 					{#if model.themes.length > 0}
 						<dt>Themes</dt>
 						<dd>
@@ -150,6 +144,12 @@
 								{#if i > 0},{/if}
 								<a href={resolve(`/themes/${theme.slug}`)}>{theme.name}</a>
 							{/each}
+						</dd>
+					{/if}
+					{#if model.franchise}
+						<dt>Franchise</dt>
+						<dd>
+							<a href={resolve(`/franchises/${model.franchise.slug}`)}>{model.franchise.name}</a>
 						</dd>
 					{/if}
 					{#if model.abbreviations.length > 0}

--- a/frontend/src/routes/titles/[slug]/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/+page.svelte
@@ -43,9 +43,6 @@
 				: `${md.year}`;
 			items.push({ text: yearText });
 		}
-		if (md.franchise) {
-			items.push({ text: md.franchise.name });
-		}
 		return items;
 	});
 </script>
@@ -187,6 +184,12 @@
 								{/each}
 							</dd>
 						{/if}
+						{#if md.franchise}
+							<dt>Franchise</dt>
+							<dd>
+								<a href={resolve(`/franchises/${md.franchise.slug}`)}>{md.franchise.name}</a>
+							</dd>
+						{/if}
 						{#if md.abbreviations.length > 0}
 							<dt>Abbrs</dt>
 							<dd>{md.abbreviations.join(', ')}</dd>
@@ -297,6 +300,13 @@
 										{#if i > 0},{/if}
 										<a href={resolve(`/themes/${theme.slug}`)}>{theme.name}</a>
 									{/each}
+								</dd>
+							{/if}
+							{#if title.franchise}
+								<dt>Franchise</dt>
+								<dd>
+									<a href={resolve(`/franchises/${title.franchise.slug}`)}>{title.franchise.name}</a
+									>
 								</dd>
 							{/if}
 							{#if title.abbreviations.length > 0}


### PR DESCRIPTION
## Summary
- Family Guy and Shrek shared an OPDB group (G5LW9) despite being unrelated IPs. Add `split_from_opdb_group` field to `titles.json` so the OPDB ingester skips creating a combined "Family Guy / Shrek" title for split groups.
- Add `franchise` to the title detail API response so multi-model title pages can display it.
- Move franchise below Themes in the sidebar on both title and model pages, and remove it from the title hero banner.

## Test plan
- [ ] Verify `/titles/family-guy` and `/titles/shrek` exist as separate titles
- [ ] Verify `/titles/family-guy-shrek` does NOT exist
- [ ] Verify franchise appears in sidebar (below Themes) on `/titles/shrek`, `/titles/the-mandalorian`
- [ ] Verify franchise appears in sidebar on model pages (e.g. `/models/shrek`)
- [ ] Verify franchise does NOT appear in the hero banner on title pages
- [ ] Run full ingest and confirm "1 split groups skipped" in OPDB output

🤖 Generated with [Claude Code](https://claude.com/claude-code)