### PR TITLE
feat: two-column layout for system detail page

### DIFF
--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from django.db.models import Count, F, Prefetch, Q
+from django.db.models import Count, F, Max, Prefetch, Q
 from django.shortcuts import get_object_or_404
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
@@ -26,6 +26,11 @@ class SystemListSchema(Schema):
     machine_count: int = 0
 
 
+class SiblingSystemSchema(Schema):
+    name: str
+    slug: str
+
+
 class SystemDetailSchema(Schema):
     name: str
     slug: str
@@ -33,6 +38,7 @@ class SystemDetailSchema(Schema):
     manufacturer_name: Optional[str] = None
     manufacturer_slug: Optional[str] = None
     titles: list[RelatedTitleSchema]
+    sibling_systems: list[SiblingSystemSchema] = []
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +109,16 @@ def get_system(request, slug: str):
             thumbnail_url = _extract_image_urls(m.extra_data or {})[0]
             if thumbnail_url:
                 titles[key]["thumbnail_url"] = thumbnail_url
+    sibling_systems = []
+    if system.manufacturer:
+        sibling_systems = list(
+            System.objects.filter(manufacturer=system.manufacturer)
+            .exclude(pk=system.pk)
+            .annotate(latest_year=Max("machine_models__year"))
+            .order_by(F("latest_year").desc(nulls_last=True), "name")
+            .values("name", "slug")
+        )
+
     return {
         "name": system.name,
         "slug": system.slug,
@@ -110,4 +126,5 @@ def get_system(request, slug: str):
         "manufacturer_name": system.manufacturer.name if system.manufacturer else None,
         "manufacturer_slug": system.manufacturer.slug if system.manufacturer else None,
         "titles": list(titles.values()),
+        "sibling_systems": sibling_systems,
     }

--- a/frontend/src/routes/systems/[slug]/+page.svelte
+++ b/frontend/src/routes/systems/[slug]/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import CardGrid from '$lib/components/grid/CardGrid.svelte';
+	import SidebarList from '$lib/components/SidebarList.svelte';
+	import SidebarListItem from '$lib/components/SidebarListItem.svelte';
+	import SidebarSection from '$lib/components/SidebarSection.svelte';
 	import TitleCard from '$lib/components/cards/TitleCard.svelte';
+	import TwoColumnLayout from '$lib/components/TwoColumnLayout.svelte';
 	import { pageTitle } from '$lib/constants';
 
 	let { data } = $props();
@@ -15,43 +19,59 @@
 <article>
 	<header>
 		<h1>{system.name}</h1>
-		{#if system.manufacturer_name}
-			<p class="manufacturer">
-				By <a href={resolve(`/manufacturers/${system.manufacturer_slug}`)}
-					>{system.manufacturer_name}</a
-				>
-			</p>
-		{/if}
-		{#if system.description}
-			<p class="description">{system.description}</p>
-		{/if}
 	</header>
 
-	{#if system.titles.length === 0}
-		<p class="empty">No titles on this system.</p>
-	{:else}
-		<section>
-			<h2>Titles ({system.titles.length})</h2>
-			<CardGrid>
-				{#each system.titles as title (title.slug)}
-					<TitleCard
-						slug={title.slug}
-						name={title.name}
-						thumbnailUrl={title.thumbnail_url}
-						manufacturerName={title.manufacturer_name}
-						year={title.year}
-					/>
-				{/each}
-			</CardGrid>
-		</section>
-	{/if}
+	<TwoColumnLayout>
+		{#snippet main()}
+			{#if system.description}
+				<p class="description">{system.description}</p>
+			{/if}
+
+			{#if system.titles.length === 0}
+				<p class="empty">No titles on this system.</p>
+			{:else}
+				<section>
+					<h2>Titles ({system.titles.length})</h2>
+					<CardGrid>
+						{#each system.titles as title (title.slug)}
+							<TitleCard
+								slug={title.slug}
+								name={title.name}
+								thumbnailUrl={title.thumbnail_url}
+								manufacturerName={title.manufacturer_name}
+								year={title.year}
+							/>
+						{/each}
+					</CardGrid>
+				</section>
+			{/if}
+		{/snippet}
+
+		{#snippet sidebar()}
+			{#if system.manufacturer_name}
+				<SidebarSection heading="Manufacturer">
+					<a href={resolve(`/manufacturers/${system.manufacturer_slug}`)}
+						>{system.manufacturer_name}</a
+					>
+				</SidebarSection>
+			{/if}
+
+			{#if system.sibling_systems.length > 0}
+				<SidebarSection heading="Other Systems By This Manufacturer">
+					<SidebarList>
+						{#each system.sibling_systems as sibling (sibling.slug)}
+							<SidebarListItem>
+								<a href={resolve(`/systems/${sibling.slug}`)}>{sibling.name}</a>
+							</SidebarListItem>
+						{/each}
+					</SidebarList>
+				</SidebarSection>
+			{/if}
+		{/snippet}
+	</TwoColumnLayout>
 </article>
 
 <style>
-	article {
-		max-width: 64rem;
-	}
-
 	header {
 		margin-bottom: var(--size-6);
 	}
@@ -63,16 +83,11 @@
 		margin-bottom: var(--size-2);
 	}
 
-	.manufacturer {
-		font-size: var(--font-size-2);
-		color: var(--color-text-muted);
-		margin-bottom: var(--size-2);
-	}
-
 	.description {
 		font-size: var(--font-size-2);
 		color: var(--color-text-muted);
 		line-height: var(--font-lineheight-3);
+		margin-bottom: var(--size-4);
 	}
 
 	h2 {


### PR DESCRIPTION
## Summary
- Refactored system detail page to use `TwoColumnLayout` with a sidebar
- Moved manufacturer link from header into a **Manufacturer** sidebar section
- Added **Other Systems By This Manufacturer** sidebar section listing sibling systems (ordered newest to oldest by latest machine year)
- Added `sibling_systems` field to the system detail API endpoint

## Test plan
- [ ] Visit `/systems/wpc-95` and verify two-column layout renders
- [ ] Verify manufacturer link appears in sidebar and navigates correctly
- [ ] Verify sibling systems are listed newest-first and link to correct pages
- [ ] Verify layout collapses to single column on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)