### PR TITLE
feat: replace search homepage with content landing page and add breadcrumbs

### DIFF
--- a/frontend/src/lib/components/Breadcrumb.svelte
+++ b/frontend/src/lib/components/Breadcrumb.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { resolveHref } from '$lib/utils';
+
+	type Crumb = { label: string; href: string };
+
+	let { crumbs, current }: { crumbs: Crumb[]; current: string } = $props();
+</script>
+
+<nav aria-label="Breadcrumb" class="breadcrumb">
+	<ol>
+		{#each crumbs as crumb (crumb.href)}
+			<li>
+				<a href={resolveHref(crumb.href)}>{crumb.label}</a>
+			</li>
+		{/each}
+		<li aria-current="page">{current}</li>
+	</ol>
+</nav>
+
+<style>
+	ol {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		gap: var(--size-1);
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+	}
+
+	li:not(:last-child)::after {
+		content: '/';
+		margin-left: var(--size-1);
+		color: var(--color-text-muted);
+	}
+
+	a {
+		color: var(--color-text-muted);
+		text-decoration: none;
+	}
+
+	a:hover {
+		color: var(--color-text-primary);
+		text-decoration: underline;
+	}
+
+	li[aria-current='page'] {
+		color: var(--color-text-primary);
+	}
+</style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,93 +1,162 @@
 <script lang="ts">
-	import { afterNavigate, replaceState } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { onMount } from 'svelte';
-	import SearchBox from '$lib/components/SearchBox.svelte';
-	import SearchResults from '$lib/components/SearchResults.svelte';
 	import { SITE_NAME } from '$lib/constants';
-	import { normalizeText } from '$lib/util';
-
-	const MIN_QUERY_LENGTH = 2;
-
-	let searchQuery = $state('');
-	let lastSyncedQ = '';
-
-	// Sync URL → state. Uses window.location directly because page.url
-	// may still reflect the prerendered URL (no query params) during hydration.
-	function syncFromUrl() {
-		const urlQ = new URLSearchParams(window.location.search).get('q') ?? '';
-		searchQuery = urlQ;
-		lastSyncedQ = urlQ.trim();
-	}
-
-	// onMount guarantees we read the real browser URL after hydration.
-	onMount(syncFromUrl);
-
-	// afterNavigate handles back/forward navigation (does NOT fire on replaceState).
-	afterNavigate(syncFromUrl);
-
-	// State → URL: update query string as user types.
-	$effect(() => {
-		const q = searchQuery.trim();
-		if (q !== lastSyncedQ) {
-			lastSyncedQ = q;
-			const search = q ? `?q=${encodeURIComponent(q)}` : '';
-			replaceState(`${resolve('/')}${search}`, {});
-		}
-	});
-
-	let isSearching = $derived(normalizeText(searchQuery.trim()).length >= MIN_QUERY_LENGTH);
+	import { resolveHref } from '$lib/utils';
 </script>
 
 <svelte:head>
 	<title>{SITE_NAME}</title>
-	<link rel="preload" as="fetch" href="/api/titles/all/" crossorigin="anonymous" />
-	<link rel="preload" as="fetch" href="/api/manufacturers/all/" crossorigin="anonymous" />
-	<link rel="preload" as="fetch" href="/api/models/all/" crossorigin="anonymous" />
-	<link rel="preload" as="fetch" href="/api/people/all/" crossorigin="anonymous" />
 </svelte:head>
 
-<div class="search-page">
-	<div class="search-hero" class:compact={isSearching}>
-		<h1 class="site-title">{SITE_NAME}</h1>
-		{#if !isSearching}
-			<p class="tagline">The open encyclopedia of pinball machines</p>
-		{/if}
-		<SearchBox bind:value={searchQuery} placeholder="Search titles, manufacturers, people..." />
-	</div>
+<div class="home">
+	<section class="intro">
+		<p>
+			Pinball is not a relic. It is a living art form — part engineering marvel, part arcade
+			theater, part competitive sport — and it has never stopped evolving. While the world chased
+			pixels, pinball kept doing what no screen can: putting a steel ball under real gravity,
+			launching it into a world of ramps, targets, and mechanical surprise, and daring you to keep
+			it alive.
+		</p>
+	</section>
 
-	<SearchResults query={searchQuery} />
+	<section class="content-block">
+		<h2>A Game That Refuses to Die</h2>
+		<p>
+			<a href={resolveHref('/manufacturers/stern-pinball')}>Stern Pinball</a> releases a half-dozen
+			new titles every year, and today the majority of machines go to private collectors rather than
+			arcades. Meanwhile, upstarts like
+			<a href={resolveHref('/manufacturers/jersey-jack')}>Jersey Jack Pinball</a>
+			and <a href={resolveHref('/manufacturers/american-pinball')}>American Pinball</a> are pushing the
+			form forward with larger-than-life LCD displays, innovative toy mechanisms, and gameplay ideas the
+			old guard never imagined. Boutique builders craft limited-run machines for devoted players, and
+			a growing DIY community designs and builds original tables from scratch.
+		</p>
+		<p>
+			Competitive pinball is thriving too. The
+			<a href="https://www.ifpapinball.com/">International Flipper Pinball Association</a> tracks thousands
+			of ranked players worldwide, and major tournaments draw crowds and prize pools that would have been
+			unthinkable a generation ago. Pinball bars and lounges have become fixtures of city nightlife from
+			Portland to Berlin.
+		</p>
+	</section>
+
+	<section class="content-block">
+		<h2>Every Machine Tells a Story</h2>
+		<p>
+			A pinball machine is a collaboration between artists, engineers, and storytellers. The
+			playfield designer sets the geometry — the angles that make a shot feel impossible and then,
+			with practice, inevitable. The artist wraps the cabinet in a world: a haunted mansion, a rock
+			concert, a deep-space odyssey. The software engineer choreographs the light shows, the music,
+			the escalating rules that reward players who dig deeper. And the mechanical engineers build
+			the physical magic — spinning discs, rising targets, magnetic ball locks — that no touchscreen
+			can replicate.
+		</p>
+		<p>
+			The result is a machine with personality. Players don't just play pinball games — they develop
+			relationships with individual tables, learning their rhythms, their quirks, their secrets.
+		</p>
+	</section>
+
+	<section class="content-block">
+		<h2>Explore the Collection</h2>
+		<p>
+			{SITE_NAME} catalogs the <a href={resolve('/titles')}>machines</a>, the
+			<a href={resolve('/manufacturers')}>manufacturers</a>, and the
+			<a href={resolve('/people')}>people</a> who have shaped pinball from its earliest coin-operated
+			ancestors to today's connected, tournament-ready designs. Browse the archive, discover forgotten
+			classics, and trace the lineage of the game that keeps defying the odds.
+		</p>
+		<nav class="explore-links">
+			<a href={resolve('/titles')} class="explore-card">
+				<span class="explore-label">Titles</span>
+				<span class="explore-desc">Every pinball machine ever made</span>
+			</a>
+			<a href={resolve('/manufacturers')} class="explore-card">
+				<span class="explore-label">Manufacturers</span>
+				<span class="explore-desc">The companies behind the games</span>
+			</a>
+			<a href={resolve('/people')} class="explore-card">
+				<span class="explore-label">People</span>
+				<span class="explore-desc">Designers, artists, and engineers</span>
+			</a>
+		</nav>
+	</section>
 </div>
 
 <style>
-	.search-page {
+	.home {
 		padding: var(--size-5) 0;
 	}
 
-	.search-hero {
-		text-align: center;
-		padding: var(--size-10) 0 var(--size-6);
-		transition: padding 0.2s ease;
+	.intro {
+		max-width: 48rem;
+		margin: 0 auto;
+		padding: var(--size-4) 0 var(--size-6);
 	}
 
-	.search-hero.compact {
-		padding: var(--size-4) 0 var(--size-4);
-	}
-
-	.site-title {
-		font-size: var(--font-size-8);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
-	}
-
-	.compact .site-title {
-		font-size: var(--font-size-5);
-	}
-
-	.tagline {
+	.intro p {
 		font-size: var(--font-size-3);
+		line-height: 1.7;
+		color: var(--color-text-primary);
+	}
+
+	.content-block {
+		max-width: 48rem;
+		margin: 0 auto;
+		padding: var(--size-4) 0;
+	}
+
+	.content-block h2 {
+		font-size: var(--font-size-5);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	.content-block p {
+		font-size: var(--font-size-2);
+		line-height: 1.7;
 		color: var(--color-text-muted);
-		margin-bottom: var(--size-6);
+		margin-bottom: var(--size-3);
+	}
+
+	.content-block p:last-of-type {
+		margin-bottom: var(--size-4);
+	}
+
+	.explore-links {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+		gap: var(--size-4);
+		margin-top: var(--size-4);
+	}
+
+	.explore-card {
+		display: flex;
+		flex-direction: column;
+		padding: var(--size-5);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-2);
+		text-decoration: none;
+		transition:
+			border-color 0.15s var(--ease-2),
+			box-shadow 0.15s var(--ease-2);
+	}
+
+	.explore-card:hover {
+		border-color: var(--color-accent);
+		box-shadow: 0 2px 8px rgb(0 0 0 / 0.08);
+	}
+
+	.explore-label {
+		font-size: var(--font-size-3);
+		font-weight: 600;
+		color: var(--color-accent);
+		margin-bottom: var(--size-1);
+	}
+
+	.explore-desc {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
 	}
 </style>

--- a/frontend/src/routes/systems/[slug]/+page.svelte
+++ b/frontend/src/routes/systems/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
 	import CardGrid from '$lib/components/grid/CardGrid.svelte';
 	import SidebarList from '$lib/components/SidebarList.svelte';
 	import SidebarListItem from '$lib/components/SidebarListItem.svelte';
@@ -18,6 +19,7 @@
 
 <article>
 	<header>
+		<Breadcrumb crumbs={[{ label: 'Systems', href: '/systems' }]} current={system.name} />
 		<h1>{system.name}</h1>
 	</header>
 


### PR DESCRIPTION
## Summary
- Replace the search-focused homepage with a content-rich landing page featuring intro text, editorial sections about pinball, and explore navigation cards linking to titles, manufacturers, and people
- Add a reusable `Breadcrumb` component (`$lib/components/Breadcrumb.svelte`)
- Wire breadcrumb navigation into the system detail page

## Test plan
- [ ] Verify homepage renders with intro text, content sections, and explore cards
- [ ] Verify explore card links navigate to correct pages
- [ ] Verify breadcrumb appears on system detail pages with correct links
- [ ] Check responsive layout of explore cards grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)