### PR TITLE
Redesign homepage with search, browse cards, and newest machines

### DIFF
--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -480,6 +480,51 @@ def _build_search_text(pm) -> str:
     return " | ".join(parts)
 
 
+class ModelRecentSchema(Schema):
+    name: str
+    slug: str
+    manufacturer_name: Optional[str] = None
+    year: Optional[int] = None
+    thumbnail_url: Optional[str] = None
+
+
+@models_router.get("/recent/", response=list[ModelRecentSchema])
+@decorate_view(cache_control(public=True, max_age=300))
+def list_recent_models(request):
+    """Return the 3 newest non-variant models, one per title."""
+    from ..models import MachineModel
+
+    qs = (
+        MachineModel.objects.filter(variant_of__isnull=True)
+        .select_related("manufacturer")
+        .order_by(
+            F("year").desc(nulls_last=True),
+            F("month").desc(nulls_last=True),
+            "-updated_at",
+        )
+    )
+    results = []
+    seen_titles: set[int | None] = set()
+    for m in qs:
+        title_id = m.title_id
+        if title_id in seen_titles:
+            continue
+        seen_titles.add(title_id)
+        thumbnail_url, _ = _extract_image_urls(m.extra_data or {})
+        results.append(
+            {
+                "name": m.name,
+                "slug": m.slug,
+                "manufacturer_name": m.manufacturer.name if m.manufacturer else None,
+                "year": m.year,
+                "thumbnail_url": thumbnail_url,
+            }
+        )
+        if len(results) == 3:
+            break
+    return results
+
+
 @models_router.get("/all/", response=list[MachineModelGridSchema])
 @decorate_view(cache_control(public=True, max_age=300))
 def list_all_models(request):

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,7 +1,30 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
+	import client from '$lib/api/client';
+	import MachineCard from '$lib/components/cards/MachineCard.svelte';
 	import { SITE_NAME } from '$lib/constants';
 	import { resolveHref } from '$lib/utils';
+	import { onMount } from 'svelte';
+	import type { components } from '$lib/api/schema';
+
+	type RecentModel = components['schemas']['ModelRecentSchema'];
+
+	let searchQuery = $state('');
+	let recentModels = $state<RecentModel[]>([]);
+
+	function handleSubmit(e: Event) {
+		e.preventDefault();
+		const q = searchQuery.trim();
+		if (q) {
+			goto(`${resolveHref('/search')}?q=${encodeURIComponent(q)}`);
+		}
+	}
+
+	onMount(async () => {
+		const { data } = await client.GET('/api/models/recent/');
+		if (data) recentModels = data;
+	});
 </script>
 
 <svelte:head>
@@ -9,78 +32,50 @@
 </svelte:head>
 
 <div class="home">
-	<section class="intro">
-		<p>
-			Pinball is not a relic. It is a living art form — part engineering marvel, part arcade
-			theater, part competitive sport — and it has never stopped evolving. While the world chased
-			pixels, pinball kept doing what no screen can: putting a steel ball under real gravity,
-			launching it into a world of ramps, targets, and mechanical surprise, and daring you to keep
-			it alive.
-		</p>
+	<section class="hero">
+		<h1 class="site-title">{SITE_NAME}</h1>
+		<p class="tagline">Cataloging every pinball machine ever made</p>
+		<form class="hero-search" onsubmit={handleSubmit}>
+			<input
+				type="search"
+				placeholder="Search titles, manufacturers, people..."
+				aria-label="Search the catalog"
+				bind:value={searchQuery}
+			/>
+		</form>
 	</section>
 
-	<section class="content-block">
-		<h2>A Game That Refuses to Die</h2>
-		<p>
-			<a href={resolveHref('/manufacturers/stern-pinball')}>Stern Pinball</a> releases a half-dozen
-			new titles every year, and today the majority of machines go to private collectors rather than
-			arcades. Meanwhile, upstarts like
-			<a href={resolveHref('/manufacturers/jersey-jack')}>Jersey Jack Pinball</a>
-			and <a href={resolveHref('/manufacturers/american-pinball')}>American Pinball</a> are pushing the
-			form forward with larger-than-life LCD displays, innovative toy mechanisms, and gameplay ideas the
-			old guard never imagined. Boutique builders craft limited-run machines for devoted players, and
-			a growing DIY community designs and builds original tables from scratch.
-		</p>
-		<p>
-			Competitive pinball is thriving too. The
-			<a href="https://www.ifpapinball.com/">International Flipper Pinball Association</a> tracks thousands
-			of ranked players worldwide, and major tournaments draw crowds and prize pools that would have been
-			unthinkable a generation ago. Pinball bars and lounges have become fixtures of city nightlife from
-			Portland to Berlin.
-		</p>
-	</section>
+	<nav class="explore-links">
+		<a href={resolve('/titles')} class="explore-card">
+			<span class="explore-label">Titles</span>
+			<span class="explore-desc">Browse thousands of pinball machines from the 1930s to today</span>
+		</a>
+		<a href={resolve('/manufacturers')} class="explore-card">
+			<span class="explore-label">Manufacturers</span>
+			<span class="explore-desc">From Gottlieb and Bally to Stern and Jersey Jack</span>
+		</a>
+		<a href={resolve('/people')} class="explore-card">
+			<span class="explore-label">People</span>
+			<span class="explore-desc">The designers, artists, and engineers behind the games</span>
+		</a>
+	</nav>
 
-	<section class="content-block">
-		<h2>Every Machine Tells a Story</h2>
-		<p>
-			A pinball machine is a collaboration between artists, engineers, and storytellers. The
-			playfield designer sets the geometry — the angles that make a shot feel impossible and then,
-			with practice, inevitable. The artist wraps the cabinet in a world: a haunted mansion, a rock
-			concert, a deep-space odyssey. The software engineer choreographs the light shows, the music,
-			the escalating rules that reward players who dig deeper. And the mechanical engineers build
-			the physical magic — spinning discs, rising targets, magnetic ball locks — that no touchscreen
-			can replicate.
-		</p>
-		<p>
-			The result is a machine with personality. Players don't just play pinball games — they develop
-			relationships with individual tables, learning their rhythms, their quirks, their secrets.
-		</p>
-	</section>
-
-	<section class="content-block">
-		<h2>Explore the Collection</h2>
-		<p>
-			{SITE_NAME} catalogs the <a href={resolve('/titles')}>machines</a>, the
-			<a href={resolve('/manufacturers')}>manufacturers</a>, and the
-			<a href={resolve('/people')}>people</a> who have shaped pinball from its earliest coin-operated
-			ancestors to today's connected, tournament-ready designs. Browse the archive, discover forgotten
-			classics, and trace the lineage of the game that keeps defying the odds.
-		</p>
-		<nav class="explore-links">
-			<a href={resolve('/titles')} class="explore-card">
-				<span class="explore-label">Titles</span>
-				<span class="explore-desc">Every pinball machine ever made</span>
-			</a>
-			<a href={resolve('/manufacturers')} class="explore-card">
-				<span class="explore-label">Manufacturers</span>
-				<span class="explore-desc">The companies behind the games</span>
-			</a>
-			<a href={resolve('/people')} class="explore-card">
-				<span class="explore-label">People</span>
-				<span class="explore-desc">Designers, artists, and engineers</span>
-			</a>
-		</nav>
-	</section>
+	{#if recentModels.length > 0}
+		<section class="recent">
+			<h2 class="recent-heading">Newest Machines</h2>
+			<div class="recent-grid">
+				{#each recentModels as model (model.slug)}
+					<MachineCard
+						slug={model.slug}
+						name={model.name}
+						thumbnailUrl={model.thumbnail_url}
+						manufacturerName={model.manufacturer_name}
+						year={model.year}
+					/>
+				{/each}
+			</div>
+		</section>
+	{/if}
 </div>
 
 <style>
@@ -88,47 +83,58 @@
 		padding: var(--size-5) 0;
 	}
 
-	.intro {
-		max-width: 48rem;
-		margin: 0 auto;
-		padding: var(--size-4) 0 var(--size-6);
+	.hero {
+		text-align: center;
+		padding: var(--size-10) 0 var(--size-8);
 	}
 
-	.intro p {
+	.site-title {
+		font-size: var(--font-size-8);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-2);
+	}
+
+	.tagline {
 		font-size: var(--font-size-3);
-		line-height: 1.7;
-		color: var(--color-text-primary);
-	}
-
-	.content-block {
-		max-width: 48rem;
-		margin: 0 auto;
-		padding: var(--size-4) 0;
-	}
-
-	.content-block h2 {
-		font-size: var(--font-size-5);
-		font-weight: 600;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-3);
-	}
-
-	.content-block p {
-		font-size: var(--font-size-2);
-		line-height: 1.7;
 		color: var(--color-text-muted);
-		margin-bottom: var(--size-3);
 	}
 
-	.content-block p:last-of-type {
-		margin-bottom: var(--size-4);
+	.hero-search {
+		max-width: 36rem;
+		margin: var(--size-6) auto 0;
+	}
+
+	.hero-search input[type='search'] {
+		width: 100%;
+		padding: var(--size-3) var(--size-4);
+		font-size: var(--font-size-2);
+		font-family: var(--font-body);
+		background-color: var(--color-input-bg);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-input-border);
+		border-radius: var(--radius-3);
+		transition:
+			border-color 0.15s var(--ease-2),
+			box-shadow 0.15s var(--ease-2);
+	}
+
+	.hero-search input[type='search']:focus {
+		outline: none;
+		border-color: var(--color-input-focus);
+		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
+	}
+
+	.hero-search input[type='search']::placeholder {
+		color: var(--color-text-muted);
 	}
 
 	.explore-links {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
 		gap: var(--size-4);
-		margin-top: var(--size-4);
+		max-width: 54rem;
+		margin: 0 auto;
 	}
 
 	.explore-card {
@@ -149,7 +155,7 @@
 	}
 
 	.explore-label {
-		font-size: var(--font-size-3);
+		font-size: var(--font-size-4);
 		font-weight: 600;
 		color: var(--color-accent);
 		margin-bottom: var(--size-1);
@@ -158,5 +164,30 @@
 	.explore-desc {
 		font-size: var(--font-size-1);
 		color: var(--color-text-muted);
+		line-height: 1.5;
+	}
+
+	.recent {
+		max-width: 54rem;
+		margin: var(--size-8) auto 0;
+	}
+
+	.recent-heading {
+		font-size: var(--font-size-4);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-4);
+	}
+
+	.recent-grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: var(--size-4);
+	}
+
+	@media (max-width: 640px) {
+		.recent-grid {
+			grid-template-columns: 1fr;
+		}
 	}
 </style>

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -43,7 +43,6 @@
 </svelte:head>
 
 <div class="search-page">
-	<h1 class="page-title">Search</h1>
 	<SearchBox
 		bind:value={searchQuery}
 		placeholder="Search titles, manufacturers, people..."
@@ -55,12 +54,5 @@
 <style>
 	.search-page {
 		padding: var(--size-5) 0;
-	}
-
-	.page-title {
-		font-size: var(--font-size-6);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 </style>


### PR DESCRIPTION
## Summary
- Replace editorial text wall with a clean museum-lobby homepage: site title, tagline, search bar, and three browse cards (Titles, Manufacturers, People)
- Add "Newest Machines" section showing 3 most recent models (one per title, ordered by year/month/updated_at), fetched client-side from new `/api/models/recent/` endpoint
- Remove redundant "Search" H1 heading from the `/search` page

## Test plan
- [ ] Visit homepage — verify search bar, browse cards, and newest machines render
- [ ] Type a query in the homepage search and press Enter — verify navigation to `/search?q=...`
- [ ] Verify newest machines show one per title (no duplicate titles)
- [ ] Visit `/search` — verify no H1 heading, search box autofocuses
- [ ] Test on mobile viewport — verify responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)