### PR TITLE
Show live catalog counts on homepage browse cards

### DIFF
--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from ninja import NinjaAPI
+from ninja import NinjaAPI, Schema
 
 from apps.accounts.api import auth_router
 from apps.catalog.api import (
@@ -20,6 +20,30 @@ api = NinjaAPI(
     title="Pinbase API",
     urls_namespace="api",
 )
+
+
+# Endpoints tagged "private" are excluded from the public API docs page.
+# The API docs expose catalog data endpoints; internal/website endpoints
+# (health checks, stats for the homepage, etc.) use tags=["private"].
+
+
+class StatsSchema(Schema):
+    titles: int
+    models: int
+    manufacturers: int
+    people: int
+
+
+@api.get("/stats", response=StatsSchema, tags=["private"])
+def stats(request):
+    from apps.catalog.models import Manufacturer, MachineModel, Person, Title
+
+    return {
+        "titles": Title.objects.count(),
+        "models": MachineModel.objects.count(),
+        "manufacturers": Manufacturer.objects.count(),
+        "people": Person.objects.count(),
+    }
 
 
 @api.get("/health", tags=["private"])

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -12,6 +12,13 @@
 
 	let searchQuery = $state('');
 	let recentModels = $state<RecentModel[]>([]);
+	let titleCount = $state<number | null>(null);
+	let manufacturerCount = $state<number | null>(null);
+	let peopleCount = $state<number | null>(null);
+
+	function fmt(n: number): string {
+		return n.toLocaleString();
+	}
 
 	function handleSubmit(e: Event) {
 		e.preventDefault();
@@ -22,8 +29,16 @@
 	}
 
 	onMount(async () => {
-		const { data } = await client.GET('/api/models/recent/');
-		if (data) recentModels = data;
+		const [recentRes, statsRes] = await Promise.all([
+			client.GET('/api/models/recent/'),
+			client.GET('/api/stats')
+		]);
+		if (recentRes.data) recentModels = recentRes.data;
+		if (statsRes.data) {
+			titleCount = statsRes.data.titles;
+			manufacturerCount = statsRes.data.manufacturers;
+			peopleCount = statsRes.data.people;
+		}
 	});
 </script>
 
@@ -44,15 +59,23 @@
 	<nav class="explore-links">
 		<a href={resolve('/titles')} class="explore-card">
 			<span class="explore-label">Titles</span>
-			<span class="explore-desc">Thousands of pinball machines from the 1930s to today</span>
+			<span class="explore-desc"
+				>{titleCount !== null ? fmt(titleCount) : 'Thousands of'} pinball machines from the 1930s to today</span
+			>
 		</a>
 		<a href={resolve('/manufacturers')} class="explore-card">
 			<span class="explore-label">Manufacturers</span>
-			<span class="explore-desc">From Gottlieb and Bally to Stern and Jersey Jack</span>
+			<span class="explore-desc"
+				>{manufacturerCount !== null ? fmt(manufacturerCount) : 'Hundreds of'} companies from Gottlieb
+				and Bally to Stern and Jersey Jack</span
+			>
 		</a>
 		<a href={resolve('/people')} class="explore-card">
 			<span class="explore-label">People</span>
-			<span class="explore-desc">The designers, artists, and engineers behind the games</span>
+			<span class="explore-desc"
+				>{peopleCount !== null ? fmt(peopleCount) : 'Hundreds of'} designers, artists, and engineers behind
+				the games</span
+			>
 		</a>
 	</nav>
 


### PR DESCRIPTION
## Summary
- Add `/api/stats` endpoint returning title, model, manufacturer, and people counts (tagged `private` to stay out of public API docs)
- Homepage fetches stats client-side and displays exact numbers (e.g. "6,219 pinball machines") with static fallbacks ("Thousands of") before data loads
- Add comment in `config/api.py` documenting the `private` tag convention

## Test plan
- [ ] Visit homepage — browse cards should show exact counts after brief load
- [ ] Before stats load, cards show "Thousands of" / "Hundreds of" fallbacks
- [ ] `/api/stats` returns correct counts
- [ ] `/api-docs` page does not show the stats endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)