### PR TITLE
refactor: consolidate normalized matching into ManufacturerResolver

### DIFF
--- a/backend/apps/catalog/ingestion/bulk_utils.py
+++ b/backend/apps/catalog/ingestion/bulk_utils.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+import re
+from typing import TYPE_CHECKING
+
 from django.utils.text import slugify
+
+if TYPE_CHECKING:
+    from apps.catalog.models import Manufacturer
 
 MAX_NAMES_SHOWN = 10
 
@@ -31,12 +37,45 @@ def generate_unique_slug(base_name: str, existing_slugs: set[str]) -> str:
     return slug
 
 
+# Common business suffixes stripped during normalized name matching.
+# Order matters: longer suffixes first to avoid partial matches.
+_BUSINESS_SUFFIXES = re.compile(
+    r",?\s+(?:Manufacturing|Electronics|Industries|Enterprises"
+    r"|Games|Pinball|Technologies|Company|Corporation"
+    r"|Inc\.?|Ltd\.?|Co\.?|LLC|GmbH|S\.?A\.?|s\.?p\.?a\.?)"
+    r"$",
+    re.IGNORECASE,
+)
+
+
+def normalize_manufacturer_name(name: str) -> str:
+    """Strip common business suffixes for fuzzy matching.
+
+    >>> normalize_manufacturer_name("Bally Manufacturing")
+    'bally'
+    >>> normalize_manufacturer_name("WMS Industries")
+    'wms'
+    >>> normalize_manufacturer_name("Sega Enterprises, Ltd.")
+    'sega'
+    """
+    stripped = _BUSINESS_SUFFIXES.sub("", name).strip()
+    # Apply repeatedly for compound suffixes like "Sega Enterprises, Ltd."
+    prev = None
+    while stripped != prev:
+        prev = stripped
+        stripped = _BUSINESS_SUFFIXES.sub("", stripped).strip()
+    return stripped.lower()
+
+
 class ManufacturerResolver:
     """Resolve manufacturer names to slugs, auto-creating on miss.
 
     Caches name→slug and trade_name→slug lookups from the database at
     construction time.  Also loads CorporateEntity name→manufacturer slug
     for IPDB's 3-priority resolution cascade.
+
+    Includes a normalized-name fallback that strips common business
+    suffixes ("Manufacturing", "Inc.", etc.) and matches when unambiguous.
 
     All lookups are case-insensitive.
     """
@@ -45,21 +84,51 @@ class ManufacturerResolver:
         from apps.catalog.models import CorporateEntity, Manufacturer
 
         self._name_to_slug: dict[str, str] = {}
+        self._slug_to_mfr: dict[str, Manufacturer] = {}
         self._slugs: set[str] = set()
         for m in Manufacturer.objects.all():
             self._name_to_slug[m.name.lower()] = m.slug
             if m.trade_name:
                 self._name_to_slug[m.trade_name.lower()] = m.slug
             self._slugs.add(m.slug)
+            self._slug_to_mfr[m.slug] = m
 
         self._entity_to_slug: dict[str, str] = {
             ce.name.lower(): ce.manufacturer.slug
             for ce in CorporateEntity.objects.select_related("manufacturer").all()
         }
 
+        # Normalized-name fallback: strip business suffixes.
+        # Only usable when the normalized form maps to exactly one record.
+        self._normalized_to_slug: dict[str, str | None] = {}
+        for m in Manufacturer.objects.all():
+            key = normalize_manufacturer_name(m.name)
+            if key in self._normalized_to_slug:
+                self._normalized_to_slug[key] = None  # ambiguous — disable
+            else:
+                self._normalized_to_slug[key] = m.slug
+
     def resolve(self, name: str) -> str | None:
         """Look up a manufacturer by name or trade name. Returns slug or None."""
         return self._name_to_slug.get(name.lower())
+
+    def resolve_normalized(self, name: str) -> str | None:
+        """Fuzzy lookup: strip business suffixes and match if unambiguous.
+
+        Returns slug or None.  Returns None for ambiguous normalized forms.
+        """
+        key = normalize_manufacturer_name(name)
+        return self._normalized_to_slug.get(key)
+
+    def resolve_object(self, name: str) -> Manufacturer | None:
+        """Look up by name or trade name. Returns Manufacturer instance or None."""
+        slug = self.resolve(name)
+        return self._slug_to_mfr.get(slug) if slug else None
+
+    def resolve_normalized_object(self, name: str) -> Manufacturer | None:
+        """Fuzzy lookup returning the Manufacturer instance or None."""
+        slug = self.resolve_normalized(name)
+        return self._slug_to_mfr.get(slug) if slug else None
 
     def resolve_entity(self, name: str) -> str | None:
         """Look up a manufacturer via CorporateEntity name. Returns slug or None."""
@@ -78,7 +147,7 @@ class ManufacturerResolver:
             return slug
 
         slug = generate_unique_slug(name, self._slugs)
-        Manufacturer.objects.create(
+        mfr = Manufacturer.objects.create(
             name=name,
             slug=slug,
             trade_name=trade_name,
@@ -86,4 +155,5 @@ class ManufacturerResolver:
         self._name_to_slug[name.lower()] = slug
         if trade_name:
             self._name_to_slug[trade_name.lower()] = slug
+        self._slug_to_mfr[slug] = mfr
         return slug

--- a/backend/apps/catalog/management/commands/ingest_fandom.py
+++ b/backend/apps/catalog/management/commands/ingest_fandom.py
@@ -33,6 +33,7 @@ import logging
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 
+from apps.catalog.ingestion.bulk_utils import ManufacturerResolver
 from apps.catalog.ingestion.person_lookup import build_person_lookup
 from apps.catalog.ingestion.fandom_wiki import (
     FandomManufacturer,
@@ -375,14 +376,7 @@ class Command(BaseCommand):
         # ------------------------------------------------------------------
         # 9. Ingest manufacturers.
         # ------------------------------------------------------------------
-        all_mfrs = list(Manufacturer.objects.all())
-        existing_mfrs_by_name: dict[str, Manufacturer] = {
-            m.name.lower(): m for m in all_mfrs
-        }
-        existing_mfrs_by_trade: dict[str, Manufacturer] = {
-            m.trade_name.lower(): m for m in all_mfrs if m.trade_name
-        }
-
+        resolver = ManufacturerResolver()
         mfr_ct_id = ContentType.objects.get_for_model(Manufacturer).pk
 
         mfrs_matched = 0
@@ -391,9 +385,9 @@ class Command(BaseCommand):
         matched_mfr_objects: list[Manufacturer] = []
 
         for fm in fandom_mfrs:
-            mfr = existing_mfrs_by_name.get(
-                fm.title.lower()
-            ) or existing_mfrs_by_trade.get(fm.title.lower())
+            mfr = resolver.resolve_object(fm.title)
+            if mfr is None:
+                mfr = resolver.resolve_normalized_object(fm.title)
             if mfr is None:
                 unmatched_mfrs.append(fm.title)
                 continue

--- a/backend/apps/catalog/management/commands/ingest_wikidata_manufacturers.py
+++ b/backend/apps/catalog/management/commands/ingest_wikidata_manufacturers.py
@@ -18,11 +18,11 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 
+from apps.catalog.ingestion.bulk_utils import ManufacturerResolver
 from apps.catalog.ingestion.wikidata_sparql import (
     WikidataManufacturer,
     fetch_manufacturer_sparql,
@@ -36,33 +36,6 @@ from apps.catalog.resolve import (
 from apps.provenance.models import Claim, Source
 
 logger = logging.getLogger(__name__)
-
-# Common business suffixes stripped during fallback name matching.
-# Order matters: longer suffixes first to avoid partial matches.
-_BUSINESS_SUFFIXES = re.compile(
-    r",?\s+(?:Manufacturing|Electronics|Industries|Enterprises"
-    r"|Games|Pinball|Technologies|Company|Corporation"
-    r"|Inc\.?|Ltd\.?|Co\.?|LLC|GmbH|S\.?A\.?|s\.?p\.?a\.?)"
-    r"$",
-    re.IGNORECASE,
-)
-
-
-def _normalize_name(name: str) -> str:
-    """Strip common business suffixes for fuzzy matching.
-
-    >>> _normalize_name("Bally Manufacturing")
-    'bally'
-    >>> _normalize_name("WMS Industries")
-    'wms'
-    """
-    stripped = _BUSINESS_SUFFIXES.sub("", name).strip()
-    # Apply repeatedly for compound suffixes like "Sega Enterprises, Ltd."
-    prev = None
-    while stripped != prev:
-        prev = stripped
-        stripped = _BUSINESS_SUFFIXES.sub("", stripped).strip()
-    return stripped.lower()
 
 
 class Command(BaseCommand):
@@ -130,22 +103,8 @@ class Command(BaseCommand):
             },
         )
 
-        # 5. Load existing Manufacturer records into lookup dicts.
-        all_mfrs = list(Manufacturer.objects.all())
-        by_name: dict[str, Manufacturer] = {m.name.lower(): m for m in all_mfrs}
-        by_trade_name: dict[str, Manufacturer] = {
-            m.trade_name.lower(): m for m in all_mfrs if m.trade_name
-        }
-        # Fallback: normalized names (business suffixes stripped).
-        # Only usable when the normalized form maps to exactly one record.
-        by_normalized: dict[str, Manufacturer | None] = {}
-        for m in all_mfrs:
-            key = _normalize_name(m.name)
-            if key in by_normalized:
-                by_normalized[key] = None  # ambiguous — disable
-            else:
-                by_normalized[key] = m
-
+        # 5. Set up manufacturer resolver and content type.
+        resolver = ManufacturerResolver()
         ct_id = ContentType.objects.get_for_model(Manufacturer).pk
 
         # 6. Match, report, collect claims.
@@ -156,12 +115,10 @@ class Command(BaseCommand):
         unmatched_count = 0
 
         for wm in wikidata_manufacturers:
-            mfr = by_name.get(wm.name.lower()) or by_trade_name.get(wm.name.lower())
+            mfr = resolver.resolve_object(wm.name)
             match_type = "exact"
             if mfr is None:
-                # Fallback: strip business suffixes and try again.
-                normalized = _normalize_name(wm.name)
-                mfr = by_normalized.get(normalized)
+                mfr = resolver.resolve_normalized_object(wm.name)
                 match_type = "normalized"
             if mfr is None:
                 unmatched_count += 1

--- a/backend/apps/catalog/tests/test_manufacturer_resolver.py
+++ b/backend/apps/catalog/tests/test_manufacturer_resolver.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from apps.catalog.ingestion.bulk_utils import ManufacturerResolver
+from apps.catalog.ingestion.bulk_utils import (
+    ManufacturerResolver,
+    normalize_manufacturer_name,
+)
 from apps.catalog.models import CorporateEntity, Manufacturer
 
 
@@ -79,3 +82,95 @@ class TestManufacturerResolver:
         slug = resolver.resolve_or_create("Acme Corp")
         assert slug != "acme"
         assert Manufacturer.objects.count() == 2
+
+    # --- resolve_normalized ---
+
+    def test_resolve_normalized_strips_suffix(self):
+        Manufacturer.objects.create(name="Bally", slug="bally")
+        resolver = ManufacturerResolver()
+        assert resolver.resolve_normalized("Bally Manufacturing") == "bally"
+
+    def test_resolve_normalized_compound_suffix(self):
+        Manufacturer.objects.create(name="Sega", slug="sega")
+        resolver = ManufacturerResolver()
+        assert resolver.resolve_normalized("Sega Enterprises, Ltd.") == "sega"
+
+    def test_resolve_normalized_ambiguous_returns_none(self):
+        Manufacturer.objects.create(name="Acme", slug="acme")
+        Manufacturer.objects.create(name="Acme Games", slug="acme-games")
+        resolver = ManufacturerResolver()
+        # Both normalize to "acme", so the lookup is ambiguous.
+        assert resolver.resolve_normalized("Acme Industries") is None
+
+    def test_resolve_normalized_no_match(self):
+        resolver = ManufacturerResolver()
+        assert resolver.resolve_normalized("Nonexistent Manufacturing") is None
+
+    # --- resolve_object ---
+
+    def test_resolve_object_returns_instance(self):
+        mfr = Manufacturer.objects.create(name="Stern", slug="stern")
+        resolver = ManufacturerResolver()
+        result = resolver.resolve_object("Stern")
+        assert result is not None
+        assert result.pk == mfr.pk
+
+    def test_resolve_object_by_trade_name(self):
+        mfr = Manufacturer.objects.create(
+            name="Midway Manufacturing", slug="bally", trade_name="Bally"
+        )
+        resolver = ManufacturerResolver()
+        result = resolver.resolve_object("Bally")
+        assert result is not None
+        assert result.pk == mfr.pk
+
+    def test_resolve_object_unknown_returns_none(self):
+        resolver = ManufacturerResolver()
+        assert resolver.resolve_object("Nonexistent") is None
+
+    # --- resolve_normalized_object ---
+
+    def test_resolve_normalized_object_returns_instance(self):
+        mfr = Manufacturer.objects.create(name="WMS", slug="wms")
+        resolver = ManufacturerResolver()
+        result = resolver.resolve_normalized_object("WMS Industries")
+        assert result is not None
+        assert result.pk == mfr.pk
+
+    def test_resolve_normalized_object_ambiguous_returns_none(self):
+        Manufacturer.objects.create(name="Acme", slug="acme")
+        Manufacturer.objects.create(name="Acme Games", slug="acme-games")
+        resolver = ManufacturerResolver()
+        assert resolver.resolve_normalized_object("Acme Industries") is None
+
+    # --- resolve_or_create populates slug_to_mfr cache ---
+
+    def test_resolve_or_create_populates_object_cache(self):
+        resolver = ManufacturerResolver()
+        slug = resolver.resolve_or_create("New Mfr")
+        result = resolver.resolve_object("New Mfr")
+        assert result is not None
+        assert result.slug == slug
+
+
+class TestNormalizeManufacturerName:
+    def test_simple_suffix(self):
+        assert normalize_manufacturer_name("Bally Manufacturing") == "bally"
+
+    def test_multiple_suffixes(self):
+        assert normalize_manufacturer_name("WMS Industries") == "wms"
+
+    def test_compound_suffix(self):
+        assert normalize_manufacturer_name("Sega Enterprises, Ltd.") == "sega"
+
+    def test_no_suffix(self):
+        assert normalize_manufacturer_name("Stern") == "stern"
+
+    def test_inc_suffix(self):
+        assert normalize_manufacturer_name("Gottlieb Inc.") == "gottlieb"
+
+    def test_gmbh_suffix(self):
+        assert normalize_manufacturer_name("Löwen GmbH") == "löwen"
+
+    def test_preserves_core_name(self):
+        assert normalize_manufacturer_name("Jersey Jack Pinball") == "jersey jack"


### PR DESCRIPTION
## Summary
- Move business-suffix stripping (`_normalize_name`, `_BUSINESS_SUFFIXES`) from `ingest_wikidata_manufacturers` into `ManufacturerResolver` as `normalize_manufacturer_name()` + `resolve_normalized()` / `resolve_normalized_object()`
- Add `resolve_object()` and `resolve_normalized_object()` methods that return `Manufacturer` instances (needed by Fandom/Wikidata callers for `.pk`, `.wikidata_id`)
- Migrate `ingest_fandom` and `ingest_wikidata_manufacturers` to use `ManufacturerResolver` instead of inline lookup dicts — Fandom gains normalized matching for free

## Test plan
- [x] 28 unit tests pass (17 new) covering normalized resolution, object resolution, ambiguity guard, and `normalize_manufacturer_name`
- [x] Full catalog test suite passes (494 tests)
- [x] Full ingest pipeline (`make ingest`) runs cleanly — 0 errors, 27/27 golden records pass
- [x] `ingest_fandom --from-dump` runs cleanly — 12/14 manufacturers matched (2 unmatched are genuinely ambiguous Stern variants)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)