### PR TITLE
feat: add entity links and fact-check system descriptions

### DIFF
--- a/data/franchises.json
+++ b/data/franchises.json
@@ -355,6 +355,11 @@
     "description": "Pinball machines based on Namco's Pac-Man video game franchise."
   },
   {
+    "slug": "phantom-of-the-opera",
+    "name": "The Phantom of the Opera",
+    "description": "Pinball machines based on The Phantom of the Opera."
+  },
+  {
     "slug": "pirates-of-the-caribbean",
     "name": "Pirates of the Caribbean",
     "description": "Pinball machines based on the Pirates of the Caribbean franchise."

--- a/data/models.json
+++ b/data/models.json
@@ -73,6 +73,13 @@
     "ipdb_id": 4432
   },
   {
+    "slug": "attila-the-hun",
+    "name": "Attila the Hun",
+    "title": "attila-the-hun",
+    "opdb_id": "GrZxD-MLO4Y",
+    "ipdb_id": 109
+  },
+  {
     "slug": "avatar-the-battle-for-pandora-collectors-edition",
     "name": "Avatar: The Battle for Pandora (Collector's Edition)",
     "title": "avatar-the-battle-for-pandora",
@@ -99,6 +106,13 @@
     "title": "avengers-infinity-quest",
     "opdb_id": "Gj66P-MXr0E-A1nx0",
     "ipdb_id": 6755
+  },
+  {
+    "slug": "banzai-run",
+    "name": "Banzai Run",
+    "title": "banzai-run",
+    "opdb_id": "GR9lZ-MkP2j",
+    "ipdb_id": 175
   },
   {
     "slug": "barry-os-barbecue-challenge-collectors-edition",
@@ -129,6 +143,13 @@
     "ipdb_id": 6354
   },
   {
+    "slug": "batman-the-dark-knight",
+    "name": "Batman: The Dark Knight",
+    "title": "batman",
+    "opdb_id": "G4yVw-M85j8",
+    "ipdb_id": 5307
+  },
+  {
     "slug": "big-dryvers",
     "name": "Big Dryvers",
     "title": "space-orbit",
@@ -143,6 +164,13 @@
     "title": "bird-watcher",
     "is_conversion": true,
     "opdb_id": "GX2zO-M5Rr4"
+  },
+  {
+    "slug": "black-hole",
+    "name": "Black Hole",
+    "title": "black-hole",
+    "opdb_id": "G41yq-MQP65",
+    "ipdb_id": 307
   },
   {
     "slug": "black-knight-limited-edition",
@@ -165,6 +193,13 @@
     "title": "black-knight-sword-of-rage",
     "opdb_id": "GD7Ld-MBRP4",
     "ipdb_id": 6568
+  },
+  {
+    "slug": "blackwater-100",
+    "name": "Blackwater 100",
+    "title": "blackwater-100",
+    "opdb_id": "G5K6X-MQjwK",
+    "ipdb_id": 319
   },
   {
     "slug": "blood-bank-billiards",
@@ -311,6 +346,20 @@
     "ipdb_id": 4984
   },
   {
+    "slug": "checkpoint",
+    "name": "Checkpoint",
+    "title": "checkpoint",
+    "opdb_id": "G4Jdp-MJNrr",
+    "ipdb_id": 498
+  },
+  {
+    "slug": "cirqus-voltaire",
+    "name": "Cirqus Voltaire",
+    "title": "cirqus-voltaire",
+    "opdb_id": "GRVjJ-MLq7W",
+    "ipdb_id": 4059
+  },
+  {
     "slug": "city-ship",
     "name": "City Ship",
     "title": "super-spin",
@@ -322,11 +371,25 @@
   {
     "slug": "cleopatra",
     "name": "Cleopatra",
+    "title": "cleopatra",
+    "opdb_id": "GrknN-MQrdv",
+    "ipdb_id": 532
+  },
+  {
+    "slug": "cleopatra-play-pool",
+    "name": "Cleopatra",
     "title": "play-pool",
     "is_conversion": true,
     "converted_from": "play-pool",
     "opdb_id": "G5n1Q-MQPRP",
     "ipdb_id": 4111
+  },
+  {
+    "slug": "comet",
+    "name": "Comet",
+    "title": "comet",
+    "opdb_id": "Gryd3-MLqjd",
+    "ipdb_id": 548
   },
   {
     "slug": "coney-island",
@@ -338,6 +401,13 @@
     "ipdb_id": 3880
   },
   {
+    "slug": "cosmic-flash",
+    "name": "Cosmic Flash",
+    "title": "cosmic-flash",
+    "opdb_id": "G5pxD-Mp48v",
+    "ipdb_id": 3639
+  },
+  {
     "slug": "cosmodrome",
     "name": "Cosmodrome",
     "title": "cosmodrome",
@@ -346,11 +416,39 @@
     "ipdb_id": 3696
   },
   {
+    "slug": "cue-ball-wizard",
+    "name": "Cue Ball Wizard",
+    "title": "cue-ball-wizard",
+    "opdb_id": "G5vPd-MJp7z",
+    "ipdb_id": 610
+  },
+  {
     "slug": "cybernaut",
     "name": "Cybernaut",
     "title": "cybernaut",
     "opdb_id": "GR69j-MW93o",
     "ipdb_id": 614
+  },
+  {
+    "slug": "cyclone",
+    "name": "Cyclone",
+    "title": "cyclone",
+    "opdb_id": "G4O2b-MJpn4",
+    "ipdb_id": 617
+  },
+  {
+    "slug": "cyclopes",
+    "name": "Cyclopes",
+    "title": "cyclopes",
+    "opdb_id": "GRwZ7-MJ7vy",
+    "ipdb_id": 619
+  },
+  {
+    "slug": "dakar",
+    "name": "Dakar",
+    "title": "dakar",
+    "opdb_id": "GR02j-MLy1Z",
+    "ipdb_id": 3629
   },
   {
     "slug": "dark-rider",
@@ -377,6 +475,13 @@
     "ipdb_id": 6559
   },
   {
+    "slug": "defender-pinball",
+    "name": "Defender",
+    "title": "defender",
+    "opdb_id": "G5p7D-MJNVo",
+    "ipdb_id": 651
+  },
+  {
     "slug": "demolition-man",
     "name": "Demolition Man",
     "title": "demolition-man",
@@ -390,6 +495,12 @@
     "is_conversion": true,
     "converted_from": "demolition-man",
     "opdb_id": "G5bv3-MePXV"
+  },
+  {
+    "slug": "dialed-in",
+    "name": "Dialed In!",
+    "title": "dialed-in",
+    "opdb_id": "G4X2l-MDqjR"
   },
   {
     "slug": "dialed-in-collectors-edition",
@@ -534,6 +645,13 @@
     "ipdb_id": 6598
   },
   {
+    "slug": "escape-from-the-lost-world",
+    "name": "Escape from the Lost World",
+    "title": "escape-from-the-lost-world",
+    "opdb_id": "G5oEz-MQ7Zw",
+    "ipdb_id": 789
+  },
+  {
     "slug": "escape-from-the-megaverse",
     "name": "Escape From The Megaverse",
     "title": "escape-from-the-megaverse",
@@ -561,6 +679,13 @@
     "opdb_id": "GYWvw-MKNP4"
   },
   {
+    "slug": "f-14-tomcat",
+    "name": "F-14 Tomcat",
+    "title": "f-14-tomcat",
+    "opdb_id": "GRY2O-MLWdy",
+    "ipdb_id": 804
+  },
+  {
     "slug": "family-guy",
     "name": "Family Guy",
     "title": "family-guy",
@@ -577,9 +702,16 @@
     "ipdb_id": 3091
   },
   {
+    "slug": "farfalla",
+    "name": "Farfalla",
+    "title": "farfalla",
+    "opdb_id": "GRVw2-M4oWO",
+    "ipdb_id": 824
+  },
+  {
     "slug": "flesh-and-blood",
     "name": "Flesh and Blood",
-    "title": "pinball-champ-82",
+    "title": "pinball-champ",
     "is_conversion": true,
     "converted_from": "pinball-champ-82",
     "opdb_id": "GrPdq-MnKwO",
@@ -656,6 +788,13 @@
     "title": "galactic-tank-force",
     "variant_of": "galactic-tank-force-classic",
     "opdb_id": "Gj6PZ-Mb5z6-A9Lbd"
+  },
+  {
+    "slug": "galaxy-stern",
+    "name": "Galaxy",
+    "title": "galaxy-stern",
+    "opdb_id": "GrdDB-ML8xK",
+    "ipdb_id": 980
   },
   {
     "slug": "gamatron",
@@ -740,6 +879,12 @@
     "ipdb_id": 1044
   },
   {
+    "slug": "goldeneye",
+    "name": "GoldenEye",
+    "title": "goldeneye",
+    "opdb_id": "G43wE-MQV5K"
+  },
+  {
     "slug": "grand-slam-rally",
     "name": "Grand Slam Rally",
     "title": "grand-slam-rally",
@@ -810,6 +955,12 @@
     "ipdb_id": 1125
   },
   {
+    "slug": "harley-davidson-bally",
+    "name": "Harley-Davidson",
+    "title": "harley-davidson-bally",
+    "opdb_id": "Gr2L0-MLOrj"
+  },
+  {
     "slug": "harry-potter-arcade-edition",
     "name": "Harry Potter (Arcade Edition)",
     "title": "harry-potter",
@@ -828,6 +979,13 @@
     "name": "Harry Potter (Wizard Edition)",
     "title": "harry-potter",
     "opdb_id": "GWyBj-MdEbK-A973V"
+  },
+  {
+    "slug": "haunted-house",
+    "name": "Haunted House",
+    "title": "haunted-house",
+    "opdb_id": "G5BP6-MJK4Z",
+    "ipdb_id": 1133
   },
   {
     "slug": "high-speed",
@@ -857,6 +1015,33 @@
     "converted_from": "space-shuttle",
     "opdb_id": "G4jyz-M5REB",
     "ipdb_id": 5118
+  },
+  {
+    "slug": "hot-fire-birds",
+    "name": "Hot Fire Birds",
+    "title": "hot-fire-birds",
+    "opdb_id": "G4xpN-MRjPo",
+    "ipdb_id": 3633
+  },
+  {
+    "slug": "hot-tip",
+    "name": "Hot Tip",
+    "title": "hot-tip",
+    "opdb_id": "Grep0-MQYN4",
+    "ipdb_id": 3163
+  },
+  {
+    "slug": "house-of-diamonds",
+    "name": "House of Diamonds",
+    "title": "house-of-diamonds",
+    "opdb_id": "GRVpL-MJjPR",
+    "ipdb_id": 3165
+  },
+  {
+    "slug": "hyperball",
+    "name": "Hyperball",
+    "title": "hyperball",
+    "ipdb_id": 3169
   },
   {
     "slug": "ice-fever",
@@ -895,6 +1080,13 @@
     "title": "iron-maiden",
     "opdb_id": "G4dOQ-MyNbb",
     "ipdb_id": 6555
+  },
+  {
+    "slug": "jack-bot",
+    "name": "Jack*Bot",
+    "title": "jack-bot",
+    "opdb_id": "GRKOX-MLyrW",
+    "ipdb_id": 3619
   },
   {
     "slug": "james-bond-007-limited-edition",
@@ -950,6 +1142,13 @@
     "name": "John Wick (Premium)",
     "title": "john-wick",
     "opdb_id": "GQK1P-Ml95Z-AOY43"
+  },
+  {
+    "slug": "joust",
+    "name": "Joust",
+    "title": "joust",
+    "opdb_id": "G4den-MLRYK",
+    "ipdb_id": 1316
   },
   {
     "slug": "jurassic-park-30th-anniversary",
@@ -1042,6 +1241,13 @@
     "ipdb_id": 1406
   },
   {
+    "slug": "laser-war",
+    "name": "Laser War",
+    "title": "laser-war",
+    "opdb_id": "G5one-MQY5V",
+    "ipdb_id": 1415
+  },
+  {
     "slug": "lawman",
     "name": "Lawman",
     "title": "lawman",
@@ -1100,6 +1306,13 @@
     "ipdb_id": 6216
   },
   {
+    "slug": "lexy-lightspeed-escape-from-earth",
+    "name": "Lexy Lightspeed: Escape from Earth",
+    "title": "lexy-lightspeed",
+    "opdb_id": "G4doo-MLEj1",
+    "ipdb_id": 6449
+  },
+  {
     "slug": "lexy-lightspeed-secret-agent-showdown",
     "name": "Lexy Lightspeed - Secret Agent Showdown",
     "title": "lexy-lightspeed-secret-agent-showdown",
@@ -1146,6 +1359,13 @@
     "ipdb_id": 4112
   },
   {
+    "slug": "lucky-seven",
+    "name": "Lucky Seven",
+    "title": "lucky-seven",
+    "opdb_id": "G5D3O-Ml9xp",
+    "ipdb_id": 3798
+  },
+  {
     "slug": "mac-jungle",
     "name": "Mac Jungle",
     "title": "macs-galaxy",
@@ -1176,6 +1396,13 @@
     "title": "mata-hari-em",
     "opdb_id": "G417e-Ml9ZE",
     "ipdb_id": 1557
+  },
+  {
+    "slug": "memory-lane",
+    "name": "Memory Lane",
+    "title": "memory-lane",
+    "opdb_id": "Gry0Z-MP3zR",
+    "ipdb_id": 1570
   },
   {
     "slug": "metallica-master-of-puppets-limited-edition",
@@ -1217,6 +1444,34 @@
     "ipdb_id": 5478
   },
   {
+    "slug": "meteor",
+    "name": "Meteor",
+    "title": "meteor",
+    "opdb_id": "G5b38-MDqkx",
+    "ipdb_id": 1580
+  },
+  {
+    "slug": "millionaire",
+    "name": "Millionaire",
+    "title": "millionaire",
+    "opdb_id": "G5n38-M1rw3",
+    "ipdb_id": 1597
+  },
+  {
+    "slug": "monte-carlo-gottlieb",
+    "name": "Monte Carlo",
+    "title": "monte-carlo-gottlieb",
+    "opdb_id": "G578Y-MJNzE",
+    "ipdb_id": 1622
+  },
+  {
+    "slug": "motor-show",
+    "name": "Motor Show",
+    "title": "motor-show",
+    "opdb_id": "GRb2y-MZezV",
+    "ipdb_id": 3631
+  },
+  {
     "slug": "mustang-limited-edition",
     "name": "Mustang (Limited Edition)",
     "title": "mustang",
@@ -1240,6 +1495,13 @@
     "ipdb_id": 3482
   },
   {
+    "slug": "night-rider",
+    "name": "Night Rider",
+    "title": "night-rider",
+    "opdb_id": "GryQj-MLvN7",
+    "ipdb_id": 4497
+  },
+  {
     "slug": "ninja-eclipse-arcade-edition",
     "name": "Ninja Eclipse (Arcade Edition)",
     "title": "ninja-eclipse",
@@ -1251,6 +1513,13 @@
     "title": "ninja-eclipse",
     "variant_of": "ninja-eclipse-arcade-edition",
     "opdb_id": "GZVXY-MyNOq-ARWE8"
+  },
+  {
+    "slug": "old-coney-island",
+    "name": "Old Coney Island!",
+    "title": "old-coney-island",
+    "opdb_id": "G4qjj-MZeyb",
+    "ipdb_id": 553
   },
   {
     "slug": "panthera",
@@ -1274,6 +1543,27 @@
     "opdb_id": "Ge1O1-MYeEB-A9wWL"
   },
   {
+    "slug": "phantom-of-the-opera",
+    "name": "The Phantom of the Opera",
+    "title": "phantom-of-the-opera",
+    "opdb_id": "Grq1D-MQokp",
+    "ipdb_id": 1777
+  },
+  {
+    "slug": "pharaoh",
+    "name": "Pharaoh",
+    "title": "pharaoh",
+    "opdb_id": "G41vn-MD1jB",
+    "ipdb_id": 1778
+  },
+  {
+    "slug": "phoenix-williams",
+    "name": "Phoenix",
+    "title": "phoenix-williams",
+    "opdb_id": "GRQp6-MJ5Wq",
+    "ipdb_id": 1780
+  },
+  {
     "slug": "pin-ball-pool",
     "name": "Pin Ball Pool",
     "title": "eight-ball-deluxe",
@@ -1285,18 +1575,32 @@
   {
     "slug": "pinball",
     "name": "Pinball",
-    "title": "pinball-champ-82",
+    "title": "pinball-champ",
     "is_conversion": true,
     "converted_from": "pinball-champ-82",
     "opdb_id": "GrPdq-MLONx",
     "ipdb_id": 3306
   },
   {
-    "slug": "pinball-champ-82",
+    "slug": "pinball-champ",
     "name": "Pinball Champ '82",
-    "title": "pinball-champ-82",
+    "title": "pinball-champ",
     "opdb_id": "GrPdq-MQYkJ",
     "ipdb_id": 1794
+  },
+  {
+    "slug": "pinball-champ-82",
+    "name": "Pinball Champ '82",
+    "title": "pinball-champ",
+    "opdb_id": "GrPdq-MQYkJ",
+    "ipdb_id": 1794
+  },
+  {
+    "slug": "pinball-stern",
+    "name": "Pinball",
+    "title": "pinball-stern",
+    "opdb_id": "GrZXj-Mq11k",
+    "ipdb_id": 1792
   },
   {
     "slug": "pirates-of-the-caribbean-collectors-edition",
@@ -1348,6 +1652,20 @@
     "opdb_id": "GV8wB-MRjKd-AOVy7"
   },
   {
+    "slug": "pokerino",
+    "name": "Pokerino",
+    "title": "pokerino",
+    "opdb_id": "G5pn8-MJ5P4",
+    "ipdb_id": 1839
+  },
+  {
+    "slug": "police-force",
+    "name": "Police Force",
+    "title": "police-force",
+    "opdb_id": "G4d8d-MVKOR",
+    "ipdb_id": 1841
+  },
+  {
     "slug": "pulp-fiction-limited-edition",
     "name": "Pulp Fiction (Limited Edition)",
     "title": "pulp-fiction",
@@ -1383,6 +1701,13 @@
     "ipdb_id": 4015
   },
   {
+    "slug": "rack-em-up",
+    "name": "Rack 'Em Up",
+    "title": "rack-em-up",
+    "opdb_id": "G4ywq-MLqxN",
+    "ipdb_id": 1902
+  },
+  {
     "slug": "ranger-in-the-ruins",
     "name": "Ranger in the Ruins",
     "title": "ranger-in-the-ruins",
@@ -1390,11 +1715,24 @@
     "opdb_id": "GLWWV-Mb5Xx"
   },
   {
+    "slug": "revenge-from-mars",
+    "name": "Revenge from Mars",
+    "title": "revenge-from-mars",
+    "opdb_id": "G50Wr-MLeZP"
+  },
+  {
     "slug": "rick-and-morty-standard-edition",
     "name": "Rick and Morty (Standard Edition)",
     "title": "rick-and-morty",
     "opdb_id": "GQKb2-MYek0",
     "ipdb_id": 6640
+  },
+  {
+    "slug": "riverboat-gambler",
+    "name": "Riverboat Gambler",
+    "title": "riverboat-gambler",
+    "opdb_id": "G4E0z-MDvl7",
+    "ipdb_id": 1966
   },
   {
     "slug": "road-racer",
@@ -1482,6 +1820,13 @@
     "opdb_id": "GllPz-MBRrV"
   },
   {
+    "slug": "scramble",
+    "name": "Scramble",
+    "title": "scramble",
+    "opdb_id": "G5p8V-MD0op",
+    "ipdb_id": 3557
+  },
+  {
     "slug": "screech",
     "name": "Screech",
     "title": "screech",
@@ -1489,6 +1834,13 @@
     "display_type": "alphanumeric",
     "opdb_id": "GPBBv-ME0x0",
     "ipdb_id": 3939
+  },
+  {
+    "slug": "secret-service",
+    "name": "Secret Service",
+    "title": "secret-service",
+    "opdb_id": "G4qqv-MDW0P",
+    "ipdb_id": 2090
   },
   {
     "slug": "sexy-girl",
@@ -1561,11 +1913,25 @@
     "ipdb_id": 3905
   },
   {
+    "slug": "solar-fire",
+    "name": "Solar Fire",
+    "title": "solar-fire",
+    "opdb_id": "GRB26-MQPwX",
+    "ipdb_id": 2238
+  },
+  {
     "slug": "sorcerers-apprentice",
     "name": "Sorcerer's Apprentice",
     "title": "sorcerers-apprentice",
     "is_conversion": true,
     "opdb_id": "G8llL-MyNwq"
+  },
+  {
+    "slug": "space-gambler",
+    "name": "Space Gambler",
+    "title": "space-gambler",
+    "opdb_id": "G5bVN-M61nY",
+    "ipdb_id": 2250
   },
   {
     "slug": "space-hawks",
@@ -1682,6 +2048,13 @@
     "ipdb_id": 6429
   },
   {
+    "slug": "stars",
+    "name": "Stars",
+    "title": "stars",
+    "opdb_id": "GrXEW-MDEwr",
+    "ipdb_id": 2366
+  },
+  {
     "slug": "stellar-airship",
     "name": "Stellar Airship",
     "title": "eight-ball",
@@ -1737,6 +2110,13 @@
     "ipdb_id": 4574
   },
   {
+    "slug": "surf-n-safari",
+    "name": "Surf 'n Safari",
+    "title": "surf-n-safari",
+    "opdb_id": "G5W0z-MLW6N",
+    "ipdb_id": 2461
+  },
+  {
     "slug": "tag-team-pinball",
     "name": "Tag-Team Pinball",
     "title": "tag-team-pinball",
@@ -1775,6 +2155,13 @@
     "title": "teenage-mutant-ninja-turtles",
     "opdb_id": "Gd2Xb-MRjpZ-A9wqN",
     "ipdb_id": 6731
+  },
+  {
+    "slug": "the-atarians",
+    "name": "The Atarians",
+    "title": "the-atarians",
+    "opdb_id": "Gry9N-MQYVj",
+    "ipdb_id": 102
   },
   {
     "slug": "the-avengers-hulk-limited-edition",
@@ -1991,6 +2378,20 @@
     "ipdb_id": 3904
   },
   {
+    "slug": "time-machine-zaccaria",
+    "name": "Time Machine",
+    "title": "time-machine-zaccaria",
+    "opdb_id": "GRnoY-MQVwx",
+    "ipdb_id": 3494
+  },
+  {
+    "slug": "torpedo-alley",
+    "name": "Torpedo Alley",
+    "title": "torpedo-alley",
+    "opdb_id": "G48on-ML8B9",
+    "ipdb_id": 2603
+  },
+  {
     "slug": "total-nuclear-annihilation",
     "name": "Total Nuclear Annihilation",
     "title": "total-nuclear-annihilation",
@@ -2049,6 +2450,13 @@
     "title": "transformers",
     "opdb_id": "GRnPz-MLBzV",
     "ipdb_id": 5709
+  },
+  {
+    "slug": "tron-legacy",
+    "name": "Disney TRON: Legacy",
+    "title": "tron",
+    "opdb_id": "GrkL5-MJoNN",
+    "ipdb_id": 5707
   },
   {
     "slug": "ultraman-kaiju-rumble-collectors-edition",
@@ -2162,6 +2570,13 @@
     "ipdb_id": 6647
   },
   {
+    "slug": "winter-sports",
+    "name": "Winter Sports",
+    "title": "winter-sports",
+    "opdb_id": "GrxWp-MDvrD",
+    "ipdb_id": 3563
+  },
+  {
     "slug": "world-defender",
     "name": "World Defender",
     "title": "world-defender",
@@ -2175,6 +2590,13 @@
     "title": "wrestlemania",
     "opdb_id": "GR6Or-MwNex",
     "ipdb_id": 6215
+  },
+  {
+    "slug": "x-force",
+    "name": "X Force",
+    "title": "x-force",
+    "opdb_id": "GRzJ1-MkPEj",
+    "ipdb_id": 3539
   },
   {
     "slug": "x-men-limited-edition",
@@ -2204,6 +2626,13 @@
     "variant_of": "x-men-limited-edition",
     "opdb_id": "Grj6X-MJNV1-AO209",
     "ipdb_id": 5824
+  },
+  {
+    "slug": "xenon",
+    "name": "Xenon",
+    "title": "xenon",
+    "opdb_id": "G42Pk-MZe2e",
+    "ipdb_id": 2821
   },
   {
     "slug": "xs-os",

--- a/data/schemas/models.schema.json
+++ b/data/schemas/models.schema.json
@@ -51,7 +51,7 @@
         "description": "Internet Pinball Database identifier"
       }
     },
-    "required": ["slug", "name", "title", "opdb_id"],
+    "required": ["slug", "name", "title"],
     "additionalProperties": false
   }
 }

--- a/data/series.json
+++ b/data/series.json
@@ -1,5 +1,10 @@
 [
   {
+    "slug": "comet",
+    "name": "Comet",
+    "description": "[[manufacturer:williams]]' amusement-park-themed trilogy: [[title:comet]] (1985), [[title:cyclone]] (1988), and Hurricane (1991). Each game featured progressively more complex rides and ramp shots."
+  },
+  {
     "slug": "eight-ball",
     "name": "Eight Ball",
     "description": "[[manufacturer:bally]]'s pool-themed trilogy spanning 1977–1985, designed by [[person:george-christian]]. [[title:eight-ball-deluxe]] became one of the best-selling pinball machines ever made."

--- a/data/systems.json
+++ b/data/systems.json
@@ -3,7 +3,7 @@
     "slug": "atari-system-1",
     "name": "Atari System 1",
     "manufacturer": "atari",
-    "description": "[[manufacturer:atari]]'s first solid-state pinball platform, used from 1976 to 1978, built around a custom discrete-logic MPU without a traditional microprocessor. It debuted with The Atarians (1976) and was used on early titles like Time 2000 and Airborne Avenger. The system used a unique design that differed significantly from the Motorola 6800-based platforms favored by competitors.",
+    "description": "[[manufacturer:atari]]'s first solid-state pinball platform, used from 1976 to 1978, built around a custom discrete-logic MPU without a traditional microprocessor. It debuted with [[title:the-atarians]] (1976) and was used on early titles like Time 2000 and Airborne Avenger. The system used a unique design that differed significantly from the Motorola 6800-based platforms favored by competitors.",
     "mpu_strings": [
       "Atari Generation/System 1"
     ],
@@ -23,7 +23,7 @@
     "slug": "atari-system-3",
     "name": "Atari System 3",
     "manufacturer": "atari",
-    "description": "[[manufacturer:atari]]'s third and final pinball hardware generation, used from approximately 1979 to 1985, built around a 6502-family CPU. Notable titles include [[title:road-runner]] (1979) and Space Invaders (1980). [[manufacturer:atari]] exited the pinball business in 1985 after declining sales.",
+    "description": "[[manufacturer:atari]]'s third and final pinball hardware generation, used from approximately 1979 to 1985, built around a 6502-family CPU. Notable titles include [[title:road-runner]] (1979). [[manufacturer:atari]] exited the pinball business in 1985 after declining sales.",
     "mpu_strings": [
       "Atari Generation/System 3"
     ],
@@ -33,7 +33,7 @@
     "slug": "bally-as2518-17",
     "name": "Bally AS-2518-17",
     "manufacturer": "bally",
-    "description": "[[manufacturer:bally]]'s first solid-state pinball MPU, introduced in 1977, based on the Motorola 6800 CPU. Used on early [[manufacturer:bally]] solid-state games such as [[title:freedom]] (1977) and Night Rider (1977). This board established [[manufacturer:bally]]'s entry into the solid-state era, replacing their earlier electromechanical designs.",
+    "description": "[[manufacturer:bally]]'s first solid-state pinball MPU, introduced in 1977, based on the Motorola 6800 CPU. Used on early [[manufacturer:bally]] solid-state games such as [[title:freedom]] (1977) and [[title:night-rider]] (1977). This board established [[manufacturer:bally]]'s entry into the solid-state era, replacing their earlier electromechanical designs.",
     "mpu_strings": [
       "Bally MPU AS-2518-17"
     ],
@@ -43,7 +43,7 @@
     "slug": "bally-as2518-35",
     "name": "Bally AS-2518-35",
     "manufacturer": "bally",
-    "description": "An updated version of [[manufacturer:bally]]'s 6800-based MPU, used from approximately 1979 to 1981. This board added support for more complex game rules and additional hardware features over the -17 board. Notable games include Xenon (1980), one of the first pinball machines with synthesized speech, and [[title:eight-ball-deluxe]] (1981).",
+    "description": "An updated version of [[manufacturer:bally]]'s 6800-based MPU, used from approximately 1979 to 1981. This board added support for more complex game rules and additional hardware features over the -17 board. Notable games include [[title:xenon]] (1980), one of the first pinball machines with synthesized speech, and [[title:eight-ball-deluxe]] (1981).",
     "mpu_strings": [
       "Bally MPU AS-2518-35"
     ],
@@ -73,7 +73,7 @@
     "slug": "bally-6803",
     "name": "Bally 6803",
     "manufacturer": "bally",
-    "description": "[[manufacturer:bally]]/Midway's mid-1980s pinball platform, based on the Motorola 6803 CPU, used from approximately 1985 to 1989. Notable titles include [[title:cybernaut]] (1985), Escape from the Lost World (1987), and Blackwater 100 (1988). This was the last [[manufacturer:bally]]-designed system before [[manufacturer:williams]] acquired [[manufacturer:bally]]/Midway.",
+    "description": "[[manufacturer:bally]]/Midway's mid-1980s pinball platform, based on the Motorola 6803 CPU, used from approximately 1985 to 1989. Notable titles include [[title:cybernaut]] (1985), [[title:escape-from-the-lost-world]] (1987), and [[title:blackwater-100]] (1988). This was the last [[manufacturer:bally]]-designed system before [[manufacturer:williams]] acquired [[manufacturer:bally]]/Midway.",
     "mpu_strings": [
       "Bally MPU A084-91786-AH06 (6803)"
     ],
@@ -93,7 +93,7 @@
     "slug": "cgc-pinball-controller-os",
     "name": "CGC Pinball Controller/OS",
     "manufacturer": "chicago-gaming",
-    "description": "The proprietary hardware and operating system developed by [[manufacturer:chicago-gaming]] Company for their recreation and remake pinball machines, including [[title:medieval-madness]] Remake (2014), [[title:attack-from-mars]] Remake (2017), and Cactus Canyon Continued (2019). The system uses modern embedded processors to faithfully reproduce classic [[manufacturer:williams]] WPC-era gameplay while adding new features and improved reliability.",
+    "description": "The proprietary hardware and operating system developed by [[manufacturer:chicago-gaming]] Company for their recreation and remake pinball machines, including [[title:medieval-madness]] Remake (2014), [[title:attack-from-mars]] Remake (2017), and [[title:cactus-canyon-remake]] (2019). The system uses modern embedded processors to faithfully reproduce classic [[manufacturer:williams]] WPC-era gameplay while adding new features and improved reliability.",
     "mpu_strings": [
       "CGC Pinball Controller/OS"
     ],
@@ -103,7 +103,7 @@
     "slug": "data-east-v1",
     "name": "Data East/Sega Version 1",
     "manufacturer": "data-east",
-    "description": "[[manufacturer:data-east]]'s first pinball hardware platform, introduced in 1987, based on the Motorola 6808 CPU. It featured an alphanumeric segmented display. Early titles include Laser War (1987), [[manufacturer:data-east]]'s first pinball machine, and Secret Service (1988).",
+    "description": "[[manufacturer:data-east]]'s first pinball hardware platform, introduced in 1987, based on the Motorola 6808 CPU. It featured an alphanumeric segmented display. It debuted with [[title:laser-war]] (1987), [[manufacturer:data-east]]'s first pinball machine.",
     "mpu_strings": [
       "DataEast/Sega Version 1"
     ],
@@ -113,7 +113,7 @@
     "slug": "data-east-v2",
     "name": "Data East/Sega Version 2",
     "manufacturer": "data-east",
-    "description": "[[manufacturer:data-east]]'s second-generation platform, introduced around 1989, transitioning to a more capable processor and adding support for 128x16 dot-matrix displays. Notable games include Checkpoint (1991), one of the earliest DMD pinball machines, and [[title:star-wars-data-east]] (1992).",
+    "description": "[[manufacturer:data-east]]'s second-generation platform, introduced around 1988, featuring an upgraded processor while retaining alphanumeric segmented displays. Notable games include [[title:secret-service]] (1988), [[title:torpedo-alley]] (1988), [[title:robocop]] (1989), and [[title:phantom-of-the-opera]] (1990). The platform was succeeded by [[system:data-east-v3]], which introduced dot-matrix displays.",
     "mpu_strings": [
       "DataEast/Sega Version 2"
     ],
@@ -123,7 +123,7 @@
     "slug": "data-east-v3",
     "name": "Data East/Sega Version 3",
     "manufacturer": "data-east",
-    "description": "The third revision of the [[manufacturer:data-east]] pinball hardware, used in the early-to-mid 1990s, with an upgraded processor and enhanced sound capabilities. This platform was used on popular titles like [[title:jurassic-park]] (1993), [[title:last-action-hero]] (1993), and [[title:tales-from-the-crypt]] (1993). It featured a 128x32 DMD.",
+    "description": "The third revision of the [[manufacturer:data-east]] pinball hardware, used from 1990 to 1994, with an upgraded processor and enhanced sound capabilities. Early Version 3 games used alphanumeric displays, but [[title:checkpoint]] (1991) introduced [[manufacturer:data-east]]'s first 128x16 dot-matrix display, making it one of the earliest DMD pinball machines. Later titles transitioned to a 128x32 DMD, including [[title:star-wars-data-east]] (1992), [[title:jurassic-park]] (1993), [[title:last-action-hero]] (1993), and [[title:tales-from-the-crypt]] (1993).",
     "mpu_strings": [
       "DataEast/Sega Version 3"
     ],
@@ -153,7 +153,7 @@
     "slug": "game-plan-mpu-1",
     "name": "Game Plan MPU-1",
     "manufacturer": "game-plan",
-    "description": "[[manufacturer:game-plan]]'s first solid-state pinball MPU, used from approximately 1978 to 1980, based on the Motorola 6800 CPU. [[manufacturer:game-plan]] was founded by former [[manufacturer:genco]]/[[manufacturer:chicago-coin]] personnel. Early titles include [[title:sharpshooter]] (1979) and Old Coney Island! (1979).",
+    "description": "[[manufacturer:game-plan]]'s first solid-state pinball MPU, used from approximately 1978 to 1980, based on the Motorola 6800 CPU. [[manufacturer:game-plan]] was founded by former [[manufacturer:genco]]/[[manufacturer:chicago-coin]] personnel. Early titles include [[title:sharpshooter]] (1979) and [[title:old-coney-island]] (1979).",
     "mpu_strings": [
       "Game Plan MPU-1"
     ],
@@ -163,7 +163,7 @@
     "slug": "game-plan-mpu-2",
     "name": "Game Plan MPU-2",
     "manufacturer": "game-plan",
-    "description": "[[manufacturer:game-plan]]'s second-generation MPU, used from approximately 1981 to 1985. It offered expanded capabilities over the MPU-1 while retaining the 6800-family architecture. Notable games include Attila the Hun (1984) and Cyclopes (1985). [[manufacturer:game-plan]] exited the pinball industry in the mid-1980s.",
+    "description": "[[manufacturer:game-plan]]'s second-generation MPU, used from approximately 1981 to 1985. It offered expanded capabilities over the MPU-1 while retaining the 6800-family architecture. Notable games include [[title:attila-the-hun]] (1984) and [[title:cyclopes]] (1985). [[manufacturer:game-plan]] exited the pinball industry in the mid-1980s.",
     "mpu_strings": [
       "Game Plan MPU-2"
     ],
@@ -173,7 +173,7 @@
     "slug": "gottlieb-system-1",
     "name": "Gottlieb System 1",
     "manufacturer": "gottlieb",
-    "description": "[[manufacturer:gottlieb]]'s first solid-state pinball system, introduced in 1977, based on the Rockwell PPS-4, a 4-bit microprocessor. It debuted with Cleopatra (1977) and was used on titles like [[title:close-encounters]] (1978) and [[title:sinbad]] (1978). The unusual choice of a 4-bit CPU made these boards distinctive among competitors who favored 8-bit Motorola processors.",
+    "description": "[[manufacturer:gottlieb]]'s first solid-state pinball system, introduced in 1977, based on the Rockwell PPS-4, a 4-bit microprocessor. It debuted with [[title:cleopatra]] (1977) and was used on titles like [[title:close-encounters]] (1978) and [[title:sinbad]] (1978). The unusual choice of a 4-bit CPU made these boards distinctive among competitors who favored 8-bit Motorola processors.",
     "mpu_strings": [
       "Gottlieb System 1"
     ],
@@ -183,7 +183,7 @@
     "slug": "gottlieb-system-80",
     "name": "Gottlieb System 80",
     "manufacturer": "gottlieb",
-    "description": "[[manufacturer:gottlieb]]'s second major solid-state platform, introduced around 1980, switching to a Rockwell 6502 CPU. Games include Haunted House (1982), notable as the first three-level playfield pinball, and Black Hole (1981), the first multi-level pinball. The system used 6- and 7-digit numeric displays.",
+    "description": "[[manufacturer:gottlieb]]'s second major solid-state platform, introduced around 1980, switching to a Rockwell 6502 CPU. Games include [[title:haunted-house]] (1982), notable as the first three-level playfield pinball, and [[title:black-hole]] (1981), the first multi-level pinball. The system used 6- and 7-digit numeric displays.",
     "mpu_strings": [
       "Gottlieb System 80"
     ],
@@ -193,7 +193,7 @@
     "slug": "gottlieb-system-80a",
     "name": "Gottlieb System 80A",
     "manufacturer": "gottlieb",
-    "description": "An incremental update to [[manufacturer:gottlieb]]'s System 80, introduced around 1983, retaining the 6502 CPU but adding alphanumeric displays for more expressive scoring and messaging. Games include Rack 'Em Up (1983) and other mid-1980s [[manufacturer:gottlieb]]/Mylstar titles.",
+    "description": "An incremental update to [[manufacturer:gottlieb]]'s System 80, introduced around 1983, retaining the 6502 CPU but adding alphanumeric displays for more expressive scoring and messaging. Games include [[title:rack-em-up]] (1983) and other mid-1980s [[manufacturer:gottlieb]]/Mylstar titles.",
     "mpu_strings": [
       "Gottlieb System 80A"
     ],
@@ -203,7 +203,7 @@
     "slug": "gottlieb-system-80b",
     "name": "Gottlieb System 80B",
     "manufacturer": "gottlieb",
-    "description": "A further evolution of the System 80 line, used from approximately 1985 to 1989, still 6502-based but with enhanced sound hardware featuring a Yamaha YM2151 synthesis chip and DAC for digitized speech. Notable games include Monte Carlo (1987) and Bone Busters Inc. (1989).",
+    "description": "A further evolution of the System 80 line, used from approximately 1985 to 1989, still 6502-based but with enhanced sound hardware featuring a Yamaha YM2151 synthesis chip and DAC for digitized speech. Notable games include [[title:monte-carlo-gottlieb]] (1987) and [[title:bone-busters-inc]] (1989).",
     "mpu_strings": [
       "Gottlieb System 80B"
     ],
@@ -213,7 +213,7 @@
     "slug": "gottlieb-system-3",
     "name": "Gottlieb System 3",
     "manufacturer": "gottlieb",
-    "description": "[[manufacturer:gottlieb]]'s final pinball hardware platform, used from 1989 to 1996, featuring a 65C02 CPU and a 128x32 dot-matrix display. Notable games include Surf 'n Safari (1991), Cue Ball Wizard (1992), and [[title:stargate]] (1995). Premier Technology ([[manufacturer:gottlieb]]'s parent) exited pinball in 1996.",
+    "description": "[[manufacturer:gottlieb]]'s final pinball hardware platform, used from 1989 to 1996, featuring a 65C02 CPU and a 128x32 dot-matrix display. Notable games include [[title:surf-n-safari]] (1991), [[title:cue-ball-wizard]] (1992), and [[title:stargate]] (1995). Premier Technology ([[manufacturer:gottlieb]]'s parent) exited pinball in 1996.",
     "mpu_strings": [
       "Gottlieb System 3"
     ],
@@ -233,7 +233,7 @@
     "slug": "jersey-jack",
     "name": "Jersey Jack",
     "manufacturer": "jersey-jack",
-    "description": "[[manufacturer:jersey-jack]]'s hardware platform, debuting with [[title:the-wizard-of-oz]] (2013), built around an Intel Celeron PC-class processor running Linux. It features a full-color high-definition LCD display in the backbox, RGB LED lighting throughout, and sophisticated audio. Subsequent titles include [[title:the-hobbit]] (2016), Dialed In! (2017), [[title:pirates-of-the-caribbean-jersey-jack-pinball]] (2018), and [[title:guns-n-roses-jersey-jack-pinball]] (2020).",
+    "description": "[[manufacturer:jersey-jack]]'s hardware platform, debuting with [[title:the-wizard-of-oz]] (2013), built around an Intel Celeron PC-class processor running Linux. It features a full-color high-definition LCD display in the backbox, RGB LED lighting throughout, and sophisticated audio. Subsequent titles include [[title:the-hobbit]] (2016), [[title:dialed-in]] (2017), [[title:pirates-of-the-caribbean-jersey-jack-pinball]] (2018), and [[title:guns-n-roses-jersey-jack-pinball]] (2020).",
     "mpu_strings": [
       "Intel Celeron"
     ],
@@ -273,7 +273,7 @@
     "slug": "mr-game-1b11188-0",
     "name": "Mr. Game 1B11188/0",
     "manufacturer": "mr-game",
-    "description": "The MPU used by [[manufacturer:mr-game]], an Italian pinball manufacturer active in the late 1980s and early 1990s. The platform was used on a small number of titles including Dakar (1988) and Motor Show (1988).",
+    "description": "The MPU used by [[manufacturer:mr-game]], an Italian pinball manufacturer active in the late 1980s and early 1990s. The platform was used on a small number of titles including [[title:dakar]] (1988) and [[title:motor-show]] (1988).",
     "mpu_strings": [
       "Mr. Game 1B11188/0"
     ],
@@ -293,7 +293,7 @@
     "slug": "multimorphic-p3-roc",
     "name": "Multimorphic P3-ROC",
     "manufacturer": "multimorphic",
-    "description": "[[manufacturer:multimorphic]]'s next-generation pinball control platform, designed specifically for their P3 modular pinball platform rather than retrofitting existing machines. It uses an FPGA-based architecture paired with a host computer running Linux and features an integrated LCD playfield display capability. The P3 platform debuted with Lexy Lightspeed: Escape from Earth and supports swappable game modules.",
+    "description": "[[manufacturer:multimorphic]]'s next-generation pinball control platform, designed specifically for their P3 modular pinball platform rather than retrofitting existing machines. It uses an FPGA-based architecture paired with a host computer running Linux and features an integrated LCD playfield display capability. The P3 platform debuted with [[title:lexy-lightspeed]]: Escape from Earth and supports swappable game modules.",
     "mpu_strings": [
       "Multimorphic P3-ROC"
     ],
@@ -303,7 +303,7 @@
     "slug": "nsm-control-unit-217838",
     "name": "NSM Control-Unit 217838",
     "manufacturer": "nsm",
-    "description": "The pinball control unit used by NSM (NSM-Löwen), a German manufacturer better known for jukeboxes, during their brief foray into pinball in the mid-1980s. NSM produced only a small number of pinball titles, including Hot Fire Birds (1985) and Cosmic Flash (1985).",
+    "description": "The pinball control unit used by NSM (NSM-Löwen), a German manufacturer better known for jukeboxes, during their brief foray into pinball in the mid-1980s. NSM produced only a small number of pinball titles, including [[title:hot-fire-birds]] (1985) and [[title:cosmic-flash]] (1985).",
     "mpu_strings": [
       "NSM Control-Unit 217838"
     ],
@@ -313,7 +313,7 @@
     "slug": "playmatic-mpu-1",
     "name": "Playmatic MPU-1",
     "manufacturer": "playmatic",
-    "description": "[[manufacturer:playmatic]]'s first solid-state pinball MPU, used by the Spanish manufacturer [[manufacturer:playmatic]] (Automáticos Montecarlo) beginning in the late 1970s. Based on a CDP 1802 COSMAC processor, an unusual choice that set [[manufacturer:playmatic]] apart from American manufacturers. Early titles include Space Gambler (1978).",
+    "description": "[[manufacturer:playmatic]]'s first solid-state pinball MPU, used by the Spanish manufacturer [[manufacturer:playmatic]] (Automáticos Montecarlo) beginning in the late 1970s. Based on a CDP 1802 COSMAC processor, an unusual choice that set [[manufacturer:playmatic]] apart from American manufacturers. Early titles include [[title:space-gambler]] (1978).",
     "mpu_strings": [
       "Playmatic MPU 1"
     ],
@@ -394,7 +394,7 @@
     "slug": "sega-95680",
     "name": "Sega 95680",
     "manufacturer": "sega",
-    "description": "A [[manufacturer:sega]] Pinball hardware board from the mid-1990s, part of the evolutionary line from [[manufacturer:data-east]]'s Version 3 platform. It featured a 128x32 DMD and enhanced sound capabilities. Titles on this or adjacent revisions include [[title:apollo-13]] (1995) and GoldenEye (1996).",
+    "description": "A [[manufacturer:sega]] Pinball hardware board from the mid-1990s, part of the evolutionary line from [[manufacturer:data-east]]'s Version 3 platform. It featured a 128x32 DMD and enhanced sound capabilities. Titles on this or adjacent revisions include [[title:apollo-13]] (1995) and [[title:goldeneye]] (1996).",
     "mpu_strings": [
       "Sega 95680"
     ],
@@ -434,7 +434,7 @@
     "slug": "stern-mpu-100",
     "name": "Stern MPU-100",
     "manufacturer": "stern-electronics",
-    "description": "[[manufacturer:stern-electronics]]' first solid-state pinball MPU, introduced in 1977, based on the Motorola 6800 CPU. It was used on early [[manufacturer:stern-electronics]] solid-state titles including Pinball (1977), Stars (1978), and Memory Lane (1978). The MPU-100 established [[manufacturer:stern-electronics]]'s entry into the solid-state era.",
+    "description": "[[manufacturer:stern-electronics]]' first solid-state pinball MPU, introduced in 1977, based on the Motorola 6800 CPU. It was used on early [[manufacturer:stern-electronics]] solid-state titles including [[title:pinball-stern]] (1977), [[title:stars]] (1978), and [[title:memory-lane]] (1978). The MPU-100 established [[manufacturer:stern-electronics]]'s entry into the solid-state era.",
     "mpu_strings": [
       "Stern M-100 MPU"
     ],
@@ -444,7 +444,7 @@
     "slug": "stern-mpu-200",
     "name": "Stern MPU-200",
     "manufacturer": "stern-electronics",
-    "description": "[[manufacturer:stern-electronics]]' updated solid-state platform, introduced around 1979, still based on the Motorola 6800 architecture with additional capabilities over the MPU-100. Notable games include Meteor (1979), Galaxy (1980), and [[title:flight-2000]] (1980). [[manufacturer:stern-electronics]] closed in 1985, unrelated to the later [[manufacturer:stern-pinball]] founded by [[person:gary-stern]] in 1999.",
+    "description": "[[manufacturer:stern-electronics]]' updated solid-state platform, introduced around 1979, still based on the Motorola 6800 architecture with additional capabilities over the MPU-100. Notable games include [[title:meteor]] (1979), [[title:galaxy-stern]] (1980), and [[title:flight-2000]] (1980). [[manufacturer:stern-electronics]] closed in 1985, unrelated to the later [[manufacturer:stern-pinball]] founded by [[person:gary-stern]] in 1999.",
     "mpu_strings": [
       "Stern M-200 MPU"
     ],
@@ -464,7 +464,7 @@
     "slug": "stern-sam",
     "name": "Stern SAM",
     "manufacturer": "stern-pinball",
-    "description": "[[manufacturer:stern-pinball]]'s S.A.M. (Stern Army Manufacturing) Board System, introduced in 2006 as the successor to [[system:stern-whitestar]], based on an Atmel AT91SAM9 ARM processor. It featured a 128x32 DMD and improved processing power. Used on popular titles including [[title:spider-man]] (2007), Batman: The Dark Knight (2008), [[title:iron-man]] (2010), Tron: Legacy (2011), [[title:the-avengers]] (2012), and [[title:metallica]] (2013).",
+    "description": "[[manufacturer:stern-pinball]]'s S.A.M. (Stern Army Manufacturing) Board System, introduced in 2006 as the successor to [[system:stern-whitestar]], based on an Atmel AT91SAM9 ARM processor. It featured a 128x32 DMD and improved processing power. Used on popular titles including [[title:spider-man]] (2007), [[title:batman]] (2008), [[title:iron-man]] (2010), [[title:tron]] (2011), [[title:the-avengers]] (2012), and [[title:metallica]] (2013).",
     "mpu_strings": [
       "Stern S.A.M. Board System"
     ],
@@ -474,7 +474,7 @@
     "slug": "stern-spike-1",
     "name": "Stern SPIKE",
     "manufacturer": "stern-pinball",
-    "description": "[[manufacturer:stern-pinball]]'s SPIKE hardware platform, introduced in 2014 with WWE Wrestlemania, replacing the SAM system. It uses a distributed node-based architecture where small processor boards throughout the cabinet and playfield connect via a serial bus to a central Linux-based CPU board. Early SPIKE games used a 128x32 DMD; titles include [[title:game-of-thrones]] (2015) and [[title:ghostbusters]] (2016).",
+    "description": "[[manufacturer:stern-pinball]]'s SPIKE hardware platform, introduced in 2014 with [[title:wrestlemania]], replacing the SAM system. It uses a distributed node-based architecture where small processor boards throughout the cabinet and playfield connect via a serial bus to a central Linux-based CPU board. Early SPIKE games used a 128x32 DMD; titles include [[title:game-of-thrones]] (2015) and [[title:ghostbusters]] (2016).",
     "mpu_strings": [
       "Stern SPIKE System",
       "Stern SPIKE\u00ae System"
@@ -506,7 +506,7 @@
     "slug": "tecnoplay-2-2c-8008-ls-68000-cpu",
     "name": "Tecnoplay \"2-2C 8008 LS\" (68000 CPU)",
     "manufacturer": "tecnoplay",
-    "description": "A pinball hardware system from [[manufacturer:tecnoplay]], an Italian manufacturer active in the late 1980s, featuring a Motorola 68000 CPU. [[manufacturer:tecnoplay]] produced a small number of titles including Scramble (1987) and Xforce (1987). The 68000 was a notably powerful processor choice for pinball at the time.",
+    "description": "A pinball hardware system from [[manufacturer:tecnoplay]], an Italian manufacturer active in the late 1980s, featuring a Motorola 68000 CPU. [[manufacturer:tecnoplay]] produced a small number of titles including [[title:scramble]] (1987) and [[title:x-force]] (1987). The 68000 was a notably powerful processor choice for pinball at the time.",
     "mpu_strings": [
       "Technoplay \"2-2C 8008 LS\" (68000 CPU)"
     ],
@@ -516,7 +516,7 @@
     "slug": "williams-system-3",
     "name": "Williams System 3",
     "manufacturer": "williams",
-    "description": "[[manufacturer:williams]]' first solid-state pinball platform, introduced in 1977, based on the Motorola 6800-family architecture. It debuted with Hot Tip (1977) and Lucky Seven (1977). The system used 6-digit numeric displays and established [[manufacturer:williams]]' solid-state design philosophy.",
+    "description": "[[manufacturer:williams]]' first solid-state pinball platform, introduced in 1977, based on the Motorola 6800-family architecture. It debuted with [[title:hot-tip]] (1977) and [[title:lucky-seven]] (1977). The system used 6-digit numeric displays and established [[manufacturer:williams]]' solid-state design philosophy.",
     "mpu_strings": [
       "Williams System 3"
     ],
@@ -526,7 +526,7 @@
     "slug": "williams-system-4",
     "name": "Williams System 4",
     "manufacturer": "williams",
-    "description": "An incremental update to [[manufacturer:williams]] System 3, introduced in 1978, retaining the 6800-family CPU. Games include Phoenix (1978) and Pokerino (1978). The update primarily addressed minor hardware revisions and manufacturing improvements.",
+    "description": "An incremental update to [[manufacturer:williams]] System 3, introduced in 1978, retaining the 6800-family CPU. Games include [[title:phoenix-williams]] (1978) and [[title:pokerino]] (1978). The update primarily addressed minor hardware revisions and manufacturing improvements.",
     "mpu_strings": [
       "Williams System 4"
     ],
@@ -556,7 +556,7 @@
     "slug": "williams-system-7",
     "name": "Williams System 7",
     "manufacturer": "williams",
-    "description": "Introduced in 1981, System 7 evolved from System 6 with the same Motorola 6808 CPU but added electronically-controlled coin lockout, improved diagnostic features, and better speech synthesis support. Notable games include Pharaoh (1981), Solar Fire (1981), Hyperball (1981), Defender (1982), and Joust (1983).",
+    "description": "Introduced in 1981, System 7 evolved from System 6 with the same Motorola 6808 CPU but added electronically-controlled coin lockout, improved diagnostic features, and better speech synthesis support. Notable games include [[title:pharaoh]] (1981), [[title:solar-fire]] (1981), [[title:hyperball]] (1981), [[title:defender]] (1982), and [[title:joust]] (1983).",
     "mpu_strings": [
       "Williams System 7"
     ],
@@ -576,7 +576,7 @@
     "slug": "williams-system-9",
     "name": "Williams System 9",
     "manufacturer": "williams",
-    "description": "Introduced in 1985, [[manufacturer:williams]] System 9 used the Motorola 6802 CPU and was a short-lived transitional platform between System 7 and System 11. Only a small number of games were produced, including [[title:space-shuttle]] (1984) and Comet (1985). It featured improved sound capabilities.",
+    "description": "Introduced in 1984, [[manufacturer:williams]] System 9 used the Motorola 6802 CPU and was a short-lived transitional platform between System 7 and System 11. Only a small number of games were produced, including [[title:space-shuttle]] (1984) and [[title:comet]] (1985). It featured improved sound capabilities.",
     "mpu_strings": [
       "Williams System 9"
     ],
@@ -596,7 +596,7 @@
     "slug": "williams-system-11",
     "name": "Williams System 11",
     "manufacturer": "williams",
-    "description": "Introduced in 1986, [[manufacturer:williams]] System 11 used a Motorola 6802 CPU and was the first [[manufacturer:williams]] platform to feature alphanumeric segmented displays with full text capability. It introduced background music and advanced sound via a separate sound board. The first System 11 game was [[title:high-speed]] (1986), designed by Steve Ritchie. Other notable titles include [[title:pinbot]] (1986) and F-14 Tomcat (1987).",
+    "description": "Introduced in 1986, [[manufacturer:williams]] System 11 used a Motorola 6802 CPU and was the first [[manufacturer:williams]] platform to feature alphanumeric segmented displays with full text capability. It introduced background music and advanced sound via a separate sound board. The first System 11 game was [[title:high-speed]] (1986), designed by Steve Ritchie. Other notable titles include [[title:pinbot]] (1986) and [[title:f-14-tomcat]] (1987).",
     "mpu_strings": [
       "Williams System 11"
     ],
@@ -606,7 +606,7 @@
     "slug": "williams-system-11a",
     "name": "Williams System 11A",
     "manufacturer": "williams",
-    "description": "A revision of [[manufacturer:williams]] System 11, introduced in 1987, with updated sound hardware. Notable games include Millionaire (1987) and F-14 Tomcat (1987). The A revision primarily improved the audio subsystem.",
+    "description": "A revision of [[manufacturer:williams]] System 11, introduced in 1987, with updated sound hardware. Notable games include [[title:millionaire]] (1987) and [[title:f-14-tomcat]] (1987). The A revision primarily improved the audio subsystem.",
     "mpu_strings": [
       "Williams System 11A"
     ],
@@ -616,7 +616,7 @@
     "slug": "williams-system-11b",
     "name": "Williams System 11B",
     "manufacturer": "williams",
-    "description": "A further revision of System 11, used from approximately 1988 to 1989, with continued refinements to the sound and control hardware. Notable games include Cyclone (1988), Banzai Run (1988) with its vertical backbox playfield, and Police Force (1989).",
+    "description": "A further revision of System 11, used from approximately 1988 to 1989, with continued refinements to the sound and control hardware. Notable games include [[title:cyclone]] (1988), [[title:banzai-run]] (1988) with its vertical backbox playfield, and [[title:police-force]] (1989).",
     "mpu_strings": [
       "Williams System 11B"
     ],
@@ -626,7 +626,7 @@
     "slug": "williams-system-11c",
     "name": "Williams System 11C",
     "manufacturer": "williams",
-    "description": "The final revision of the System 11 line, used from approximately 1989 to 1990, bridging the gap to the WPC era. Notable games include Riverboat Gambler (1990) and [[title:rollergames]] (1990). By this point [[manufacturer:williams]] was developing the WPC platform that would define the 1990s.",
+    "description": "The final revision of the System 11 line, used from approximately 1989 to 1990, bridging the gap to the WPC era. Notable games include [[title:riverboat-gambler]] (1990) and [[title:rollergames]] (1990). By this point [[manufacturer:williams]] was developing the WPC platform that would define the 1990s.",
     "mpu_strings": [
       "Williams System 11C"
     ],
@@ -636,7 +636,7 @@
     "slug": "williams-wpc-alphanumeric",
     "name": "Williams WPC Alphanumeric",
     "manufacturer": "williams",
-    "description": "The first generation of [[manufacturer:williams]]' WPC ([[manufacturer:williams]] Pinball Controller) platform, introduced in 1990, using a Motorola 6809 CPU. This initial version retained alphanumeric segmented displays. [[title:funhouse]] (1990) and Harley-Davidson (1991) are notable titles. It established the WPC architecture that would dominate the 1990s.",
+    "description": "The first generation of [[manufacturer:williams]]' WPC ([[manufacturer:williams]] Pinball Controller) platform, introduced in 1990, using a Motorola 6809 CPU. This initial version retained alphanumeric segmented displays. [[title:funhouse]] (1990) and [[title:harley-davidson-bally]] (1991) are notable titles. It established the WPC architecture that would dominate the 1990s.",
     "mpu_strings": [
       "Williams WPC (Alpha Numeric)"
     ],
@@ -686,7 +686,7 @@
     "slug": "williams-wpc-s",
     "name": "Williams WPC-S",
     "manufacturer": "williams",
-    "description": "WPC-Security, introduced in 1994, added an ASIC security chip to combat ROM piracy and bootleg copies. It retained the DCS sound system. Notable games include [[title:the-flintstones]] (1994), [[title:johnny-mnemonic]] (1995), Jack*Bot (1995), and [[title:no-fear]] (1995).",
+    "description": "WPC-Security, introduced in 1994, added an ASIC security chip to combat ROM piracy and bootleg copies. It retained the DCS sound system. Notable games include [[title:the-flintstones]] (1994), [[title:johnny-mnemonic]] (1995), [[title:jack-bot]] (1995), and [[title:no-fear]] (1995).",
     "mpu_strings": [
       "Williams WPC Security (WPC-S)"
     ],
@@ -696,7 +696,7 @@
     "slug": "wpc-95",
     "name": "Williams WPC-95",
     "manufacturer": "williams",
-    "description": "The final major WPC revision, introduced in 1995, featuring a redesigned and consolidated main board that reduced component count and manufacturing cost. Notable games include [[title:congo]] (1995), [[title:attack-from-mars]] (1995), [[title:medieval-madness]] (1997), Cirqus Voltaire (1997), and [[title:monster-bash]] (1998) — several of which are among the most sought-after pinball machines ever made.",
+    "description": "The final major WPC revision, introduced in 1995, featuring a redesigned and consolidated main board that reduced component count and manufacturing cost. Notable games include [[title:congo]] (1995), [[title:attack-from-mars]] (1995), [[title:medieval-madness]] (1997), [[title:cirqus-voltaire]] (1997), and [[title:monster-bash]] (1998) — several of which are among the most sought-after pinball machines ever made.",
     "mpu_strings": [
       "Williams WPC-95"
     ],
@@ -706,7 +706,7 @@
     "slug": "williams-pinball-2000",
     "name": "Williams Pinball 2000",
     "manufacturer": "williams",
-    "description": "[[manufacturer:williams]]' final pinball platform, introduced in 1999, which projected video game-style graphics onto the playfield glass using a monitor and half-mirror (Pepper's ghost effect), blending video imagery with the physical playfield. Based on a PC-class Intel Pentium processor. Only two games were produced — Revenge from Mars (1999) and [[title:star-wars-episode-i]] (1999) — before [[manufacturer:williams]]/[[manufacturer:bally]]/Midway exited the pinball business entirely in October 1999.",
+    "description": "[[manufacturer:williams]]' final pinball platform, introduced in 1999, which projected video game-style graphics onto the playfield glass using a monitor and half-mirror (Pepper's ghost effect), blending video imagery with the physical playfield. Based on a PC-class Intel Pentium processor. Only two games were produced — [[title:revenge-from-mars]] (1999) and [[title:star-wars-episode-i]] (1999) — before [[manufacturer:williams]]/[[manufacturer:bally]]/Midway exited the pinball business entirely in October 1999.",
     "mpu_strings": [
       "Williams Pinball 2000"
     ],
@@ -716,7 +716,7 @@
     "slug": "zaccaria-gen-1",
     "name": "Zaccaria Generation 1",
     "manufacturer": "zaccaria",
-    "description": "[[manufacturer:zaccaria]]'s first solid-state pinball platform, introduced in the late 1970s by the Italian manufacturer, based on the Signetics 2650 processor — a unique choice among pinball manufacturers. Games include Winter Sports (1978) and House of Diamonds (1978). [[manufacturer:zaccaria]] was one of the most prolific European pinball manufacturers of the era.",
+    "description": "[[manufacturer:zaccaria]]'s first solid-state pinball platform, introduced in the late 1970s by the Italian manufacturer, based on the Signetics 2650 processor — a unique choice among pinball manufacturers. Games include [[title:winter-sports]] (1978) and [[title:house-of-diamonds]] (1978). [[manufacturer:zaccaria]] was one of the most prolific European pinball manufacturers of the era.",
     "mpu_strings": [
       "Zaccaria Generation 1"
     ],
@@ -726,7 +726,7 @@
     "slug": "zaccaria-gen-2",
     "name": "Zaccaria Generation 2",
     "manufacturer": "zaccaria",
-    "description": "[[manufacturer:zaccaria]]'s second-generation solid-state platform, used from the early 1980s onward, transitioning to a Motorola 6802 CPU. This brought [[manufacturer:zaccaria]]'s hardware more in line with American manufacturers' architectures. Notable games include Pinball Champ (1982), Time Machine (1983), and Farfalla (1983). [[manufacturer:zaccaria]] ceased pinball production in the late 1980s.",
+    "description": "[[manufacturer:zaccaria]]'s second-generation solid-state platform, used from the early 1980s onward, transitioning to a Motorola 6802 CPU. This brought [[manufacturer:zaccaria]]'s hardware more in line with American manufacturers' architectures. Notable games include [[title:pinball-champ]] (1982), [[title:time-machine-zaccaria]] (1983), and [[title:farfalla]] (1983). [[manufacturer:zaccaria]] ceased pinball production in the late 1980s.",
     "mpu_strings": [
       "Zaccaria Generation 2"
     ],

--- a/data/titles.json
+++ b/data/titles.json
@@ -68,6 +68,11 @@
     "opdb_group_id": "G4do5"
   },
   {
+    "slug": "attila-the-hun",
+    "name": "Attila the Hun",
+    "opdb_group_id": "GrZxD"
+  },
+  {
     "slug": "austin-powers",
     "name": "Austin Powers",
     "opdb_group_id": "G43BW",
@@ -114,6 +119,11 @@
   {
     "slug": "baffle-ball",
     "name": "Baffle Ball"
+  },
+  {
+    "slug": "banzai-run",
+    "name": "Banzai Run",
+    "opdb_group_id": "GR9lZ"
   },
   {
     "slug": "barb-wire",
@@ -194,6 +204,11 @@
     "opdb_group_id": "GX2zO"
   },
   {
+    "slug": "black-hole",
+    "name": "Black Hole",
+    "opdb_group_id": "G41yq"
+  },
+  {
     "slug": "black-knight",
     "name": "Black Knight",
     "opdb_group_id": "GrO7w",
@@ -228,6 +243,11 @@
     "abbreviations": [
       "BV"
     ]
+  },
+  {
+    "slug": "blackwater-100",
+    "name": "Blackwater 100",
+    "opdb_group_id": "G5K6X"
   },
   {
     "slug": "blood-bank-billiards",
@@ -307,6 +327,21 @@
     ]
   },
   {
+    "slug": "checkpoint",
+    "name": "Checkpoint",
+    "opdb_group_id": "G4Jdp"
+  },
+  {
+    "slug": "cirqus-voltaire",
+    "name": "Cirqus Voltaire",
+    "opdb_group_id": "GRVjJ"
+  },
+  {
+    "slug": "cleopatra",
+    "name": "Cleopatra",
+    "opdb_group_id": "GrknN"
+  },
+  {
     "slug": "close-encounters",
     "name": "Close Encounters of the Third Kind",
     "opdb_group_id": "G4qvL",
@@ -316,6 +351,12 @@
     ]
   },
   {
+    "slug": "comet",
+    "name": "Comet",
+    "opdb_group_id": "Gryd3",
+    "series_slug": "comet"
+  },
+  {
     "slug": "congo",
     "name": "Congo",
     "opdb_group_id": "GrNd0",
@@ -323,6 +364,11 @@
     "abbreviations": [
       "CNG"
     ]
+  },
+  {
+    "slug": "cosmic-flash",
+    "name": "Cosmic Flash",
+    "opdb_group_id": "G5pxD"
   },
   {
     "slug": "cosmodrome",
@@ -348,9 +394,30 @@
     ]
   },
   {
+    "slug": "cue-ball-wizard",
+    "name": "Cue Ball Wizard",
+    "opdb_group_id": "G5vPd"
+  },
+  {
     "slug": "cybernaut",
     "name": "Cybernaut",
     "opdb_group_id": "GR69j"
+  },
+  {
+    "slug": "cyclone",
+    "name": "Cyclone",
+    "opdb_group_id": "G4O2b",
+    "series_slug": "comet"
+  },
+  {
+    "slug": "cyclopes",
+    "name": "Cyclopes",
+    "opdb_group_id": "GRwZ7"
+  },
+  {
+    "slug": "dakar",
+    "name": "Dakar",
+    "opdb_group_id": "GR02j"
   },
   {
     "slug": "deadpool",
@@ -360,6 +427,11 @@
     "abbreviations": [
       "DP"
     ]
+  },
+  {
+    "slug": "defender",
+    "name": "Defender",
+    "opdb_group_id": "G5p7D"
   },
   {
     "slug": "demolition-man",
@@ -505,6 +577,11 @@
     "franchise_slug": "elvis"
   },
   {
+    "slug": "escape-from-the-lost-world",
+    "name": "Escape from the Lost World",
+    "opdb_group_id": "G5oEz"
+  },
+  {
     "slug": "escape-from-the-megaverse",
     "name": "Escape From The Megaverse",
     "opdb_group_id": "G0lop"
@@ -527,10 +604,20 @@
     ]
   },
   {
+    "slug": "f-14-tomcat",
+    "name": "F-14 Tomcat",
+    "opdb_group_id": "GRY2O"
+  },
+  {
     "slug": "family-guy",
     "name": "Family Guy",
     "franchise_slug": "family-guy",
     "split_from_opdb_group": "G5LW9"
+  },
+  {
+    "slug": "farfalla",
+    "name": "Farfalla",
+    "opdb_group_id": "GRVw2"
   },
   {
     "slug": "firepower",
@@ -584,6 +671,11 @@
     "slug": "galactic-tank-force",
     "name": "Galactic Tank Force",
     "opdb_group_id": "Gj6PZ"
+  },
+  {
+    "slug": "galaxy-stern",
+    "name": "Galaxy",
+    "opdb_group_id": "GrdDB"
   },
   {
     "slug": "gamatron",
@@ -720,6 +812,11 @@
     "opdb_group_id": "GWyBj"
   },
   {
+    "slug": "haunted-house",
+    "name": "Haunted House",
+    "opdb_group_id": "G5BP6"
+  },
+  {
     "slug": "heavy-metal",
     "name": "Heavy Metal",
     "opdb_group_id": "GoEej",
@@ -754,6 +851,16 @@
     "opdb_group_id": "G188W"
   },
   {
+    "slug": "hot-fire-birds",
+    "name": "Hot Fire Birds",
+    "opdb_group_id": "G4xpN"
+  },
+  {
+    "slug": "hot-tip",
+    "name": "Hot Tip",
+    "opdb_group_id": "Grep0"
+  },
+  {
     "slug": "hot-wheels",
     "name": "Hot Wheels",
     "opdb_group_id": "GEL31",
@@ -768,9 +875,18 @@
     "opdb_group_id": "GvBQX"
   },
   {
+    "slug": "house-of-diamonds",
+    "name": "House of Diamonds",
+    "opdb_group_id": "GRVpL"
+  },
+  {
     "slug": "humpty-dumpty",
     "name": "Humpty Dumpty",
     "opdb_group_id": "GyVVQ"
+  },
+  {
+    "slug": "hyperball",
+    "name": "Hyperball"
   },
   {
     "slug": "ice-fever",
@@ -823,6 +939,11 @@
     ]
   },
   {
+    "slug": "jack-bot",
+    "name": "Jack*Bot",
+    "opdb_group_id": "GRKOX"
+  },
+  {
     "slug": "james-bond-007",
     "name": "James Bond 007",
     "opdb_group_id": "GQKyP",
@@ -867,6 +988,11 @@
     "abbreviations": [
       "JM"
     ]
+  },
+  {
+    "slug": "joust",
+    "name": "Joust",
+    "opdb_group_id": "G4den"
   },
   {
     "slug": "judge-dredd",
@@ -947,6 +1073,11 @@
     "opdb_group_id": "G48NN"
   },
   {
+    "slug": "laser-war",
+    "name": "Laser War",
+    "opdb_group_id": "G5one"
+  },
+  {
     "slug": "last-action-hero",
     "name": "Last Action Hero",
     "opdb_group_id": "GRwyq",
@@ -984,6 +1115,11 @@
     ]
   },
   {
+    "slug": "lexy-lightspeed",
+    "name": "Lexy Lightspeed",
+    "opdb_group_id": "G4doo"
+  },
+  {
     "slug": "lexy-lightspeed-secret-agent-showdown",
     "name": "Lexy Lightspeed - Secret Agent Showdown",
     "opdb_group_id": "GpeeL"
@@ -1017,6 +1153,11 @@
     ]
   },
   {
+    "slug": "lucky-seven",
+    "name": "Lucky Seven",
+    "opdb_group_id": "G5D3O"
+  },
+  {
     "slug": "macs-galaxy",
     "name": "Mac's Galaxy",
     "opdb_group_id": "G4Z6n"
@@ -1044,6 +1185,11 @@
     ]
   },
   {
+    "slug": "memory-lane",
+    "name": "Memory Lane",
+    "opdb_group_id": "Gry0Z"
+  },
+  {
     "slug": "metallica",
     "name": "Metallica",
     "opdb_group_id": "GRBE4",
@@ -1056,6 +1202,16 @@
     "slug": "metallica-remastered",
     "name": "Metallica Remastered",
     "opdb_group_id": "GO0q3"
+  },
+  {
+    "slug": "meteor",
+    "name": "Meteor",
+    "opdb_group_id": "G5b38"
+  },
+  {
+    "slug": "millionaire",
+    "name": "Millionaire",
+    "opdb_group_id": "G5n38"
   },
   {
     "slug": "monopoly",
@@ -1074,6 +1230,16 @@
     "abbreviations": [
       "MB"
     ]
+  },
+  {
+    "slug": "monte-carlo-gottlieb",
+    "name": "Monte Carlo",
+    "opdb_group_id": "G578Y"
+  },
+  {
+    "slug": "motor-show",
+    "name": "Motor Show",
+    "opdb_group_id": "GRb2y"
   },
   {
     "slug": "mr-mrs-pac-man",
@@ -1120,6 +1286,11 @@
     "opdb_group_id": "GRB8Z"
   },
   {
+    "slug": "night-rider",
+    "name": "Night Rider",
+    "opdb_group_id": "GryQj"
+  },
+  {
     "slug": "nightmare-on-elm-street",
     "name": "Freddy: A Nightmare On Elm Street",
     "opdb_group_id": "GRzB7",
@@ -1148,6 +1319,11 @@
     "opdb_group_id": "GLWBV"
   },
   {
+    "slug": "old-coney-island",
+    "name": "Old Coney Island!",
+    "opdb_group_id": "G4qjj"
+  },
+  {
     "slug": "pabst-blue-ribbon",
     "name": "Whoa Nellie / PBR",
     "opdb_group_id": "GRYX4",
@@ -1164,14 +1340,35 @@
     "opdb_group_id": "Ge1O1"
   },
   {
-    "slug": "pinball-champ-82",
-    "name": "Pinball Champ '82",
+    "slug": "phantom-of-the-opera",
+    "name": "The Phantom of the Opera",
+    "opdb_group_id": "Grq1D",
+    "franchise_slug": "phantom-of-the-opera"
+  },
+  {
+    "slug": "pharaoh",
+    "name": "Pharaoh",
+    "opdb_group_id": "G41vn"
+  },
+  {
+    "slug": "phoenix-williams",
+    "name": "Phoenix",
+    "opdb_group_id": "GRQp6"
+  },
+  {
+    "slug": "pinball-champ",
+    "name": "Pinball Champ",
     "opdb_group_id": "GrPdq"
   },
   {
     "slug": "pinball-magic",
     "name": "Pinball Magic",
     "opdb_group_id": "GrZnn"
+  },
+  {
+    "slug": "pinball-stern",
+    "name": "Pinball",
+    "opdb_group_id": "GrZXj"
   },
   {
     "slug": "pinbot",
@@ -1238,6 +1435,16 @@
     "opdb_group_id": "GV8wB"
   },
   {
+    "slug": "pokerino",
+    "name": "Pokerino",
+    "opdb_group_id": "G5pn8"
+  },
+  {
+    "slug": "police-force",
+    "name": "Police Force",
+    "opdb_group_id": "G4d8d"
+  },
+  {
     "slug": "popeye",
     "name": "Popeye Saves the Earth",
     "opdb_group_id": "GR0lW",
@@ -1257,9 +1464,19 @@
     "opdb_group_id": "GELkO"
   },
   {
+    "slug": "rack-em-up",
+    "name": "Rack 'Em Up",
+    "opdb_group_id": "G4ywq"
+  },
+  {
     "slug": "ranger-in-the-ruins",
     "name": "Ranger in the Ruins",
     "opdb_group_id": "GLWWV"
+  },
+  {
+    "slug": "revenge-from-mars",
+    "name": "Revenge from Mars",
+    "opdb_group_id": "G50Wr"
   },
   {
     "slug": "rick-and-morty",
@@ -1280,9 +1497,9 @@
     ]
   },
   {
-    "slug": "revenge-from-mars",
-    "name": "Revenge from Mars",
-    "opdb_group_id": "G50Wr"
+    "slug": "riverboat-gambler",
+    "name": "Riverboat Gambler",
+    "opdb_group_id": "G4E0z"
   },
   {
     "slug": "road-runner",
@@ -1373,6 +1590,11 @@
     "opdb_group_id": "GllPz"
   },
   {
+    "slug": "scramble",
+    "name": "Scramble",
+    "opdb_group_id": "G5p8V"
+  },
+  {
     "slug": "screech",
     "name": "Screech",
     "opdb_group_id": "GPBBv"
@@ -1381,6 +1603,11 @@
     "slug": "seawitch",
     "name": "Seawitch",
     "opdb_group_id": "GR6kB"
+  },
+  {
+    "slug": "secret-service",
+    "name": "Secret Service",
+    "opdb_group_id": "G4qqv"
   },
   {
     "slug": "shaq",
@@ -1425,6 +1652,11 @@
     "opdb_group_id": "Gr3VN"
   },
   {
+    "slug": "solar-fire",
+    "name": "Solar Fire",
+    "opdb_group_id": "GRB26"
+  },
+  {
     "slug": "sorcerers-apprentice",
     "name": "Sorcerer's Apprentice",
     "opdb_group_id": "G8llL"
@@ -1437,6 +1669,11 @@
     "abbreviations": [
       "SP"
     ]
+  },
+  {
+    "slug": "space-gambler",
+    "name": "Space Gambler",
+    "opdb_group_id": "G5bVN"
   },
   {
     "slug": "space-jam",
@@ -1594,6 +1831,11 @@
     ]
   },
   {
+    "slug": "stars",
+    "name": "Stars",
+    "opdb_group_id": "GrXEW"
+  },
+  {
     "slug": "starship-troopers",
     "name": "Starship Troopers",
     "opdb_group_id": "G5we0",
@@ -1635,6 +1877,11 @@
     "name": "Superman",
     "opdb_group_id": "GR73N",
     "franchise_slug": "superman"
+  },
+  {
+    "slug": "surf-n-safari",
+    "name": "Surf 'n Safari",
+    "opdb_group_id": "G5W0z"
   },
   {
     "slug": "tag-team-pinball",
@@ -1691,6 +1938,11 @@
     "abbreviations": [
       "TAF"
     ]
+  },
+  {
+    "slug": "the-atarians",
+    "name": "The Atarians",
+    "opdb_group_id": "Gry9N"
   },
   {
     "slug": "the-avengers",
@@ -1915,6 +2167,16 @@
     "opdb_group_id": "G4eEJ"
   },
   {
+    "slug": "time-machine-zaccaria",
+    "name": "Time Machine",
+    "opdb_group_id": "GRnoY"
+  },
+  {
+    "slug": "torpedo-alley",
+    "name": "Torpedo Alley",
+    "opdb_group_id": "G48on"
+  },
+  {
     "slug": "total-nuclear-annihilation",
     "name": "Total Nuclear Annihilation",
     "opdb_group_id": "GRD79"
@@ -2013,6 +2275,11 @@
     ]
   },
   {
+    "slug": "winter-sports",
+    "name": "Winter Sports",
+    "opdb_group_id": "GrxWp"
+  },
+  {
     "slug": "wizard",
     "name": "Wizard!",
     "opdb_group_id": "G4l8K",
@@ -2047,6 +2314,11 @@
     ]
   },
   {
+    "slug": "x-force",
+    "name": "X Force",
+    "opdb_group_id": "GRzJ1"
+  },
+  {
     "slug": "x-men",
     "name": "X-Men",
     "opdb_group_id": "Grj6X",
@@ -2054,6 +2326,11 @@
     "abbreviations": [
       "XM"
     ]
+  },
+  {
+    "slug": "xenon",
+    "name": "Xenon",
+    "opdb_group_id": "G42Pk"
   },
   {
     "slug": "xs-os",


### PR DESCRIPTION
## Summary
- Link ~60 title references across all system descriptions with `[[title:slug]]` markup
- Add 56 new titles, 62 new models, 1 series (Comet trilogy), 1 franchise (Phantom of the Opera)
- Fact-check and fix errors in data-east-v1/v2/v3, williams-system-9, atari-system-3
- Make `opdb_id` optional in models schema (supports models like Hyperball with no OPDB entry)
- Give `cleopatra` slug to the Gottlieb SS game; merge duplicate `pinball-champ-82` title

## Test plan
- [ ] `make ingest` completes without errors
- [ ] Verify links render on [data-east-v2](http://localhost:5173/systems/data-east-v2) (no Checkpoint/DMD)
- [ ] Verify links render on [zaccaria-gen-2](http://localhost:5173/systems/zaccaria-gen-2)
- [ ] Verify links render on [wpc-95](http://localhost:5173/systems/wpc-95) (Cirqus Voltaire)
- [ ] Spot-check new title pages: [xenon](http://localhost:5173/titles/xenon), [cleopatra](http://localhost:5173/titles/cleopatra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)