### PR TITLE
feat: link ManilaMatic system refs to Gottlieb System 80A/80B

### DIFF
--- a/data/systems.json
+++ b/data/systems.json
@@ -253,7 +253,7 @@
     "slug": "manilamatic-system-80a",
     "name": "ManilaMatic System 80A",
     "manufacturer": "manilamatic",
-    "description": "A pinball hardware system from [[manufacturer:manilamatic]], a Philippine pinball manufacturer. It appears to share design lineage or naming conventions with [[manufacturer:gottlieb]]'s System 80A architecture.",
+    "description": "A pinball hardware system from [[manufacturer:manilamatic]], a Philippine pinball manufacturer. It appears to share design lineage or naming conventions with [[manufacturer:gottlieb]]'s [[system:gottlieb-system-80a]] architecture.",
     "mpu_strings": [
       "ManilaMatic System 80A Combi"
     ],
@@ -263,7 +263,7 @@
     "slug": "manilamatic-system-80b",
     "name": "ManilaMatic System 80B",
     "manufacturer": "manilamatic",
-    "description": "A pinball hardware system from [[manufacturer:manilamatic]], a Philippine pinball manufacturer, sharing naming conventions with [[manufacturer:gottlieb]]'s System 80B.",
+    "description": "A pinball hardware system from [[manufacturer:manilamatic]], a Philippine pinball manufacturer, sharing naming conventions with [[manufacturer:gottlieb]]'s [[system:gottlieb-system-80b]].",
     "mpu_strings": [
       "ManilaMatic System 80B Combi"
     ],


### PR DESCRIPTION
## Summary
- Link ManilaMatic System 80A description to `[[system:gottlieb-system-80a]]`
- Link ManilaMatic System 80B description to `[[system:gottlieb-system-80b]]`

## Test plan
- [ ] http://localhost:5173/systems/manilamatic-system-80a — "System 80A" is a clickable link
- [ ] http://localhost:5173/systems/manilamatic-system-80b — "System 80B" is a clickable link

🤖 Generated with [Claude Code](https://claude.com/claude-code)