### PR TITLE
feat: name and link competitors in Atari System 1 description

### DIFF
--- a/data/systems.json
+++ b/data/systems.json
@@ -3,7 +3,7 @@
     "slug": "atari-system-1",
     "name": "Atari System 1",
     "manufacturer": "atari",
-    "description": "[[manufacturer:atari]]'s first solid-state pinball platform, used from 1976 to 1978, built around a custom discrete-logic MPU without a traditional microprocessor. It debuted with [[title:the-atarians]] (1976) and was used on early titles like Time 2000 and Airborne Avenger. The system used a unique design that differed significantly from the Motorola 6800-based platforms favored by competitors.",
+    "description": "[[manufacturer:atari]]'s first solid-state pinball platform, used from 1976 to 1978, built around a custom discrete-logic MPU without a traditional microprocessor. It debuted with [[title:the-atarians]] (1976) and was used on early titles like Time 2000 and Airborne Avenger. The system used a unique design that differed significantly from the Motorola 6800-based platforms favored by competitors such as [[manufacturer:williams]], [[manufacturer:bally]], and [[manufacturer:stern-electronics]].",
     "mpu_strings": [
       "Atari Generation/System 1"
     ],


### PR DESCRIPTION
## Summary
- Replace vague "competitors" in Atari System 1 description with linked references to Williams, Bally, and Stern Electronics

## Test plan
- [ ] http://localhost:5173/systems/atari-system-1 — Williams, Bally, Stern Electronics render as clickable links

🤖 Generated with [Claude Code](https://claude.com/claude-code)