### PR TITLE
Fix R2 dual manifests, rename pinbase_export to pinbase

### DIFF
--- a/backend/apps/catalog/ingestion/constants.py
+++ b/backend/apps/catalog/ingestion/constants.py
@@ -6,4 +6,4 @@ IPDB_SKIP_MANUFACTURER_IDS: frozenset[int] = frozenset({0, 328})
 DEFAULT_IPDB_PATH = "../data/ingest_sources/ipdb_xantari.json"
 DEFAULT_OPDB_PATH = "../data/ingest_sources/opdb_export_machines.json"
 DEFAULT_OPDB_CHANGELOG_PATH = "../data/ingest_sources/opdb_changelog.json"
-DEFAULT_EXPORT_DIR = "../data/ingest_sources/pinbase_export/"
+DEFAULT_EXPORT_DIR = "../data/ingest_sources/pinbase/"

--- a/backend/apps/catalog/management/commands/ingest_pinbase.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase.py
@@ -58,7 +58,7 @@ from apps.provenance.models import Claim, Source
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_EXPORT_DIR = Path(__file__).parents[5] / "data" / "explore" / "pinbase_export"
+DEFAULT_EXPORT_DIR = Path(__file__).parents[5] / "data" / "explore" / "pinbase"
 
 # Map authored credit role names to CreditRole slugs.
 _CREDIT_ROLE_MAP: dict[str, str] = {

--- a/backend/apps/catalog/management/commands/pull_and_ingest.py
+++ b/backend/apps/catalog/management/commands/pull_and_ingest.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
             "ipdb": f"{dest}/ipdb_xantari.json",
             "opdb": f"{dest}/opdb_export_machines.json",
             "opdb_changelog": f"{dest}/opdb_changelog.json",
-            "export_dir": f"{dest}/pinbase_export/",
+            "export_dir": f"{dest}/pinbase/",
         }
         if write:
             kwargs["write"] = True

--- a/backend/apps/catalog/management/commands/pull_ingest_sources.py
+++ b/backend/apps/catalog/management/commands/pull_ingest_sources.py
@@ -1,8 +1,13 @@
 """Download ingest source files from Cloudflare R2.
 
 Uses only stdlib (urllib.request) so it works on Railway's slim Python image.
-Fetches manifest.json, then downloads only the files needed by the ingest
-pipeline (IPDB, OPDB, and pinbase_export/).
+
+The R2 bucket has two manifests:
+  - manifest.json          — root-level ingest sources (IPDB, OPDB, etc.),
+                             published by pinexplore.
+  - pinbase/manifest.json  — catalog export files, published by pindata.
+
+This command fetches both and downloads the files the ingest pipeline needs.
 
 Usage (local):
     uv run python manage.py pull_ingest_sources --dest ../data/ingest_sources
@@ -23,13 +28,20 @@ from django.core.management.base import BaseCommand
 _OPENER = urllib.request.build_opener()
 _OPENER.addheaders = [("User-Agent", "pinbase/1.0")]
 
-# Only download files the ingest pipeline needs.
+# Only download these root-level files from the ingest-sources manifest.
 _NEEDED_FILES = {
     "ipdb_xantari.json",
     "opdb_export_machines.json",
     "opdb_changelog.json",
 }
-_NEEDED_PREFIXES = ("pinbase_export/",)
+
+# Manifests to fetch: (url_path, local_prefix)
+# - Root manifest entries are stored as-is under dest.
+# - pinbase/ manifest entries are stored under pinbase/ locally.
+_MANIFESTS = [
+    ("manifest.json", ""),
+    ("pinbase/manifest.json", "pinbase/"),
+]
 
 
 def _urlopen(url: str):
@@ -65,54 +77,65 @@ class Command(BaseCommand):
         base_url = options["url"].rstrip("/")
         dest = options["dest"]
 
-        # Fetch manifest
-        manifest_url = f"{base_url}/manifest.json"
-        self.stdout.write(f"Fetching manifest from {manifest_url}")
-        with _urlopen(manifest_url) as resp:
-            manifest = json.loads(resp.read())
-
         downloaded = 0
-        skipped = 0
+        up_to_date = 0
         ignored = 0
 
-        for entry in manifest:
-            rel_path = entry["path"]
-
-            if rel_path not in _NEEDED_FILES and not rel_path.startswith(
-                _NEEDED_PREFIXES
-            ):
-                ignored += 1
+        for manifest_path, local_prefix in _MANIFESTS:
+            manifest_url = f"{base_url}/{manifest_path}"
+            self.stdout.write(f"Fetching {manifest_url}")
+            try:
+                with _urlopen(manifest_url) as resp:
+                    manifest = json.loads(resp.read())
+            except urllib.error.HTTPError as e:
+                self.stdout.write(self.style.WARNING(f"  Skipped ({e.code})"))
                 continue
-            expected_size = entry["size"]
-            expected_sha = entry["sha256"]
-            local_path = os.path.join(dest, rel_path)
 
-            # Skip if local file matches size and checksum
-            if (
-                os.path.exists(local_path)
-                and os.path.getsize(local_path) == expected_size
-            ):
-                if _sha256(local_path) == expected_sha:
-                    skipped += 1
+            # Determine the base URL for files in this manifest.
+            # pinbase/manifest.json lists files relative to pinbase/.
+            manifest_base = base_url
+            if "/" in manifest_path:
+                manifest_base = f"{base_url}/{manifest_path.rsplit('/', 1)[0]}"
+
+            for entry in manifest:
+                rel_path = entry["path"]
+
+                # For the root manifest, only download _NEEDED_FILES.
+                # For prefixed manifests, download everything.
+                if not local_prefix and rel_path not in _NEEDED_FILES:
+                    ignored += 1
                     continue
 
-            os.makedirs(os.path.dirname(local_path), exist_ok=True)
-            file_url = f"{base_url}/{rel_path}"
-            self.stdout.write(f"  {rel_path}")
-            with _urlopen(file_url) as resp, open(local_path, "wb") as f:
-                f.write(resp.read())
+                expected_size = entry["size"]
+                expected_sha = entry["sha256"]
+                local_path = os.path.join(dest, local_prefix + rel_path)
 
-            # Verify checksum after download
-            actual_sha = _sha256(local_path)
-            if actual_sha != expected_sha:
-                raise RuntimeError(
-                    f"Checksum mismatch for {rel_path}: "
-                    f"expected {expected_sha}, got {actual_sha}"
-                )
-            downloaded += 1
+                # Skip if local file matches size and checksum
+                if (
+                    os.path.exists(local_path)
+                    and os.path.getsize(local_path) == expected_size
+                ):
+                    if _sha256(local_path) == expected_sha:
+                        up_to_date += 1
+                        continue
+
+                os.makedirs(os.path.dirname(local_path), exist_ok=True)
+                file_url = f"{manifest_base}/{rel_path}"
+                self.stdout.write(f"  {local_prefix}{rel_path}")
+                with _urlopen(file_url) as resp, open(local_path, "wb") as f:
+                    f.write(resp.read())
+
+                # Verify checksum after download
+                actual_sha = _sha256(local_path)
+                if actual_sha != expected_sha:
+                    raise RuntimeError(
+                        f"Checksum mismatch for {rel_path}: "
+                        f"expected {expected_sha}, got {actual_sha}"
+                    )
+                downloaded += 1
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"Done. {downloaded} downloaded, {skipped} up-to-date, {ignored} skipped."
+                f"Done. {downloaded} downloaded, {up_to_date} up-to-date, {ignored} skipped."
             )
         )

--- a/docs/plans/AllTheData.md
+++ b/docs/plans/AllTheData.md
@@ -662,7 +662,7 @@ Before narrowing OPDB/IPDB ingest, add the new Pinbase Markdown data to DuckDB s
 
 Steps:
 
-1. Write a Python export script that reads `data/pinbase/**/*.md` via the shared loader and emits normalized JSON files into `data/explore/pinbase_export/`.
+1. Write a Python export script that reads `data/pinbase/**/*.md` via the shared loader and emits normalized JSON files into `data/explore/pinbase/`.
 2. Add DuckDB views in `01_raw.sql` that read those exported JSON files as `pinbase_md_models`, `pinbase_md_titles`, etc. — alongside the existing `pinbase_models`, `pinbase_titles` views that read `data/*.json`.
 3. Write comparison queries: join Markdown-layer data against merged views and OPDB/IPDB raw views to surface discrepancies in slugs, names, relationships, and field coverage.
 4. Fix data quality issues discovered during exploration: slug naming (e.g. obscure games holding simple slugs, slugs that don't match full names), relationship correctness, missing fields.


### PR DESCRIPTION
## Summary
- **pindata** and **pinexplore** now push to the same R2 bucket independently with separate manifests (`pinbase/manifest.json` for catalog exports, root `manifest.json` for raw ingest sources)
- `pull_ingest_sources` reads both manifests, fixing the bug where pindata's manifest overwrote pinexplore's and caused 0 files to download
- Renamed local `pinbase_export/` directory to `pinbase/` to match the R2 prefix

## Test plan
- [x] `make pull-ingest` downloads files from both manifests
- [x] `make ingest` runs successfully against fresh DB
- [ ] Verify on Railway via `pull_and_ingest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)