### PR TITLE
Fix corporate entity dedup: use slug instead of (manufacturer, name)

### DIFF
--- a/backend/apps/catalog/management/commands/ingest_pinbase.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase.py
@@ -348,14 +348,12 @@ class Command(BaseCommand):
         source = self.editorial_source
         ct_id = ContentType.objects.get_for_model(CorporateEntity).pk
         mfr_by_slug = {m.slug: m for m in Manufacturer.objects.all()}
-        existing_keys = set(
-            CorporateEntity.objects.values_list("manufacturer_id", "name")
-        )
+        existing_slugs = set(CorporateEntity.objects.values_list("slug", flat=True))
 
         objs = []
         valid_entries = []
         missing_mfr: list[str] = []
-        seen_keys: set[tuple[int, str]] = set()
+        seen_slugs: set[str] = set()
 
         for entry in entries:
             mfr_slug = entry["manufacturer_slug"]
@@ -367,16 +365,11 @@ class Command(BaseCommand):
                 )
                 continue
 
-            # Skip duplicates by (manufacturer, name) — data quality issue.
-            key = (mfr.pk, entry["name"])
-            if key in seen_keys:
-                logger.warning(
-                    "Duplicate corporate entity %r for %r — skipping",
-                    entry["name"],
-                    mfr_slug,
-                )
+            slug = entry.get("slug", "")
+            if slug in seen_slugs:
+                logger.warning("Duplicate corporate entity slug %r — skipping", slug)
                 continue
-            seen_keys.add(key)
+            seen_slugs.add(slug)
 
             objs.append(
                 CorporateEntity(
@@ -396,9 +389,7 @@ class Command(BaseCommand):
             update_fields=["name", "year_start", "year_end"],
         )
 
-        created = sum(
-            1 for o in objs if (o.manufacturer_id, o.name) not in existing_keys
-        )
+        created = sum(1 for o in objs if o.slug not in existing_slugs)
         self.stdout.write(
             f"  Corporate entities: {created} created, {len(objs) - created} updated"
         )

--- a/backend/apps/catalog/migrations/0001_initial.py
+++ b/backend/apps/catalog/migrations/0001_initial.py
@@ -963,13 +963,6 @@ class Migration(migrations.Migration):
                 "ordering": ["value"],
             },
         ),
-        migrations.AddConstraint(
-            model_name="corporateentity",
-            constraint=models.UniqueConstraint(
-                fields=("manufacturer", "name"),
-                name="catalog_unique_corporate_entity_per_manufacturer",
-            ),
-        ),
         migrations.AlterUniqueTogether(
             name="modelabbreviation",
             unique_together={("machine_model", "value")},

--- a/backend/apps/catalog/models/manufacturer.py
+++ b/backend/apps/catalog/models/manufacturer.py
@@ -93,12 +93,7 @@ class CorporateEntity(TimeStampedModel):
         ordering = ["manufacturer", "year_start"]
         verbose_name = "corporate entity"
         verbose_name_plural = "corporate entities"
-        constraints = [
-            models.UniqueConstraint(
-                fields=["manufacturer", "name"],
-                name="catalog_unique_corporate_entity_per_manufacturer",
-            ),
-        ]
+        constraints = []
 
     def __str__(self) -> str:
         if self.year_start:


### PR DESCRIPTION
## Summary
- Removed `UniqueConstraint` on `(manufacturer, name)` — two legitimate entities can share the same name under the same manufacturer (different locations, different IPDB IDs)
- Changed ingest dedup logic to key on slug, which is already unique
- Fixes 2 corporate entities that were incorrectly skipped: "Automatic Games Company" and "Shyvers Manufacturing Company"

## Test plan
- [x] `make ingest` on fresh DB creates 760 corporate entities (was 758)
- [x] No duplicate warnings in output
- [x] All backend tests pass
- [ ] Verify on Railway after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)