### PR TITLE
Fix OPDB alias matching: fall back to ipdb_id

### DIFF
--- a/backend/apps/catalog/management/commands/ingest_opdb.py
+++ b/backend/apps/catalog/management/commands/ingest_opdb.py
@@ -190,6 +190,10 @@ class Command(BaseCommand):
         for rec in aliases:
             pm = by_opdb_id.get(rec.opdb_id)
 
+            # Fallback: match by ipdb_id (pinbase may store the parent opdb_id).
+            if not pm and rec.ipdb_id:
+                pm = by_ipdb_id.get(rec.ipdb_id)
+
             if pm:
                 alias_linked += 1
             else:


### PR DESCRIPTION
## Summary
- OPDB aliases have three-part opdb_ids (e.g., `G43W4-MrRpw-A1B7O`) while pinbase stores the parent machine ID (`G43W4-MrRpw`), so they don't match by opdb_id
- Added ipdb_id fallback to the alias loop, matching the pattern already used in the main machine loop
- Fixes 7 duplicate models being created (AC/DC LE, Metallica variants, Addams Family SCE, Bride of Pinbot variants, Challenger I)

## Test plan
- [x] 518 backend tests pass
- [x] `make ingest` on fresh DB: Aliases — Linked: 203, Created: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)