### PR TITLE
Fix scraped images not displaying in frontend

### DIFF
--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -77,12 +77,13 @@ def _extract_image_urls(extra_data: dict) -> tuple[str | None, str | None]:
             if thumbnail or hero:
                 return thumbnail, hero
 
-    # Fall back to IPDB flat URL list.
-    image_urls = extra_data.get("ipdb.image_urls")
-    if image_urls and isinstance(image_urls, list):
-        first = image_urls[0]
-        if isinstance(first, str) and first:
-            return first, first
+    # Fall back to flat URL list (IPDB-sourced or scraped).
+    for key in ("ipdb.image_urls", "image_urls"):
+        image_urls = extra_data.get(key)
+        if image_urls and isinstance(image_urls, list):
+            first = image_urls[0]
+            if isinstance(first, str) and first:
+                return first, first
 
     return None, None
 

--- a/backend/apps/catalog/management/commands/scrape_images.py
+++ b/backend/apps/catalog/management/commands/scrape_images.py
@@ -62,9 +62,10 @@ MANUAL_IMAGES: dict[str, list[str]] = {
 
 def _has_images(extra_data: dict) -> bool:
     """Check if extra_data already contains usable image URLs."""
-    if extra_data.get("image_urls"):
-        return True
-    images = extra_data.get("images")
+    for key in ("image_urls", "ipdb.image_urls"):
+        if extra_data.get(key):
+            return True
+    images = extra_data.get("opdb.images")
     if images and isinstance(images, list):
         return True
     return False


### PR DESCRIPTION
## Summary
- The image scraper stores URLs as `image_urls` claims, but the API only checked for `ipdb.image_urls` — scraped images were invisible
- `_extract_image_urls` now checks both `ipdb.image_urls` and `image_urls`
- `_has_images` in the scraper now detects existing images from all sources (IPDB, OPDB, scraped) to avoid re-scraping

## Test plan
- [x] 451 catalog tests pass
- [x] Scraped images (e.g., Pokémon Pro) now appear in the API response
- [ ] Verify on Railway after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)