### PR TITLE
fix: sort manufacturer detail titles by year descending

### DIFF
--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -106,7 +106,7 @@ def _collect_titles(models, *, include_manufacturer: bool = False) -> list[dict]
             thumbnail_url = _extract_image_urls(m.extra_data or {})[0]
             if thumbnail_url:
                 titles[key]["thumbnail_url"] = thumbnail_url
-    return list(titles.values())
+    return sorted(titles.values(), key=lambda t: (t["year"] is None, -(t["year"] or 0)))
 
 
 def _serialize_manufacturer_detail(mfr) -> dict:

--- a/backend/apps/catalog/tests/test_api_manufacturers.py
+++ b/backend/apps/catalog/tests/test_api_manufacturers.py
@@ -91,6 +91,33 @@ class TestManufacturersAPI:
         data = resp.json()
         assert data[0]["thumbnail_url"] == "https://img.opdb.org/year-md.jpg"
 
+    def test_get_manufacturer_detail_titles_sorted_year_desc(
+        self, client, manufacturer, williams_entity, db
+    ):
+        """Titles should be sorted newest-first, even across multiple entities."""
+        entity2 = CorporateEntity.objects.create(
+            manufacturer=manufacturer,
+            name="Williams Early",
+            slug="williams-early",
+            year_start=1943,
+            year_end=1985,
+        )
+        t_old = Title.objects.create(name="Old Game", opdb_id="T-old")
+        t_mid = Title.objects.create(name="Mid Game", opdb_id="T-mid")
+        t_new = Title.objects.create(name="New Game", opdb_id="T-new")
+        MachineModel.objects.create(
+            name="Old", corporate_entity=entity2, title=t_old, year=1960
+        )
+        MachineModel.objects.create(
+            name="Mid", corporate_entity=williams_entity, title=t_mid, year=1995
+        )
+        MachineModel.objects.create(
+            name="New", corporate_entity=williams_entity, title=t_new, year=2020
+        )
+        resp = client.get(f"/api/manufacturers/{manufacturer.slug}")
+        years = [t["year"] for t in resp.json()["titles"]]
+        assert years == [2020, 1995, 1960]
+
     def test_get_manufacturer_detail_nulls_last(
         self, client, manufacturer, williams_entity, db
     ):


### PR DESCRIPTION
## Summary
- Titles on the manufacturer detail page were appearing in entity-insertion order instead of newest-first
- When a manufacturer has multiple corporate entities (ordered by `year_start` asc), older entity models came first
- Sort collected titles by year descending with nulls last in `_collect_titles()`

## Test plan
- [x] Added `test_get_manufacturer_detail_titles_sorted_year_desc` covering multiple entities
- [x] Existing `test_get_manufacturer_detail_nulls_last` still passes
- [x] All 6 manufacturer API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)