### PR TITLE
feat: add manufacturer filter sidebar

### DIFF
--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -15,10 +15,13 @@ from ninja.errors import HttpError
 from ninja.pagination import PageNumberPagination, paginate
 from ninja.security import django_auth
 
+from django.utils.text import slugify
+
 from ..cache import MANUFACTURERS_ALL_KEY, invalidate_all
 from .constants import DEFAULT_PAGE_SIZE
 from .helpers import _build_activity, _claims_prefetch, _extract_image_urls
 from .schemas import ClaimPatchSchema, ClaimSchema, RelatedTitleSchema
+from .titles import FacetRef, _dedup_facet_refs
 
 # ---------------------------------------------------------------------------
 # Schemas
@@ -31,6 +34,11 @@ class ManufacturerGridSchema(Schema):
     model_count: int = 0
     thumbnail_url: Optional[str] = None
     search_text: Optional[str] = None
+    locations: list[FacetRef] = []
+    year_min: Optional[int] = None
+    year_max: Optional[int] = None
+    persons: list[FacetRef] = []
+    tech_generations: list[FacetRef] = []
 
 
 class ManufacturerSchema(Schema):
@@ -166,6 +174,34 @@ def _manufacturer_qs():
     )
 
 
+def _build_location_refs(entities) -> list[dict]:
+    """Build composite location FacetRefs at every granularity level.
+
+    For an address with city="Chicago", state="Illinois", country="USA",
+    emits three refs:
+      - "Chicago, Illinois, USA"
+      - "Illinois, USA"
+      - "USA"
+    """
+    refs: dict[str, str] = {}  # slug -> display name
+    for entity in entities:
+        for addr in entity.addresses.all():
+            parts = []
+            if addr.city:
+                parts.append(addr.city)
+            if addr.state:
+                parts.append(addr.state)
+            if addr.country:
+                parts.append(addr.country)
+            # Emit a ref for each suffix: [city,state,country], [state,country], [country]
+            for i in range(len(parts)):
+                name = ", ".join(parts[i:])
+                slug = slugify(name)
+                if slug and slug not in refs:
+                    refs[slug] = name
+    return [{"slug": s, "name": n} for s, n in refs.items()]
+
+
 # ---------------------------------------------------------------------------
 # Router
 # ---------------------------------------------------------------------------
@@ -212,9 +248,9 @@ def list_all_manufacturers(request):
                     Prefetch(
                         "models",
                         queryset=MachineModel.objects.filter(variant_of__isnull=True)
-                        .exclude(extra_data={})
-                        .order_by(F("year").desc(nulls_last=True))
-                        .only("id", "corporate_entity_id", "year", "extra_data"),
+                        .select_related("technology_generation")
+                        .prefetch_related("credits__person")
+                        .order_by(F("year").desc(nulls_last=True)),
                     ),
                 ),
             ),
@@ -225,31 +261,44 @@ def list_all_manufacturers(request):
     result = []
     for mfr in qs:
         thumb = None
+        search_parts: list[str] = []
+        tech_gen_pairs: list[tuple[str, str]] = []
+        person_pairs: list[tuple[str, str]] = []
+
+        model_years: list[int] = []
+
         for entity in mfr.entities.all():
-            for model in entity.models.all():
-                thumb, _ = _extract_image_urls(model.extra_data)
-                if thumb:
-                    break
-            if thumb:
-                break
-        # Build search text from entities and addresses.
-        parts: list[str] = []
-        for entity in mfr.entities.all():
-            parts.append(entity.name)
+            search_parts.append(entity.name)
             for addr in entity.addresses.all():
                 if addr.city:
-                    parts.append(addr.city)
+                    search_parts.append(addr.city)
                 if addr.state:
-                    parts.append(addr.state)
+                    search_parts.append(addr.state)
                 if addr.country:
-                    parts.append(addr.country)
+                    search_parts.append(addr.country)
+            for model in entity.models.all():
+                if thumb is None and model.extra_data:
+                    thumb, _ = _extract_image_urls(model.extra_data)
+                if model.year is not None:
+                    model_years.append(model.year)
+                if model.technology_generation:
+                    tg = model.technology_generation
+                    tech_gen_pairs.append((tg.slug, tg.name))
+                for credit in model.credits.all():
+                    person_pairs.append((credit.person.slug, credit.person.name))
+
         result.append(
             {
                 "name": mfr.name,
                 "slug": mfr.slug,
                 "model_count": mfr.model_count,
                 "thumbnail_url": thumb,
-                "search_text": " | ".join(parts) if parts else None,
+                "search_text": " | ".join(search_parts) if search_parts else None,
+                "locations": _build_location_refs(mfr.entities.all()),
+                "year_min": min(model_years) if model_years else None,
+                "year_max": max(model_years) if model_years else None,
+                "persons": _dedup_facet_refs(person_pairs),
+                "tech_generations": _dedup_facet_refs(tech_gen_pairs),
             }
         )
     cache.set(MANUFACTURERS_ALL_KEY, result, timeout=None)

--- a/backend/apps/catalog/ingestion/parsers.py
+++ b/backend/apps/catalog/ingestion/parsers.py
@@ -102,6 +102,7 @@ def parse_ipdb_manufacturer_string(raw: str | None) -> dict[str, str]:
 
 
 # US state names for disambiguating IPDB location parsing.
+# Includes IPDB typo variants (e.g. "NewYork") so they're recognized as states.
 _US_STATES = frozenset(
     {
         "Alabama",
@@ -154,8 +155,132 @@ _US_STATES = frozenset(
         "West Virginia",
         "Wisconsin",
         "Wyoming",
+        # IPDB typos
+        "NewYork",
+        "SouthCarolina",
     }
 )
+
+# Canonical country names — every country that appears in the data must be here.
+# Values from the normalization map are included automatically.
+_KNOWN_COUNTRIES = frozenset(
+    {
+        "Argentina",
+        "Australia",
+        "Austria",
+        "Belgium",
+        "Brazil",
+        "Canada",
+        "China",
+        "France",
+        "Germany",
+        "Italy",
+        "Japan",
+        "Netherlands",
+        "New Zealand",
+        "Portugal",
+        "Russia",
+        "Slovenia",
+        "Spain",
+        "Sweden",
+        "Taiwan",
+        "United Kingdom",
+        "USA",
+    }
+)
+
+# Canonical US state names (post-normalization) for validating US addresses.
+_CANONICAL_US_STATES = frozenset(
+    {
+        "Alabama",
+        "Alaska",
+        "Arizona",
+        "Arkansas",
+        "California",
+        "Colorado",
+        "Connecticut",
+        "D.C.",
+        "Delaware",
+        "Florida",
+        "Georgia",
+        "Hawaii",
+        "Idaho",
+        "Illinois",
+        "Indiana",
+        "Iowa",
+        "Kansas",
+        "Kentucky",
+        "Louisiana",
+        "Maine",
+        "Maryland",
+        "Massachusetts",
+        "Michigan",
+        "Minnesota",
+        "Mississippi",
+        "Missouri",
+        "Montana",
+        "Nebraska",
+        "Nevada",
+        "New Hampshire",
+        "New Jersey",
+        "New Mexico",
+        "New York",
+        "North Carolina",
+        "North Dakota",
+        "Ohio",
+        "Oklahoma",
+        "Oregon",
+        "Pennsylvania",
+        "Rhode Island",
+        "South Carolina",
+        "South Dakota",
+        "Tennessee",
+        "Texas",
+        "Utah",
+        "Vermont",
+        "Virginia",
+        "Washington",
+        "West Virginia",
+        "Wisconsin",
+        "Wyoming",
+    }
+)
+
+# Normalization maps ported from pinexplore/sql/01_reference.sql.
+_COUNTRY_NORMALIZATION: dict[str, str] = {
+    "England": "United Kingdom",
+    "Britain": "United Kingdom",
+    "UK": "United Kingdom",
+    "U.K.": "United Kingdom",
+    "West Germany": "Germany",
+    "Holland": "Netherlands",
+    "The Netherlands": "Netherlands",
+    "R.O.C.": "Taiwan",
+}
+
+_STATE_NORMALIZATION: dict[str, str] = {
+    "NewYork": "New York",
+    "SouthCarolina": "South Carolina",
+}
+
+# Per-manufacturer-ID location overrides for IPDB records with malformed
+# location strings (missing commas, multi-city HQs, etc.).
+_IPDB_LOCATION_OVERRIDES: dict[int, dict[str, str]] = {
+    532: {"city": "Chicago", "state": "Illinois", "country": "USA"},
+    607: {"city": "Long Island City", "state": "New York", "country": "USA"},
+    764: {"city": "Lincoln", "state": "Nebraska", "country": "USA"},
+    696: {"city": "Youngstown", "state": "Ohio", "country": "USA"},
+    439: {"city": "Madrid", "state": "", "country": "Spain"},
+    364: {"city": "Marcoussis", "state": "", "country": "France"},
+    135: {"city": "Avenza", "state": "", "country": "Italy"},
+}
+
+
+def _normalize_location(result: dict[str, str]) -> dict[str, str]:
+    """Apply state and country normalization to a parsed location dict."""
+    result["state"] = _STATE_NORMALIZATION.get(result["state"], result["state"])
+    result["country"] = _COUNTRY_NORMALIZATION.get(result["country"], result["country"])
+    return result
 
 
 def parse_ipdb_location(location: str) -> dict[str, str]:
@@ -168,25 +293,81 @@ def parse_ipdb_location(location: str) -> dict[str, str]:
     - 1-part US state: "Illinois" → ""/state/USA
     - 1-part non-US: "Germany" → ""/""/country
 
+    Strips parenthetical suffixes (e.g. years that leaked into location).
+    Normalizes country and state names (e.g. "England" → "United Kingdom",
+    "NewYork" → "New York").
+
     Returns dict with keys: city, state, country (all default to "").
     """
     if not location:
         return {"city": "", "state": "", "country": ""}
 
+    # Strip parenthetical suffixes (e.g. "(0-1925)" years that leaked into location)
+    location = re.sub(r"\s*\(.*?\)\s*$", "", location)
+
     parts = [p.strip() for p in location.split(",")]
 
     if len(parts) >= 3:
-        return {"city": parts[0], "state": parts[1], "country": parts[2]}
+        return _normalize_location(
+            {"city": parts[0], "state": parts[1], "country": parts[2]}
+        )
 
     if len(parts) == 2:
         if parts[1] in _US_STATES:
-            return {"city": parts[0], "state": parts[1], "country": "USA"}
-        return {"city": parts[0], "state": "", "country": parts[1]}
+            return _normalize_location(
+                {"city": parts[0], "state": parts[1], "country": "USA"}
+            )
+        return _normalize_location({"city": parts[0], "state": "", "country": parts[1]})
 
     # Single part
     if parts[0] in _US_STATES:
-        return {"city": "", "state": parts[0], "country": "USA"}
-    return {"city": "", "state": "", "country": parts[0]}
+        return _normalize_location({"city": "", "state": parts[0], "country": "USA"})
+    return _normalize_location({"city": "", "state": "", "country": parts[0]})
+
+
+class LocationValidationError(ValueError):
+    """Raised when a parsed IPDB location contains unrecognized values."""
+
+
+def _validate_location(result: dict[str, str], mfr_id: int, raw: str) -> None:
+    """Validate a parsed location dict against known countries and states.
+
+    Raises ``LocationValidationError`` for unrecognized values so the ingest
+    fails loudly rather than silently storing bad data.
+    """
+    country = result["country"]
+    state = result["state"]
+
+    if country and country not in _KNOWN_COUNTRIES:
+        raise LocationValidationError(
+            f"IPDB manufacturer {mfr_id}: unknown country {country!r} "
+            f"(from {raw!r}). Add it to _KNOWN_COUNTRIES in parsers.py, "
+            f"or add a normalization mapping, or add an override."
+        )
+
+    if country == "USA" and state and state not in _CANONICAL_US_STATES:
+        raise LocationValidationError(
+            f"IPDB manufacturer {mfr_id}: unknown US state {state!r} "
+            f"(from {raw!r}). Add it to _CANONICAL_US_STATES in parsers.py, "
+            f"or add a normalization mapping, or add an override."
+        )
+
+
+def get_ipdb_location(mfr_id: int, location: str) -> dict[str, str]:
+    """Get normalized location for an IPDB manufacturer.
+
+    Checks per-manufacturer overrides first (for malformed IPDB strings),
+    then falls back to ``parse_ipdb_location``.
+
+    Raises ``LocationValidationError`` if the result contains an unrecognized
+    country or US state.
+    """
+    override = _IPDB_LOCATION_OVERRIDES.get(mfr_id)
+    if override is not None:
+        return dict(override)
+    result = parse_ipdb_location(location)
+    _validate_location(result, mfr_id, location)
+    return result
 
 
 def parse_credit_string(raw: str | None) -> list[str]:

--- a/backend/apps/catalog/management/commands/ingest_ipdb.py
+++ b/backend/apps/catalog/management/commands/ingest_ipdb.py
@@ -26,9 +26,10 @@ from apps.catalog.ingestion.ipdb.records import IpdbRecord
 from apps.catalog.ingestion.person_lookup import build_person_lookup
 from apps.catalog.ingestion.ipdb_title_fixes import TITLE_FIXES
 from apps.catalog.ingestion.parsers import (
+    LocationValidationError,
+    get_ipdb_location,
     parse_credit_string,
     parse_ipdb_date,
-    parse_ipdb_location,
     parse_ipdb_machine_type,
     parse_ipdb_manufacturer_string,
 )
@@ -550,7 +551,10 @@ class Command(BaseCommand):
 
             # --- Step 3: Create address on CE when location is available ---
             if location:
-                addr = parse_ipdb_location(location)
+                try:
+                    addr = get_ipdb_location(mfr_id, location)
+                except LocationValidationError as exc:
+                    raise CommandError(str(exc)) from exc
                 if addr["city"] or addr["state"] or addr["country"]:
                     Address.objects.get_or_create(
                         corporate_entity=ce,

--- a/backend/apps/catalog/tests/test_parsers.py
+++ b/backend/apps/catalog/tests/test_parsers.py
@@ -1,6 +1,10 @@
 """Unit tests for ingestion parsers — pure functions, no database."""
 
+import pytest
+
 from apps.catalog.ingestion.parsers import (
+    LocationValidationError,
+    get_ipdb_location,
     map_opdb_display,
     map_opdb_type,
     parse_credit_string,
@@ -198,3 +202,125 @@ class TestParseIpdbLocation:
     def test_empty(self):
         result = parse_ipdb_location("")
         assert result == {"city": "", "state": "", "country": ""}
+
+    # Country normalization
+    def test_england_normalized_to_united_kingdom(self):
+        result = parse_ipdb_location("London, England")
+        assert result == {"city": "London", "state": "", "country": "United Kingdom"}
+
+    def test_britain_normalized(self):
+        result = parse_ipdb_location("Britain")
+        assert result == {"city": "", "state": "", "country": "United Kingdom"}
+
+    def test_uk_normalized(self):
+        result = parse_ipdb_location("London, UK")
+        assert result == {"city": "London", "state": "", "country": "United Kingdom"}
+
+    def test_holland_normalized(self):
+        result = parse_ipdb_location("Tilburg, Holland")
+        assert result == {"city": "Tilburg", "state": "", "country": "Netherlands"}
+
+    def test_west_germany_normalized(self):
+        result = parse_ipdb_location("Bochum, West Germany")
+        assert result == {"city": "Bochum", "state": "", "country": "Germany"}
+
+    def test_the_netherlands_normalized(self):
+        result = parse_ipdb_location("Reuver, The Netherlands")
+        assert result == {"city": "Reuver", "state": "", "country": "Netherlands"}
+
+    def test_roc_normalized(self):
+        result = parse_ipdb_location("Kaohsiung City, Taiwan, R.O.C.")
+        assert result == {
+            "city": "Kaohsiung City",
+            "state": "Taiwan",
+            "country": "Taiwan",
+        }
+
+    # State normalization
+    def test_newyork_typo_normalized(self):
+        result = parse_ipdb_location("Elmira, NewYork")
+        assert result == {"city": "Elmira", "state": "New York", "country": "USA"}
+
+    def test_southcarolina_typo_normalized(self):
+        result = parse_ipdb_location("Greenville, SouthCarolina")
+        assert result == {
+            "city": "Greenville",
+            "state": "South Carolina",
+            "country": "USA",
+        }
+
+    # Three-part with normalization
+    def test_three_parts_with_country_normalization(self):
+        result = parse_ipdb_location("Cardiff, Wales, UK")
+        assert result == {
+            "city": "Cardiff",
+            "state": "Wales",
+            "country": "United Kingdom",
+        }
+
+    # Parenthetical stripping
+    def test_strips_parenthetical_years(self):
+        result = parse_ipdb_location("Jersey City, New Jersey, USA (0-1925)")
+        assert result == {
+            "city": "Jersey City",
+            "state": "New Jersey",
+            "country": "USA",
+        }
+
+    def test_strips_parenthetical_years_two_part(self):
+        result = parse_ipdb_location("New York, New York (0-0)")
+        assert result == {"city": "New York", "state": "New York", "country": "USA"}
+
+
+class TestGetIpdbLocation:
+    def test_override_chicago_illinois(self):
+        result = get_ipdb_location(532, "Chicago Illinois")
+        assert result == {"city": "Chicago", "state": "Illinois", "country": "USA"}
+
+    def test_override_long_island_city(self):
+        result = get_ipdb_location(607, "Long Island City, Queens, New York")
+        assert result == {
+            "city": "Long Island City",
+            "state": "New York",
+            "country": "USA",
+        }
+
+    def test_override_madrid(self):
+        result = get_ipdb_location(439, "Madrid")
+        assert result == {"city": "Madrid", "state": "", "country": "Spain"}
+
+    def test_fallback_to_parser(self):
+        result = get_ipdb_location(999, "Chicago, Illinois")
+        assert result == {"city": "Chicago", "state": "Illinois", "country": "USA"}
+
+    def test_override_returns_copy(self):
+        """Modifying the returned dict should not affect the override."""
+        result = get_ipdb_location(532, "anything")
+        result["city"] = "modified"
+        assert get_ipdb_location(532, "anything")["city"] == "Chicago"
+
+    def test_unknown_country_raises(self):
+        with pytest.raises(
+            LocationValidationError, match="unknown country 'Freedonia'"
+        ):
+            get_ipdb_location(999, "Springfield, Freedonia")
+
+    def test_unknown_us_state_raises(self):
+        with pytest.raises(
+            LocationValidationError, match="unknown US state 'Freedonia'"
+        ):
+            get_ipdb_location(999, "Springfield, Freedonia, USA")
+
+    def test_known_country_passes(self):
+        result = get_ipdb_location(999, "Bologna, Italy")
+        assert result["country"] == "Italy"
+
+    def test_normalized_country_passes(self):
+        """Countries that normalize to known values should pass validation."""
+        result = get_ipdb_location(999, "London, England")
+        assert result["country"] == "United Kingdom"
+
+    def test_override_skips_validation(self):
+        """Overrides are trusted and bypass validation."""
+        result = get_ipdb_location(532, "total garbage")
+        assert result["country"] == "USA"

--- a/frontend/src/lib/components/ManufacturerActiveFilterChips.svelte
+++ b/frontend/src/lib/components/ManufacturerActiveFilterChips.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import {
+		getMfrActiveFilterLabels,
+		type FacetedManufacturer,
+		type MfrActiveFilterLabel,
+		type MfrFilterState
+	} from '$lib/manufacturer-facet-engine';
+
+	let {
+		filters = $bindable(),
+		allManufacturers
+	}: {
+		filters: MfrFilterState;
+		allManufacturers: FacetedManufacturer[];
+	} = $props();
+
+	let activeLabels = $derived(getMfrActiveFilterLabels(filters, allManufacturers));
+
+	function removeFilter(label: MfrActiveFilterLabel) {
+		if (label.field === 'yearMin') {
+			filters.yearMin = null;
+			filters.yearMax = null;
+		} else {
+			(filters as unknown as Record<string, unknown>)[label.field] = null;
+		}
+	}
+</script>
+
+{#if activeLabels.length > 0}
+	<div class="active-filters" role="list" aria-label="Active filters">
+		{#each activeLabels as chip (chip.key)}
+			<span class="filter-chip" role="listitem">
+				{chip.label}
+				<button
+					class="chip-remove"
+					aria-label="Remove filter: {chip.label}"
+					onclick={() => removeFilter(chip)}
+				>
+					&times;
+				</button>
+			</span>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.active-filters {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--size-1);
+		margin-bottom: var(--size-3);
+	}
+
+	.filter-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--size-1);
+		padding: var(--size-1) var(--size-2);
+		font-size: var(--font-size-0);
+		background-color: var(--color-accent);
+		color: white;
+		border-radius: var(--radius-2);
+	}
+
+	.chip-remove {
+		background: none;
+		border: none;
+		color: rgba(255, 255, 255, 0.8);
+		cursor: pointer;
+		padding: 0;
+		font-size: var(--font-size-1);
+		line-height: 1;
+	}
+
+	.chip-remove:hover {
+		color: white;
+	}
+</style>

--- a/frontend/src/lib/components/ManufacturerFilterSidebar.svelte
+++ b/frontend/src/lib/components/ManufacturerFilterSidebar.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+	import ChipGroup from './ChipGroup.svelte';
+	import SearchableSelect from './SearchableSelect.svelte';
+	import { buildFacetRefOptions } from '$lib/facet-engine';
+	import {
+		computeMfrFacetCounts,
+		emptyMfrFilterState,
+		type FacetedManufacturer,
+		type MfrFilterState
+	} from '$lib/manufacturer-facet-engine';
+
+	let {
+		allManufacturers,
+		filters = $bindable()
+	}: {
+		allManufacturers: FacetedManufacturer[];
+		filters: MfrFilterState;
+	} = $props();
+
+	// -----------------------------------------------------------------------
+	// Facet counts (N-1 approach)
+	// -----------------------------------------------------------------------
+	let facetCounts = $derived(computeMfrFacetCounts(allManufacturers, filters));
+
+	// -----------------------------------------------------------------------
+	// Option lists (unique values enriched with live counts)
+	// -----------------------------------------------------------------------
+	let locationOptions = $derived(
+		buildFacetRefOptions(allManufacturers, (m) => m.locations, facetCounts.location)
+	);
+	let personOptions = $derived(
+		buildFacetRefOptions(allManufacturers, (m) => m.persons, facetCounts.person)
+	);
+	let techGenOptions = $derived(
+		buildFacetRefOptions(allManufacturers, (m) => m.tech_generations, facetCounts.techGeneration)
+	);
+
+	// -----------------------------------------------------------------------
+	// Active filter detection
+	// -----------------------------------------------------------------------
+	let hasActiveFilters = $derived(
+		filters.location != null ||
+			filters.yearMin != null ||
+			filters.yearMax != null ||
+			filters.person != null ||
+			filters.techGeneration != null
+	);
+
+	function clearAll() {
+		filters = emptyMfrFilterState();
+	}
+</script>
+
+<aside class="sidebar">
+	<div class="sidebar-header">
+		<h2>Filters</h2>
+		{#if hasActiveFilters}
+			<button class="clear-all" onclick={clearAll}>Clear all</button>
+		{/if}
+	</div>
+
+	<div class="filter-section">
+		<SearchableSelect
+			label="Location"
+			options={locationOptions}
+			bind:selected={filters.location}
+			placeholder="Search locations..."
+		/>
+	</div>
+
+	<div class="filter-section year-range">
+		<span class="filter-label">Year</span>
+		<div class="year-inputs">
+			<input
+				type="number"
+				placeholder="From"
+				aria-label="Year from"
+				value={filters.yearMin ?? ''}
+				onchange={(e) => {
+					const v = e.currentTarget.value;
+					filters.yearMin = v ? Number(v) : null;
+				}}
+			/>
+			<span class="year-sep">&ndash;</span>
+			<input
+				type="number"
+				placeholder="To"
+				aria-label="Year to"
+				value={filters.yearMax ?? ''}
+				onchange={(e) => {
+					const v = e.currentTarget.value;
+					filters.yearMax = v ? Number(v) : null;
+				}}
+			/>
+		</div>
+	</div>
+
+	<div class="filter-section">
+		<SearchableSelect
+			label="Person"
+			options={personOptions}
+			bind:selected={filters.person}
+			placeholder="Search people..."
+		/>
+	</div>
+
+	<div class="filter-section">
+		<ChipGroup
+			label="Tech generation"
+			options={techGenOptions}
+			bind:selected={filters.techGeneration}
+		/>
+	</div>
+</aside>
+
+<style>
+	.sidebar {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-3);
+	}
+
+	.sidebar-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.sidebar-header h2 {
+		font-size: var(--font-size-2);
+		margin: 0;
+	}
+
+	.clear-all {
+		background: none;
+		border: none;
+		color: var(--color-accent);
+		cursor: pointer;
+		font-size: var(--font-size-0);
+		font-family: var(--font-body);
+		padding: 0;
+	}
+
+	.clear-all:hover {
+		text-decoration: underline;
+	}
+
+	.filter-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-1);
+	}
+
+	.filter-label {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+	}
+
+	.year-inputs {
+		display: flex;
+		align-items: center;
+		gap: var(--size-2);
+	}
+
+	.year-inputs input {
+		width: 5.5rem;
+		padding: var(--size-2) var(--size-2);
+		font-size: var(--font-size-1);
+		font-family: var(--font-body);
+		background-color: var(--color-input-bg);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-input-border);
+		border-radius: var(--radius-2);
+	}
+
+	.year-inputs input:focus {
+		outline: none;
+		border-color: var(--color-input-focus);
+		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
+	}
+
+	.year-sep {
+		color: var(--color-text-muted);
+	}
+</style>

--- a/frontend/src/lib/facet-engine.ts
+++ b/frontend/src/lib/facet-engine.ts
@@ -380,13 +380,13 @@ export interface FacetOption {
 	count: number;
 }
 
-export function buildFacetRefOptions(
-	titles: FacetedTitle[],
-	extractor: (t: FacetedTitle) => FacetRef[],
+export function buildFacetRefOptions<T>(
+	items: T[],
+	extractor: (t: T) => FacetRef[],
 	counts: Map<string, number>
 ): FacetOption[] {
 	const seen = new Map<string, string>();
-	for (const t of titles) {
+	for (const t of items) {
 		for (const ref of extractor(t)) {
 			if (!seen.has(ref.slug)) seen.set(ref.slug, ref.name);
 		}
@@ -398,13 +398,13 @@ export function buildFacetRefOptions(
 	}));
 }
 
-export function buildSingleRefOptions(
-	titles: FacetedTitle[],
-	extractor: (t: FacetedTitle) => FacetRef | null | undefined,
+export function buildSingleRefOptions<T>(
+	items: T[],
+	extractor: (t: T) => FacetRef | null | undefined,
 	counts: Map<string, number>
 ): FacetOption[] {
 	const seen = new Map<string, string>();
-	for (const t of titles) {
+	for (const t of items) {
 		const ref = extractor(t);
 		if (ref && !seen.has(ref.slug)) seen.set(ref.slug, ref.name);
 	}

--- a/frontend/src/lib/manufacturer-facet-engine.test.ts
+++ b/frontend/src/lib/manufacturer-facet-engine.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import {
+	filterManufacturers,
+	computeMfrFacetCounts,
+	emptyMfrFilterState,
+	mfrFiltersFromParams,
+	mfrFiltersToParams,
+	getMfrActiveFilterLabels,
+	type FacetedManufacturer,
+	type MfrFilterState
+} from './manufacturer-facet-engine';
+
+// ---------------------------------------------------------------------------
+// Test data factory
+// ---------------------------------------------------------------------------
+
+function makeMfr(overrides: Partial<FacetedManufacturer> = {}): FacetedManufacturer {
+	return {
+		name: 'Test Mfr',
+		slug: 'test-mfr',
+		model_count: 1,
+		locations: [],
+		persons: [],
+		tech_generations: [],
+		...overrides
+	};
+}
+
+const williams = makeMfr({
+	name: 'Williams',
+	slug: 'williams',
+	model_count: 50,
+	search_text: 'Williams Electronic Manufacturing | Chicago | Illinois | USA',
+	locations: [
+		{ slug: 'chicago-illinois-usa', name: 'Chicago, Illinois, USA' },
+		{ slug: 'illinois-usa', name: 'Illinois, USA' },
+		{ slug: 'usa', name: 'USA' }
+	],
+	year_min: 1958,
+	year_max: 1999,
+	persons: [
+		{ slug: 'pat-lawlor', name: 'Pat Lawlor' },
+		{ slug: 'steve-ritchie', name: 'Steve Ritchie' }
+	],
+	tech_generations: [
+		{ slug: 'electromechanical', name: 'Electromechanical' },
+		{ slug: 'solid-state', name: 'Solid State' }
+	]
+});
+
+const stern = makeMfr({
+	name: 'Stern',
+	slug: 'stern',
+	model_count: 80,
+	search_text: 'Stern Pinball | Elk Grove Village | Illinois | USA',
+	locations: [
+		{ slug: 'elk-grove-village-illinois-usa', name: 'Elk Grove Village, Illinois, USA' },
+		{ slug: 'illinois-usa', name: 'Illinois, USA' },
+		{ slug: 'usa', name: 'USA' }
+	],
+	year_min: 1999,
+	year_max: 2025,
+	persons: [{ slug: 'steve-ritchie', name: 'Steve Ritchie' }],
+	tech_generations: [{ slug: 'solid-state', name: 'Solid State' }]
+});
+
+const zaccaria = makeMfr({
+	name: 'Zaccaria',
+	slug: 'zaccaria',
+	model_count: 30,
+	search_text: 'Zaccaria | Bologna | Italy',
+	locations: [
+		{ slug: 'bologna-italy', name: 'Bologna, Italy' },
+		{ slug: 'italy', name: 'Italy' }
+	],
+	year_min: 1974,
+	year_max: 1987,
+	persons: [],
+	tech_generations: [{ slug: 'solid-state', name: 'Solid State' }]
+});
+
+const allMfrs = [williams, stern, zaccaria];
+
+// ---------------------------------------------------------------------------
+// filterManufacturers
+// ---------------------------------------------------------------------------
+
+describe('filterManufacturers', () => {
+	it('returns all when no filters active', () => {
+		expect(filterManufacturers(allMfrs, emptyMfrFilterState())).toHaveLength(3);
+	});
+
+	it('filters by query', () => {
+		const f = { ...emptyMfrFilterState(), query: 'williams' };
+		expect(filterManufacturers(allMfrs, f).map((m) => m.slug)).toEqual(['williams']);
+	});
+
+	it('filters by location', () => {
+		const f = { ...emptyMfrFilterState(), location: 'italy' };
+		expect(filterManufacturers(allMfrs, f).map((m) => m.slug)).toEqual(['zaccaria']);
+	});
+
+	it('location filter matches at country level', () => {
+		const f = { ...emptyMfrFilterState(), location: 'usa' };
+		expect(filterManufacturers(allMfrs, f).map((m) => m.slug)).toEqual(['williams', 'stern']);
+	});
+
+	it('filters by year min', () => {
+		const f = { ...emptyMfrFilterState(), yearMin: 1990 };
+		// Williams (1958-1999) overlaps, Stern (1999-2025) overlaps, Zaccaria (1974-1987) doesn't
+		expect(filterManufacturers(allMfrs, f).map((m) => m.slug)).toEqual(['williams', 'stern']);
+	});
+
+	it('filters by year max', () => {
+		const f = { ...emptyMfrFilterState(), yearMax: 1980 };
+		// Williams (1958-1999) overlaps, Zaccaria (1974-1987) overlaps, Stern doesn't
+		expect(filterManufacturers(allMfrs, f).map((m) => m.slug)).toEqual(['williams', 'zaccaria']);
+	});
+
+	it('filters by person', () => {
+		const f = { ...emptyMfrFilterState(), person: 'pat-lawlor' };
+		expect(filterManufacturers(allMfrs, f).map((m) => m.slug)).toEqual(['williams']);
+	});
+
+	it('filters by tech generation', () => {
+		const f = { ...emptyMfrFilterState(), techGeneration: 'electromechanical' };
+		expect(filterManufacturers(allMfrs, f).map((m) => m.slug)).toEqual(['williams']);
+	});
+
+	it('combines multiple filters', () => {
+		const f: MfrFilterState = {
+			...emptyMfrFilterState(),
+			location: 'usa',
+			techGeneration: 'solid-state'
+		};
+		expect(filterManufacturers(allMfrs, f).map((m) => m.slug)).toEqual(['williams', 'stern']);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// computeMfrFacetCounts (N-1 approach)
+// ---------------------------------------------------------------------------
+
+describe('computeMfrFacetCounts', () => {
+	it('counts all locations when no filters', () => {
+		const counts = computeMfrFacetCounts(allMfrs, emptyMfrFilterState());
+		expect(counts.location.get('usa')).toBe(2);
+		expect(counts.location.get('italy')).toBe(1);
+	});
+
+	it('excludes own dimension (N-1)', () => {
+		// Filter by location=italy → location counts should still include all
+		// (because location dimension is excluded from location counts)
+		const f = { ...emptyMfrFilterState(), location: 'italy' };
+		const counts = computeMfrFacetCounts(allMfrs, f);
+		expect(counts.location.get('usa')).toBe(2);
+		expect(counts.location.get('italy')).toBe(1);
+	});
+
+	it('cross-dimension counts respect other filters', () => {
+		// Filter by location=italy → person counts only from zaccaria (no persons)
+		const f = { ...emptyMfrFilterState(), location: 'italy' };
+		const counts = computeMfrFacetCounts(allMfrs, f);
+		expect(counts.person.get('pat-lawlor')).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// URL serialization round-trip
+// ---------------------------------------------------------------------------
+
+describe('mfrFiltersFromParams / mfrFiltersToParams', () => {
+	it('round-trips all fields', () => {
+		const original: MfrFilterState = {
+			query: 'test',
+			location: 'usa',
+			yearMin: 1990,
+			yearMax: 2000,
+			person: 'pat-lawlor',
+			techGeneration: 'solid-state'
+		};
+		const sp = mfrFiltersToParams(original, new URLSearchParams());
+		const restored = mfrFiltersFromParams(sp);
+		expect(restored).toEqual(original);
+	});
+
+	it('empty state produces no params', () => {
+		const sp = mfrFiltersToParams(emptyMfrFilterState(), new URLSearchParams());
+		expect(sp.toString()).toBe('');
+	});
+
+	it('reads partial params', () => {
+		const sp = new URLSearchParams('loc=usa&gen=solid-state');
+		const f = mfrFiltersFromParams(sp);
+		expect(f.location).toBe('usa');
+		expect(f.techGeneration).toBe('solid-state');
+		expect(f.person).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getMfrActiveFilterLabels
+// ---------------------------------------------------------------------------
+
+describe('getMfrActiveFilterLabels', () => {
+	it('returns empty for no active filters', () => {
+		expect(getMfrActiveFilterLabels(emptyMfrFilterState(), allMfrs)).toEqual([]);
+	});
+
+	it('includes location label', () => {
+		const f = { ...emptyMfrFilterState(), location: 'usa' };
+		const labels = getMfrActiveFilterLabels(f, allMfrs);
+		expect(labels).toHaveLength(1);
+		expect(labels[0].label).toBe('USA');
+		expect(labels[0].field).toBe('location');
+	});
+
+	it('includes year range label', () => {
+		const f = { ...emptyMfrFilterState(), yearMin: 1990, yearMax: 2000 };
+		const labels = getMfrActiveFilterLabels(f, allMfrs);
+		expect(labels).toHaveLength(1);
+		expect(labels[0].label).toBe('Year: 1990\u20132000');
+		expect(labels[0].field).toBe('yearMin');
+	});
+
+	it('includes person label with resolved name', () => {
+		const f = { ...emptyMfrFilterState(), person: 'pat-lawlor' };
+		const labels = getMfrActiveFilterLabels(f, allMfrs);
+		expect(labels[0].label).toBe('Pat Lawlor');
+	});
+
+	it('falls back to slug when name not found', () => {
+		const f = { ...emptyMfrFilterState(), person: 'unknown-person' };
+		const labels = getMfrActiveFilterLabels(f, allMfrs);
+		expect(labels[0].label).toBe('unknown-person');
+	});
+});

--- a/frontend/src/lib/manufacturer-facet-engine.ts
+++ b/frontend/src/lib/manufacturer-facet-engine.ts
@@ -1,0 +1,284 @@
+/**
+ * Pure functions for client-side faceted filtering of manufacturers.
+ * Mirrors facet-engine.ts but with manufacturer-specific dimensions.
+ */
+
+import type { FacetRef, FacetOption } from '$lib/facet-engine';
+import { normalizeText } from '$lib/util';
+
+export type { FacetRef, FacetOption };
+
+export interface MfrActiveFilterLabel {
+	key: string;
+	label: string;
+	field: keyof MfrFilterState;
+	value?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FacetedManufacturer {
+	name: string;
+	slug: string;
+	model_count: number;
+	thumbnail_url?: string | null;
+	search_text?: string | null;
+	locations: FacetRef[];
+	year_min?: number | null;
+	year_max?: number | null;
+	persons: FacetRef[];
+	tech_generations: FacetRef[];
+}
+
+export interface MfrFilterState {
+	query: string;
+	location: string | null;
+	yearMin: number | null;
+	yearMax: number | null;
+	person: string | null;
+	techGeneration: string | null;
+}
+
+export interface MfrFacetCounts {
+	location: Map<string, number>;
+	person: Map<string, number>;
+	techGeneration: Map<string, number>;
+}
+
+export function emptyMfrFilterState(): MfrFilterState {
+	return {
+		query: '',
+		location: null,
+		yearMin: null,
+		yearMax: null,
+		person: null,
+		techGeneration: null
+	};
+}
+
+// ---------------------------------------------------------------------------
+// URL <-> MfrFilterState serialization
+// ---------------------------------------------------------------------------
+
+const PARAM_MAP: {
+	param: string;
+	get: (f: MfrFilterState) => string | null;
+	set: (f: MfrFilterState, v: string) => void;
+}[] = [
+	{ param: 'q', get: (f) => f.query || null, set: (f, v) => (f.query = v) },
+	{ param: 'loc', get: (f) => f.location, set: (f, v) => (f.location = v) },
+	{
+		param: 'ymin',
+		get: (f) => (f.yearMin != null ? String(f.yearMin) : null),
+		set: (f, v) => (f.yearMin = Number(v))
+	},
+	{
+		param: 'ymax',
+		get: (f) => (f.yearMax != null ? String(f.yearMax) : null),
+		set: (f, v) => (f.yearMax = Number(v))
+	},
+	{ param: 'person', get: (f) => f.person, set: (f, v) => (f.person = v) },
+	{ param: 'gen', get: (f) => f.techGeneration, set: (f, v) => (f.techGeneration = v) }
+];
+
+export function mfrFiltersFromParams(sp: URLSearchParams): MfrFilterState {
+	const f = emptyMfrFilterState();
+	for (const { param, set } of PARAM_MAP) {
+		const v = sp.get(param);
+		if (v != null) set(f, v);
+	}
+	return f;
+}
+
+export function mfrFiltersToParams(f: MfrFilterState, sp: URLSearchParams): URLSearchParams {
+	for (const { param } of PARAM_MAP) sp.delete(param);
+	for (const { param, get } of PARAM_MAP) {
+		const v = get(f);
+		if (v != null) sp.set(param, v);
+	}
+	return sp;
+}
+
+// ---------------------------------------------------------------------------
+// Individual filter predicates
+// ---------------------------------------------------------------------------
+
+type Predicate = (m: FacetedManufacturer) => boolean;
+
+function matchesQuery(m: FacetedManufacturer, q: string): boolean {
+	if (!q) return true;
+	if (normalizeText(m.name).includes(q)) return true;
+	if (m.search_text && normalizeText(m.search_text).includes(q)) return true;
+	return false;
+}
+
+function matchesLocation(m: FacetedManufacturer, slug: string | null): boolean {
+	if (!slug) return true;
+	return m.locations.some((loc) => loc.slug === slug);
+}
+
+function matchesYear(m: FacetedManufacturer, ymin: number | null, ymax: number | null): boolean {
+	if (ymin == null && ymax == null) return true;
+	if (m.year_min == null && m.year_max == null) return false;
+	const mMin = m.year_min ?? m.year_max!;
+	const mMax = m.year_max ?? m.year_min!;
+	if (ymin != null && mMax < ymin) return false;
+	if (ymax != null && mMin > ymax) return false;
+	return true;
+}
+
+function matchesPerson(m: FacetedManufacturer, slug: string | null): boolean {
+	if (!slug) return true;
+	return m.persons.some((p) => p.slug === slug);
+}
+
+function matchesTechGen(m: FacetedManufacturer, slug: string | null): boolean {
+	if (!slug) return true;
+	return m.tech_generations.some((tg) => tg.slug === slug);
+}
+
+// ---------------------------------------------------------------------------
+// Build per-dimension predicates
+// ---------------------------------------------------------------------------
+
+interface DimensionPredicates {
+	query: Predicate;
+	location: Predicate;
+	year: Predicate;
+	person: Predicate;
+	techGeneration: Predicate;
+}
+
+function buildPredicates(state: MfrFilterState): DimensionPredicates {
+	const q = normalizeText(state.query.trim());
+	return {
+		query: (m) => matchesQuery(m, q),
+		location: (m) => matchesLocation(m, state.location),
+		year: (m) => matchesYear(m, state.yearMin, state.yearMax),
+		person: (m) => matchesPerson(m, state.person),
+		techGeneration: (m) => matchesTechGen(m, state.techGeneration)
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Filtering
+// ---------------------------------------------------------------------------
+
+export function filterManufacturers(
+	manufacturers: FacetedManufacturer[],
+	state: MfrFilterState
+): FacetedManufacturer[] {
+	const preds = buildPredicates(state);
+	const all = Object.values(preds);
+	return manufacturers.filter((m) => all.every((p) => p(m)));
+}
+
+// ---------------------------------------------------------------------------
+// Facet counts (N-1 approach)
+// ---------------------------------------------------------------------------
+
+export function computeMfrFacetCounts(
+	manufacturers: FacetedManufacturer[],
+	state: MfrFilterState
+): MfrFacetCounts {
+	const preds = buildPredicates(state);
+	const predKeys = Object.keys(preds) as (keyof DimensionPredicates)[];
+	const predValues = Object.values(preds);
+
+	// Compute a bitmask per manufacturer
+	const masks = new Uint8Array(manufacturers.length);
+	const allBits = (1 << predKeys.length) - 1;
+	for (let i = 0; i < manufacturers.length; i++) {
+		let mask = 0;
+		for (let pi = 0; pi < predValues.length; pi++) {
+			if (predValues[pi](manufacturers[i])) {
+				mask |= 1 << pi;
+			}
+		}
+		masks[i] = mask;
+	}
+
+	const dimIndex = (key: keyof DimensionPredicates) => predKeys.indexOf(key);
+
+	function countFacetRefs(
+		dimKey: keyof DimensionPredicates,
+		extractor: (m: FacetedManufacturer) => FacetRef[]
+	): Map<string, number> {
+		const excludeBit = 1 << dimIndex(dimKey);
+		const requiredMask = allBits & ~excludeBit;
+		const counts = new Map<string, number>();
+		for (let i = 0; i < manufacturers.length; i++) {
+			if ((masks[i] & requiredMask) === requiredMask) {
+				for (const ref of extractor(manufacturers[i])) {
+					counts.set(ref.slug, (counts.get(ref.slug) ?? 0) + 1);
+				}
+			}
+		}
+		return counts;
+	}
+
+	return {
+		location: countFacetRefs('location', (m) => m.locations),
+		person: countFacetRefs('person', (m) => m.persons),
+		techGeneration: countFacetRefs('techGeneration', (m) => m.tech_generations)
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Active filter label extraction
+// ---------------------------------------------------------------------------
+
+export function getMfrActiveFilterLabels(
+	filters: MfrFilterState,
+	allManufacturers: FacetedManufacturer[]
+): MfrActiveFilterLabel[] {
+	const labels: MfrActiveFilterLabel[] = [];
+
+	// Build slug→name lookups
+	const locationNames = new Map<string, string>();
+	const personNames = new Map<string, string>();
+	const techGenNames = new Map<string, string>();
+
+	for (const m of allManufacturers) {
+		for (const ref of m.locations) locationNames.set(ref.slug, ref.name);
+		for (const ref of m.persons) personNames.set(ref.slug, ref.name);
+		for (const ref of m.tech_generations) techGenNames.set(ref.slug, ref.name);
+	}
+
+	if (filters.location) {
+		labels.push({
+			key: `location:${filters.location}`,
+			label: locationNames.get(filters.location) ?? filters.location,
+			field: 'location'
+		});
+	}
+	if (filters.person) {
+		labels.push({
+			key: `person:${filters.person}`,
+			label: personNames.get(filters.person) ?? filters.person,
+			field: 'person'
+		});
+	}
+	if (filters.techGeneration) {
+		labels.push({
+			key: `techGeneration:${filters.techGeneration}`,
+			label: techGenNames.get(filters.techGeneration) ?? filters.techGeneration,
+			field: 'techGeneration'
+		});
+	}
+	if (filters.yearMin != null || filters.yearMax != null) {
+		const parts: string[] = [];
+		if (filters.yearMin != null) parts.push(String(filters.yearMin));
+		parts.push('\u2013');
+		if (filters.yearMax != null) parts.push(String(filters.yearMax));
+		labels.push({
+			key: 'year',
+			label: `Year: ${parts.join('')}`,
+			field: 'yearMin'
+		});
+	}
+
+	return labels;
+}

--- a/frontend/src/routes/manufacturers/+page.svelte
+++ b/frontend/src/routes/manufacturers/+page.svelte
@@ -1,14 +1,51 @@
 <script lang="ts">
+	import { replaceState } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import client from '$lib/api/client';
 	import { createAsyncLoader } from '$lib/async-loader.svelte';
-	import SearchableGrid from '$lib/components/grid/SearchableGrid.svelte';
+	import ManufacturerActiveFilterChips from '$lib/components/ManufacturerActiveFilterChips.svelte';
+	import CardGrid from '$lib/components/grid/CardGrid.svelte';
+	import FilterDrawer from '$lib/components/FilterDrawer.svelte';
+	import ClientFilteredGrid from '$lib/components/grid/ClientFilteredGrid.svelte';
+	import SearchBox from '$lib/components/SearchBox.svelte';
+	import SkeletonCard from '$lib/components/cards/SkeletonCard.svelte';
 	import ManufacturerCard from '$lib/components/cards/ManufacturerCard.svelte';
+	import ManufacturerFilterSidebar from '$lib/components/ManufacturerFilterSidebar.svelte';
 	import { pageTitle } from '$lib/constants';
+	import {
+		filterManufacturers,
+		mfrFiltersFromParams,
+		mfrFiltersToParams,
+		type FacetedManufacturer
+	} from '$lib/manufacturer-facet-engine';
 
+	const SKELETON_INDICES = Array.from({ length: 12 }, (_, i) => i);
+
+	// -----------------------------------------------------------------------
+	// Data loading
+	// -----------------------------------------------------------------------
 	const manufacturers = createAsyncLoader(async () => {
 		const { data } = await client.GET('/api/manufacturers/all/');
-		return data ?? [];
-	}, []);
+		return (data ?? []) as FacetedManufacturer[];
+	}, [] as FacetedManufacturer[]);
+
+	// -----------------------------------------------------------------------
+	// Filter state — initialized from URL, synced back on change
+	// -----------------------------------------------------------------------
+	let filters = $state(mfrFiltersFromParams(new URLSearchParams(window.location.search)));
+
+	let initialRun = true;
+	$effect(() => {
+		const sp = mfrFiltersToParams(filters, new URLSearchParams());
+		const search = sp.toString();
+		if (initialRun) {
+			initialRun = false;
+			return;
+		}
+		replaceState(`${resolve('/manufacturers')}${search ? `?${search}` : ''}`, {});
+	});
+
+	let filteredManufacturers = $derived(filterManufacturers(manufacturers.data, filters));
 </script>
 
 <svelte:head>
@@ -16,20 +53,65 @@
 	<link rel="preload" as="fetch" href="/api/manufacturers/all/" crossorigin="anonymous" />
 </svelte:head>
 
-<SearchableGrid
-	items={manufacturers.data}
-	loading={manufacturers.loading}
-	error={manufacturers.error}
-	filterFields={(item) => [item.name]}
-	placeholder="Search manufacturers..."
-	entityName="manufacturer"
->
-	{#snippet children(mfr)}
-		<ManufacturerCard
-			slug={mfr.slug}
-			name={mfr.name}
-			thumbnailUrl={mfr.thumbnail_url}
-			modelCount={mfr.model_count}
-		/>
-	{/snippet}
-</SearchableGrid>
+<div class="manufacturers-page">
+	<SearchBox bind:value={filters.query} placeholder="Search manufacturers..." />
+
+	{#if manufacturers.loading}
+		<CardGrid>
+			{#each SKELETON_INDICES as i (i)}
+				<SkeletonCard />
+			{/each}
+		</CardGrid>
+	{:else if manufacturers.error}
+		<p class="error">{manufacturers.error}</p>
+	{:else}
+		<div class="layout">
+			<FilterDrawer label="Filter manufacturers">
+				<ManufacturerFilterSidebar allManufacturers={manufacturers.data} bind:filters />
+			</FilterDrawer>
+
+			<main class="results">
+				<ManufacturerActiveFilterChips bind:filters allManufacturers={manufacturers.data} />
+				<ClientFilteredGrid items={filteredManufacturers} entityName="manufacturer">
+					{#snippet children(mfr)}
+						<ManufacturerCard
+							slug={mfr.slug}
+							name={mfr.name}
+							thumbnailUrl={mfr.thumbnail_url}
+							modelCount={mfr.model_count}
+						/>
+					{/snippet}
+				</ClientFilteredGrid>
+			</main>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.manufacturers-page {
+		padding: var(--size-5) 0;
+	}
+
+	.layout {
+		display: grid;
+		grid-template-columns: 16rem 1fr;
+		gap: var(--size-5);
+		align-items: start;
+	}
+
+	.results {
+		min-width: 0;
+	}
+
+	.error {
+		text-align: center;
+		color: var(--color-error);
+		padding: var(--size-6) 0;
+	}
+
+	@media (max-width: 640px) {
+		.layout {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/frontend/src/routes/manufacturers/+page.ts
+++ b/frontend/src/routes/manufacturers/+page.ts
@@ -1,1 +1,2 @@
-export const prerender = true;
+export const prerender = false;
+export const ssr = false;


### PR DESCRIPTION
## Summary

Add a faceted filter sidebar to the manufacturer list page (`/manufacturers`) with Location, Year, Person, and Tech Generation filters — matching the existing titles page pattern.

- **IPDB location normalization**: Port country/state normalization from pinexplore (England→United Kingdom, NewYork→New York, etc.) with per-manufacturer overrides for malformed IPDB strings. Ingest now fails loudly on unknown countries or US states.
- **Location filter**: Single typeahead dropdown with composite location strings at every granularity level (city+state+country, state+country, country)
- **Year filter**: Min/max range based on model production years
- **Person filter**: Searchable dropdown of people credited on machines by each manufacturer
- **Tech Generation filter**: Chip group (Electromechanical, Solid State, Pure Mechanical)
- All filters use N-1 facet counts and URL-synced state

## Test plan

- [ ] Run `make pull-ingest && make ingest` — verify ingest completes with no errors and clean country names
- [ ] Visit `/manufacturers` — filter sidebar visible on desktop, drawer on mobile
- [ ] Test Location filter: type "USA" → shows US manufacturers; type "Chicago" → shows Chicago manufacturers
- [ ] Test Year filter: set max to 2000 → shows manufacturers active before 2000
- [ ] Test Person filter: search "Pat Lawlor" → shows Williams
- [ ] Test Tech Generation: click "Electromechanical" → filters correctly
- [ ] Verify active filter chips appear and are removable
- [ ] Verify URL updates with filter state (e.g. `?loc=usa&gen=solid-state`)
- [ ] Run `make test` — all backend and frontend tests pass
- [ ] Run `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)