### PR TITLE
chore: add PreToolUse hook for auto-approving safe bash commands

### DIFF
--- a/.claude/hooks/approve-bash.sh
+++ b/.claude/hooks/approve-bash.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# PreToolUse hook: auto-approve Bash commands that match allowed prefixes,
+# bypassing Claude Code's broken quote-tracking in prefix matching.
+#
+# This fixes a known bug where single quotes in commands cause
+# permission prompts even when the command prefix is explicitly allowed.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Allowed command prefixes — add more as needed
+ALLOWED_PREFIXES=(
+  "curl"
+  "detect-secrets scan"
+  "duckdb"
+  "find"
+  "gh "
+  "git add"
+  "git branch"
+  "git cherry-pick"
+  "git checkout"
+  "git count-objects"
+  "git diff"
+  "git fetch"
+  "git log"
+  "git ls-remote"
+  "git merge"
+  "git mv"
+  "git pull"
+  "git push"
+  "git rebase"
+  "git remote"
+  "git rev-list"
+  "git rev-parse"
+  "git rm"
+  "git show"
+  "git stash"
+  "git status"
+  "git switch"
+  "git tag"
+  "grep"
+  "ls"
+  "make"
+  "npm view"
+  "npx eslint"
+  "npx prettier"
+  "npx vitest"
+  "pnpm"
+  "pre-commit"
+  "python3"
+  "pyenv versions"
+  "uv add"
+  "uv pip list"
+  "uv run"
+  "uv sync"
+  "uv tool run"
+  "wc"
+)
+
+for prefix in "${ALLOWED_PREFIXES[@]}"; do
+  if [[ "$COMMAND" == "$prefix"* ]]; then
+    echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
+    exit 0
+  fi
+done
+
+# Not matched — fall through to normal permission handling
+exit 0


### PR DESCRIPTION
## Summary
- Adds a Claude Code PreToolUse hook that auto-approves bash commands matching safe prefixes (git, make, pnpm, uv, etc.)
- Workaround for a known Claude Code bug where single quotes in commands cause unnecessary permission prompts even when the prefix is explicitly allowed

## Test plan
- [x] Verify hook script is executable and correctly parses JSON input
- [x] Confirm safe commands (e.g. `git status`, `make dev`) are auto-approved
- [x] Confirm unmatched commands fall through to normal permission handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)