### PR TITLE
fix(locations): refresh cached trees and link stateless cities

### DIFF
--- a/backend/apps/catalog/api/locations.py
+++ b/backend/apps/catalog/api/locations.py
@@ -180,7 +180,7 @@ def _serialize_cities(cities_dict):
             }
             for city_slug, city_data in cities_dict.items()
         ],
-        key=lambda c: c["name"],
+        key=lambda c: (-c["manufacturer_count"], c["name"]),
     )
 
 

--- a/backend/apps/catalog/signals.py
+++ b/backend/apps/catalog/signals.py
@@ -14,7 +14,9 @@ def _invalidate_cache(sender, **kwargs):
 def connect():
     """Connect cache-invalidation signals. Called from AppConfig.ready()."""
     from .models import (
+        Address,
         Credit,
+        CorporateEntity,
         MachineModel,
         Manufacturer,
         Person,
@@ -22,9 +24,11 @@ def connect():
     )
 
     for model in (
+        Address,
         MachineModel,
         Manufacturer,
         Person,
+        CorporateEntity,
         Credit,
         Title,
     ):

--- a/backend/apps/catalog/tests/test_api_locations.py
+++ b/backend/apps/catalog/tests/test_api_locations.py
@@ -155,6 +155,78 @@ class TestStateDetail:
         assert "Chicago" in city_names
         assert "Elk Grove Village" in city_names
 
+    def test_cities_sorted_by_manufacturer_count_then_name(self, client, db):
+        alpha = Manufacturer.objects.create(name="Alpha Manufacturing")
+        alpha_entity = CorporateEntity.objects.create(
+            name="Alpha Manufacturing",
+            slug="alpha-manufacturing",
+            manufacturer=alpha,
+        )
+        Address.objects.create(
+            corporate_entity=alpha_entity,
+            city="Albany",
+            state="Illinois",
+            country="USA",
+        )
+
+        zeta_one = Manufacturer.objects.create(name="Zeta One")
+        zeta_one_entity = CorporateEntity.objects.create(
+            name="Zeta One",
+            slug="zeta-one",
+            manufacturer=zeta_one,
+        )
+        Address.objects.create(
+            corporate_entity=zeta_one_entity,
+            city="Zephyr",
+            state="Illinois",
+            country="USA",
+        )
+
+        zeta_two = Manufacturer.objects.create(name="Zeta Two")
+        zeta_two_entity = CorporateEntity.objects.create(
+            name="Zeta Two",
+            slug="zeta-two",
+            manufacturer=zeta_two,
+        )
+        Address.objects.create(
+            corporate_entity=zeta_two_entity,
+            city="Zephyr",
+            state="Illinois",
+            country="USA",
+        )
+
+        resp = client.get("/api/locations/usa/illinois")
+        data = resp.json()
+
+        assert [city["name"] for city in data["cities"]] == ["Zephyr", "Albany"]
+
+
+class TestLocationsCacheInvalidation:
+    def test_country_detail_refreshes_when_address_changes(self, client, db):
+        _setup_locations(db)
+
+        initial = client.get("/api/locations/usa")
+        assert initial.status_code == 200
+        assert initial.json()["manufacturer_count"] == 3
+
+        williams_entity = CorporateEntity.objects.get(slug="williams-electronics")
+        Address.objects.create(
+            corporate_entity=williams_entity,
+            city="Rockford",
+            state="Illinois",
+            country="USA",
+        )
+
+        refreshed = client.get("/api/locations/usa")
+        data = refreshed.json()
+
+        assert data["manufacturer_count"] == 3
+        assert {city["name"] for city in data["states"][0]["cities"]} == {
+            "Chicago",
+            "Elk Grove Village",
+            "Rockford",
+        }
+
     def test_includes_manufacturers(self, client, db):
         _setup_locations(db)
         resp = client.get("/api/locations/usa/illinois")

--- a/frontend/src/lib/components/LocationLink.svelte
+++ b/frontend/src/lib/components/LocationLink.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { components } from '$lib/api/schema';
+	import { buildLocationParts } from '$lib/location-links';
 	import { resolveHref } from '$lib/utils';
 
 	let {
@@ -10,29 +11,12 @@
 
 	type Part = { text: string; href?: string };
 
-	let parts = $derived.by(() => {
-		const result: Part[] = [];
-		if (addr.city) {
-			const href =
-				addr.country_slug && addr.state_slug
-					? resolveHref(`/locations/${addr.country_slug}/${addr.state_slug}/${addr.city_slug}`)
-					: undefined;
-			result.push({ text: addr.city, href });
-		}
-		if (addr.state) {
-			const href = addr.country_slug
-				? resolveHref(`/locations/${addr.country_slug}/${addr.state_slug}`)
-				: undefined;
-			result.push({ text: addr.state, href });
-		}
-		if (addr.country) {
-			result.push({
-				text: addr.country,
-				href: resolveHref(`/locations/${addr.country_slug}`)
-			});
-		}
-		return result;
-	});
+	let parts = $derived.by((): Part[] =>
+		buildLocationParts(addr).map((part) => ({
+			...part,
+			href: part.href ? resolveHref(part.href) : undefined
+		}))
+	);
 </script>
 
 {#if parts.length > 0}

--- a/frontend/src/lib/location-links.test.ts
+++ b/frontend/src/lib/location-links.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildLocationParts } from './location-links';
+
+describe('buildLocationParts', () => {
+	it('links stateless cities through the country city route', () => {
+		expect(
+			buildLocationParts({
+				city: 'Bologna',
+				state: '',
+				country: 'Italy',
+				city_slug: 'bologna',
+				state_slug: '',
+				country_slug: 'italy'
+			})
+		).toEqual([
+			{ text: 'Bologna', href: '/locations/italy/cities/bologna' },
+			{ text: 'Italy', href: '/locations/italy' }
+		]);
+	});
+
+	it('links stateful cities through the state city route', () => {
+		expect(
+			buildLocationParts({
+				city: 'Chicago',
+				state: 'Illinois',
+				country: 'USA',
+				city_slug: 'chicago',
+				state_slug: 'illinois',
+				country_slug: 'usa'
+			})
+		).toEqual([
+			{ text: 'Chicago', href: '/locations/usa/illinois/chicago' },
+			{ text: 'Illinois', href: '/locations/usa/illinois' },
+			{ text: 'USA', href: '/locations/usa' }
+		]);
+	});
+});

--- a/frontend/src/lib/location-links.ts
+++ b/frontend/src/lib/location-links.ts
@@ -1,0 +1,38 @@
+import type { components } from '$lib/api/schema';
+
+type AddressSchema = components['schemas']['AddressSchema'];
+
+export type LocationPart = {
+	text: string;
+	href?: string;
+};
+
+export function buildLocationParts(addr: AddressSchema): LocationPart[] {
+	const parts: LocationPart[] = [];
+
+	if (addr.city) {
+		const href =
+			addr.country_slug && addr.state_slug
+				? `/locations/${addr.country_slug}/${addr.state_slug}/${addr.city_slug}`
+				: addr.country_slug
+					? `/locations/${addr.country_slug}/cities/${addr.city_slug}`
+					: undefined;
+		parts.push({ text: addr.city, href });
+	}
+
+	if (addr.state) {
+		const href = addr.country_slug
+			? `/locations/${addr.country_slug}/${addr.state_slug}`
+			: undefined;
+		parts.push({ text: addr.state, href });
+	}
+
+	if (addr.country) {
+		parts.push({
+			text: addr.country,
+			href: addr.country_slug ? `/locations/${addr.country_slug}` : undefined
+		});
+	}
+
+	return parts;
+}


### PR DESCRIPTION
## Summary

Fix location-page regressions by refreshing cached location trees when address data changes, sorting state-detail cities by manufacturer count, and linking stateless manufacturer cities like Bologna through the country city route.

- Invalidate the shared locations cache on `Address` and `CorporateEntity` writes so country and state pages do not get stuck on stale manufacturer counts
- Sort serialized cities by manufacturer count descending and then name ascending
- Route stateless city links in the manufacturer sidebar to `/locations/{country}/cities/{city}` and cover both link shapes with a frontend test

## Test plan

- [x] `uv run pytest apps/catalog/tests/test_api_locations.py -k "country_detail_refreshes_when_address_changes or cities_sorted_by_manufacturer_count_then_name"`
- [x] `pnpm test -- src/lib/location-links.test.ts`
- [x] Pre-commit hooks passed during `git commit` (frontend lint, frontend type check, frontend tests, backend tests)
