### PR TITLE
refactor: remove remaining address references from locations refactor

### DIFF
--- a/backend/apps/catalog/claims.py
+++ b/backend/apps/catalog/claims.py
@@ -26,7 +26,7 @@ RELATIONSHIP_SCHEMAS: dict[str, dict[str, str]] = {
     "gameplay_feature": {"gameplay_feature_slug": "gameplay_feature"},
     "reward_type": {"reward_type_slug": "reward_type"},
     "abbreviation": {"value": "value"},
-    # Address relationship — claim lives on CorporateEntity
+    # Location relationship — claim lives on CorporateEntity
     "location": {"location_path": "location"},
     # Alias namespaces — claim lives on the parent object
     "theme_alias": {"alias_value": "alias"},

--- a/backend/apps/catalog/ingestion/parsers.py
+++ b/backend/apps/catalog/ingestion/parsers.py
@@ -313,11 +313,11 @@ class _IPDBLocationLookup:
                 country_map = self._by_country.setdefault(root.location_path, {})
                 country_map.setdefault(val, loc.location_path)
 
-    def resolve(self, addr: dict[str, str]) -> str | None:
+    def resolve(self, parsed: dict[str, str]) -> str | None:
         """Resolve a parsed {city, state, country} dict to a location_path, or None."""
-        country_name = addr.get("country", "").strip()
-        state_name = addr.get("state", "").strip()
-        city_name = addr.get("city", "").strip()
+        country_name = parsed.get("country", "").strip()
+        state_name = parsed.get("state", "").strip()
+        city_name = parsed.get("city", "").strip()
 
         if not country_name:
             return None
@@ -365,10 +365,10 @@ def get_ipdb_location(
     override = _IPDB_LOCATION_OVERRIDES.get(mfr_id)
     if override is not None:
         return override
-    addr = parse_ipdb_location(location)
-    if not any(addr.values()):
+    parsed = parse_ipdb_location(location)
+    if not any(parsed.values()):
         return None
-    return lookup.resolve(addr)
+    return lookup.resolve(parsed)
 
 
 def parse_credit_string(raw: str | None) -> list[str]:

--- a/backend/apps/catalog/management/commands/ingest_pinbase.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase.py
@@ -892,12 +892,12 @@ class Command(BaseCommand):
             )
         resolve_corporate_entity_aliases()
 
-        # Assert address relationship claims and sync CorporateEntityLocation rows.
+        # Assert location relationship claims and sync CorporateEntityLocation rows.
         loc_by_path = {
             loc.location_path: loc
             for loc in Location.objects.only("location_path", "pk")
         }
-        address_claims: list[Claim] = []
+        location_claims: list[Claim] = []
         all_ce_pks: set[int] = {obj.pk for obj in objs}
 
         for obj, entry in zip(objs, valid_entries):
@@ -906,7 +906,7 @@ class Command(BaseCommand):
                 claim_key, value = build_relationship_claim(
                     "location", {"location_path": hq_path}
                 )
-                address_claims.append(
+                location_claims.append(
                     Claim(
                         content_type_id=ct_id,
                         object_id=obj.pk,
@@ -923,7 +923,7 @@ class Command(BaseCommand):
 
         Claim.objects.bulk_assert_claims(
             source,
-            address_claims,
+            location_claims,
             sweep_field="location",
             authoritative_scope=make_authoritative_scope(CorporateEntity, all_ce_pks),
         )

--- a/backend/apps/catalog/models/location.py
+++ b/backend/apps/catalog/models/location.py
@@ -81,7 +81,7 @@ class LocationAlias(AliasBase):
 class CorporateEntityLocation(models.Model):
     """Associates a CorporateEntity with a canonical Location.
 
-    One-to-many: a CE can have addresses in multiple locations.
+    One-to-many: a CE can have multiple locations.
     ``location`` points to the most specific known level (city, subdivision,
     or country).  The full hierarchy is accessible via ``location.parent``.
 

--- a/backend/apps/catalog/models/manufacturer.py
+++ b/backend/apps/catalog/models/manufacturer.py
@@ -1,4 +1,4 @@
-"""Manufacturer, CorporateEntity, and Address models."""
+"""Manufacturer and CorporateEntity models."""
 
 from __future__ import annotations
 

--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -214,7 +214,7 @@ def resolve_all(stdout=None) -> int:
     resolve_all_aliases()
     _status("Hierarchy and aliases resolved")
 
-    # 0a3. Sync CorporateEntityLocation rows from address claims.
+    # 0a3. Sync CorporateEntityLocation rows from location claims.
     resolve_all_corporate_entity_locations()
     _status("Corporate entity locations resolved")
 

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -1102,7 +1102,7 @@ def resolve_all_location_aliases() -> None:
 
 
 def resolve_all_corporate_entity_locations() -> dict[str, int]:
-    """Sync CorporateEntityLocation rows from active 'address' claims on CorporateEntity.
+    """Sync CorporateEntityLocation rows from active 'location' claims on CorporateEntity.
 
     Loads ALL existing CorporateEntityLocation rows so that CEs whose claims
     were all deactivated also have their stale rows removed.

--- a/backend/apps/catalog/tests/test_parsers.py
+++ b/backend/apps/catalog/tests/test_parsers.py
@@ -372,7 +372,7 @@ class TestIPDBLocationLookup:
             is None
         )
 
-    def test_empty_addr_returns_none(self, loc_tree):
+    def test_empty_parsed_returns_none(self, loc_tree):
         lookup = _IPDBLocationLookup()
         assert lookup.resolve({"city": "", "state": "", "country": ""}) is None
 

--- a/backend/apps/catalog/tests/test_resolve.py
+++ b/backend/apps/catalog/tests/test_resolve.py
@@ -404,7 +404,7 @@ class TestResolveCorporateEntityLocations:
             location_type="city",
         )
 
-    def _assert_address(self, source, ce, path):
+    def _assert_location(self, source, ce, path):
         claim_key, value = build_relationship_claim("location", {"location_path": path})
         Claim.objects.assert_claim(
             ce, "location", value, source=source, claim_key=claim_key
@@ -414,7 +414,7 @@ class TestResolveCorporateEntityLocations:
         source = Source.objects.create(name="PB", source_type="editorial", priority=300)
         ce = self._make_ce("williams")
         loc = self._make_location("usa/il/chicago")
-        self._assert_address(source, ce, "usa/il/chicago")
+        self._assert_location(source, ce, "usa/il/chicago")
 
         resolve_all_corporate_entity_locations()
 
@@ -426,7 +426,7 @@ class TestResolveCorporateEntityLocations:
         source = Source.objects.create(name="PB", source_type="editorial", priority=300)
         ce = self._make_ce("williams")
         self._make_location("usa/il/chicago")
-        self._assert_address(source, ce, "usa/il/chicago")
+        self._assert_location(source, ce, "usa/il/chicago")
         resolve_all_corporate_entity_locations()
         assert CorporateEntityLocation.objects.filter(corporate_entity=ce).count() == 1
 
@@ -442,8 +442,8 @@ class TestResolveCorporateEntityLocations:
         ce2 = self._make_ce("bally")
         self._make_location("usa/il/chicago")
         self._make_location("usa/il/elk-grove-village")
-        self._assert_address(source, ce1, "usa/il/chicago")
-        self._assert_address(source, ce2, "usa/il/elk-grove-village")
+        self._assert_location(source, ce1, "usa/il/chicago")
+        self._assert_location(source, ce2, "usa/il/elk-grove-village")
 
         result = resolve_all_corporate_entity_locations()
 

--- a/frontend/src/lib/components/LocationLink.svelte
+++ b/frontend/src/lib/components/LocationLink.svelte
@@ -4,15 +4,15 @@
 	import { resolveHref } from '$lib/utils';
 
 	let {
-		addr
+		loc
 	}: {
-		addr: components['schemas']['CorporateEntityLocationSchema'];
+		loc: components['schemas']['CorporateEntityLocationSchema'];
 	} = $props();
 
 	type Part = { text: string; href?: string };
 
 	let parts = $derived.by((): Part[] =>
-		buildLocationParts(addr).map((part) => ({
+		buildLocationParts(loc).map((part) => ({
 			...part,
 			href: part.href ? resolveHref(part.href) : undefined
 		}))

--- a/frontend/src/routes/manufacturers/[slug]/+layout.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+layout.svelte
@@ -30,7 +30,7 @@
 		auth.load();
 	});
 
-	let hasEntityAddresses = $derived(mfr.entities.some((e) => e.locations.length > 0));
+	let hasEntityLocations = $derived(mfr.entities.some((e) => e.locations.length > 0));
 
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
@@ -109,8 +109,8 @@
 											{/if}
 										</span>
 									{/if}
-									{#each entity.locations as addr, i (i)}
-										<LocationLink {addr} />
+									{#each entity.locations as loc, i (i)}
+										<LocationLink {loc} />
 									{/each}
 								</div>
 							</SidebarListItem>
@@ -119,7 +119,7 @@
 				</SidebarSection>
 			{/if}
 
-			{#if !hasEntityAddresses && (mfr.headquarters || mfr.country)}
+			{#if !hasEntityLocations && (mfr.headquarters || mfr.country)}
 				<SidebarSection heading="Location">
 					<p class="sidebar-value">
 						{[mfr.headquarters, mfr.country].filter(Boolean).join(', ')}


### PR DESCRIPTION
## Summary

Clean up stale naming left over from the Address model that was replaced by Location in #110.

- Rename `address_claims` → `location_claims` in ingest
- Rename `_assert_address` → `_assert_location` in tests
- Rename `hasEntityAddresses` → `hasEntityLocations` in frontend
- Rename `addr` loop variable and prop → `loc` in LocationLink and manufacturer layout
- Rename `addr` parameter → `parsed` in `_IPDBLocationLookup.resolve()`
- Update comments and docstrings throughout

## Test plan

- [ ] `make test` passes (653 backend + 85 frontend)