### PR TITLE
fix(frontend): remove duplicate manufacturer count on location pages

### DIFF
--- a/frontend/src/lib/components/LocationDetailPage.svelte
+++ b/frontend/src/lib/components/LocationDetailPage.svelte
@@ -58,7 +58,7 @@
 
 		<TwoColumnLayout>
 			{#snippet main()}
-				<ManufacturerCardGrid {manufacturers} />
+				<ManufacturerCardGrid {manufacturers} showCount={false} />
 			{/snippet}
 
 			{#snippet sidebar()}

--- a/frontend/src/lib/components/ManufacturerCardGrid.svelte
+++ b/frontend/src/lib/components/ManufacturerCardGrid.svelte
@@ -3,7 +3,8 @@
 	import ManufacturerCard from '$lib/components/cards/ManufacturerCard.svelte';
 
 	let {
-		manufacturers
+		manufacturers,
+		showCount = true
 	}: {
 		manufacturers: {
 			name: string;
@@ -11,10 +12,11 @@
 			model_count: number;
 			thumbnail_url?: string | null;
 		}[];
+		showCount?: boolean;
 	} = $props();
 </script>
 
-<ClientFilteredGrid items={manufacturers} entityName="manufacturer">
+<ClientFilteredGrid items={manufacturers} entityName="manufacturer" {showCount}>
 	{#snippet children(mfr)}
 		<ManufacturerCard
 			slug={mfr.slug}


### PR DESCRIPTION
## Summary

The manufacturer count was displayed twice on location detail pages: once in the page subtitle and again inside the grid via `ClientFilteredGrid`'s built-in count label.

- Added `showCount` prop to `ManufacturerCardGrid` (defaults to `true` for backward compatibility)
- Location detail pages pass `showCount={false}` to suppress the redundant grid count

## Test plan

- [ ] Visit a location page with manufacturers (e.g. `/locations/usa/il/chicago`) and confirm the count appears only once in the subtitle
- [ ] Visit the main manufacturers page and confirm the count still appears there (default behavior unchanged)