### PR TITLE
chore: improve display policy labels and update footer copyright

### DIFF
--- a/backend/apps/core/licensing.py
+++ b/backend/apps/core/licensing.py
@@ -7,7 +7,6 @@ DISPLAY_POLICY_RANKS: dict[str, int] = {
     "show-all": 0,  # Everything, including Not Allowed
     "include-unknown": 5,  # Unknown (null, rank 5) + all licensed content
     "licensed-only": 38,  # Lowest CC license (CC BY-NC-ND 2.0) and above
-    "public-domain-only": 99,  # CC0 and Public Domain only
 }
 
 # Effective rank for null (unknown) license.

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -186,10 +186,9 @@ if "pytest" in sys.modules:
     CONSTANCE_BACKEND = "constance.backends.memory.MemoryBackend"
 
 DISPLAY_POLICY_CHOICES = (
-    ("show-all", "Show all content (including Not Allowed — internal demos only)"),
-    ("include-unknown", "Show unknown + licensed content (e.g., OPDB images)"),
-    ("licensed-only", "Show only licensed content (excludes unknown and not-allowed)"),
-    ("public-domain-only", "Show only Public Domain / CC0 content"),
+    ("show-all", "☠️ Show All Content — includes Not Allowed (e.g. IPDB images)"),
+    ("include-unknown", "⚠️ Include Unknown License Content (e.g. OPDB images)"),
+    ("licensed-only", "✅ Show Only Licensed Content — no OPDB or IPDB images"),
 )
 
 CONSTANCE_CONFIG = {

--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { SITE_NAME } from '$lib/constants';
 	import { resolveHref } from '$lib/utils';
 </script>
 
@@ -11,7 +10,7 @@
 			<a href={resolveHref('/privacy')}>Privacy</a>
 			<a href={resolveHref('/api-docs')}>API</a>
 		</nav>
-		<p class="copyright">&copy; {new Date().getFullYear()} {SITE_NAME}</p>
+		<p class="copyright">&copy; {new Date().getFullYear()} The Flip</p>
 	</div>
 </footer>
 


### PR DESCRIPTION
## Summary
- Updated CONTENT_DISPLAY_POLICY admin choices with clearer emoji-prefixed labels and concrete examples (IPDB/OPDB images)
- Removed unused `public-domain-only` policy option
- Changed footer copyright from dynamic site name to "The Flip"

## Test plan
- [x] All backend tests pass (including licensing tests)
- [x] All frontend tests pass
- [ ] Verify display policy labels render correctly in Django admin constance config
- [ ] Verify footer shows "© 2026 The Flip"

🤖 Generated with [Claude Code](https://claude.com/claude-code)