### PR TITLE
fix(frontend): pin footer to bottom of viewport on short-content pages

### DIFF
--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -17,7 +17,6 @@
 <style>
 	.site-footer {
 		border-top: 1px solid var(--color-border-soft);
-		margin-top: var(--size-8);
 		padding: var(--size-5) 0;
 	}
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -6,16 +6,26 @@
 	let { children } = $props();
 </script>
 
-<Nav />
+<div class="site-shell">
+	<Nav />
 
-<main class="page-content">
-	{@render children()}
-</main>
+	<main class="page-content">
+		{@render children()}
+	</main>
 
-<Footer />
+	<Footer />
+</div>
 
 <style>
+	.site-shell {
+		display: flex;
+		flex-direction: column;
+		min-height: 100dvh;
+	}
+
 	.page-content {
+		flex: 1;
+		width: 100%;
 		max-width: 72rem;
 		margin: 0 auto;
 		padding: var(--size-6) var(--size-5);


### PR DESCRIPTION
## Summary
- Wrap root layout in a flex column with `min-height: 100dvh` so the footer stays at the viewport bottom on short-content pages
- Main content area gets `flex: 1` to fill available space, pushing the footer down
- Remove `margin-top` from footer since flex layout handles spacing

## Test plan
- [ ] Visit a short-content page (e.g. /licensing) — footer should be at the bottom of the viewport
- [ ] Visit a long-content page — footer should be below the content, not visible on initial load
- [ ] Check on mobile — `100dvh` accounts for browser chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)