### PR TITLE
feat(frontend): vintage polaroid card and header styling

### DIFF
--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -30,7 +30,92 @@
 		await auth.logout();
 		await goto(resolveHref('/'));
 	}
+
+	// Unique ID for SVG filter references
+	const uid = Math.random().toString(36).slice(2, 8);
+
+	// Random seeds for stain patterns
+	const stainSeed1 = Math.floor(Math.random() * 1000);
+	const stainSeed2 = Math.floor(Math.random() * 1000);
+	const stainSeed3 = Math.floor(Math.random() * 1000);
+
+	// Stain positions (spread across the header width)
+	const stain1X = 5 + Math.random() * 25;
+	const stain1Y = 10 + Math.random() * 80;
+	const stain2X = 40 + Math.random() * 20;
+	const stain2Y = 10 + Math.random() * 80;
+	const stain3X = 70 + Math.random() * 25;
+	const stain3Y = 10 + Math.random() * 80;
+
+	// Torn edge: a random jagged bottom border
+	const tornSeed = Math.floor(Math.random() * 1000);
 </script>
+
+<!-- Hidden SVG filter definitions -->
+<svg class="svg-filters" aria-hidden="true">
+	<defs>
+		<!-- Stain filters with different seeds -->
+		<filter id="hdr-stain1-{uid}" x="-50%" y="-50%" width="200%" height="200%">
+			<feTurbulence
+				type="fractalNoise"
+				baseFrequency="0.03"
+				numOctaves="5"
+				seed={stainSeed1}
+				result="noise"
+			/>
+			<feComponentTransfer in="noise" result="blobs">
+				<feFuncA type="discrete" tableValues="0 0 0 0 0 0 0.5 0.7" />
+			</feComponentTransfer>
+			<feFlood flood-color="rgb(120, 80, 30)" flood-opacity="0.12" result="color" />
+			<feComposite in="color" in2="blobs" operator="in" result="stain" />
+			<feGaussianBlur in="stain" stdDeviation="4" />
+		</filter>
+
+		<filter id="hdr-stain2-{uid}" x="-50%" y="-50%" width="200%" height="200%">
+			<feTurbulence
+				type="fractalNoise"
+				baseFrequency="0.04"
+				numOctaves="4"
+				seed={stainSeed2}
+				result="noise"
+			/>
+			<feComponentTransfer in="noise" result="blobs">
+				<feFuncA type="discrete" tableValues="0 0 0 0 0 0 0 0.4" />
+			</feComponentTransfer>
+			<feFlood flood-color="rgb(100, 65, 20)" flood-opacity="0.08" result="color" />
+			<feComposite in="color" in2="blobs" operator="in" result="stain" />
+			<feGaussianBlur in="stain" stdDeviation="5" />
+		</filter>
+
+		<filter id="hdr-stain3-{uid}" x="-50%" y="-50%" width="200%" height="200%">
+			<feTurbulence
+				type="fractalNoise"
+				baseFrequency="0.025"
+				numOctaves="5"
+				seed={stainSeed3}
+				result="noise"
+			/>
+			<feComponentTransfer in="noise" result="blobs">
+				<feFuncA type="discrete" tableValues="0 0 0 0 0 0.4 0.6 0.8" />
+			</feComponentTransfer>
+			<feFlood flood-color="rgb(130, 90, 35)" flood-opacity="0.1" result="color" />
+			<feComposite in="color" in2="blobs" operator="in" result="stain" />
+			<feGaussianBlur in="stain" stdDeviation="3" />
+		</filter>
+
+		<!-- Torn bottom edge displacement -->
+		<filter id="hdr-tear-{uid}" x="-2%" y="-2%" width="104%" height="120%">
+			<feTurbulence
+				type="turbulence"
+				baseFrequency="0.06 0.02"
+				numOctaves="4"
+				seed={tornSeed}
+				result="warp"
+			/>
+			<feDisplacementMap in="SourceGraphic" in2="warp" scale="6" yChannelSelector="R" />
+		</filter>
+	</defs>
+</svg>
 
 <header class="site-header">
 	<div class="header-inner">
@@ -78,30 +163,106 @@
 			</button>
 		</div>
 	</div>
+
+	<!-- Coffee stain overlays -->
+	<svg class="stain-overlay" aria-hidden="true">
+		<rect
+			x="{stain1X}%"
+			y="{stain1Y}%"
+			width="20%"
+			height="80%"
+			filter="url(#{`hdr-stain1-${uid}`})"
+		/>
+		<rect
+			x="{stain2X}%"
+			y="{stain2Y}%"
+			width="15%"
+			height="70%"
+			filter="url(#{`hdr-stain2-${uid}`})"
+		/>
+		<rect
+			x="{stain3X}%"
+			y="{stain3Y}%"
+			width="18%"
+			height="75%"
+			filter="url(#{`hdr-stain3-${uid}`})"
+		/>
+	</svg>
+
+	<!-- Torn bottom edge -->
+	<div class="torn-edge" style:filter="url(#{`hdr-tear-${uid}`})"></div>
 </header>
 
 <style>
+	.svg-filters {
+		position: absolute;
+		width: 0;
+		height: 0;
+		overflow: hidden;
+		pointer-events: none;
+	}
+
 	.site-header {
-		background-color: var(--color-surface);
-		border-bottom: 1px solid var(--color-border-soft);
 		position: sticky;
 		top: 0;
 		z-index: 100;
+		background-color: #efe8dc;
+		border-bottom: none;
+	}
+
+	/* Subtle paper grain via repeating gradient */
+	.site-header::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: repeating-linear-gradient(
+			0deg,
+			transparent,
+			transparent 2px,
+			rgba(0, 0, 0, 0.01) 2px,
+			rgba(0, 0, 0, 0.01) 4px
+		);
+		pointer-events: none;
+		z-index: 1;
+	}
+
+	.stain-overlay {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+		z-index: 2;
+		overflow: hidden;
+	}
+
+	/* Torn paper bottom edge — a strip that gets displaced by SVG turbulence */
+	.torn-edge {
+		position: absolute;
+		bottom: -4px;
+		left: 0;
+		right: 0;
+		height: 8px;
+		background: #efe8dc;
+		pointer-events: none;
+		z-index: 3;
 	}
 
 	.header-inner {
+		position: relative;
 		max-width: 72rem;
 		margin: 0 auto;
 		padding: var(--size-3) var(--size-5);
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+		z-index: 10;
 	}
 
 	.site-title {
 		font-size: var(--font-size-4);
 		font-weight: 700;
-		color: var(--color-text-primary);
+		color: #3d3529;
 		text-decoration: none;
 	}
 
@@ -115,7 +276,7 @@
 	}
 
 	.nav-link {
-		color: var(--color-text-muted);
+		color: #6b5d4d;
 		text-decoration: none;
 		font-size: var(--font-size-2);
 		font-weight: 500;
@@ -127,7 +288,7 @@
 	}
 
 	.nav-link:hover {
-		color: var(--color-text-primary);
+		color: #3d3529;
 	}
 
 	.nav-link.active {
@@ -142,7 +303,7 @@
 	}
 
 	.search-link {
-		color: var(--color-text-muted);
+		color: #6b5d4d;
 		padding: var(--size-1);
 		display: flex;
 		align-items: center;
@@ -150,7 +311,7 @@
 	}
 
 	.search-link:hover {
-		color: var(--color-text-primary);
+		color: #3d3529;
 	}
 
 	.search-link.active {
@@ -164,12 +325,12 @@
 
 	.auth-user {
 		font-size: var(--font-size-2);
-		color: var(--color-text-muted);
+		color: #6b5d4d;
 	}
 
 	.auth-link {
 		font-size: var(--font-size-2);
-		color: var(--color-text-muted);
+		color: #6b5d4d;
 		text-decoration: none;
 		background: none;
 		border: none;
@@ -180,14 +341,14 @@
 	}
 
 	.auth-link:hover {
-		color: var(--color-text-primary);
+		color: #3d3529;
 	}
 
 	.mobile-toggle {
 		display: none;
 		background: none;
 		border: none;
-		color: var(--color-text-primary);
+		color: #3d3529;
 		cursor: pointer;
 		padding: var(--size-1);
 	}
@@ -209,14 +370,72 @@
 			top: 100%;
 			left: 0;
 			right: 0;
-			background-color: var(--color-surface);
-			border-bottom: 1px solid var(--color-border-soft);
+			background-color: #efe8dc;
+			border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 			padding: var(--size-3) var(--size-5);
 			gap: var(--size-2);
 		}
 
 		.site-nav.open {
 			display: flex;
+		}
+	}
+
+	/* ---- Dark mode ---- */
+	@media (prefers-color-scheme: dark) {
+		.site-header {
+			background-color: var(--color-surface);
+		}
+
+		.site-header::before {
+			background: none;
+		}
+
+		.torn-edge {
+			background: var(--color-surface);
+		}
+
+		.site-title {
+			color: var(--color-text-primary);
+		}
+
+		.nav-link {
+			color: var(--color-text-muted);
+		}
+
+		.nav-link:hover {
+			color: var(--color-text-primary);
+		}
+
+		.search-link {
+			color: var(--color-text-muted);
+		}
+
+		.search-link:hover {
+			color: var(--color-text-primary);
+		}
+
+		.auth-user {
+			color: var(--color-text-muted);
+		}
+
+		.auth-link {
+			color: var(--color-text-muted);
+		}
+
+		.auth-link:hover {
+			color: var(--color-text-primary);
+		}
+
+		.mobile-toggle {
+			color: var(--color-text-primary);
+		}
+
+		@media (max-width: 640px) {
+			.site-nav {
+				background-color: var(--color-surface);
+				border-bottom-color: var(--color-border-soft);
+			}
 		}
 	}
 </style>

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -384,7 +384,7 @@
 	/* ---- Dark mode ---- */
 	@media (prefers-color-scheme: dark) {
 		.site-header {
-			background-color: var(--color-surface);
+			background-color: #26221d;
 		}
 
 		.site-header::before {
@@ -392,7 +392,7 @@
 		}
 
 		.torn-edge {
-			background: var(--color-surface);
+			background: #26221d;
 		}
 
 		.site-title {
@@ -433,7 +433,7 @@
 
 		@media (max-width: 640px) {
 			.site-nav {
-				background-color: var(--color-surface);
+				background-color: #26221d;
 				border-bottom-color: var(--color-border-soft);
 			}
 		}

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { faBars, faMagnifyingGlass, faXmark } from '@fortawesome/free-solid-svg-icons';
 	import FaIcon from './FaIcon.svelte';
+	import CoffeeStain from './effects/CoffeeStain.svelte';
 	import { SITE_NAME } from '$lib/constants';
 	import { resolveHref } from '$lib/utils';
 	import { auth } from '$lib/auth.svelte';
@@ -31,80 +32,22 @@
 		await goto(resolveHref('/'));
 	}
 
-	// Unique ID for SVG filter references
-	const uid = Math.random().toString(36).slice(2, 8);
+	const randInt = (max: number) => Math.floor(Math.random() * max);
 
-	// Random seeds for stain patterns
-	const stainSeed1 = Math.floor(Math.random() * 1000);
-	const stainSeed2 = Math.floor(Math.random() * 1000);
-	const stainSeed3 = Math.floor(Math.random() * 1000);
+	// Stain seeds (one per stain strip)
+	const stainSeed1 = randInt(1000);
+	const stainSeed2 = randInt(1000);
+	const stainSeed3 = randInt(1000);
 
-	// Stain positions (spread across the header width)
-	const stain1X = 5 + Math.random() * 25;
-	const stain1Y = 10 + Math.random() * 80;
-	const stain2X = 40 + Math.random() * 20;
-	const stain2Y = 10 + Math.random() * 80;
-	const stain3X = 70 + Math.random() * 25;
-	const stain3Y = 10 + Math.random() * 80;
-
-	// Torn edge: a random jagged bottom border
-	const tornSeed = Math.floor(Math.random() * 1000);
+	// Torn bottom edge
+	const tornId = `tear-${crypto.randomUUID()}`;
+	const tornSeed = randInt(1000);
 </script>
 
-<!-- Hidden SVG filter definitions -->
+<!-- Torn edge filter definition -->
 <svg class="svg-filters" aria-hidden="true">
 	<defs>
-		<!-- Stain filters with different seeds -->
-		<filter id="hdr-stain1-{uid}" x="-50%" y="-50%" width="200%" height="200%">
-			<feTurbulence
-				type="fractalNoise"
-				baseFrequency="0.03"
-				numOctaves="5"
-				seed={stainSeed1}
-				result="noise"
-			/>
-			<feComponentTransfer in="noise" result="blobs">
-				<feFuncA type="discrete" tableValues="0 0 0 0 0 0 0.5 0.7" />
-			</feComponentTransfer>
-			<feFlood flood-color="rgb(120, 80, 30)" flood-opacity="0.12" result="color" />
-			<feComposite in="color" in2="blobs" operator="in" result="stain" />
-			<feGaussianBlur in="stain" stdDeviation="4" />
-		</filter>
-
-		<filter id="hdr-stain2-{uid}" x="-50%" y="-50%" width="200%" height="200%">
-			<feTurbulence
-				type="fractalNoise"
-				baseFrequency="0.04"
-				numOctaves="4"
-				seed={stainSeed2}
-				result="noise"
-			/>
-			<feComponentTransfer in="noise" result="blobs">
-				<feFuncA type="discrete" tableValues="0 0 0 0 0 0 0 0.4" />
-			</feComponentTransfer>
-			<feFlood flood-color="rgb(100, 65, 20)" flood-opacity="0.08" result="color" />
-			<feComposite in="color" in2="blobs" operator="in" result="stain" />
-			<feGaussianBlur in="stain" stdDeviation="5" />
-		</filter>
-
-		<filter id="hdr-stain3-{uid}" x="-50%" y="-50%" width="200%" height="200%">
-			<feTurbulence
-				type="fractalNoise"
-				baseFrequency="0.025"
-				numOctaves="5"
-				seed={stainSeed3}
-				result="noise"
-			/>
-			<feComponentTransfer in="noise" result="blobs">
-				<feFuncA type="discrete" tableValues="0 0 0 0 0 0.4 0.6 0.8" />
-			</feComponentTransfer>
-			<feFlood flood-color="rgb(130, 90, 35)" flood-opacity="0.1" result="color" />
-			<feComposite in="color" in2="blobs" operator="in" result="stain" />
-			<feGaussianBlur in="stain" stdDeviation="3" />
-		</filter>
-
-		<!-- Torn bottom edge displacement -->
-		<filter id="hdr-tear-{uid}" x="-2%" y="-2%" width="104%" height="120%">
+		<filter id={tornId} x="-2%" y="-2%" width="104%" height="120%">
 			<feTurbulence
 				type="turbulence"
 				baseFrequency="0.06 0.02"
@@ -164,33 +107,40 @@
 		</div>
 	</div>
 
-	<!-- Coffee stain overlays -->
-	<svg class="stain-overlay" aria-hidden="true">
-		<rect
-			x="{stain1X}%"
-			y="{stain1Y}%"
-			width="20%"
-			height="80%"
-			filter="url(#{`hdr-stain1-${uid}`})"
-		/>
-		<rect
-			x="{stain2X}%"
-			y="{stain2Y}%"
-			width="15%"
-			height="70%"
-			filter="url(#{`hdr-stain2-${uid}`})"
-		/>
-		<rect
-			x="{stain3X}%"
-			y="{stain3Y}%"
-			width="18%"
-			height="75%"
-			filter="url(#{`hdr-stain3-${uid}`})"
-		/>
-	</svg>
+	<!-- Coffee stain overlays — three strips covering full width -->
+	<CoffeeStain
+		seed={stainSeed1}
+		frequency={0.03}
+		opacity={0.12}
+		blur={4}
+		threshold="0 0 0 0 0 0 0.5 0.7"
+		x="0%"
+		width="40%"
+	/>
+	<CoffeeStain
+		seed={stainSeed2}
+		frequency={0.04}
+		octaves={4}
+		opacity={0.08}
+		blur={5}
+		threshold="0 0 0 0 0 0 0 0.4"
+		color="rgb(100, 65, 20)"
+		x="30%"
+		width="40%"
+	/>
+	<CoffeeStain
+		seed={stainSeed3}
+		frequency={0.025}
+		opacity={0.1}
+		blur={3}
+		threshold="0 0 0 0 0 0.4 0.6 0.8"
+		color="rgb(130, 90, 35)"
+		x="60%"
+		width="40%"
+	/>
 
 	<!-- Torn bottom edge -->
-	<div class="torn-edge" style:filter="url(#{`hdr-tear-${uid}`})"></div>
+	<div class="torn-edge" style:filter="url(#{tornId})"></div>
 </header>
 
 <style>
@@ -203,10 +153,15 @@
 	}
 
 	.site-header {
+		/* Color tokens — overridden in dark mode */
+		--header-bg: #efe8dc;
+		--header-ink: #3d3529;
+		--header-ink-muted: #6b5d4d;
+
 		position: sticky;
 		top: 0;
 		z-index: 100;
-		background-color: #efe8dc;
+		background-color: var(--header-bg);
 		border-bottom: none;
 	}
 
@@ -226,24 +181,14 @@
 		z-index: 1;
 	}
 
-	.stain-overlay {
-		position: absolute;
-		inset: 0;
-		width: 100%;
-		height: 100%;
-		pointer-events: none;
-		z-index: 2;
-		overflow: hidden;
-	}
-
-	/* Torn paper bottom edge — a strip that gets displaced by SVG turbulence */
+	/* Torn paper bottom edge — shares background color via token */
 	.torn-edge {
 		position: absolute;
 		bottom: -4px;
 		left: 0;
 		right: 0;
 		height: 8px;
-		background: #efe8dc;
+		background: var(--header-bg);
 		pointer-events: none;
 		z-index: 3;
 	}
@@ -262,7 +207,7 @@
 	.site-title {
 		font-size: var(--font-size-4);
 		font-weight: 700;
-		color: #3d3529;
+		color: var(--header-ink);
 		text-decoration: none;
 	}
 
@@ -276,7 +221,7 @@
 	}
 
 	.nav-link {
-		color: #6b5d4d;
+		color: var(--header-ink-muted);
 		text-decoration: none;
 		font-size: var(--font-size-2);
 		font-weight: 500;
@@ -288,7 +233,7 @@
 	}
 
 	.nav-link:hover {
-		color: #3d3529;
+		color: var(--header-ink);
 	}
 
 	.nav-link.active {
@@ -303,7 +248,7 @@
 	}
 
 	.search-link {
-		color: #6b5d4d;
+		color: var(--header-ink-muted);
 		padding: var(--size-1);
 		display: flex;
 		align-items: center;
@@ -311,7 +256,7 @@
 	}
 
 	.search-link:hover {
-		color: #3d3529;
+		color: var(--header-ink);
 	}
 
 	.search-link.active {
@@ -325,12 +270,12 @@
 
 	.auth-user {
 		font-size: var(--font-size-2);
-		color: #6b5d4d;
+		color: var(--header-ink-muted);
 	}
 
 	.auth-link {
 		font-size: var(--font-size-2);
-		color: #6b5d4d;
+		color: var(--header-ink-muted);
 		text-decoration: none;
 		background: none;
 		border: none;
@@ -341,14 +286,14 @@
 	}
 
 	.auth-link:hover {
-		color: #3d3529;
+		color: var(--header-ink);
 	}
 
 	.mobile-toggle {
 		display: none;
 		background: none;
 		border: none;
-		color: #3d3529;
+		color: var(--header-ink);
 		cursor: pointer;
 		padding: var(--size-1);
 	}
@@ -370,7 +315,7 @@
 			top: 100%;
 			left: 0;
 			right: 0;
-			background-color: #efe8dc;
+			background-color: var(--header-bg);
 			border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 			padding: var(--size-3) var(--size-5);
 			gap: var(--size-2);
@@ -384,56 +329,17 @@
 	/* ---- Dark mode ---- */
 	@media (prefers-color-scheme: dark) {
 		.site-header {
-			background-color: #26221d;
+			--header-bg: #26221d;
+			--header-ink: var(--color-text-primary);
+			--header-ink-muted: var(--color-text-muted);
 		}
 
 		.site-header::before {
 			background: none;
 		}
 
-		.torn-edge {
-			background: #26221d;
-		}
-
-		.site-title {
-			color: var(--color-text-primary);
-		}
-
-		.nav-link {
-			color: var(--color-text-muted);
-		}
-
-		.nav-link:hover {
-			color: var(--color-text-primary);
-		}
-
-		.search-link {
-			color: var(--color-text-muted);
-		}
-
-		.search-link:hover {
-			color: var(--color-text-primary);
-		}
-
-		.auth-user {
-			color: var(--color-text-muted);
-		}
-
-		.auth-link {
-			color: var(--color-text-muted);
-		}
-
-		.auth-link:hover {
-			color: var(--color-text-primary);
-		}
-
-		.mobile-toggle {
-			color: var(--color-text-primary);
-		}
-
 		@media (max-width: 640px) {
 			.site-nav {
-				background-color: #26221d;
 				border-bottom-color: var(--color-border-soft);
 			}
 		}

--- a/frontend/src/lib/components/cards/Card.svelte
+++ b/frontend/src/lib/components/cards/Card.svelte
@@ -14,6 +14,43 @@
 		children?: Snippet;
 	} = $props();
 
+	// Unique ID per component instance for SVG filter references
+	const uid = Math.random().toString(36).slice(2, 8);
+
+	// Random seeds for SVG turbulence (each card gets different noise patterns)
+	const grainSeed = Math.floor(Math.random() * 1000);
+	const stainSeed = Math.floor(Math.random() * 1000);
+	const stainSeed2 = Math.floor(Math.random() * 1000);
+
+	// Randomize stain blob position (as fraction 0–1)
+	const stainX = 0.15 + Math.random() * 0.7;
+	const stainY = 0.15 + Math.random() * 0.7;
+	const stain2X = 0.1 + Math.random() * 0.8;
+	const stain2Y = 0.1 + Math.random() * 0.8;
+
+	// Wear effect: ~40% of cards get a dog-ear, crease, or torn corner
+	type WearType = 'none' | 'dog-ear' | 'crease' | 'torn-corner';
+	const wearRoll = Math.random();
+	const wearType: WearType =
+		wearRoll < 0.6
+			? 'none'
+			: wearRoll < 0.73
+				? 'dog-ear'
+				: wearRoll < 0.87
+					? 'crease'
+					: 'torn-corner';
+
+	// Which corner for dog-ear / torn-corner (top-right, top-left, bottom-right, bottom-left)
+	const corners = ['tr', 'tl', 'br', 'bl'] as const;
+	const wearCorner = corners[Math.floor(Math.random() * corners.length)];
+
+	// Crease angle and position
+	const creaseAngle = -25 + Math.random() * 50; // -25° to 25°
+	const creasePos = 30 + Math.random() * 40; // 30%–70% from top
+
+	// Dog-ear size
+	const earSize = 1 + Math.random() * 0.8; // 1rem to 1.8rem
+
 	/**
 	 * Svelte action that assigns random CSS custom properties to each card,
 	 * giving every polaroid a unique aged/worn appearance.
@@ -30,28 +67,75 @@
 		node.style.setProperty('--contrast', `${rand(0.85, 0.95)}`);
 		node.style.setProperty('--saturate', `${rand(0.6, 0.85)}`);
 
-		// Coffee stain: randomize position, size, and opacity
-		node.style.setProperty('--stain-x', `${rand(15, 85)}%`);
-		node.style.setProperty('--stain-y', `${rand(15, 85)}%`);
-		node.style.setProperty('--stain-size', `${rand(3, 7)}rem`);
-		node.style.setProperty('--stain-opacity', `${rand(0.06, 0.18)}`);
-
-		// Second, subtler stain for realism
-		node.style.setProperty('--stain2-x', `${rand(10, 90)}%`);
-		node.style.setProperty('--stain2-y', `${rand(10, 90)}%`);
-		node.style.setProperty('--stain2-size', `${rand(2, 5)}rem`);
-		node.style.setProperty('--stain2-opacity', `${rand(0.03, 0.1)}`);
-
 		// Yellowed paper tint intensity
 		node.style.setProperty('--paper-yellow', `${rand(0.03, 0.08)}`);
 	};
 </script>
 
+<!-- Hidden SVG filter definitions (one per card instance) -->
+<svg class="svg-filters" aria-hidden="true">
+	<defs>
+		<!-- Film grain overlay for the photo -->
+		<filter id="grain-{uid}" x="0%" y="0%" width="100%" height="100%">
+			<feTurbulence
+				type="fractalNoise"
+				baseFrequency="0.7"
+				numOctaves="3"
+				seed={grainSeed}
+				result="grain"
+			/>
+			<feColorMatrix type="saturate" values="0" in="grain" result="grainMono" />
+			<feBlend in="SourceGraphic" in2="grainMono" mode="multiply" />
+		</filter>
+
+		<!-- Organic coffee stain blob -->
+		<filter id="stain-{uid}" x="-50%" y="-50%" width="200%" height="200%">
+			<feTurbulence
+				type="fractalNoise"
+				baseFrequency="0.035"
+				numOctaves="5"
+				seed={stainSeed}
+				result="noise"
+			/>
+			<feComponentTransfer in="noise" result="blobs">
+				<feFuncA type="discrete" tableValues="0 0 0 0 0 0 0.6 0.8" />
+			</feComponentTransfer>
+			<feFlood flood-color="rgb(120, 80, 30)" flood-opacity="0.15" result="color" />
+			<feComposite in="color" in2="blobs" operator="in" result="stain" />
+			<feGaussianBlur in="stain" stdDeviation="3" />
+		</filter>
+
+		<!-- Second stain with different pattern -->
+		<filter id="stain2-{uid}" x="-50%" y="-50%" width="200%" height="200%">
+			<feTurbulence
+				type="fractalNoise"
+				baseFrequency="0.045"
+				numOctaves="4"
+				seed={stainSeed2}
+				result="noise"
+			/>
+			<feComponentTransfer in="noise" result="blobs">
+				<feFuncA type="discrete" tableValues="0 0 0 0 0 0 0 0.5" />
+			</feComponentTransfer>
+			<feFlood flood-color="rgb(100, 65, 20)" flood-opacity="0.1" result="color" />
+			<feComposite in="color" in2="blobs" operator="in" result="stain" />
+			<feGaussianBlur in="stain" stdDeviation="4" />
+		</filter>
+	</defs>
+</svg>
+
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href is pre-resolved by caller -->
 <a {href} class="card" use:polaroid>
 	<div class="card-photo">
 		{#if thumbnailUrl}
-			<img src={thumbnailUrl} alt="" class="card-img" loading="lazy" />
+			<img
+				src={thumbnailUrl}
+				alt=""
+				class="card-img"
+				loading="lazy"
+				style:filter="url(#{`grain-${uid}`}) sepia(var(--sepia, 0.5)) brightness(var(--brightness,
+				0.95)) contrast(var(--contrast, 0.9)) saturate(var(--saturate, 0.7))"
+			/>
 		{:else}
 			<div class="card-img-placeholder"></div>
 		{/if}
@@ -62,9 +146,47 @@
 			{@render children()}
 		{/if}
 	</div>
+	<!-- SVG stain overlays with organic shapes -->
+	<svg class="stain-overlay" aria-hidden="true">
+		<rect
+			x="{(stainX - 0.2) * 100}%"
+			y="{(stainY - 0.2) * 100}%"
+			width="40%"
+			height="40%"
+			filter="url(#{`stain-${uid}`})"
+		/>
+		<rect
+			x="{(stain2X - 0.15) * 100}%"
+			y="{(stain2Y - 0.15) * 100}%"
+			width="30%"
+			height="30%"
+			filter="url(#{`stain2-${uid}`})"
+		/>
+	</svg>
+
+	<!-- Wear effects: dog-ear, crease, or torn corner -->
+	{#if wearType === 'dog-ear'}
+		<div class="dog-ear dog-ear--{wearCorner}" style:--ear-size="{earSize}rem"></div>
+	{:else if wearType === 'crease'}
+		<div
+			class="crease"
+			style:--crease-angle="{creaseAngle}deg"
+			style:--crease-pos="{creasePos}%"
+		></div>
+	{:else if wearType === 'torn-corner'}
+		<div class="torn-corner torn-corner--{wearCorner}"></div>
+	{/if}
 </a>
 
 <style>
+	.svg-filters {
+		position: absolute;
+		width: 0;
+		height: 0;
+		overflow: hidden;
+		pointer-events: none;
+	}
+
 	.card {
 		position: relative;
 		display: flex;
@@ -96,36 +218,24 @@
 		z-index: 2;
 	}
 
-	/* Coffee stain — two overlapping radial gradients */
-	.card::after {
-		content: '';
-		position: absolute;
-		inset: 0;
-		background:
-			radial-gradient(
-				ellipse var(--stain-size, 5rem) var(--stain-size, 5rem) at var(--stain-x, 70%)
-					var(--stain-y, 30%),
-				rgba(120, 80, 30, var(--stain-opacity, 0.1)) 0%,
-				rgba(120, 80, 30, calc(var(--stain-opacity, 0.1) * 0.4)) 40%,
-				transparent 70%
-			),
-			radial-gradient(
-				ellipse var(--stain2-size, 3rem) var(--stain2-size, 3rem) at var(--stain2-x, 30%)
-					var(--stain2-y, 70%),
-				rgba(100, 70, 25, var(--stain2-opacity, 0.06)) 0%,
-				transparent 60%
-			);
-		pointer-events: none;
-		border-radius: 2px;
-		z-index: 3;
-	}
-
 	.card:hover {
 		transform: rotate(0deg) scale(1.03);
 		box-shadow:
 			0 4px 12px rgba(0, 0, 0, 0.15),
 			0 8px 20px rgba(0, 0, 0, 0.08);
 		z-index: 1;
+	}
+
+	/* Organic coffee stain SVG overlay */
+	.stain-overlay {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+		z-index: 3;
+		border-radius: 2px;
+		overflow: hidden;
 	}
 
 	.card-photo {
@@ -138,8 +248,6 @@
 		width: 100%;
 		height: 8rem;
 		object-fit: cover;
-		filter: sepia(var(--sepia, 0.5)) brightness(var(--brightness, 0.95))
-			contrast(var(--contrast, 0.9)) saturate(var(--saturate, 0.7));
 	}
 
 	.card-img-placeholder {
@@ -159,6 +267,232 @@
 		margin-bottom: var(--size-1);
 	}
 
+	/* =============================================
+	   DOG-EAR: folded corner triangle
+	   ============================================= */
+	.dog-ear {
+		position: absolute;
+		width: var(--ear-size, 1.4rem);
+		height: var(--ear-size, 1.4rem);
+		pointer-events: none;
+		z-index: 4;
+		overflow: hidden;
+	}
+
+	/* The fold itself: a triangle that looks like paper folded over */
+	.dog-ear::before {
+		content: '';
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		background: linear-gradient(
+			135deg,
+			rgba(0, 0, 0, 0.06) 0%,
+			rgba(0, 0, 0, 0.02) 50%,
+			#e8e0d0 50%,
+			#ded5c4 100%
+		);
+	}
+
+	/* Shadow beneath the fold */
+	.dog-ear::after {
+		content: '';
+		position: absolute;
+		width: 140%;
+		height: 140%;
+		background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.1) 0%, transparent 70%);
+	}
+
+	/* Position each corner variant */
+	.dog-ear--tr {
+		top: 0;
+		right: 0;
+	}
+	.dog-ear--tr::before {
+		background: linear-gradient(
+			225deg,
+			rgba(0, 0, 0, 0.06) 0%,
+			rgba(0, 0, 0, 0.02) 50%,
+			#e8e0d0 50%,
+			#ded5c4 100%
+		);
+	}
+	.dog-ear--tr::after {
+		bottom: -20%;
+		left: -20%;
+	}
+
+	.dog-ear--tl {
+		top: 0;
+		left: 0;
+	}
+	.dog-ear--tl::before {
+		background: linear-gradient(
+			315deg,
+			rgba(0, 0, 0, 0.06) 0%,
+			rgba(0, 0, 0, 0.02) 50%,
+			#e8e0d0 50%,
+			#ded5c4 100%
+		);
+	}
+	.dog-ear--tl::after {
+		bottom: -20%;
+		right: -20%;
+	}
+
+	.dog-ear--br {
+		bottom: 0;
+		right: 0;
+	}
+	.dog-ear--br::before {
+		background: linear-gradient(
+			135deg,
+			#e8e0d0 0%,
+			#ded5c4 50%,
+			rgba(0, 0, 0, 0.02) 50%,
+			rgba(0, 0, 0, 0.06) 100%
+		);
+	}
+	.dog-ear--br::after {
+		top: -20%;
+		left: -20%;
+	}
+
+	.dog-ear--bl {
+		bottom: 0;
+		left: 0;
+	}
+	.dog-ear--bl::before {
+		background: linear-gradient(
+			45deg,
+			rgba(0, 0, 0, 0.06) 0%,
+			rgba(0, 0, 0, 0.02) 50%,
+			#e8e0d0 50%,
+			#ded5c4 100%
+		);
+	}
+	.dog-ear--bl::after {
+		top: -20%;
+		right: -20%;
+	}
+
+	/* =============================================
+	   CREASE: diagonal fold line across the card
+	   ============================================= */
+	.crease {
+		position: absolute;
+		left: -5%;
+		right: -5%;
+		top: var(--crease-pos, 50%);
+		height: 2px;
+		pointer-events: none;
+		z-index: 4;
+		transform: rotate(var(--crease-angle, 0deg));
+		transform-origin: center;
+	}
+
+	/* Main crease line */
+	.crease::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(
+			to right,
+			transparent 0%,
+			rgba(0, 0, 0, 0.08) 15%,
+			rgba(0, 0, 0, 0.12) 50%,
+			rgba(0, 0, 0, 0.08) 85%,
+			transparent 100%
+		);
+	}
+
+	/* Highlight along one side of crease (paper catching light) */
+	.crease::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: -1px;
+		height: 1px;
+		background: linear-gradient(
+			to right,
+			transparent 0%,
+			rgba(255, 255, 255, 0.15) 20%,
+			rgba(255, 255, 255, 0.25) 50%,
+			rgba(255, 255, 255, 0.15) 80%,
+			transparent 100%
+		);
+	}
+
+	/* =============================================
+	   TORN CORNER: ragged missing piece
+	   ============================================= */
+	.torn-corner {
+		position: absolute;
+		width: 1.6rem;
+		height: 1.6rem;
+		pointer-events: none;
+		z-index: 4;
+		overflow: hidden;
+	}
+
+	/*
+	 * The torn effect: a jagged-edged shape that matches the page
+	 * background color, masking out the card corner.
+	 * Uses a polygon clip-path for the rough tear line.
+	 */
+	.torn-corner::before {
+		content: '';
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		background: var(--color-background, #f5f5f5);
+		clip-path: polygon(
+			0% 0%,
+			100% 0%,
+			85% 15%,
+			95% 30%,
+			75% 45%,
+			90% 55%,
+			70% 70%,
+			80% 85%,
+			60% 100%,
+			0% 100%
+		);
+	}
+
+	/* Subtle shadow along the tear edge */
+	.torn-corner::after {
+		content: '';
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		background: linear-gradient(135deg, transparent 40%, rgba(0, 0, 0, 0.1) 60%, transparent 80%);
+	}
+
+	.torn-corner--tr {
+		top: 0;
+		right: 0;
+		transform: rotate(90deg);
+	}
+
+	.torn-corner--tl {
+		top: 0;
+		left: 0;
+	}
+
+	.torn-corner--br {
+		bottom: 0;
+		right: 0;
+		transform: rotate(180deg);
+	}
+
+	.torn-corner--bl {
+		bottom: 0;
+		left: 0;
+		transform: rotate(270deg);
+	}
+
 	/* ---- Dark mode: aged polaroid on a dark surface ---- */
 	@media (prefers-color-scheme: dark) {
 		.card {
@@ -168,27 +502,8 @@
 				0 4px 8px rgba(0, 0, 0, 0.25);
 		}
 
-		/* Paper tint: warmer/subtler on dark background */
 		.card::before {
 			background: rgba(140, 110, 60, var(--paper-yellow, 0.05));
-		}
-
-		/* Coffee stains: darker brown tones */
-		.card::after {
-			background:
-				radial-gradient(
-					ellipse var(--stain-size, 5rem) var(--stain-size, 5rem) at var(--stain-x, 70%)
-						var(--stain-y, 30%),
-					rgba(80, 55, 20, var(--stain-opacity, 0.1)) 0%,
-					rgba(80, 55, 20, calc(var(--stain-opacity, 0.1) * 0.4)) 40%,
-					transparent 70%
-				),
-				radial-gradient(
-					ellipse var(--stain2-size, 3rem) var(--stain2-size, 3rem) at var(--stain2-x, 30%)
-						var(--stain2-y, 70%),
-					rgba(60, 40, 15, var(--stain2-opacity, 0.06)) 0%,
-					transparent 60%
-				);
 		}
 
 		.card:hover {
@@ -197,17 +512,47 @@
 				0 8px 20px rgba(0, 0, 0, 0.3);
 		}
 
-		.card-img {
-			filter: sepia(var(--sepia, 0.5)) brightness(calc(var(--brightness, 0.95) * 0.85))
-				contrast(var(--contrast, 0.9)) saturate(var(--saturate, 0.7));
-		}
-
 		.card-img-placeholder {
 			background-color: #3a342b;
 		}
 
 		.card-title {
 			color: #c8bfb0;
+		}
+
+		/* Dog-ear: darker fold colors */
+		.dog-ear--tr::before,
+		.dog-ear--tl::before,
+		.dog-ear--br::before,
+		.dog-ear--bl::before {
+			filter: brightness(0.5);
+		}
+
+		/* Torn corner: reveal dark background */
+		.torn-corner::before {
+			background: var(--color-background, #1f1f1f);
+		}
+
+		/* Crease: invert highlight/shadow for dark paper */
+		.crease::before {
+			background: linear-gradient(
+				to right,
+				transparent 0%,
+				rgba(0, 0, 0, 0.15) 15%,
+				rgba(0, 0, 0, 0.2) 50%,
+				rgba(0, 0, 0, 0.15) 85%,
+				transparent 100%
+			);
+		}
+		.crease::after {
+			background: linear-gradient(
+				to right,
+				transparent 0%,
+				rgba(255, 255, 255, 0.06) 20%,
+				rgba(255, 255, 255, 0.1) 50%,
+				rgba(255, 255, 255, 0.06) 80%,
+				transparent 100%
+			);
 		}
 	}
 </style>

--- a/frontend/src/lib/components/cards/Card.svelte
+++ b/frontend/src/lib/components/cards/Card.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import type { Action } from 'svelte/action';
+	import CoffeeStain from '../effects/CoffeeStain.svelte';
+	import WearEffect from './WearEffect.svelte';
 
 	let {
 		href,
@@ -14,21 +15,26 @@
 		children?: Snippet;
 	} = $props();
 
-	// Unique ID per component instance for SVG filter references
-	const uid = Math.random().toString(36).slice(2, 8);
+	const rand = (min: number, max: number) => Math.random() * (max - min) + min;
+	const randInt = (max: number) => Math.floor(Math.random() * max);
 
-	// Random seeds for SVG turbulence (each card gets different noise patterns)
-	const grainSeed = Math.floor(Math.random() * 1000);
-	const stainSeed = Math.floor(Math.random() * 1000);
-	const stainSeed2 = Math.floor(Math.random() * 1000);
+	// Film grain filter (unique per card)
+	const grainId = `grain-${crypto.randomUUID()}`;
+	const grainSeed = randInt(1000);
 
-	// Randomize stain blob position (as fraction 0–1)
-	const stainX = 0.15 + Math.random() * 0.7;
-	const stainY = 0.15 + Math.random() * 0.7;
-	const stain2X = 0.1 + Math.random() * 0.8;
-	const stain2Y = 0.1 + Math.random() * 0.8;
+	// Stain seeds and positions
+	const stain1 = { seed: randInt(1000), x: `${rand(-5, 55)}%`, y: `${rand(-5, 55)}%` };
+	const stain2 = { seed: randInt(1000), x: `${rand(-5, 65)}%`, y: `${rand(-5, 65)}%` };
 
-	// Wear effect: ~40% of cards get a dog-ear, crease, or torn corner
+	// Photo aging — all declarative, no action needed
+	const rotation = `${rand(-3, 3)}deg`;
+	const sepia = `${rand(0.3, 0.7)}`;
+	const brightness = `${rand(0.9, 1.05)}`;
+	const contrast = `${rand(0.85, 0.95)}`;
+	const saturate = `${rand(0.6, 0.85)}`;
+	const paperYellow = `${rand(0.03, 0.08)}`;
+
+	// Wear effect: ~40% of cards get one
 	type WearType = 'none' | 'dog-ear' | 'crease' | 'torn-corner';
 	const wearRoll = Math.random();
 	const wearType: WearType =
@@ -40,43 +46,17 @@
 					? 'crease'
 					: 'torn-corner';
 
-	// Which corner for dog-ear / torn-corner (top-right, top-left, bottom-right, bottom-left)
 	const corners = ['tr', 'tl', 'br', 'bl'] as const;
-	const wearCorner = corners[Math.floor(Math.random() * corners.length)];
-
-	// Crease angle and position
-	const creaseAngle = -25 + Math.random() * 50; // -25° to 25°
-	const creasePos = 30 + Math.random() * 40; // 30%–70% from top
-
-	// Dog-ear size
-	const earSize = 1 + Math.random() * 0.8; // 1rem to 1.8rem
-
-	/**
-	 * Svelte action that assigns random CSS custom properties to each card,
-	 * giving every polaroid a unique aged/worn appearance.
-	 */
-	const polaroid: Action = (node) => {
-		const rand = (min: number, max: number) => Math.random() * (max - min) + min;
-
-		// Slight random rotation for that pinned-to-a-board feel
-		node.style.setProperty('--rotation', `${rand(-3, 3)}deg`);
-
-		// Faded photo: randomize sepia/brightness/contrast
-		node.style.setProperty('--sepia', `${rand(0.3, 0.7)}`);
-		node.style.setProperty('--brightness', `${rand(0.9, 1.05)}`);
-		node.style.setProperty('--contrast', `${rand(0.85, 0.95)}`);
-		node.style.setProperty('--saturate', `${rand(0.6, 0.85)}`);
-
-		// Yellowed paper tint intensity
-		node.style.setProperty('--paper-yellow', `${rand(0.03, 0.08)}`);
-	};
+	const wearCorner = corners[randInt(corners.length)];
+	const creaseAngle = -25 + Math.random() * 50;
+	const creasePos = 30 + Math.random() * 40;
+	const earSize = 1 + Math.random() * 0.8;
 </script>
 
-<!-- Hidden SVG filter definitions (one per card instance) -->
+<!-- Film grain filter definition -->
 <svg class="svg-filters" aria-hidden="true">
 	<defs>
-		<!-- Film grain overlay for the photo -->
-		<filter id="grain-{uid}" x="0%" y="0%" width="100%" height="100%">
+		<filter id={grainId} x="0%" y="0%" width="100%" height="100%">
 			<feTurbulence
 				type="fractalNoise"
 				baseFrequency="0.7"
@@ -87,55 +67,24 @@
 			<feColorMatrix type="saturate" values="0" in="grain" result="grainMono" />
 			<feBlend in="SourceGraphic" in2="grainMono" mode="multiply" />
 		</filter>
-
-		<!-- Organic coffee stain blob -->
-		<filter id="stain-{uid}" x="-50%" y="-50%" width="200%" height="200%">
-			<feTurbulence
-				type="fractalNoise"
-				baseFrequency="0.035"
-				numOctaves="5"
-				seed={stainSeed}
-				result="noise"
-			/>
-			<feComponentTransfer in="noise" result="blobs">
-				<feFuncA type="discrete" tableValues="0 0 0 0 0 0 0.6 0.8" />
-			</feComponentTransfer>
-			<feFlood flood-color="rgb(120, 80, 30)" flood-opacity="0.15" result="color" />
-			<feComposite in="color" in2="blobs" operator="in" result="stain" />
-			<feGaussianBlur in="stain" stdDeviation="3" />
-		</filter>
-
-		<!-- Second stain with different pattern -->
-		<filter id="stain2-{uid}" x="-50%" y="-50%" width="200%" height="200%">
-			<feTurbulence
-				type="fractalNoise"
-				baseFrequency="0.045"
-				numOctaves="4"
-				seed={stainSeed2}
-				result="noise"
-			/>
-			<feComponentTransfer in="noise" result="blobs">
-				<feFuncA type="discrete" tableValues="0 0 0 0 0 0 0 0.5" />
-			</feComponentTransfer>
-			<feFlood flood-color="rgb(100, 65, 20)" flood-opacity="0.1" result="color" />
-			<feComposite in="color" in2="blobs" operator="in" result="stain" />
-			<feGaussianBlur in="stain" stdDeviation="4" />
-		</filter>
 	</defs>
 </svg>
 
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href is pre-resolved by caller -->
-<a {href} class="card" use:polaroid>
+<a
+	{href}
+	class="card"
+	style:--rotation={rotation}
+	style:--sepia={sepia}
+	style:--brightness={brightness}
+	style:--contrast={contrast}
+	style:--saturate={saturate}
+	style:--paper-yellow={paperYellow}
+	style:--grain-url="url(#{grainId})"
+>
 	<div class="card-photo">
 		{#if thumbnailUrl}
-			<img
-				src={thumbnailUrl}
-				alt=""
-				class="card-img"
-				loading="lazy"
-				style:filter="url(#{`grain-${uid}`}) sepia(var(--sepia, 0.5)) brightness(var(--brightness,
-				0.95)) contrast(var(--contrast, 0.9)) saturate(var(--saturate, 0.7))"
-			/>
+			<img src={thumbnailUrl} alt="" class="card-img" loading="lazy" />
 		{:else}
 			<div class="card-img-placeholder"></div>
 		{/if}
@@ -146,35 +95,33 @@
 			{@render children()}
 		{/if}
 	</div>
-	<!-- SVG stain overlays with organic shapes -->
-	<svg class="stain-overlay" aria-hidden="true">
-		<rect
-			x="{(stainX - 0.2) * 100}%"
-			y="{(stainY - 0.2) * 100}%"
-			width="40%"
-			height="40%"
-			filter="url(#{`stain-${uid}`})"
-		/>
-		<rect
-			x="{(stain2X - 0.15) * 100}%"
-			y="{(stain2Y - 0.15) * 100}%"
-			width="30%"
-			height="30%"
-			filter="url(#{`stain2-${uid}`})"
-		/>
-	</svg>
 
-	<!-- Wear effects: dog-ear, crease, or torn corner -->
-	{#if wearType === 'dog-ear'}
-		<div class="dog-ear dog-ear--{wearCorner}" style:--ear-size="{earSize}rem"></div>
-	{:else if wearType === 'crease'}
-		<div
-			class="crease"
-			style:--crease-angle="{creaseAngle}deg"
-			style:--crease-pos="{creasePos}%"
-		></div>
-	{:else if wearType === 'torn-corner'}
-		<div class="torn-corner torn-corner--{wearCorner}"></div>
+	<CoffeeStain
+		seed={stain1.seed}
+		x={stain1.x}
+		y={stain1.y}
+		width="40%"
+		height="40%"
+		opacity={0.15}
+		blur={3}
+		threshold="0 0 0 0 0 0 0.6 0.8"
+	/>
+	<CoffeeStain
+		seed={stain2.seed}
+		frequency={0.045}
+		octaves={4}
+		x={stain2.x}
+		y={stain2.y}
+		width="30%"
+		height="30%"
+		opacity={0.1}
+		blur={4}
+		threshold="0 0 0 0 0 0 0 0.5"
+		color="rgb(100, 65, 20)"
+	/>
+
+	{#if wearType !== 'none'}
+		<WearEffect type={wearType} corner={wearCorner} {earSize} {creaseAngle} {creasePos} />
 	{/if}
 </a>
 
@@ -188,13 +135,18 @@
 	}
 
 	.card {
+		/* Color tokens — overridden in dark mode */
+		--polaroid-paper: #faf6f0;
+		--polaroid-paper-dim: #e8e0d4;
+		--polaroid-ink: #3d3529;
+
 		position: relative;
 		display: flex;
 		flex-direction: column;
-		background-color: #faf6f0;
+		background-color: var(--polaroid-paper);
 		border: none;
 		border-radius: 2px;
-		overflow: visible;
+		overflow: hidden;
 		text-decoration: none;
 		color: inherit;
 		padding: 0.6rem 0.6rem 1.6rem;
@@ -226,18 +178,6 @@
 		z-index: 1;
 	}
 
-	/* Organic coffee stain SVG overlay */
-	.stain-overlay {
-		position: absolute;
-		inset: 0;
-		width: 100%;
-		height: 100%;
-		pointer-events: none;
-		z-index: 3;
-		border-radius: 2px;
-		overflow: hidden;
-	}
-
 	.card-photo {
 		position: relative;
 		overflow: hidden;
@@ -248,12 +188,14 @@
 		width: 100%;
 		height: 8rem;
 		object-fit: cover;
+		filter: var(--grain-url) sepia(var(--sepia, 0.5)) brightness(var(--brightness, 0.95))
+			contrast(var(--contrast, 0.9)) saturate(var(--saturate, 0.7));
 	}
 
 	.card-img-placeholder {
 		width: 100%;
 		height: 8rem;
-		background-color: #e8e0d4;
+		background-color: var(--polaroid-paper-dim);
 	}
 
 	.card-body {
@@ -263,240 +205,17 @@
 	.card-title {
 		font-size: var(--font-size-2);
 		font-weight: 600;
-		color: #3d3529;
+		color: var(--polaroid-ink);
 		margin-bottom: var(--size-1);
 	}
 
-	/* =============================================
-	   DOG-EAR: folded corner triangle
-	   ============================================= */
-	.dog-ear {
-		position: absolute;
-		width: var(--ear-size, 1.4rem);
-		height: var(--ear-size, 1.4rem);
-		pointer-events: none;
-		z-index: 4;
-		overflow: hidden;
-	}
-
-	/* The fold itself: a triangle that looks like paper folded over */
-	.dog-ear::before {
-		content: '';
-		position: absolute;
-		width: 100%;
-		height: 100%;
-		background: linear-gradient(
-			135deg,
-			rgba(0, 0, 0, 0.06) 0%,
-			rgba(0, 0, 0, 0.02) 50%,
-			#e8e0d0 50%,
-			#ded5c4 100%
-		);
-	}
-
-	/* Shadow beneath the fold */
-	.dog-ear::after {
-		content: '';
-		position: absolute;
-		width: 140%;
-		height: 140%;
-		background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.1) 0%, transparent 70%);
-	}
-
-	/* Position each corner variant */
-	.dog-ear--tr {
-		top: 0;
-		right: 0;
-	}
-	.dog-ear--tr::before {
-		background: linear-gradient(
-			225deg,
-			rgba(0, 0, 0, 0.06) 0%,
-			rgba(0, 0, 0, 0.02) 50%,
-			#e8e0d0 50%,
-			#ded5c4 100%
-		);
-	}
-	.dog-ear--tr::after {
-		bottom: -20%;
-		left: -20%;
-	}
-
-	.dog-ear--tl {
-		top: 0;
-		left: 0;
-	}
-	.dog-ear--tl::before {
-		background: linear-gradient(
-			315deg,
-			rgba(0, 0, 0, 0.06) 0%,
-			rgba(0, 0, 0, 0.02) 50%,
-			#e8e0d0 50%,
-			#ded5c4 100%
-		);
-	}
-	.dog-ear--tl::after {
-		bottom: -20%;
-		right: -20%;
-	}
-
-	.dog-ear--br {
-		bottom: 0;
-		right: 0;
-	}
-	.dog-ear--br::before {
-		background: linear-gradient(
-			135deg,
-			#e8e0d0 0%,
-			#ded5c4 50%,
-			rgba(0, 0, 0, 0.02) 50%,
-			rgba(0, 0, 0, 0.06) 100%
-		);
-	}
-	.dog-ear--br::after {
-		top: -20%;
-		left: -20%;
-	}
-
-	.dog-ear--bl {
-		bottom: 0;
-		left: 0;
-	}
-	.dog-ear--bl::before {
-		background: linear-gradient(
-			45deg,
-			rgba(0, 0, 0, 0.06) 0%,
-			rgba(0, 0, 0, 0.02) 50%,
-			#e8e0d0 50%,
-			#ded5c4 100%
-		);
-	}
-	.dog-ear--bl::after {
-		top: -20%;
-		right: -20%;
-	}
-
-	/* =============================================
-	   CREASE: diagonal fold line across the card
-	   ============================================= */
-	.crease {
-		position: absolute;
-		left: -5%;
-		right: -5%;
-		top: var(--crease-pos, 50%);
-		height: 2px;
-		pointer-events: none;
-		z-index: 4;
-		transform: rotate(var(--crease-angle, 0deg));
-		transform-origin: center;
-	}
-
-	/* Main crease line */
-	.crease::before {
-		content: '';
-		position: absolute;
-		inset: 0;
-		background: linear-gradient(
-			to right,
-			transparent 0%,
-			rgba(0, 0, 0, 0.08) 15%,
-			rgba(0, 0, 0, 0.12) 50%,
-			rgba(0, 0, 0, 0.08) 85%,
-			transparent 100%
-		);
-	}
-
-	/* Highlight along one side of crease (paper catching light) */
-	.crease::after {
-		content: '';
-		position: absolute;
-		left: 0;
-		right: 0;
-		top: -1px;
-		height: 1px;
-		background: linear-gradient(
-			to right,
-			transparent 0%,
-			rgba(255, 255, 255, 0.15) 20%,
-			rgba(255, 255, 255, 0.25) 50%,
-			rgba(255, 255, 255, 0.15) 80%,
-			transparent 100%
-		);
-	}
-
-	/* =============================================
-	   TORN CORNER: ragged missing piece
-	   ============================================= */
-	.torn-corner {
-		position: absolute;
-		width: 1.6rem;
-		height: 1.6rem;
-		pointer-events: none;
-		z-index: 4;
-		overflow: hidden;
-	}
-
-	/*
-	 * The torn effect: a jagged-edged shape that matches the page
-	 * background color, masking out the card corner.
-	 * Uses a polygon clip-path for the rough tear line.
-	 */
-	.torn-corner::before {
-		content: '';
-		position: absolute;
-		width: 100%;
-		height: 100%;
-		background: var(--color-background, #f5f5f5);
-		clip-path: polygon(
-			0% 0%,
-			100% 0%,
-			85% 15%,
-			95% 30%,
-			75% 45%,
-			90% 55%,
-			70% 70%,
-			80% 85%,
-			60% 100%,
-			0% 100%
-		);
-	}
-
-	/* Subtle shadow along the tear edge */
-	.torn-corner::after {
-		content: '';
-		position: absolute;
-		width: 100%;
-		height: 100%;
-		background: linear-gradient(135deg, transparent 40%, rgba(0, 0, 0, 0.1) 60%, transparent 80%);
-	}
-
-	.torn-corner--tr {
-		top: 0;
-		right: 0;
-		transform: rotate(90deg);
-	}
-
-	.torn-corner--tl {
-		top: 0;
-		left: 0;
-	}
-
-	.torn-corner--br {
-		bottom: 0;
-		right: 0;
-		transform: rotate(180deg);
-	}
-
-	.torn-corner--bl {
-		bottom: 0;
-		left: 0;
-		transform: rotate(270deg);
-	}
-
-	/* ---- Dark mode: aged polaroid on a dark surface ---- */
+	/* ---- Dark mode ---- */
 	@media (prefers-color-scheme: dark) {
 		.card {
-			background-color: #2e2a24;
+			--polaroid-paper: #2e2a24;
+			--polaroid-paper-dim: #3a342b;
+			--polaroid-ink: #c8bfb0;
+
 			box-shadow:
 				0 1px 3px rgba(0, 0, 0, 0.4),
 				0 4px 8px rgba(0, 0, 0, 0.25);
@@ -512,47 +231,10 @@
 				0 8px 20px rgba(0, 0, 0, 0.3);
 		}
 
-		.card-img-placeholder {
-			background-color: #3a342b;
-		}
-
-		.card-title {
-			color: #c8bfb0;
-		}
-
-		/* Dog-ear: darker fold colors */
-		.dog-ear--tr::before,
-		.dog-ear--tl::before,
-		.dog-ear--br::before,
-		.dog-ear--bl::before {
-			filter: brightness(0.5);
-		}
-
-		/* Torn corner: reveal dark background */
-		.torn-corner::before {
-			background: var(--color-background, #1f1f1f);
-		}
-
-		/* Crease: invert highlight/shadow for dark paper */
-		.crease::before {
-			background: linear-gradient(
-				to right,
-				transparent 0%,
-				rgba(0, 0, 0, 0.15) 15%,
-				rgba(0, 0, 0, 0.2) 50%,
-				rgba(0, 0, 0, 0.15) 85%,
-				transparent 100%
-			);
-		}
-		.crease::after {
-			background: linear-gradient(
-				to right,
-				transparent 0%,
-				rgba(255, 255, 255, 0.06) 20%,
-				rgba(255, 255, 255, 0.1) 50%,
-				rgba(255, 255, 255, 0.06) 80%,
-				transparent 100%
-			);
+		.card-img {
+			filter: var(--grain-url) sepia(var(--sepia, 0.5))
+				brightness(calc(var(--brightness, 0.95) * 0.85)) contrast(var(--contrast, 0.9))
+				saturate(var(--saturate, 0.7));
 		}
 	}
 </style>

--- a/frontend/src/lib/components/cards/Card.svelte
+++ b/frontend/src/lib/components/cards/Card.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import type { Action } from 'svelte/action';
 
 	let {
 		href,
@@ -12,15 +13,49 @@
 		thumbnailUrl?: string | null;
 		children?: Snippet;
 	} = $props();
+
+	/**
+	 * Svelte action that assigns random CSS custom properties to each card,
+	 * giving every polaroid a unique aged/worn appearance.
+	 */
+	const polaroid: Action = (node) => {
+		const rand = (min: number, max: number) => Math.random() * (max - min) + min;
+
+		// Slight random rotation for that pinned-to-a-board feel
+		node.style.setProperty('--rotation', `${rand(-3, 3)}deg`);
+
+		// Faded photo: randomize sepia/brightness/contrast
+		node.style.setProperty('--sepia', `${rand(0.3, 0.7)}`);
+		node.style.setProperty('--brightness', `${rand(0.9, 1.05)}`);
+		node.style.setProperty('--contrast', `${rand(0.85, 0.95)}`);
+		node.style.setProperty('--saturate', `${rand(0.6, 0.85)}`);
+
+		// Coffee stain: randomize position, size, and opacity
+		node.style.setProperty('--stain-x', `${rand(15, 85)}%`);
+		node.style.setProperty('--stain-y', `${rand(15, 85)}%`);
+		node.style.setProperty('--stain-size', `${rand(3, 7)}rem`);
+		node.style.setProperty('--stain-opacity', `${rand(0.06, 0.18)}`);
+
+		// Second, subtler stain for realism
+		node.style.setProperty('--stain2-x', `${rand(10, 90)}%`);
+		node.style.setProperty('--stain2-y', `${rand(10, 90)}%`);
+		node.style.setProperty('--stain2-size', `${rand(2, 5)}rem`);
+		node.style.setProperty('--stain2-opacity', `${rand(0.03, 0.1)}`);
+
+		// Yellowed paper tint intensity
+		node.style.setProperty('--paper-yellow', `${rand(0.03, 0.08)}`);
+	};
 </script>
 
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href is pre-resolved by caller -->
-<a {href} class="card">
-	{#if thumbnailUrl}
-		<img src={thumbnailUrl} alt="" class="card-img" loading="lazy" />
-	{:else}
-		<div class="card-img-placeholder"></div>
-	{/if}
+<a {href} class="card" use:polaroid>
+	<div class="card-photo">
+		{#if thumbnailUrl}
+			<img src={thumbnailUrl} alt="" class="card-img" loading="lazy" />
+		{:else}
+			<div class="card-img-placeholder"></div>
+		{/if}
+	</div>
 	<div class="card-body">
 		<h3 class="card-title">{title}</h3>
 		{#if children}
@@ -31,44 +66,148 @@
 
 <style>
 	.card {
+		position: relative;
 		display: flex;
 		flex-direction: column;
-		background-color: var(--color-surface);
-		border: 1px solid var(--color-border-soft);
-		border-radius: var(--radius-2);
-		overflow: hidden;
+		background-color: #faf6f0;
+		border: none;
+		border-radius: 2px;
+		overflow: visible;
 		text-decoration: none;
 		color: inherit;
+		padding: 0.6rem 0.6rem 1.6rem;
+		transform: rotate(var(--rotation, 0deg));
+		box-shadow:
+			0 1px 3px rgba(0, 0, 0, 0.12),
+			0 4px 8px rgba(0, 0, 0, 0.06);
 		transition:
-			border-color 0.15s var(--ease-2),
-			box-shadow 0.15s var(--ease-2);
+			transform 0.2s ease,
+			box-shadow 0.2s ease;
+	}
+
+	/* Yellowed paper tint overlay */
+	.card::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: rgba(180, 150, 80, var(--paper-yellow, 0.05));
+		pointer-events: none;
+		border-radius: 2px;
+		z-index: 2;
+	}
+
+	/* Coffee stain — two overlapping radial gradients */
+	.card::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background:
+			radial-gradient(
+				ellipse var(--stain-size, 5rem) var(--stain-size, 5rem) at var(--stain-x, 70%)
+					var(--stain-y, 30%),
+				rgba(120, 80, 30, var(--stain-opacity, 0.1)) 0%,
+				rgba(120, 80, 30, calc(var(--stain-opacity, 0.1) * 0.4)) 40%,
+				transparent 70%
+			),
+			radial-gradient(
+				ellipse var(--stain2-size, 3rem) var(--stain2-size, 3rem) at var(--stain2-x, 30%)
+					var(--stain2-y, 70%),
+				rgba(100, 70, 25, var(--stain2-opacity, 0.06)) 0%,
+				transparent 60%
+			);
+		pointer-events: none;
+		border-radius: 2px;
+		z-index: 3;
 	}
 
 	.card:hover {
-		border-color: var(--color-accent);
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+		transform: rotate(0deg) scale(1.03);
+		box-shadow:
+			0 4px 12px rgba(0, 0, 0, 0.15),
+			0 8px 20px rgba(0, 0, 0, 0.08);
+		z-index: 1;
+	}
+
+	.card-photo {
+		position: relative;
+		overflow: hidden;
+		border-radius: 1px;
 	}
 
 	.card-img {
 		width: 100%;
 		height: 8rem;
 		object-fit: cover;
+		filter: sepia(var(--sepia, 0.5)) brightness(var(--brightness, 0.95))
+			contrast(var(--contrast, 0.9)) saturate(var(--saturate, 0.7));
 	}
 
 	.card-img-placeholder {
 		width: 100%;
 		height: 8rem;
-		background-color: var(--color-border-soft);
+		background-color: #e8e0d4;
 	}
 
 	.card-body {
-		padding: var(--size-3);
+		padding: var(--size-3) 0 0;
 	}
 
 	.card-title {
 		font-size: var(--font-size-2);
 		font-weight: 600;
-		color: var(--color-text-primary);
+		color: #3d3529;
 		margin-bottom: var(--size-1);
+	}
+
+	/* ---- Dark mode: aged polaroid on a dark surface ---- */
+	@media (prefers-color-scheme: dark) {
+		.card {
+			background-color: #2e2a24;
+			box-shadow:
+				0 1px 3px rgba(0, 0, 0, 0.4),
+				0 4px 8px rgba(0, 0, 0, 0.25);
+		}
+
+		/* Paper tint: warmer/subtler on dark background */
+		.card::before {
+			background: rgba(140, 110, 60, var(--paper-yellow, 0.05));
+		}
+
+		/* Coffee stains: darker brown tones */
+		.card::after {
+			background:
+				radial-gradient(
+					ellipse var(--stain-size, 5rem) var(--stain-size, 5rem) at var(--stain-x, 70%)
+						var(--stain-y, 30%),
+					rgba(80, 55, 20, var(--stain-opacity, 0.1)) 0%,
+					rgba(80, 55, 20, calc(var(--stain-opacity, 0.1) * 0.4)) 40%,
+					transparent 70%
+				),
+				radial-gradient(
+					ellipse var(--stain2-size, 3rem) var(--stain2-size, 3rem) at var(--stain2-x, 30%)
+						var(--stain2-y, 70%),
+					rgba(60, 40, 15, var(--stain2-opacity, 0.06)) 0%,
+					transparent 60%
+				);
+		}
+
+		.card:hover {
+			box-shadow:
+				0 4px 12px rgba(0, 0, 0, 0.4),
+				0 8px 20px rgba(0, 0, 0, 0.3);
+		}
+
+		.card-img {
+			filter: sepia(var(--sepia, 0.5)) brightness(calc(var(--brightness, 0.95) * 0.85))
+				contrast(var(--contrast, 0.9)) saturate(var(--saturate, 0.7));
+		}
+
+		.card-img-placeholder {
+			background-color: #3a342b;
+		}
+
+		.card-title {
+			color: #c8bfb0;
+		}
 	}
 </style>

--- a/frontend/src/lib/components/cards/WearEffect.svelte
+++ b/frontend/src/lib/components/cards/WearEffect.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+	let {
+		type,
+		corner,
+		earSize,
+		creaseAngle,
+		creasePos
+	}: {
+		type: 'dog-ear' | 'crease' | 'torn-corner';
+		corner: 'tr' | 'tl' | 'br' | 'bl';
+		earSize: number;
+		creaseAngle: number;
+		creasePos: number;
+	} = $props();
+</script>
+
+{#if type === 'dog-ear'}
+	<div class="dog-ear dog-ear--{corner}" style:--ear-size="{earSize}rem"></div>
+{:else if type === 'crease'}
+	<div
+		class="crease"
+		style:--crease-angle="{creaseAngle}deg"
+		style:--crease-pos="{creasePos}%"
+	></div>
+{:else if type === 'torn-corner'}
+	<div class="torn-corner torn-corner--{corner}"></div>
+{/if}
+
+<style>
+	/* =============================================
+	   DOG-EAR: folded corner triangle
+	   ============================================= */
+	.dog-ear {
+		position: absolute;
+		width: var(--ear-size, 1.4rem);
+		height: var(--ear-size, 1.4rem);
+		pointer-events: none;
+		z-index: 4;
+		overflow: hidden;
+	}
+
+	.dog-ear::before {
+		content: '';
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		background: linear-gradient(
+			135deg,
+			rgba(0, 0, 0, 0.06) 0%,
+			rgba(0, 0, 0, 0.02) 50%,
+			var(--polaroid-fold-light, #e8e0d0) 50%,
+			var(--polaroid-fold-dark, #ded5c4) 100%
+		);
+	}
+
+	.dog-ear::after {
+		content: '';
+		position: absolute;
+		width: 140%;
+		height: 140%;
+		background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.1) 0%, transparent 70%);
+	}
+
+	/* Position each corner variant */
+	.dog-ear--tr {
+		top: 0;
+		right: 0;
+	}
+	.dog-ear--tr::before {
+		background: linear-gradient(
+			225deg,
+			rgba(0, 0, 0, 0.06) 0%,
+			rgba(0, 0, 0, 0.02) 50%,
+			var(--polaroid-fold-light, #e8e0d0) 50%,
+			var(--polaroid-fold-dark, #ded5c4) 100%
+		);
+	}
+	.dog-ear--tr::after {
+		bottom: -20%;
+		left: -20%;
+	}
+
+	.dog-ear--tl {
+		top: 0;
+		left: 0;
+	}
+	.dog-ear--tl::before {
+		background: linear-gradient(
+			315deg,
+			rgba(0, 0, 0, 0.06) 0%,
+			rgba(0, 0, 0, 0.02) 50%,
+			var(--polaroid-fold-light, #e8e0d0) 50%,
+			var(--polaroid-fold-dark, #ded5c4) 100%
+		);
+	}
+	.dog-ear--tl::after {
+		bottom: -20%;
+		right: -20%;
+	}
+
+	.dog-ear--br {
+		bottom: 0;
+		right: 0;
+	}
+	.dog-ear--br::before {
+		background: linear-gradient(
+			135deg,
+			var(--polaroid-fold-light, #e8e0d0) 0%,
+			var(--polaroid-fold-dark, #ded5c4) 50%,
+			rgba(0, 0, 0, 0.02) 50%,
+			rgba(0, 0, 0, 0.06) 100%
+		);
+	}
+	.dog-ear--br::after {
+		top: -20%;
+		left: -20%;
+	}
+
+	.dog-ear--bl {
+		bottom: 0;
+		left: 0;
+	}
+	.dog-ear--bl::before {
+		background: linear-gradient(
+			45deg,
+			rgba(0, 0, 0, 0.06) 0%,
+			rgba(0, 0, 0, 0.02) 50%,
+			var(--polaroid-fold-light, #e8e0d0) 50%,
+			var(--polaroid-fold-dark, #ded5c4) 100%
+		);
+	}
+	.dog-ear--bl::after {
+		top: -20%;
+		right: -20%;
+	}
+
+	/* =============================================
+	   CREASE: diagonal fold line across the card
+	   ============================================= */
+	.crease {
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: var(--crease-pos, 50%);
+		height: 2px;
+		pointer-events: none;
+		z-index: 4;
+		transform: rotate(var(--crease-angle, 0deg));
+		transform-origin: center;
+	}
+
+	.crease::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(
+			to right,
+			transparent 0%,
+			rgba(0, 0, 0, 0.08) 15%,
+			rgba(0, 0, 0, 0.12) 50%,
+			rgba(0, 0, 0, 0.08) 85%,
+			transparent 100%
+		);
+	}
+
+	.crease::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: -1px;
+		height: 1px;
+		background: linear-gradient(
+			to right,
+			transparent 0%,
+			rgba(255, 255, 255, 0.15) 20%,
+			rgba(255, 255, 255, 0.25) 50%,
+			rgba(255, 255, 255, 0.15) 80%,
+			transparent 100%
+		);
+	}
+
+	/* =============================================
+	   TORN CORNER: ragged missing piece
+	   ============================================= */
+	.torn-corner {
+		position: absolute;
+		width: 1.6rem;
+		height: 1.6rem;
+		pointer-events: none;
+		z-index: 4;
+		overflow: hidden;
+	}
+
+	.torn-corner::before {
+		content: '';
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		background: var(--color-background, #f5f5f5);
+		clip-path: polygon(
+			0% 0%,
+			100% 0%,
+			85% 15%,
+			95% 30%,
+			75% 45%,
+			90% 55%,
+			70% 70%,
+			80% 85%,
+			60% 100%,
+			0% 100%
+		);
+	}
+
+	.torn-corner::after {
+		content: '';
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		background: linear-gradient(135deg, transparent 40%, rgba(0, 0, 0, 0.1) 60%, transparent 80%);
+	}
+
+	.torn-corner--tr {
+		top: 0;
+		right: 0;
+		transform: rotate(90deg);
+	}
+
+	.torn-corner--tl {
+		top: 0;
+		left: 0;
+	}
+
+	.torn-corner--br {
+		bottom: 0;
+		right: 0;
+		transform: rotate(180deg);
+	}
+
+	.torn-corner--bl {
+		bottom: 0;
+		left: 0;
+		transform: rotate(270deg);
+	}
+
+	/* ---- Dark mode ---- */
+	@media (prefers-color-scheme: dark) {
+		.dog-ear--tr::before,
+		.dog-ear--tl::before,
+		.dog-ear--br::before,
+		.dog-ear--bl::before {
+			filter: brightness(0.5);
+		}
+
+		.torn-corner::before {
+			background: var(--color-background, #1f1f1f);
+		}
+
+		.crease::before {
+			background: linear-gradient(
+				to right,
+				transparent 0%,
+				rgba(0, 0, 0, 0.15) 15%,
+				rgba(0, 0, 0, 0.2) 50%,
+				rgba(0, 0, 0, 0.15) 85%,
+				transparent 100%
+			);
+		}
+		.crease::after {
+			background: linear-gradient(
+				to right,
+				transparent 0%,
+				rgba(255, 255, 255, 0.06) 20%,
+				rgba(255, 255, 255, 0.1) 50%,
+				rgba(255, 255, 255, 0.06) 80%,
+				transparent 100%
+			);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/effects/CoffeeStain.svelte
+++ b/frontend/src/lib/components/effects/CoffeeStain.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	/**
+	 * Self-contained coffee stain overlay.
+	 *
+	 * Renders an absolutely-positioned SVG that covers its nearest positioned
+	 * parent. Uses SVG turbulence to generate organic blob shapes — each
+	 * instance gets a unique noise pattern via the `seed` prop.
+	 *
+	 * The parent element must have `position: relative` (or similar).
+	 */
+	let {
+		seed,
+		frequency = 0.035,
+		octaves = 5,
+		opacity = 0.12,
+		blur = 4,
+		threshold = '0 0 0 0 0 0 0.5 0.7',
+		color = 'rgb(120, 80, 30)',
+		x = '0%',
+		y = '0%',
+		width = '100%',
+		height = '100%'
+	}: {
+		seed: number;
+		frequency?: number;
+		octaves?: number;
+		opacity?: number;
+		blur?: number;
+		threshold?: string;
+		color?: string;
+		x?: string;
+		y?: string;
+		width?: string;
+		height?: string;
+	} = $props();
+
+	const filterId = `stain-${crypto.randomUUID()}`;
+</script>
+
+<svg class="coffee-stain" aria-hidden="true">
+	<defs>
+		<filter id={filterId} x="-50%" y="-50%" width="200%" height="200%">
+			<feTurbulence
+				type="fractalNoise"
+				baseFrequency={frequency}
+				numOctaves={octaves}
+				{seed}
+				result="noise"
+			/>
+			<feComponentTransfer in="noise" result="blobs">
+				<feFuncA type="discrete" tableValues={threshold} />
+			</feComponentTransfer>
+			<feFlood flood-color={color} flood-opacity={opacity} result="color" />
+			<feComposite in="color" in2="blobs" operator="in" result="stain" />
+			<feGaussianBlur in="stain" stdDeviation={blur} />
+		</filter>
+	</defs>
+	<rect {x} {y} {width} {height} filter="url(#{filterId})" />
+</svg>
+
+<style>
+	.coffee-stain {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+		z-index: 3;
+		overflow: hidden;
+	}
+</style>


### PR DESCRIPTION
## Summary

Restyle cards and site header with a vintage polaroid / aged paper aesthetic, including randomized per-card variation.

- Cards: polaroid frame with random rotation, faded sepia photo filters (SVG film grain), organic coffee stains (SVG turbulence), and random wear effects (dog-ear folds, creases, torn corners)
- Header: aged paper background with coffee stains and torn bottom edge
- All effects support dark mode with warm walnut tones
- Each card/page load produces unique randomized variation via Svelte actions and SVG filter seeds

## Test plan

- [ ] Verify cards render with polaroid styling in light mode (rotation, sepia photos, visible stains)
- [ ] Verify ~40% of cards show a wear effect (dog-ear, crease, or torn corner)
- [ ] Verify header has aged paper background with stains and torn bottom edge in light mode
- [ ] Switch to dark mode and verify cards/header use warm dark tones
- [ ] Refresh page multiple times to confirm randomization produces varied results
- [ ] Test mobile viewport — verify mobile nav dropdown matches header styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)