### PR TITLE
Wikilink autocomplete and markdown editing

### DIFF
--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -243,10 +243,16 @@ def _build_rich_text(obj, field_name: str, active_claims=None) -> dict:
 
     Reads the raw text from obj.{field_name}, renders HTML via
     render_markdown_fields, and extracts attribution from the winning claim.
+
+    The ``text`` value is returned in authoring format (``[[type:slug]]``)
+    so edit forms show human-readable link references.  The ``html`` value
+    is rendered from the storage format and is display-ready.
     """
     from apps.core.markdown import render_markdown_fields
+    from apps.core.markdown_links import convert_storage_to_authoring
 
-    text = getattr(obj, field_name, "") or ""
+    raw_text = getattr(obj, field_name, "") or ""
+    text = convert_storage_to_authoring(raw_text) if raw_text else raw_text
     html_fields = render_markdown_fields(obj)
     html = html_fields.get(f"{field_name}_html", "")
 

--- a/backend/apps/catalog/apps.py
+++ b/backend/apps/catalog/apps.py
@@ -37,6 +37,9 @@ class CatalogConfig(AppConfig):
         from apps.core.markdown_links import LinkType, register
         from apps.core.models import LinkableModel
 
+        def _default_serialize(obj):
+            return {"ref": obj.slug, "label": str(obj.name)}
+
         for model in apps.get_app_config("catalog").get_models():
             if not issubclass(model, LinkableModel) or model._meta.abstract:
                 continue
@@ -63,5 +66,25 @@ class CatalogConfig(AppConfig):
                     url_field="slug",
                     label_field="name",
                     sort_order=getattr(model, "link_sort_order", 100),
+                    autocomplete_search_fields=getattr(
+                        model,
+                        "link_autocomplete_search_fields",
+                        ("name__icontains",),
+                    ),
+                    autocomplete_ordering=getattr(
+                        model,
+                        "link_autocomplete_ordering",
+                        ("name",),
+                    ),
+                    autocomplete_select_related=getattr(
+                        model,
+                        "link_autocomplete_select_related",
+                        (),
+                    ),
+                    autocomplete_serialize=getattr(
+                        model,
+                        "link_autocomplete_serialize",
+                        _default_serialize,
+                    ),
                 )
             )

--- a/backend/apps/catalog/models/machine_model.py
+++ b/backend/apps/catalog/models/machine_model.py
@@ -39,6 +39,7 @@ class MachineModel(EntityStatusMixin, SluggedModel, LinkableModel, TimeStampedMo
     """
 
     link_url_pattern = "/models/{slug}"
+    link_sort_order = 20
 
     # Identity
     name = models.CharField(max_length=300, validators=[validate_no_mojibake])

--- a/backend/apps/catalog/models/manufacturer.py
+++ b/backend/apps/catalog/models/manufacturer.py
@@ -41,6 +41,7 @@ class Manufacturer(EntityStatusMixin, SluggedModel, LinkableModel, TimeStampedMo
     """
 
     link_url_pattern = "/manufacturers/{slug}"
+    link_sort_order = 30
 
     name = models.CharField(
         max_length=200, unique=True, validators=[validate_no_mojibake]

--- a/backend/apps/catalog/models/person.py
+++ b/backend/apps/catalog/models/person.py
@@ -32,6 +32,7 @@ class Person(EntityStatusMixin, SluggedModel, LinkableModel, TimeStampedModel):
     """A person involved in pinball machine design (designer, artist, etc.)."""
 
     link_url_pattern = "/people/{slug}"
+    link_sort_order = 40
 
     name = models.CharField(max_length=200, validators=[validate_no_mojibake])
     description = MarkdownField(blank=True)

--- a/backend/apps/catalog/models/title.py
+++ b/backend/apps/catalog/models/title.py
@@ -35,6 +35,7 @@ class Title(EntityStatusMixin, SluggedModel, LinkableModel, TimeStampedModel):
     """
 
     link_url_pattern = "/titles/{slug}"
+    link_sort_order = 10
 
     opdb_id = models.CharField(
         max_length=50,

--- a/backend/apps/catalog/tests/test_description_html.py
+++ b/backend/apps/catalog/tests/test_description_html.py
@@ -77,6 +77,49 @@ class TestSystemDescriptionHtml:
 
 
 @pytest.mark.django_db
+class TestDescriptionAuthoringFormat:
+    """API responses return description text in authoring format for editing."""
+
+    def test_storage_links_converted_to_authoring_in_text(self, client, db):
+        """description.text returns [[type:slug]] not [[type:id:N]]."""
+        williams = Manufacturer.objects.create(name="Williams", slug="williams")
+        System.objects.create(
+            name="WPC-95",
+            slug="wpc-95",
+            manufacturer=williams,
+            description=f"Made by [[manufacturer:id:{williams.pk}]].",
+        )
+        resp = client.get("/api/systems/wpc-95")
+        data = resp.json()
+        # text field should have authoring format (slug-based)
+        assert "[[manufacturer:williams]]" in data["description"]["text"]
+        assert f"[[manufacturer:id:{williams.pk}]]" not in data["description"]["text"]
+        # html field should still render the link correctly
+        assert "/manufacturers/williams" in data["description"]["html"]
+
+    def test_plain_text_description_unchanged(self, client, db):
+        """Descriptions without links are returned as-is."""
+        Manufacturer.objects.create(
+            name="Stern", slug="stern", description="Modern manufacturer."
+        )
+        resp = client.get("/api/manufacturers/stern")
+        data = resp.json()
+        assert data["description"]["text"] == "Modern manufacturer."
+
+    def test_broken_link_kept_in_storage_format(self, client, db):
+        """Links to deleted entities stay in storage format (graceful degradation)."""
+        Manufacturer.objects.create(
+            name="Stern",
+            slug="stern",
+            description="See [[manufacturer:id:99999]].",
+        )
+        resp = client.get("/api/manufacturers/stern")
+        data = resp.json()
+        # Broken link stays in storage format since there's no slug to convert to
+        assert "[[manufacturer:id:99999]]" in data["description"]["text"]
+
+
+@pytest.mark.django_db
 class TestReferenceSync:
     def test_resolve_creates_references(self):
         """Resolving a manufacturer with links creates RecordReference rows."""

--- a/backend/apps/core/api.py
+++ b/backend/apps/core/api.py
@@ -1,0 +1,80 @@
+"""API endpoints for the core app.
+
+Router: link_types — wikilink autocomplete support.
+Wired into the main NinjaAPI instance in config/api.py.
+"""
+
+from __future__ import annotations
+
+from django.db.models import Q
+from ninja import Router, Schema
+from ninja.errors import HttpError
+
+from apps.core.markdown_links import get_autocomplete_types, get_link_type
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+AUTOCOMPLETE_RESULT_LIMIT = 20
+
+
+class LinkTypeSchema(Schema):
+    name: str
+    label: str
+    description: str
+
+
+class LinkTargetSchema(Schema):
+    ref: str
+    label: str
+
+
+class LinkTargetsResponseSchema(Schema):
+    results: list[LinkTargetSchema]
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+link_types_router = Router(tags=["private"])
+
+
+@link_types_router.get("/", response=list[LinkTypeSchema])
+def list_link_types(request):
+    """Return all link types that support autocomplete, for the type picker."""
+    return get_autocomplete_types()
+
+
+@link_types_router.get("/targets/", response=LinkTargetsResponseSchema)
+def search_link_targets(request, type: str, q: str = ""):
+    """Search within a link type for autocomplete results."""
+    lt = get_link_type(type)
+    if lt is None or not lt.is_enabled() or not lt.autocomplete_serialize:
+        raise HttpError(400, f"Invalid or unsupported link type: {type!r}")
+
+    model = lt.get_model()
+
+    # Use .active() when available (EntityStatusMixin models) to exclude
+    # soft-deleted entities; fall back to .all() for models without it.
+    qs = (
+        model.objects.active()
+        if hasattr(model.objects, "active")
+        else model.objects.all()
+    )
+
+    if lt.autocomplete_select_related:
+        qs = qs.select_related(*lt.autocomplete_select_related)
+
+    if lt.autocomplete_ordering:
+        qs = qs.order_by(*lt.autocomplete_ordering)
+
+    if q and lt.autocomplete_search_fields:
+        q_filter = Q()
+        for field in lt.autocomplete_search_fields:
+            q_filter |= Q(**{field: q})
+        qs = qs.filter(q_filter)
+
+    results = [lt.autocomplete_serialize(obj) for obj in qs[:AUTOCOMPLETE_RESULT_LIMIT]]
+    return {"results": results}

--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -314,7 +314,10 @@ class LinkableModel(models.Model):
     - link_label: str — human-readable label for type picker
     - link_description: str — brief description
     - link_url_pattern: str — URL pattern like "/manufacturers/{slug}"
-    - link_sort_order: int — display order in type picker
+    - link_sort_order: int — display order in type picker (lower = higher)
+    - link_autocomplete_search_fields: tuple[str, ...] — model fields to search
+    - link_autocomplete_ordering: tuple[str, ...] — result ordering
+    - link_autocomplete_select_related: tuple[str, ...] — eager loading
     """
 
     class Meta:

--- a/backend/apps/core/tests/test_link_types_api.py
+++ b/backend/apps/core/tests/test_link_types_api.py
@@ -1,0 +1,86 @@
+"""Tests for the wikilink autocomplete API endpoints."""
+
+import pytest
+from django.test import Client
+
+
+@pytest.fixture
+def api():
+    return Client()
+
+
+@pytest.fixture
+def manufacturer(db):
+    from apps.catalog.models import Manufacturer
+
+    return Manufacturer.objects.create(
+        name="Williams", slug="williams", status="active"
+    )
+
+
+@pytest.fixture
+def deleted_manufacturer(db):
+    from apps.catalog.models import Manufacturer
+
+    return Manufacturer.objects.create(
+        name="Defunct Co", slug="defunct-co", status="deleted"
+    )
+
+
+@pytest.mark.django_db
+class TestListLinkTypes:
+    def test_returns_all_autocomplete_types(self, api):
+        resp = api.get("/api/link-types/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        # Each type has required fields
+        first = data[0]
+        assert "name" in first
+        assert "label" in first
+        assert "description" in first
+
+    def test_primary_types_sorted_first(self, api):
+        resp = api.get("/api/link-types/")
+        names = [t["name"] for t in resp.json()]
+        # Title, MachineModel, Manufacturer, Person should appear before taxonomy types
+        assert names.index("title") < names.index("tag")
+        assert names.index("manufacturer") < names.index("cabinet")
+
+
+@pytest.mark.django_db
+class TestSearchLinkTargets:
+    def test_search_returns_matching_results(self, api, manufacturer):
+        resp = api.get("/api/link-types/targets/", {"type": "manufacturer", "q": "wil"})
+        assert resp.status_code == 200
+        refs = [r["ref"] for r in resp.json()["results"]]
+        assert "williams" in refs
+
+    def test_search_returns_label(self, api, manufacturer):
+        resp = api.get("/api/link-types/targets/", {"type": "manufacturer", "q": "wil"})
+        result = resp.json()["results"][0]
+        assert result["label"] == "Williams"
+        assert result["ref"] == "williams"
+
+    def test_empty_query_returns_results(self, api, manufacturer):
+        resp = api.get("/api/link-types/targets/", {"type": "manufacturer", "q": ""})
+        assert resp.status_code == 200
+        assert len(resp.json()["results"]) >= 1
+
+    def test_no_match_returns_empty(self, api, manufacturer):
+        resp = api.get(
+            "/api/link-types/targets/", {"type": "manufacturer", "q": "zzzznotfound"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["results"] == []
+
+    def test_invalid_type_returns_400(self, api):
+        resp = api.get("/api/link-types/targets/", {"type": "nonexistent", "q": ""})
+        assert resp.status_code == 400
+
+    def test_excludes_deleted_entities(self, api, manufacturer, deleted_manufacturer):
+        resp = api.get("/api/link-types/targets/", {"type": "manufacturer", "q": ""})
+        refs = [r["ref"] for r in resp.json()["results"]]
+        assert "williams" in refs
+        assert "defunct-co" not in refs

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -25,6 +25,7 @@ from apps.catalog.api import (
     themes_router,
     titles_router,
 )
+from apps.core.api import link_types_router
 from apps.provenance.api import review_router, sources_router
 
 api = NinjaAPI(
@@ -90,6 +91,7 @@ api.add_router("/locations/", locations_router)
 api.add_router("/reward-types/", reward_types_router)
 api.add_router("/tags/", tags_router)
 api.add_router("/technology-subgenerations/", technology_subgenerations_router)
+api.add_router("/link-types/", link_types_router)
 api.add_router("/sources/", sources_router)
 api.add_router("/review/", review_router)
 

--- a/frontend/src/lib/api/link-types.test.ts
+++ b/frontend/src/lib/api/link-types.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchLinkTypes, searchLinkTargets, _resetCache } from './link-types';
+
+const MOCK_TYPES = [
+	{ name: 'title', label: 'Title', description: 'Link to a title' },
+	{ name: 'manufacturer', label: 'Manufacturer', description: 'Link to a manufacturer' }
+];
+
+const MOCK_TARGETS = {
+	results: [{ ref: 'williams', label: 'Williams' }]
+};
+
+beforeEach(() => {
+	_resetCache();
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	_resetCache();
+});
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+	return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+		ok,
+		status,
+		json: () => Promise.resolve(body)
+	} as Response);
+}
+
+describe('fetchLinkTypes', () => {
+	it('fetches from API on first call', async () => {
+		const spy = mockFetch(MOCK_TYPES);
+		const result = await fetchLinkTypes();
+		expect(result).toEqual(MOCK_TYPES);
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith('/api/link-types/');
+	});
+
+	it('returns cached result on second call without fetching', async () => {
+		const spy = mockFetch(MOCK_TYPES);
+		await fetchLinkTypes();
+		const result = await fetchLinkTypes();
+		expect(result).toEqual(MOCK_TYPES);
+		expect(spy).toHaveBeenCalledOnce();
+	});
+
+	it('throws on non-ok response', async () => {
+		mockFetch(null, false, 500);
+		await expect(fetchLinkTypes()).rejects.toThrow('Failed to fetch link types: 500');
+	});
+});
+
+describe('searchLinkTargets', () => {
+	it('fetches with type and query params', async () => {
+		const spy = mockFetch(MOCK_TARGETS);
+		const result = await searchLinkTargets('manufacturer', 'wil');
+		expect(result).toEqual(MOCK_TARGETS);
+		expect(spy).toHaveBeenCalledWith('/api/link-types/targets/?type=manufacturer&q=wil');
+	});
+
+	it('encodes query parameter', async () => {
+		const spy = mockFetch(MOCK_TARGETS);
+		await searchLinkTargets('title', 'hello world');
+		expect(spy).toHaveBeenCalledWith('/api/link-types/targets/?type=title&q=hello+world');
+	});
+
+	it('throws on non-ok response', async () => {
+		mockFetch(null, false, 400);
+		await expect(searchLinkTargets('invalid', '')).rejects.toThrow(
+			'Failed to search link targets: 400'
+		);
+	});
+});

--- a/frontend/src/lib/api/link-types.ts
+++ b/frontend/src/lib/api/link-types.ts
@@ -1,0 +1,47 @@
+/**
+ * API client for wikilink autocomplete endpoints.
+ *
+ * Separate from the openapi-fetch client because these endpoints have
+ * a simple, stable contract and don't need generated types.
+ */
+
+export type LinkType = {
+	name: string;
+	label: string;
+	description: string;
+};
+
+export type LinkTarget = {
+	ref: string;
+	label: string;
+};
+
+type LinkTargetsResponse = {
+	results: LinkTarget[];
+};
+
+// Module-level cache — link types don't change at runtime.
+let cachedTypes: LinkType[] | null = null;
+
+/** Reset cache — for tests only. */
+export function _resetCache(): void {
+	cachedTypes = null;
+}
+
+export async function fetchLinkTypes(): Promise<LinkType[]> {
+	if (cachedTypes) return cachedTypes;
+
+	const resp = await fetch('/api/link-types/');
+	if (!resp.ok) throw new Error(`Failed to fetch link types: ${resp.status}`);
+
+	cachedTypes = (await resp.json()) as LinkType[];
+	return cachedTypes;
+}
+
+export async function searchLinkTargets(type: string, query: string): Promise<LinkTargetsResponse> {
+	const params = new URLSearchParams({ type, q: query });
+	const resp = await fetch(`/api/link-types/targets/?${params}`);
+	if (!resp.ok) throw new Error(`Failed to search link targets: ${resp.status}`);
+
+	return (await resp.json()) as LinkTargetsResponse;
+}

--- a/frontend/src/lib/components/form/EditFormShell.svelte
+++ b/frontend/src/lib/components/form/EditFormShell.svelte
@@ -92,9 +92,4 @@
 	.save-feedback.error {
 		color: var(--color-error, #c0392b);
 	}
-
-	.not-authenticated {
-		font-size: var(--font-size-1);
-		color: var(--color-text-muted);
-	}
 </style>

--- a/frontend/src/lib/components/form/MarkdownTextArea.svelte
+++ b/frontend/src/lib/components/form/MarkdownTextArea.svelte
@@ -1,0 +1,658 @@
+<script lang="ts">
+	import FieldGroup from './FieldGroup.svelte';
+	import { fetchLinkTypes, searchLinkTargets } from '$lib/api/link-types';
+	import type { LinkType, LinkTarget } from '$lib/api/link-types';
+	import { detectTrigger, formatLinkText, spliceLink } from './wikilink-helpers';
+	import {
+		toggleMarker,
+		wrapSelection,
+		insertLink as insertMdLink,
+		pasteLink,
+		indentLines,
+		listEnter,
+		applyResult
+	} from './markdown-shortcuts';
+	import type { EditResult } from './markdown-shortcuts';
+
+	let {
+		label,
+		value = $bindable(''),
+		id = '',
+		rows = 4
+	}: {
+		label: string;
+		value?: string;
+		id?: string;
+		rows?: number;
+	} = $props();
+
+	// -----------------------------------------------------------------------
+	// State
+	// -----------------------------------------------------------------------
+
+	let textareaEl: HTMLTextAreaElement | undefined = $state();
+	let wrapperEl: HTMLDivElement | undefined = $state();
+	let mirrorEl: HTMLDivElement | undefined = $state();
+
+	// Dropdown state
+	let open = $state(false);
+	let stage = $state<'type' | 'search'>('type');
+	let triggerStart = $state(-1);
+	let dropdownLeft = $state(0);
+	let dropdownTop = $state(0);
+
+	// Type picker
+	let linkTypes = $state<LinkType[]>([]);
+	let typeIndex = $state(-1);
+
+	// Search
+	let selectedType = $state<LinkType | null>(null);
+	let searchQuery = $state('');
+	let searchResults = $state<LinkTarget[]>([]);
+	let searchIndex = $state(-1);
+	let searchInputEl: HTMLInputElement | undefined = $state();
+	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let searchGeneration = 0;
+
+	// Prefetch link types on mount so they're cached by the time user types [[
+	fetchLinkTypes();
+
+	// -----------------------------------------------------------------------
+	// Cursor position via mirror div
+	// -----------------------------------------------------------------------
+
+	function getCursorPosition(): { left: number; top: number } {
+		if (!textareaEl || !mirrorEl) return { left: 0, top: 0 };
+
+		// Copy textarea styles to mirror
+		const computed = window.getComputedStyle(textareaEl);
+		mirrorEl.style.fontFamily = computed.fontFamily;
+		mirrorEl.style.fontSize = computed.fontSize;
+		mirrorEl.style.fontWeight = computed.fontWeight;
+		mirrorEl.style.lineHeight = computed.lineHeight;
+		mirrorEl.style.padding = computed.padding;
+		mirrorEl.style.border = computed.border;
+		mirrorEl.style.boxSizing = computed.boxSizing;
+		mirrorEl.style.width = textareaEl.offsetWidth + 'px';
+
+		// Render text up to cursor with a marker span
+		const text = textareaEl.value.substring(0, textareaEl.selectionStart);
+		const escaped = text
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/\n/g, '<br>');
+		// eslint-disable-next-line svelte/no-dom-manipulating -- mirror div is not Svelte-managed
+		mirrorEl.innerHTML = escaped + '<span data-cursor></span>';
+
+		const cursorSpan = mirrorEl.querySelector('[data-cursor]');
+		if (!cursorSpan) return { left: 0, top: 0 };
+
+		const cursorRect = cursorSpan.getBoundingClientRect();
+		const textareaRect = textareaEl.getBoundingClientRect();
+
+		let left = cursorRect.left - textareaRect.left + textareaEl.scrollLeft;
+		let top = cursorRect.top - textareaRect.top - textareaEl.scrollTop + cursorSpan.clientHeight;
+		top = Math.min(top, textareaEl.offsetHeight - 20);
+
+		return { left, top };
+	}
+
+	// -----------------------------------------------------------------------
+	// Trigger detection
+	// -----------------------------------------------------------------------
+
+	function handleInput() {
+		if (!textareaEl || open) return;
+
+		const pos = detectTrigger(textareaEl.value, textareaEl.selectionStart);
+		if (pos >= 0) {
+			triggerStart = pos;
+			openTypePicker();
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Type picker stage
+	// -----------------------------------------------------------------------
+
+	async function openTypePicker() {
+		const pos = getCursorPosition();
+		dropdownLeft = pos.left;
+		dropdownTop = pos.top;
+
+		linkTypes = await fetchLinkTypes();
+		typeIndex = 0;
+		stage = 'type';
+		open = true;
+	}
+
+	function selectType(lt: LinkType) {
+		selectedType = lt;
+		searchQuery = '';
+		searchResults = [];
+		searchIndex = -1;
+		stage = 'search';
+
+		requestAnimationFrame(() => searchInputEl?.focus());
+		doSearch('');
+	}
+
+	// -----------------------------------------------------------------------
+	// Search stage
+	// -----------------------------------------------------------------------
+
+	function handleSearchInput(e: Event) {
+		searchQuery = (e.currentTarget as HTMLInputElement).value;
+		searchIndex = -1;
+		clearTimeout(debounceTimer);
+		// Immediate fetch for empty query (showing all results), debounced otherwise
+		const delay = searchQuery ? 200 : 0;
+		debounceTimer = setTimeout(() => doSearch(searchQuery), delay);
+	}
+
+	async function doSearch(q: string) {
+		if (!selectedType) return;
+		const gen = ++searchGeneration;
+		const response = await searchLinkTargets(selectedType.name, q);
+		if (gen !== searchGeneration) return;
+		searchResults = response.results;
+	}
+
+	function selectResult(target: LinkTarget) {
+		if (!textareaEl || !selectedType || triggerStart < 0) return;
+		insertWikilink(formatLinkText(selectedType.name, target.ref));
+	}
+
+	// -----------------------------------------------------------------------
+	// Wikilink insertion (preserves undo stack)
+	// -----------------------------------------------------------------------
+
+	function insertWikilink(linkText: string) {
+		if (!textareaEl) return;
+
+		const replaceEnd = textareaEl.selectionStart;
+		textareaEl.focus();
+		textareaEl.setSelectionRange(triggerStart, replaceEnd);
+
+		if (!document.execCommand('insertText', false, linkText)) {
+			const result = spliceLink(textareaEl.value, triggerStart, replaceEnd, linkText);
+			textareaEl.value = result.newText;
+		}
+
+		value = textareaEl.value;
+
+		const newPos = triggerStart + linkText.length;
+		textareaEl.setSelectionRange(newPos, newPos);
+
+		closeDropdown();
+	}
+
+	// -----------------------------------------------------------------------
+	// Markdown shortcuts
+	// -----------------------------------------------------------------------
+
+	function applyAndSync(result: EditResult | null): boolean {
+		if (!result || !textareaEl) return false;
+		applyResult(textareaEl, result);
+		value = textareaEl.value;
+		return true;
+	}
+
+	function handleTextareaKeydown(e: KeyboardEvent) {
+		if (e.isComposing) return;
+
+		// Wikilink dropdown keyboard nav takes priority when open
+		if (open && stage === 'type') {
+			handleTypeKeydown(e);
+			return;
+		}
+		if (open) return;
+
+		if (!textareaEl) return;
+		const { value: v, selectionStart: s, selectionEnd: end } = textareaEl;
+		const mod = e.metaKey || e.ctrlKey;
+
+		// Cmd/Ctrl shortcuts
+		if (mod && !e.shiftKey) {
+			if (e.key === 'b') {
+				e.preventDefault();
+				applyAndSync(toggleMarker(v, s, end, '**'));
+				return;
+			}
+			if (e.key === 'i') {
+				e.preventDefault();
+				applyAndSync(toggleMarker(v, s, end, '*'));
+				return;
+			}
+			if (e.key === 'k') {
+				e.preventDefault();
+				applyAndSync(insertMdLink(v, s, end));
+				return;
+			}
+		}
+
+		// Tab / Shift+Tab
+		if (e.key === 'Tab') {
+			e.preventDefault();
+			applyAndSync(indentLines(v, s, end, e.shiftKey));
+			return;
+		}
+
+		// Enter — list continuation
+		if (e.key === 'Enter' && !mod && !e.shiftKey) {
+			const result = listEnter(v, s, end);
+			if (result) {
+				e.preventDefault();
+				applyAndSync(result);
+			}
+			return;
+		}
+
+		// Smart wrapping (`, *, _)
+		if (s !== end && (e.key === '`' || e.key === '*' || e.key === '_')) {
+			const result = wrapSelection(v, s, end, e.key);
+			if (result) {
+				e.preventDefault();
+				applyAndSync(result);
+			}
+		}
+	}
+
+	function handlePaste(e: ClipboardEvent) {
+		if (!textareaEl) return;
+		const { value: v, selectionStart: s, selectionEnd: end } = textareaEl;
+		const pasted = e.clipboardData?.getData('text/plain') ?? '';
+		const result = pasteLink(v, s, end, pasted);
+		if (result) {
+			e.preventDefault();
+			applyAndSync(result);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Dropdown management
+	// -----------------------------------------------------------------------
+
+	function closeDropdown() {
+		open = false;
+		stage = 'type';
+		selectedType = null;
+		searchQuery = '';
+		searchResults = [];
+		typeIndex = -1;
+		searchIndex = -1;
+		triggerStart = -1;
+		clearTimeout(debounceTimer);
+	}
+
+	// Click outside to close
+	$effect(() => {
+		if (!open) return;
+		function onPointerDown(e: PointerEvent) {
+			if (!wrapperEl?.contains(e.target as Node)) {
+				closeDropdown();
+			}
+		}
+		document.addEventListener('pointerdown', onPointerDown);
+		return () => document.removeEventListener('pointerdown', onPointerDown);
+	});
+
+	// Clicking the textarea itself closes the dropdown
+	function handleTextareaClick() {
+		if (open) closeDropdown();
+	}
+
+	// Close on blur, with delay to allow focus to move between textarea and search input
+	const BLUR_DELAY_MS = 150;
+
+	function handleTextareaBlur() {
+		if (!open || stage !== 'type') return;
+		setTimeout(() => {
+			if (!searchInputEl?.matches(':focus')) {
+				closeDropdown();
+			}
+		}, BLUR_DELAY_MS);
+	}
+
+	function handleSearchBlur() {
+		if (!open) return;
+		setTimeout(() => {
+			if (!textareaEl?.matches(':focus') && !searchInputEl?.matches(':focus')) {
+				closeDropdown();
+			}
+		}, BLUR_DELAY_MS);
+	}
+
+	// -----------------------------------------------------------------------
+	// Dropdown keyboard navigation
+	// -----------------------------------------------------------------------
+
+	function handleTypeKeydown(e: KeyboardEvent) {
+		switch (e.key) {
+			case 'ArrowDown':
+				e.preventDefault();
+				typeIndex = Math.min(typeIndex + 1, linkTypes.length - 1);
+				break;
+			case 'ArrowUp':
+				e.preventDefault();
+				typeIndex = Math.max(typeIndex - 1, 0);
+				break;
+			case 'Enter':
+			case 'ArrowRight':
+				e.preventDefault();
+				if (typeIndex >= 0 && typeIndex < linkTypes.length) {
+					selectType(linkTypes[typeIndex]);
+				}
+				break;
+			case 'Escape':
+				e.preventDefault();
+				closeDropdown();
+				textareaEl?.focus();
+				break;
+			case 'Backspace':
+			case 'ArrowLeft':
+				// Browser will delete a [ / move cursor — close since trigger is being left
+				closeDropdown();
+				break;
+		}
+	}
+
+	function handleSearchKeydown(e: KeyboardEvent) {
+		switch (e.key) {
+			case 'ArrowDown':
+				e.preventDefault();
+				searchIndex = Math.min(searchIndex + 1, searchResults.length - 1);
+				scrollActiveIntoView();
+				break;
+			case 'ArrowUp':
+				e.preventDefault();
+				searchIndex = Math.max(searchIndex - 1, 0);
+				scrollActiveIntoView();
+				break;
+			case 'Enter':
+				e.preventDefault();
+				if (searchIndex >= 0 && searchIndex < searchResults.length) {
+					selectResult(searchResults[searchIndex]);
+				}
+				break;
+			case 'Escape':
+				e.preventDefault();
+				closeDropdown();
+				textareaEl?.focus();
+				break;
+			case 'Backspace':
+				if (!searchQuery) {
+					e.preventDefault();
+					goBackToTypePicker();
+				}
+				break;
+			case 'ArrowLeft':
+				if (searchInputEl && searchInputEl.selectionStart === 0) {
+					e.preventDefault();
+					goBackToTypePicker();
+				}
+				break;
+		}
+	}
+
+	function goBackToTypePicker() {
+		stage = 'type';
+		selectedType = null;
+		searchQuery = '';
+		searchResults = [];
+		searchIndex = -1;
+		typeIndex = 0;
+		clearTimeout(debounceTimer);
+		requestAnimationFrame(() => {
+			textareaEl?.focus();
+			// Restore cursor to right after [[
+			if (textareaEl && triggerStart >= 0) {
+				textareaEl.setSelectionRange(triggerStart + 2, triggerStart + 2);
+			}
+		});
+	}
+
+	function scrollActiveIntoView() {
+		requestAnimationFrame(() => {
+			wrapperEl?.querySelector('[data-active="true"]')?.scrollIntoView({ block: 'nearest' });
+		});
+	}
+</script>
+
+<div class="markdown-textarea" bind:this={wrapperEl}>
+	<FieldGroup {label} {id}>
+		{#snippet children(inputId)}
+			<textarea
+				bind:this={textareaEl}
+				id={inputId}
+				{rows}
+				bind:value
+				oninput={handleInput}
+				onkeydown={handleTextareaKeydown}
+				onpaste={handlePaste}
+				onclick={handleTextareaClick}
+				onblur={handleTextareaBlur}
+			></textarea>
+		{/snippet}
+	</FieldGroup>
+
+	<!-- Mirror div for cursor position measurement -->
+	<div class="cursor-mirror" bind:this={mirrorEl} aria-hidden="true"></div>
+
+	{#if open}
+		<div
+			class="link-dropdown"
+			role="listbox"
+			style:left="{dropdownLeft}px"
+			style:top="{dropdownTop}px"
+		>
+			{#if stage === 'type'}
+				<div class="dropdown-header">Insert link</div>
+				{#each linkTypes as lt, i (lt.name)}
+					<div
+						role="option"
+						tabindex="-1"
+						aria-selected={i === typeIndex}
+						data-active={i === typeIndex}
+						class="dropdown-item"
+						class:active={i === typeIndex}
+						onpointerdown={(e) => {
+							e.preventDefault();
+							selectType(lt);
+						}}
+					>
+						<span class="item-label">{lt.label}</span>
+						<span class="item-desc">{lt.description}</span>
+					</div>
+				{/each}
+			{:else}
+				<div class="dropdown-header">
+					<button
+						class="back-btn"
+						onpointerdown={(e) => {
+							e.preventDefault();
+							goBackToTypePicker();
+						}}
+					>
+						&larr;
+					</button>
+					{selectedType?.label}
+				</div>
+				<div class="search-wrap">
+					<input
+						bind:this={searchInputEl}
+						type="text"
+						class="search-input"
+						placeholder="Search {selectedType?.label ?? ''}..."
+						value={searchQuery}
+						oninput={handleSearchInput}
+						onkeydown={handleSearchKeydown}
+						onblur={handleSearchBlur}
+					/>
+				</div>
+				<div class="results-list">
+					{#each searchResults as target, i (target.ref)}
+						<div
+							role="option"
+							tabindex="-1"
+							aria-selected={i === searchIndex}
+							data-active={i === searchIndex}
+							class="dropdown-item"
+							class:active={i === searchIndex}
+							onpointerdown={(e) => {
+								e.preventDefault();
+								selectResult(target);
+							}}
+						>
+							<span class="item-label">{target.label}</span>
+						</div>
+					{:else}
+						<div class="no-results">
+							{searchQuery ? 'No matches' : 'Type to search...'}
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.markdown-textarea {
+		position: relative;
+	}
+
+	textarea {
+		width: 100%;
+		padding: var(--size-2) var(--size-3);
+		font-size: var(--font-size-1);
+		font-family: inherit;
+		background-color: var(--color-input-bg);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-input-border);
+		border-radius: var(--radius-2);
+		resize: vertical;
+	}
+
+	textarea:focus {
+		outline: none;
+		border-color: var(--color-input-focus);
+		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
+	}
+
+	/* ----- Mirror (hidden, for cursor measurement) ----- */
+
+	.cursor-mirror {
+		position: absolute;
+		top: 0;
+		left: 0;
+		visibility: hidden;
+		pointer-events: none;
+		white-space: pre-wrap;
+		word-wrap: break-word;
+		overflow: hidden;
+		height: auto;
+	}
+
+	/* ----- Dropdown ----- */
+
+	.link-dropdown {
+		position: absolute;
+		z-index: 10;
+		max-width: 24rem;
+		max-height: 20rem;
+		overflow-y: auto;
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-2);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+	}
+
+	.dropdown-header {
+		display: flex;
+		align-items: center;
+		gap: var(--size-2);
+		padding: var(--size-2) var(--size-3);
+		font-size: var(--font-size-0);
+		font-weight: 600;
+		color: var(--color-text-muted);
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.back-btn {
+		background: none;
+		border: none;
+		color: var(--color-text-muted);
+		cursor: pointer;
+		padding: 0;
+		font-size: var(--font-size-1);
+		line-height: 1;
+	}
+
+	.back-btn:hover {
+		color: var(--color-text-primary);
+	}
+
+	.dropdown-item {
+		display: flex;
+		align-items: baseline;
+		gap: var(--size-2);
+		padding: var(--size-2) var(--size-3);
+		cursor: pointer;
+		font-size: var(--font-size-1);
+	}
+
+	.dropdown-item:hover,
+	.dropdown-item.active {
+		background-color: var(--color-input-focus-ring);
+	}
+
+	.item-label {
+		flex-shrink: 0;
+	}
+
+	.item-desc {
+		color: var(--color-text-muted);
+		font-size: var(--font-size-0);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* ----- Search ----- */
+
+	.search-wrap {
+		padding: var(--size-2) var(--size-3);
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.search-input {
+		width: 100%;
+		padding: var(--size-1) var(--size-2);
+		font-size: var(--font-size-1);
+		font-family: inherit;
+		background-color: var(--color-input-bg);
+		color: var(--color-text-primary);
+		border: 1px solid var(--color-input-border);
+		border-radius: var(--radius-2);
+	}
+
+	.search-input:focus {
+		outline: none;
+		border-color: var(--color-input-focus);
+		box-shadow: 0 0 0 2px var(--color-input-focus-ring);
+	}
+
+	.results-list {
+		max-height: 14rem;
+		overflow-y: auto;
+	}
+
+	.no-results {
+		padding: var(--size-3);
+		color: var(--color-text-muted);
+		text-align: center;
+		font-size: var(--font-size-1);
+	}
+</style>

--- a/frontend/src/lib/components/form/markdown-shortcuts.test.ts
+++ b/frontend/src/lib/components/form/markdown-shortcuts.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import {
+	toggleMarker,
+	wrapSelection,
+	insertLink,
+	pasteLink,
+	indentLines,
+	listEnter
+} from './markdown-shortcuts';
+
+describe('toggleMarker (bold/italic)', () => {
+	it('wraps selection with marker', () => {
+		const r = toggleMarker('hello world', 6, 11, '**');
+		expect(r.replacement).toBe('**world**');
+		expect(r.selectionStart).toBe(8);
+		expect(r.selectionEnd).toBe(13);
+	});
+
+	it('unwraps when markers already present', () => {
+		const r = toggleMarker('hello **world** end', 8, 13, '**');
+		expect(r.replacement).toBe('world');
+		expect(r.replaceStart).toBe(6);
+		expect(r.replaceEnd).toBe(15);
+	});
+
+	it('inserts empty marker pair with no selection', () => {
+		const r = toggleMarker('hello ', 6, 6, '*');
+		expect(r.replacement).toBe('**');
+		expect(r.selectionStart).toBe(7);
+		expect(r.selectionEnd).toBe(7);
+	});
+});
+
+describe('wrapSelection', () => {
+	it('wraps with backtick', () => {
+		const r = wrapSelection('hello world', 6, 11, '`');
+		expect(r!.replacement).toBe('`world`');
+	});
+
+	it('returns null without selection', () => {
+		expect(wrapSelection('hello', 3, 3, '`')).toBeNull();
+	});
+
+	it('returns null for unknown char', () => {
+		expect(wrapSelection('hello', 0, 5, '!')).toBeNull();
+	});
+});
+
+describe('insertLink', () => {
+	it('wraps selection as link text', () => {
+		const r = insertLink('click here end', 6, 10);
+		expect(r.replacement).toBe('[here](url)');
+		// "url" should be selected
+		expect(r.selectionStart).toBe(13);
+		expect(r.selectionEnd).toBe(16);
+	});
+
+	it('inserts empty link with no selection', () => {
+		const r = insertLink('text ', 5, 5);
+		expect(r.replacement).toBe('[](url)');
+		expect(r.selectionStart).toBe(8);
+		expect(r.selectionEnd).toBe(11);
+	});
+});
+
+describe('pasteLink', () => {
+	it('creates markdown link from selected text + pasted URL', () => {
+		const r = pasteLink('click Google end', 6, 12, 'https://google.com');
+		expect(r!.replacement).toBe('[Google](https://google.com)');
+	});
+
+	it('returns null without selection', () => {
+		expect(pasteLink('text', 2, 2, 'https://example.com')).toBeNull();
+	});
+
+	it('returns null for non-URL paste', () => {
+		expect(pasteLink('hello world', 0, 5, 'not a url')).toBeNull();
+	});
+
+	it('accepts http URLs', () => {
+		const r = pasteLink('text', 0, 4, 'http://example.com');
+		expect(r).not.toBeNull();
+	});
+});
+
+describe('indentLines', () => {
+	it('indents single line by 2 spaces', () => {
+		const r = indentLines('hello', 0, 5, false);
+		expect(r.replacement).toBe('  hello');
+	});
+
+	it('indents multiple lines', () => {
+		const r = indentLines('a\nb\nc', 0, 5, false);
+		expect(r.replacement).toBe('  a\n  b\n  c');
+	});
+
+	it('dedents a line', () => {
+		const r = indentLines('  hello', 0, 7, true);
+		expect(r.replacement).toBe('hello');
+	});
+
+	it('dedents only 1 space when less than indent', () => {
+		const r = indentLines(' hello', 0, 6, true);
+		expect(r.replacement).toBe('hello');
+	});
+
+	it('does nothing when dedenting unindented line', () => {
+		const r = indentLines('hello', 0, 5, true);
+		expect(r.replacement).toBe('hello');
+	});
+});
+
+describe('listEnter', () => {
+	it('continues a bullet list', () => {
+		const r = listEnter('- item one', 10, 10);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n- ');
+	});
+
+	it('continues a numbered list with increment', () => {
+		const r = listEnter('1. first', 8, 8);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n2. ');
+	});
+
+	it('removes empty bullet item', () => {
+		const r = listEnter('- ', 2, 2);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('');
+		expect(r!.replaceStart).toBe(0);
+	});
+
+	it('continues a task list with unchecked checkbox', () => {
+		const r = listEnter('- [x] done task', 15, 15);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n- [ ] ');
+	});
+
+	it('returns null when not on a list line', () => {
+		expect(listEnter('regular text', 12, 12)).toBeNull();
+	});
+
+	it('returns null when there is a selection', () => {
+		expect(listEnter('- item', 0, 4)).toBeNull();
+	});
+
+	it('splits content at cursor', () => {
+		// cursor after "- hell" → afterCursor is "o world"
+		const r = listEnter('- hello world', 6, 6);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n- o world');
+	});
+
+	it('continues indented list preserving indent', () => {
+		const r = listEnter('  - nested item', 15, 15);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n  - ');
+	});
+
+	it('removes empty indented list item', () => {
+		const r = listEnter('  - ', 4, 4);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('  ');
+	});
+
+	it('continues with + marker', () => {
+		const r = listEnter('+ item', 6, 6);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n+ ');
+	});
+
+	it('continues with * marker', () => {
+		const r = listEnter('* item', 6, 6);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n* ');
+	});
+
+	it('increments multi-digit numbered list', () => {
+		const r = listEnter('10. tenth item', 14, 14);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n11. ');
+	});
+
+	it('handles task list with unchecked box', () => {
+		const r = listEnter('- [ ] todo item', 15, 15);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n- [ ] ');
+	});
+
+	it('removes empty task list item', () => {
+		const r = listEnter('- [ ] ', 6, 6);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('');
+	});
+
+	it('handles cursor on middle line of multiline text', () => {
+		// 'first line\n- list item\nthird line'
+		//  0123456789 0 1234567890 1 — position 22 is end of "list item"
+		const r = listEnter('first line\n- list item\nthird line', 22, 22);
+		expect(r).not.toBeNull();
+		expect(r!.replacement).toBe('\n- ');
+	});
+});

--- a/frontend/src/lib/components/form/markdown-shortcuts.ts
+++ b/frontend/src/lib/components/form/markdown-shortcuts.ts
@@ -1,0 +1,298 @@
+/**
+ * Pure markdown editing shortcuts for textareas.
+ *
+ * Each function takes textarea state (value, selectionStart, selectionEnd)
+ * and returns a result descriptor, or null if no action should be taken.
+ * The caller applies the result via execCommand for undo support.
+ */
+
+export type EditResult = {
+	replaceStart: number;
+	replaceEnd: number;
+	replacement: string;
+	selectionStart: number;
+	selectionEnd: number;
+};
+
+// ---------------------------------------------------------------------------
+// Bold / Italic toggle (Cmd+B, Cmd+I)
+// ---------------------------------------------------------------------------
+
+export function toggleMarker(
+	value: string,
+	start: number,
+	end: number,
+	marker: string
+): EditResult {
+	const len = marker.length;
+
+	if (start !== end) {
+		// Selection exists — check if already wrapped
+		const before = value.substring(start - len, start);
+		const after = value.substring(end, end + len);
+
+		if (before === marker && after === marker) {
+			// Unwrap: remove markers around selection
+			return {
+				replaceStart: start - len,
+				replaceEnd: end + len,
+				replacement: value.substring(start, end),
+				selectionStart: start - len,
+				selectionEnd: end - len
+			};
+		}
+
+		// Wrap selection
+		const selected = value.substring(start, end);
+		return {
+			replaceStart: start,
+			replaceEnd: end,
+			replacement: marker + selected + marker,
+			selectionStart: start + len,
+			selectionEnd: end + len
+		};
+	}
+
+	// No selection — insert empty marker pair with cursor between
+	return {
+		replaceStart: start,
+		replaceEnd: start,
+		replacement: marker + marker,
+		selectionStart: start + len,
+		selectionEnd: start + len
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Smart character wrapping (`, *, _)
+// ---------------------------------------------------------------------------
+
+const WRAP_CHARS: Record<string, [string, string]> = {
+	'`': ['`', '`'],
+	'*': ['*', '*'],
+	_: ['_', '_']
+};
+
+export function wrapSelection(
+	value: string,
+	start: number,
+	end: number,
+	char: string
+): EditResult | null {
+	if (start === end) return null; // No selection — normal typing
+
+	const pair = WRAP_CHARS[char];
+	if (!pair) return null;
+
+	const [open, close] = pair;
+	const selected = value.substring(start, end);
+	return {
+		replaceStart: start,
+		replaceEnd: end,
+		replacement: open + selected + close,
+		selectionStart: start + open.length,
+		selectionEnd: end + open.length
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Link insertion (Cmd+K)
+// ---------------------------------------------------------------------------
+
+export function insertLink(value: string, start: number, end: number): EditResult {
+	if (start !== end) {
+		// Has selection — wrap as link text, select "url" placeholder
+		const selected = value.substring(start, end);
+		const replacement = `[${selected}](url)`;
+		return {
+			replaceStart: start,
+			replaceEnd: end,
+			replacement,
+			selectionStart: start + selected.length + 3, // after ](
+			selectionEnd: start + selected.length + 6 // after url
+		};
+	}
+
+	// No selection — insert empty link, select "url"
+	const replacement = '[](url)';
+	return {
+		replaceStart: start,
+		replaceEnd: start,
+		replacement,
+		selectionStart: start + 3,
+		selectionEnd: start + 6
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Paste URL over selection
+// ---------------------------------------------------------------------------
+
+export function pasteLink(
+	value: string,
+	start: number,
+	end: number,
+	pastedText: string
+): EditResult | null {
+	if (start === end) return null;
+	if (!/^https?:\/\//.test(pastedText)) return null;
+
+	const selected = value.substring(start, end);
+	const replacement = `[${selected}](${pastedText})`;
+	return {
+		replaceStart: start,
+		replaceEnd: end,
+		replacement,
+		selectionStart: start,
+		selectionEnd: start + replacement.length
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tab indentation
+// ---------------------------------------------------------------------------
+
+const INDENT = '  ';
+
+export function indentLines(
+	value: string,
+	start: number,
+	end: number,
+	dedent: boolean
+): EditResult {
+	// Find the start of the first selected line
+	const lineStart = value.lastIndexOf('\n', start - 1) + 1;
+	// Find the end of the last selected line
+	let lineEnd = value.indexOf('\n', end);
+	if (lineEnd === -1) lineEnd = value.length;
+
+	const block = value.substring(lineStart, lineEnd);
+	const lines = block.split('\n');
+
+	let selectionDelta = 0; // change to start position (first line only)
+	let totalDelta = 0;
+
+	const newLines = lines.map((line, i) => {
+		if (dedent) {
+			let removed = 0;
+			if (line.startsWith(INDENT)) {
+				removed = INDENT.length;
+			} else if (line.startsWith(' ')) {
+				removed = 1;
+			}
+			if (i === 0) selectionDelta = -removed;
+			totalDelta -= removed;
+			return line.substring(removed);
+		} else {
+			if (i === 0) selectionDelta = INDENT.length;
+			totalDelta += INDENT.length;
+			return INDENT + line;
+		}
+	});
+
+	return {
+		replaceStart: lineStart,
+		replaceEnd: lineEnd,
+		replacement: newLines.join('\n'),
+		selectionStart: Math.max(lineStart, start + selectionDelta),
+		selectionEnd: end + totalDelta
+	};
+}
+
+// ---------------------------------------------------------------------------
+// List enter continuation
+// ---------------------------------------------------------------------------
+
+const TASK_LIST_RE = /^((?:>\s*)*\s*)([-*+]|\d+\.)\s+\[([^\]]*)\]\s?(.*)$/;
+const PLAIN_LIST_RE = /^((?:>\s*)*\s*)([-*+]|\d+\.)\s(.*)$/;
+
+function nextMarker(marker: string): string {
+	const num = parseInt(marker, 10);
+	if (!isNaN(num)) return `${num + 1}.`;
+	return marker;
+}
+
+export function listEnter(value: string, start: number, end: number): EditResult | null {
+	if (start !== end) return null; // Has selection — normal Enter
+
+	// Find the current line
+	const lineStart = value.lastIndexOf('\n', start - 1) + 1;
+	const lineEnd = value.indexOf('\n', start);
+	const fullLine = value.substring(lineStart, lineEnd === -1 ? value.length : lineEnd);
+	const beforeCursor = fullLine.substring(0, start - lineStart);
+	const afterCursor = fullLine.substring(start - lineStart);
+
+	// Try task list first
+	let match = TASK_LIST_RE.exec(fullLine);
+	if (match) {
+		const [, prefix, marker] = match;
+		const contentBeforeCursor = beforeCursor.replace(TASK_LIST_RE, '$4');
+		const isEmpty = !contentBeforeCursor.trim() && !afterCursor.trim();
+
+		if (isEmpty) {
+			// Empty item — remove it, leave just the prefix
+			return {
+				replaceStart: lineStart,
+				replaceEnd: lineEnd === -1 ? value.length : lineEnd,
+				replacement: prefix,
+				selectionStart: lineStart + prefix.length,
+				selectionEnd: lineStart + prefix.length
+			};
+		}
+
+		const newItem = `\n${prefix}${nextMarker(marker)} [ ] ${afterCursor}`;
+		return {
+			replaceStart: start,
+			replaceEnd: start + afterCursor.length,
+			replacement: newItem,
+			selectionStart: start + newItem.length,
+			selectionEnd: start + newItem.length
+		};
+	}
+
+	// Try plain list
+	match = PLAIN_LIST_RE.exec(fullLine);
+	if (match) {
+		const [, prefix, marker] = match;
+		const contentBeforeCursor = beforeCursor.replace(PLAIN_LIST_RE, '$3');
+		const isEmpty = !contentBeforeCursor.trim() && !afterCursor.trim();
+
+		if (isEmpty) {
+			return {
+				replaceStart: lineStart,
+				replaceEnd: lineEnd === -1 ? value.length : lineEnd,
+				replacement: prefix,
+				selectionStart: lineStart + prefix.length,
+				selectionEnd: lineStart + prefix.length
+			};
+		}
+
+		const newItem = `\n${prefix}${nextMarker(marker)} ${afterCursor}`;
+		return {
+			replaceStart: start,
+			replaceEnd: start + afterCursor.length,
+			replacement: newItem,
+			selectionStart: start + newItem.length,
+			selectionEnd: start + newItem.length
+		};
+	}
+
+	return null; // Not a list line — normal Enter
+}
+
+// ---------------------------------------------------------------------------
+// Apply result to textarea (undo-safe)
+// ---------------------------------------------------------------------------
+
+export function applyResult(textarea: HTMLTextAreaElement, result: EditResult): void {
+	textarea.focus();
+	textarea.setSelectionRange(result.replaceStart, result.replaceEnd);
+
+	if (!document.execCommand('insertText', false, result.replacement)) {
+		const before = textarea.value.substring(0, result.replaceStart);
+		const after = textarea.value.substring(result.replaceEnd);
+		textarea.value = before + result.replacement + after;
+	}
+
+	textarea.setSelectionRange(result.selectionStart, result.selectionEnd);
+}

--- a/frontend/src/lib/components/form/wikilink-helpers.test.ts
+++ b/frontend/src/lib/components/form/wikilink-helpers.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { detectTrigger, formatLinkText, spliceLink } from './wikilink-helpers';
+
+describe('detectTrigger', () => {
+	it('detects [[ at cursor position', () => {
+		expect(detectTrigger('hello [[', 8)).toBe(6);
+	});
+
+	it('detects [[ at the very start of the text', () => {
+		expect(detectTrigger('[[', 2)).toBe(0);
+	});
+
+	it('returns -1 when no [[ before cursor', () => {
+		expect(detectTrigger('hello world', 5)).toBe(-1);
+	});
+
+	it('returns -1 when cursor is too early', () => {
+		expect(detectTrigger('[', 1)).toBe(-1);
+	});
+
+	it('returns -1 for single bracket', () => {
+		expect(detectTrigger('hello [x', 7)).toBe(-1);
+	});
+
+	it('returns -1 when [[ is not immediately before cursor', () => {
+		expect(detectTrigger('hello [[ world', 14)).toBe(-1);
+	});
+
+	it('detects [[ after existing link syntax', () => {
+		expect(detectTrigger('See [[manufacturer:williams]] and [[', 36)).toBe(34);
+	});
+});
+
+describe('formatLinkText', () => {
+	it('formats a basic link', () => {
+		expect(formatLinkText('manufacturer', 'williams')).toBe('[[manufacturer:williams]]');
+	});
+
+	it('handles slugs with hyphens', () => {
+		expect(formatLinkText('machinemodel', 'medieval-madness')).toBe(
+			'[[machinemodel:medieval-madness]]'
+		);
+	});
+});
+
+describe('spliceLink', () => {
+	it('replaces [[ with the link text', () => {
+		const result = spliceLink('hello [[', 6, 8, '[[manufacturer:williams]]');
+		expect(result.newText).toBe('hello [[manufacturer:williams]]');
+		expect(result.newCursorPos).toBe(31);
+	});
+
+	it('replaces [[ plus extra typed chars', () => {
+		// User typed [[ then "ma" before selecting — cursor is past [[
+		const result = spliceLink('hello [[ma', 6, 10, '[[manufacturer:williams]]');
+		expect(result.newText).toBe('hello [[manufacturer:williams]]');
+		expect(result.newCursorPos).toBe(31);
+	});
+
+	it('works at the start of the text', () => {
+		const result = spliceLink('[[', 0, 2, '[[title:medieval-madness]]');
+		expect(result.newText).toBe('[[title:medieval-madness]]');
+		expect(result.newCursorPos).toBe(26);
+	});
+
+	it('preserves text after cursor', () => {
+		const result = spliceLink('See [[ for details.', 4, 6, '[[title:funhouse]]');
+		expect(result.newText).toBe('See [[title:funhouse]] for details.');
+		expect(result.newCursorPos).toBe(22);
+	});
+
+	it('works in the middle of existing content with links', () => {
+		const text = 'First [[manufacturer:williams]] and [[';
+		const result = spliceLink(text, 36, 38, '[[title:funhouse]]');
+		expect(result.newText).toBe('First [[manufacturer:williams]] and [[title:funhouse]]');
+		expect(result.newCursorPos).toBe(54);
+	});
+});

--- a/frontend/src/lib/components/form/wikilink-helpers.ts
+++ b/frontend/src/lib/components/form/wikilink-helpers.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure helper functions for wikilink autocomplete.
+ *
+ * Extracted from MarkdownTextArea so they can be tested without DOM/Svelte.
+ */
+
+/**
+ * Detect whether a `[[` trigger was just typed at the cursor position.
+ * Returns the start index of `[[` if found, or -1.
+ */
+export function detectTrigger(text: string, cursorPos: number): number {
+	if (cursorPos >= 2 && text.substring(cursorPos - 2, cursorPos) === '[[') {
+		return cursorPos - 2;
+	}
+	return -1;
+}
+
+/**
+ * Build the link text to insert: `[[type:ref]]`.
+ */
+export function formatLinkText(typeName: string, ref: string): string {
+	return `[[${typeName}:${ref}]]`;
+}
+
+/**
+ * Compute the result of splicing a link into textarea content.
+ *
+ * Replaces everything from `triggerStart` to `cursorPos` (the `[[` plus
+ * any additional characters typed while the dropdown was open) with the
+ * link text.
+ *
+ * Returns the new text and where the cursor should be placed.
+ */
+export function spliceLink(
+	text: string,
+	triggerStart: number,
+	cursorPos: number,
+	linkText: string
+): { newText: string; newCursorPos: number } {
+	const before = text.substring(0, triggerStart);
+	const after = text.substring(cursorPos);
+	return {
+		newText: before + linkText + after,
+		newCursorPos: triggerStart + linkText.length
+	};
+}

--- a/frontend/src/routes/cabinets/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/cabinets/[slug]/edit/+page.svelte
@@ -4,7 +4,7 @@
 	import client from '$lib/api/client';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 
 	let { data } = $props();
@@ -62,6 +62,6 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 	<NumberField label="Display Order" bind:value={editFields.display_order} />
 </EditFormShell>

--- a/frontend/src/routes/corporate-entities/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/corporate-entities/[slug]/edit/+page.svelte
@@ -6,7 +6,7 @@
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TagInput from '$lib/components/form/TagInput.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 	import { fetchFieldConstraints, fc, type FieldConstraints } from '$lib/field-constraints';
 	import {
@@ -69,7 +69,7 @@
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
 	<TextField label="Slug" bind:value={editFields.slug} />
-	<TextAreaField label="Description" bind:value={editFields.description} rows={6} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} rows={6} />
 
 	<fieldset class="date-group">
 		<legend>Years active</legend>

--- a/frontend/src/routes/display-subtypes/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/display-subtypes/[slug]/edit/+page.svelte
@@ -4,7 +4,7 @@
 	import client from '$lib/api/client';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 
 	let { data } = $props();
@@ -63,6 +63,6 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 	<NumberField label="Display Order" bind:value={editFields.display_order} />
 </EditFormShell>

--- a/frontend/src/routes/display-types/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/display-types/[slug]/edit/+page.svelte
@@ -4,7 +4,7 @@
 	import client from '$lib/api/client';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 
 	let { data } = $props();
@@ -63,6 +63,6 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 	<NumberField label="Display Order" bind:value={editFields.display_order} />
 </EditFormShell>

--- a/frontend/src/routes/franchises/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/franchises/[slug]/edit/+page.svelte
@@ -6,7 +6,7 @@
 	import { getEditRedirectHref } from '$lib/edit-routes';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 
 	let { data } = $props();
 	let franchise = $derived(data.franchise);
@@ -61,5 +61,5 @@
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
 	<TextField label="Slug" bind:value={editFields.slug} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 </EditFormShell>

--- a/frontend/src/routes/game-formats/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/game-formats/[slug]/edit/+page.svelte
@@ -4,7 +4,7 @@
 	import client from '$lib/api/client';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 
 	let { data } = $props();
@@ -63,6 +63,6 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 	<NumberField label="Display Order" bind:value={editFields.display_order} />
 </EditFormShell>

--- a/frontend/src/routes/gameplay-features/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/gameplay-features/[slug]/edit/+page.svelte
@@ -6,7 +6,7 @@
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TagInput from '$lib/components/form/TagInput.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import { buildHierarchyPatchBody, hierarchyToFormFields } from '$lib/hierarchy-edit';
 
 	let { data } = $props();
@@ -81,7 +81,7 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} rows={6} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} rows={6} />
 
 	<div class="field-group">
 		<SearchableSelect

--- a/frontend/src/routes/manufacturers/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/edit/+page.svelte
@@ -5,7 +5,7 @@
 	import { getEditRedirectHref } from '$lib/edit-routes';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import { buildManufacturerPatchBody, manufacturerToFormFields } from './manufacturer-edit';
 
 	let { data } = $props();
@@ -49,7 +49,7 @@
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
 	<TextField label="Slug" bind:value={editFields.slug} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 	<TextField label="Website" bind:value={editFields.website} type="url" />
 	<TextField label="Logo URL" bind:value={editFields.logo_url} type="url" />
 </EditFormShell>

--- a/frontend/src/routes/models/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/models/[slug]/edit/+page.svelte
@@ -8,7 +8,7 @@
 	import SearchableSelect from '$lib/components/SearchableSelect.svelte';
 	import TagInput from '$lib/components/form/TagInput.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 	import MonthSelect from '$lib/components/form/MonthSelect.svelte';
 	import { fetchFieldConstraints, fc, type FieldConstraints } from '$lib/field-constraints';
@@ -194,7 +194,7 @@
 	<!-- Identity -->
 	<TextField label="Name" bind:value={editFields.name} />
 	<TextField label="Slug" bind:value={editFields.slug} />
-	<TextAreaField label="Description" bind:value={editFields.description} rows={6} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} rows={6} />
 
 	<!-- Date -->
 	<fieldset class="field-group">

--- a/frontend/src/routes/people/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/people/[slug]/edit/+page.svelte
@@ -5,7 +5,7 @@
 	import { getEditRedirectHref } from '$lib/edit-routes';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 	import MonthSelect from '$lib/components/form/MonthSelect.svelte';
 	import { fetchFieldConstraints, fc, type FieldConstraints } from '$lib/field-constraints';
@@ -99,7 +99,7 @@
 	</fieldset>
 
 	<TextField label="Photo URL" bind:value={editFields.photo_url} type="url" />
-	<TextAreaField label="Bio" bind:value={editFields.description} rows={8} />
+	<MarkdownTextArea label="Bio" bind:value={editFields.description} rows={8} />
 </EditFormShell>
 
 <style>

--- a/frontend/src/routes/reward-types/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/reward-types/[slug]/edit/+page.svelte
@@ -4,7 +4,7 @@
 	import client from '$lib/api/client';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 
 	let { data } = $props();
@@ -63,6 +63,6 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 	<NumberField label="Display Order" bind:value={editFields.display_order} />
 </EditFormShell>

--- a/frontend/src/routes/series/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/series/[slug]/edit/+page.svelte
@@ -6,7 +6,7 @@
 	import { getEditRedirectHref } from '$lib/edit-routes';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 
 	let { data } = $props();
 	let series = $derived(data.series);
@@ -61,5 +61,5 @@
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
 	<TextField label="Slug" bind:value={editFields.slug} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 </EditFormShell>

--- a/frontend/src/routes/systems/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/systems/[slug]/edit/+page.svelte
@@ -4,7 +4,7 @@
 	import client from '$lib/api/client';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 
 	let { data } = $props();
 	let system = $derived(data.system);
@@ -59,5 +59,5 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 </EditFormShell>

--- a/frontend/src/routes/tags/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/tags/[slug]/edit/+page.svelte
@@ -4,7 +4,7 @@
 	import client from '$lib/api/client';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 
 	let { data } = $props();
@@ -63,6 +63,6 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 	<NumberField label="Display Order" bind:value={editFields.display_order} />
 </EditFormShell>

--- a/frontend/src/routes/technology-generations/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/technology-generations/[slug]/edit/+page.svelte
@@ -4,7 +4,7 @@
 	import client from '$lib/api/client';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 
 	let { data } = $props();
@@ -66,6 +66,6 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 	<NumberField label="Display Order" bind:value={editFields.display_order} />
 </EditFormShell>

--- a/frontend/src/routes/technology-subgenerations/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/technology-subgenerations/[slug]/edit/+page.svelte
@@ -4,7 +4,7 @@
 	import client from '$lib/api/client';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import NumberField from '$lib/components/form/NumberField.svelte';
 
 	let { data } = $props();
@@ -66,6 +66,6 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} />
 	<NumberField label="Display Order" bind:value={editFields.display_order} />
 </EditFormShell>

--- a/frontend/src/routes/themes/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/themes/[slug]/edit/+page.svelte
@@ -6,7 +6,7 @@
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
 	import TagInput from '$lib/components/form/TagInput.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
-	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import { buildHierarchyPatchBody, hierarchyToFormFields } from '$lib/hierarchy-edit';
 
 	let { data } = $props();
@@ -79,7 +79,7 @@
 
 <EditFormShell {saveStatus} {saveError} onsave={saveChanges}>
 	<TextField label="Name" bind:value={editFields.name} />
-	<TextAreaField label="Description" bind:value={editFields.description} rows={6} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} rows={6} />
 
 	<div class="field-group">
 		<SearchableSelect

--- a/frontend/src/routes/titles/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/edit/+page.svelte
@@ -6,6 +6,7 @@
 	import { getEditRedirectHref } from '$lib/edit-routes';
 	import SearchableSelect from '$lib/components/SearchableSelect.svelte';
 	import EditFormShell from '$lib/components/form/EditFormShell.svelte';
+	import MarkdownTextArea from '$lib/components/form/MarkdownTextArea.svelte';
 	import TextAreaField from '$lib/components/form/TextAreaField.svelte';
 	import TextField from '$lib/components/form/TextField.svelte';
 	import { buildModelBoundary, buildTitlePatchBody, titleToFormState } from '../title-edit';
@@ -113,7 +114,7 @@
 
 	<TextField label="Name" bind:value={editFields.name} />
 	<TextField label="Slug" bind:value={editFields.slug} />
-	<TextAreaField label="Description" bind:value={editFields.description} rows={6} />
+	<MarkdownTextArea label="Description" bind:value={editFields.description} rows={6} />
 
 	<div class="field-group">
 		<SearchableSelect


### PR DESCRIPTION
## Summary

- Two-stage `[[wikilink]]` autocomplete for all description/bio textareas — type `[[` to pick a link type, search within it, insert `[[type:slug]]`
- Markdown editing shortcuts: Cmd+B bold, Cmd+I italic, Cmd+K link, Tab indent, Enter list continuation, smart character wrapping, paste-URL-as-link
- Cursor-positioned dropdown via mirror div (adapted from Flipfix)
- Backend autocomplete API (`GET /api/link-types/` and `/api/link-types/targets/`) with soft-delete filtering
- API responses now return description text in authoring format (`[[type:slug]]`) for editing

## Test plan

- [ ] Type `[[` in any description field → dropdown appears at cursor
- [ ] Arrow keys navigate types, Enter/ArrowRight selects, Escape/ArrowLeft/Backspace closes
- [ ] Search stage: type to filter, arrow keys navigate results, Enter/click selects
- [ ] Backspace/ArrowLeft on empty search → back to type picker
- [ ] Selected result inserts `[[type:slug]]`, Cmd+Z undoes
- [ ] Save form → link persists; detail page renders clickable link
- [ ] Cmd+B, Cmd+I, Cmd+K, Tab, Shift+Tab, Enter on list lines all work
- [ ] Select text + paste URL → creates `[text](url)`
- [ ] Clicking textarea or blurring closes dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)