### PR TITLE
docs: add project documentation and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Pinball Database
+# Pinbase
 
-An interactive database of pinball machines.
+An interactive, collaborative database of pinball knowledge.
 
 ## Architecture
 
@@ -31,15 +31,17 @@ cd backend && uv run python manage.py createsuperuser
 
 ## Commands
 
-| Command           | What it does                                               |
-| ----------------- | ---------------------------------------------------------- |
-| `make bootstrap`  | Install all deps, run migrations, generate API types       |
-| `make dev`        | Start Django + SvelteKit dev servers                       |
-| `make test`       | Run backend (pytest) + frontend (vitest) tests             |
-| `make lint`       | Run ruff (backend) + eslint/prettier (frontend)            |
-| `make quality`    | Lint + type check (svelte-check)                           |
-| `make api-gen`    | Export OpenAPI schema and regenerate TypeScript types      |
-| `make agent-docs` | Regenerate CLAUDE.md and AGENTS.md from docs/AGENTS.src.md |
+| Command            | What it does                                               |
+| ------------------ | ---------------------------------------------------------- |
+| `make bootstrap`   | Install all deps, run migrations, generate API types       |
+| `make dev`         | Start Django + SvelteKit dev servers                       |
+| `make test`        | Run backend (pytest) + frontend (vitest) tests             |
+| `make lint`        | Run ruff (backend) + eslint/prettier (frontend)            |
+| `make quality`     | Lint + type check (svelte-check)                           |
+| `make api-gen`     | Export OpenAPI schema and regenerate TypeScript types      |
+| `make pull-ingest` | Download ingest source data                                |
+| `make ingest`      | Run the ingest pipeline                                    |
+| `make agent-docs`  | Regenerate CLAUDE.md and AGENTS.md from docs/AGENTS.src.md |
 
 ## Project Structure
 
@@ -47,9 +49,21 @@ cd backend && uv run python manage.py createsuperuser
 backend/          Django project (uv, pyproject.toml)
 frontend/         SvelteKit project (pnpm, package.json)
 scripts/          POSIX shell scripts for bootstrap, dev, test, lint
-docs/             Agent documentation source
+docs/             Product, architecture, development, and operations docs
 Makefile          Thin wrappers around scripts/
 ```
+
+## Further Reading
+
+- [docs/Overview.md](docs/Overview.md)
+- [docs/Architecture.md](docs/Architecture.md)
+- [docs/WebArchitecture.md](docs/WebArchitecture.md)
+- [docs/AppBoundaries.md](docs/AppBoundaries.md)
+- [docs/DomainModel.md](docs/DomainModel.md)
+- [docs/Provenance.md](docs/Provenance.md)
+- [docs/Ingest.md](docs/Ingest.md)
+- [docs/Development.md](docs/Development.md)
+- [docs/Hosting.md](docs/Hosting.md)
 
 ## Contributing
 

--- a/docs/AppBoundaries.md
+++ b/docs/AppBoundaries.md
@@ -1,0 +1,22 @@
+# Django App Boundaries
+
+This document defines the dependency rules and responsibilities of Pinbase's Django apps.
+
+## Apps
+
+- `core`: shared foundation layer used by the rest of the project
+- `accounts`: authentication and account-specific behavior
+- `catalog`: the pinball business/domain model and catalog-facing APIs
+- `provenance`: the generic claims, source, and audit system
+- `media`: Pinbase-hosted media infrastructure
+
+## Dependencies
+
+```text
+catalog | provenance | media
+____________________________
+    core  |   accounts
+```
+
+- `core` and `accounts` depend on nothing.
+- `catalog`, `provenance`, and `media` may depend on `core` and `accounts` but not on each other.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,57 @@
+# Architecture
+
+This documents the project's system architecture.
+
+## High-Level Shape
+
+This is a Django + SvelteKit monorepo with a small number of clear subsystems.
+
+- Django owns the backend: data model, provenance/claims logic, ingest pipeline, API, and admin UI.
+- SvelteKit owns the frontend.
+- The production system is deployed as a single service.
+- No Node.js server runs in production.
+
+At a high level:
+
+```text
+Browser
+  -> same-origin web application
+     -> Django API and admin
+     -> built SvelteKit frontend
+```
+
+## Major Pieces
+
+### Web application
+
+The web application is split between Django and SvelteKit.
+
+- Django owns the backend, API, admin, auth authority, and business truth.
+- SvelteKit owns the user-facing frontend.
+- The browser interacts with the system through a same-origin model in both development and production.
+
+See [WebArchitecture.md](WebArchitecture.md).
+
+### Backend application layers
+
+Within Django, responsibilities are split across backend apps with explicit boundaries.
+
+- `core` shared foundation layer.
+- `catalog` the pinball business/domain model.
+- `provenance` the claims and audit machinery.
+- `media` photo and video upload and hosting infrastructure.
+- `accounts` auth/account-specific behavior.
+
+These boundaries matter because Pinbase's value depends on a clear domain model, a generic provenance engine, and infrastructure concerns that do not leak across the system.
+
+See [AppBoundaries.md](AppBoundaries.md).
+
+## Read Next
+
+- [Overview.md](Overview.md)
+- [DomainModel.md](DomainModel.md)
+- [WebArchitecture.md](WebArchitecture.md)
+- [AppBoundaries.md](AppBoundaries.md)
+- [Provenance.md](Provenance.md)
+- [Ingest.md](Ingest.md)
+- [Hosting.md](Hosting.md)

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -1,0 +1,69 @@
+# Development
+
+This document is the contributor-facing hub for working on the Pinbase codebase.
+
+It does not try to restate every project rule. Instead, it points to the more specific docs that define how work in this repository should be approached.
+
+## Start Here
+
+- [../README.md](../README.md) for setup, commands, and local development
+- [Architecture.md](Architecture.md) for the top-level system map
+- [WebArchitecture.md](WebArchitecture.md) for the Django + SvelteKit web stack
+- [AppBoundaries.md](AppBoundaries.md) for backend app dependency rules
+- [DomainModel.md](DomainModel.md) for the business/domain model of pinball
+
+## Modeling and Schema Work
+
+When changing models, constraints, or persistence structure, read:
+
+- [DataModeling.md](DataModeling.md)
+
+If a lower-level technical data-model reference is added later, link it here.
+
+## Testing
+
+For testing expectations and strategy, read:
+
+- [Testing.md](Testing.md)
+
+## Domain-Specific System Docs
+
+When working in these areas, use the focused reference docs:
+
+- [Provenance.md](Provenance.md) for claims, resolution, and audit model
+- [Ingest.md](Ingest.md) for ingest architecture and source flow
+- [Hosting.md](Hosting.md) for deployment and runtime operations
+
+When a stable media reference doc exists, add it here as well.
+
+## Working Across App Boundaries
+
+Before adding imports across Django apps, read [AppBoundaries.md](AppBoundaries.md).
+
+When strict app boundaries make integration awkward, prefer these patterns over widening imports:
+
+- generic foreign keys and content types for cross-domain references where appropriate
+- registration hooks, where a generic subsystem lets another app register behavior without becoming coupled to it
+- serialized or value-level contracts rather than direct model imports
+- orchestration in higher-level entrypoints, such as API composition or management commands, rather than deep lateral imports
+
+The important rule is: solve integration by designing a boundary, not by punching through one.
+
+## Principles
+
+As a contributor, keep these distinctions clear:
+
+- product and domain docs explain what Pinbase is modeling
+- architecture docs explain how the system is organized
+- development docs explain how to work safely in the codebase
+- plan docs in [plans/README.md](plans/README.md) are historical reference, not canonical current documentation
+
+## To Expand
+
+This doc is intentionally a skeleton. It will likely grow sections for:
+
+- common workflows
+- code generation and derived artifacts
+- local data and ingest setup
+- frontend/backend development notes
+- release or migration checklists

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -1,0 +1,84 @@
+# Overview
+
+## What
+
+This project is an interactive, collaborative database of pinball knowledge. It aims to be an authoritative, easy-to-use repository of all the machines, manufacturers and people involved in pinball.
+
+## Why
+
+[The Flip](https://www.theflip.museum/), Chicago's playable pinball museum, wants a database of pinball machines.
+
+Creating exhibits, both physcial and digital, relies on having a complete and accurate corpus of pinball knowledge.
+
+As a nonprofit and a dedicated proponent of open source, The Flip wants to establish a corpus of pinball information that is:
+
+- **Easy to use**
+  - easy to explore
+  - easy to edit and contribute to
+  - easy to extract information out of
+- **Accurate**
+  - structured in a way that helps enforce data accuracy and effective dispute resolution.
+- **Open**
+  - As much as possible, have permissive licensing, ideally public domain. We're still working through exactly what's possible here.
+
+## Who It Serves
+
+- Museum staff and curators
+- Pinball players and collectors
+- Researchers and historians
+- Contributors and editors
+- Downstream users of open data
+
+## What Makes This Project Different
+
+- a domain model that matches how people actually think about pinball
+- provenance and dispute resolution
+- openness and extractability
+- support for both casual exploration and serious research
+- editorial curation without losing source history
+
+## Why Provenance Is A Differentiator
+
+Most databases collapse every question down to a single stored answer. That makes the data easy to display, but it hides where the answer came from, makes disagreements hard to inspect, and makes later correction or comparison much harder.
+
+Pinbase treats [provenance](Provenance.md) as part of the product, not just as backend bookkeeping.
+
+- every important fact can carry attribution: who said it, where it came from, and when it entered the system
+- conflicting claims from different sources can coexist instead of forcing the system to pretend there was never a dispute
+- the product can resolve those conflicts deterministically while still preserving the underlying evidence
+- editors and researchers can inspect the history of a fact instead of trusting an opaque final value
+- adding a new source does not require rethinking the whole data model for every field
+
+This matters for pinball because the subject is full of messy history, conflicting sources, changing corporate identities, incomplete credits, regional variations, and editorial judgment calls. A provenance-aware system is better suited to that reality than a database that only stores one decontextualized answer per field.
+
+## Why Openness Is A Differentiator
+
+Pinbase is being built as an open system, not a walled garden.
+
+- the codebase is open source
+- the project is intended to make pinball knowledge easier to inspect, reuse, and build on
+- structured data is easier to extract and analyze than information trapped in ad hoc pages or opaque software
+- APIs and exports make the data more useful to museums, researchers, hobbyists, and downstream tools
+- provenance and licensing make it easier to understand what can be reused, under what terms, and where it came from
+
+This does not mean every piece of information in Pinbase is automatically public domain or free of constraints. Some data originates from outside sources with their own licensing limits, and the project is still working through what the most permissive responsible approach can be in each area.
+
+But openness is still a core differentiator. The goal is for Pinbase to make pinball knowledge more available, more legible, and more reusable than systems where the data is difficult to access, difficult to verify, or effectively locked away.
+
+## Why The Domain Model Is A Differentiator
+
+Pinbase treats the structure of pinball knowledge as the most critical part of the product, via a rich [domain model](DomainModel.md),
+
+- games are modeled at multiple levels, including Titles, Models, variants, remakes, and conversions
+- makers are not treated as one flat name field; brands, manufacturers, corporate entities, and hardware systems can each be represented precisely
+- people, credits, taxonomy, and other descriptive dimensions are treated as first-class parts of the domain rather than loose free-form notes
+- the same underlying structure supports both a more approachable Title-based user experience and deeper exploration across many dimensions
+
+Most pinball sites are built by and for collectors and are oriented around the concept of a model. That works for learning all about that model, but it tends to flatten the domain and leave important distinctions implicit, inconsistent, or missing entirely.
+
+This is important because the public usually thinks in terms of titles, not specific moels within a title, while researchers and serious enthusiasts often need much more precision than a simple model lists can provide. By modeling the pinball world with more care, Pinbase can be easier to browse, more flexible to explore, and more accurate than systems that rely more heavily on free-form or flattened data.
+
+## Read Next
+
+[DomainModel.md](DomainModel.md)
+[Provenance.md](Provenance.md)

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,0 +1,95 @@
+# Testing
+
+This document describes the project's testing expectations and strategy.
+
+## Running Tests
+
+### Main Commands
+
+- `make test` runs the main backend and frontend test suites
+- backend tests use `pytest`
+- frontend tests use `vitest`
+
+Use narrower commands when appropriate during development, then widen as needed for confidence.
+
+### Core Rule
+
+For any change, identify and run the smallest meaningful test set.
+
+Do not default to running everything if a narrower test selection will give the answer you need.
+
+### How To Choose a Test Scope
+
+#### Prefer the smallest meaningful scope
+
+Examples:
+
+- a pure backend model/helper change: run the relevant backend tests first
+- a frontend component or module change: run the relevant frontend tests first
+- a schema or cross-cutting change: run the focused local tests, then widen appropriately
+
+### Widen when risk increases
+
+Run a broader set when:
+
+- the change affects shared infrastructure
+- the change crosses app boundaries
+- the change affects generated API contracts or backend/frontend integration
+- the narrow tests do not give enough confidence
+
+## Writing Tests
+
+### Bug Fixes Require TDD
+
+When fixing a bug, follow this order:
+
+1. Write a failing test that reproduces the bug.
+2. Run the test and confirm it fails for the expected reason.
+3. Fix the code.
+4. Run the test again and confirm it passes.
+
+Do NOT fix the bug first and backfill the test later.
+
+### Backend Testing
+
+Backend tests should generally cover:
+
+- model behavior and DB constraints
+- claim/provenance behavior
+- ingest behavior
+- API behavior
+- management command behavior where it matters
+
+When testing DB constraints, prefer direct ORM writes that hit the database constraint path rather than relying on `full_clean()`. See [DataModeling.md](DataModeling.md).
+
+### Frontend Testing
+
+Frontend tests should generally cover:
+
+- TypeScript module logic
+- component behavior where UI wiring matters
+- data-shape expectations against the API contract where appropriate
+
+Prefer testing logic in small TypeScript units where possible rather than over-relying on broad UI tests.
+
+### Documentation and Tests
+
+When a doc describes a strict engineering rule that affects implementation behavior, make sure the code and tests reflect it. Documentation alone is not enforcement.
+
+Relevant supporting docs:
+
+- [Development.md](Development.md)
+- [DataModeling.md](DataModeling.md)
+- [Architecture.md](Architecture.md)
+- [AppBoundaries.md](AppBoundaries.md)
+
+## To Expand
+
+This doc is intentionally a skeleton. It will likely grow sections for:
+
+- concrete command examples
+- test layout by area
+- fixtures and helper conventions
+- frontend testing patterns
+- integration vs unit guidance
+- coverage expectations, if the project wants them

--- a/docs/WebArchitecture.md
+++ b/docs/WebArchitecture.md
@@ -1,0 +1,103 @@
+# Web Architecture
+
+This document describes how Pinbase's web application is split between Django and SvelteKit, how browser requests flow through the stack, and why the system uses a same-origin model.
+
+For the top-level system map, see [Architecture.md](Architecture.md). For deployment details, see [Hosting.md](Hosting.md).
+
+## Responsibilities
+
+### Django backend
+
+Django is the source of truth for:
+
+- the catalog and supporting models
+- provenance, claim assertion, and claim resolution
+- ingest from external and editorial sources
+- authentication and authorization
+- admin and operational tooling
+- the API contract exported to the frontend
+
+### SvelteKit frontend
+
+SvelteKit is responsible for:
+
+- the public-facing browsing experience
+- authenticated user-facing application flows
+- consuming the Django API
+- rendering prerendered public pages and CSR application pages
+
+The frontend does not own business truth. It presents and edits data through the backend.
+
+## Same-Origin Model
+
+Pinbase uses a same-origin model in both development and production.
+
+### Why
+
+This keeps authentication and CSRF simple:
+
+- Django session auth works naturally
+- the browser does not need cross-origin API calls
+- no JWT or CORS architecture is required
+- Django admin and the user-facing app share the same auth authority
+
+## Development
+
+In local development, the browser talks to the SvelteKit dev server, which proxies `/api/` and `/admin/` to Django.
+
+```text
+Browser
+  -> SvelteKit dev server
+     -> /api/*, /admin/* proxied to Django
+     -> frontend routes handled by SvelteKit
+```
+
+This preserves the same-origin mental model during development even though two processes are running.
+
+## Production
+
+In production, one Django service handles:
+
+- `/api/` via Django Ninja
+- `/admin/` via Django admin
+- static frontend assets
+- prerendered HTML or the SPA shell for frontend routes
+
+At a high level:
+
+```text
+Browser
+  -> Django/Gunicorn
+     -> /api/* handled by Django Ninja
+     -> /admin/* handled by Django admin
+     -> static assets served from the built frontend output
+     -> frontend routes served as prerendered HTML or SPA shell
+```
+
+See [Hosting.md](Hosting.md) for the production serving details.
+
+## API Contract
+
+The backend API is the contract between Django and the frontend.
+
+- Django Ninja exposes the API schema.
+- TypeScript types are generated from the OpenAPI output.
+- The generated types are derived artifacts, not the source of truth.
+
+This keeps the frontend strongly typed without making TypeScript definitions a separate hand-maintained interface.
+
+## Runtime Model
+
+Pinbase intentionally avoids a separate frontend runtime in production.
+
+- Node.js is used during frontend development and build time.
+- Node.js does not run in production to serve the site.
+- Django remains the single production runtime for API, admin, and frontend delivery.
+
+This keeps the deployed system simpler to operate and keeps auth and request handling centered in one place.
+
+## Read Next
+
+- [Architecture.md](Architecture.md)
+- [AppBoundaries.md](AppBoundaries.md)
+- [Hosting.md](Hosting.md)

--- a/docs/plans/DocRefresh.md
+++ b/docs/plans/DocRefresh.md
@@ -1,0 +1,158 @@
+# Documentation Refresh Plan
+
+This document proposes a refreshed documentation set for the project and maps the current docs into it.
+
+## Goals
+
+- Create a real first-stop human document for understanding the product and system.
+- Separate product, architecture, domain, and implementation-reference concerns.
+- Move implemented architecture out of plan docs and into stable reference docs.
+- Reduce overlap between the domain/terminology docs.
+
+## Proposed Documentation Set
+
+### Contributor entrypoint
+
+- [README.md](../../README.md)
+  Keep this as contributor quickstart only: setup, commands, local dev, CI expectations. It should not try to carry the product or system narrative.
+
+### Product docs
+
+- `docs/Overview.md`
+  New. This should be the first-stop human document. It should explain what Pinbase is, who it serves, the main product surfaces, where data comes from, and the high-level shape of the system.
+
+- [docs/DomainModel.md](../DomainModel.md)
+  Keep, but narrow and strengthen it. This doc should describe the business domain of pinball as Pinbase understands it: Titles, Models, variants, remakes, manufacturers, taxonomy, locations, credits, and related concepts. This is not a technical entity-model or schema-reference doc. It is the product-facing domain model: how the public thinks about pinball, how the museum thinks about pinball, and how Pinbase organizes the world so information can slot in cleanly. It should open with a short "Terminology" or "Core distinctions" section that absorbs the most important content from [Definitions.md](../Definitions.md), then proceed into the domain concepts and their relationships. It should stop being part business-domain doc and part ingest design.
+
+## Architecture & system docs
+
+- `docs/Architecture.md`
+  New. This should be the short top-level system map: the major pieces of Pinbase, how they relate, and where to go for deeper architectural docs.
+
+- `docs/WebArchitecture.md`
+  New. This should describe the Django + SvelteKit web stack: same-origin auth, dev proxy, production serving model, and the API contract between backend and frontend.
+
+- `docs/AppBoundaries.md`
+  New. This should document backend app responsibilities and dependency rules, especially the rule that `core` is the shared foundation layer and that `catalog`, `provenance`, and `media` do not depend on one another.
+
+- [docs/Provenance.md](../Provenance.md)
+  Rewrite as the canonical reference for claims, resolution, relationship namespaces, `ChangeSet`, `IngestRun`, retractions, and claim-controlled entity lifecycle/status. The now-implemented parts of [ClaimsNextGen.md](ClaimsNextGen.md) and [ChangeSet.md](ChangeSet.md) should move here.
+
+- [docs/Ingest.md](../Ingest.md)
+  Rewrite around the current plan/apply architecture, source adapters, dry-run behavior, run reporting, current command surface, and source-specific notes. Operational instructions should remain, but they should be secondary to "how ingest works now".
+
+- `docs/Media.md`
+  New stable reference doc. This should describe the media domain, ownership boundary, uploaded-vs-third-party policy, the `MediaAsset` / `MediaRendition` / `EntityMedia` split, and the current implementation status. Source material exists in [Media.md](Media.md).
+
+### Development docs
+
+- `docs/Development.md`
+  New. This should be the engineering/navigation doc for contributors working in the codebase. It should point to the more specific development references instead of trying to replace them. In particular, it should link to [DataModeling.md](../DataModeling.md) and a future `docs/Testing.md`.
+
+- `docs/DataModel.md` (only if needed)
+  Optional. Create this only if the project ends up needing a lower-level technical reference for the actual Django/entity model, persistence structure, or implementation details that do not belong in [DomainModel.md](../DomainModel.md). Do not let this displace or dilute the importance of the business-domain doc.
+
+- [docs/DataModeling.md](../DataModeling.md)
+  Keep as the engineering rules doc for schema design, constraints, and modeling patterns.
+
+- `docs/Testing.md`
+  New. This should collect testing strategy and repo-specific testing expectations in one place: how to choose the smallest meaningful test set, TDD expectations for bug fixes, backend/frontend test layout, and any common patterns worth standardizing.
+
+### Operations docs
+
+- [docs/Hosting.md](../Hosting.md)
+  Keep as deployment and operations documentation.
+
+## Resulting Reading Order
+
+Suggested human reading order:
+
+1. `docs/Overview.md`
+2. `docs/Architecture.md`
+3. [DomainModel.md](../DomainModel.md)
+4. `docs/WebArchitecture.md`
+5. `docs/AppBoundaries.md`
+6. [Provenance.md](../Provenance.md)
+7. [Ingest.md](../Ingest.md)
+8. `docs/Media.md`
+9. `docs/Development.md`
+
+Suggested contributor/supporting references:
+
+- [README.md](../../README.md)
+- `docs/Development.md`
+- `docs/DataModel.md` (if created)
+- [DataModeling.md](../DataModeling.md)
+- `docs/Testing.md`
+- [Hosting.md](../Hosting.md)
+
+## Migration Notes
+
+### Product and architecture split
+
+The biggest missing piece is a genuine overview doc. [README.md](../../README.md) is intentionally lightweight and contributor-oriented. [ProjectBrief.md](ProjectBrief.md) captures early architecture rationale, but not the product. The refresh should therefore create `docs/Overview.md` mostly from scratch, while using [ProjectBrief.md](ProjectBrief.md) only as source material for the architecture docs.
+
+### Domain and terminology split
+
+[DomainModel.md](../DomainModel.md) and [Definitions.md](../Definitions.md) currently overlap too heavily to justify separate docs. The refresh should merge them by:
+
+- Keeping [DomainModel.md](../DomainModel.md) as the canonical business-domain doc
+- Adding a short opening "Terminology" or "Core distinctions" section there
+- Moving the useful conceptual distinctions from [Definitions.md](../Definitions.md) into that opening section
+- Retiring [Definitions.md](../Definitions.md) once its useful content has been absorbed
+
+This keeps one authoritative explanation of `Title`, `Model`, `Variant`, `Remake`, and related distinctions in the product's core domain language.
+
+If the project later needs a lower-level technical reference for the actual Django/entity model, that should live in a separate `docs/DataModel.md`, not in [DomainModel.md](../DomainModel.md).
+
+### Development docs split
+
+The repo also needs an explicit development-doc entrypoint. Today contributor guidance is spread across [README.md](../../README.md), [DataModeling.md](../DataModeling.md), [AGENTS.src.md](../AGENTS.src.md), and inline conventions. A new `docs/Development.md` should gather and route that information:
+
+- `docs/Development.md` as the contributor-facing hub
+- [DataModeling.md](../DataModeling.md) for schema/modeling rules
+- `docs/Testing.md` for testing strategy and expectations
+
+This keeps the overview and architecture docs from turning into contributor handbooks, while also keeping README from having to carry every engineering convention.
+
+### README refresh
+
+[README.md](../../README.md) is still broadly accurate as a contributor quickstart, but it is too thin and slightly stale as a repository landing page.
+
+What should stay:
+
+- Setup and local development commands
+- Core architecture bullets
+- Project structure at a high level
+
+What should change:
+
+- Update the description of `docs/` in the project structure section. It is no longer just agent-doc source.
+- Add command references for `make pull-ingest` and `make ingest`.
+- Add a short "Further reading" section linking to `docs/Overview.md`, `docs/Architecture.md`, `docs/WebArchitecture.md`, `docs/AppBoundaries.md`, [DomainModel.md](../DomainModel.md), [Provenance.md](../Provenance.md), [Ingest.md](../Ingest.md), `docs/Development.md`, and [Hosting.md](../Hosting.md). When a stable media reference exists, include that too.
+- Keep README focused on onboarding and navigation, not on carrying the full product/system explanation. That belongs in `docs/Overview.md` and `docs/Architecture.md`.
+
+### Plan docs are historical reference
+
+The `docs/plans/` folder is for historical plans. Those docs are expected to go stale once implementation lands. They should remain available for historical reference, but they are not canonical product or system documentation.
+
+The refresh should move implemented decisions into stable docs such as [Provenance.md](../Provenance.md), [Ingest.md](../Ingest.md), and `docs/Media.md`, while leaving plan docs like [ClaimsNextGen.md](ClaimsNextGen.md), [ChangeSet.md](ChangeSet.md), [Media.md](Media.md), and [ProjectBrief.md](ProjectBrief.md) in place as historical artifacts. A short `docs/plans/README.md` should make that status explicit.
+
+## Proposed End State
+
+After the refresh, the docs should answer these questions cleanly:
+
+- "What is Pinbase?" -> `docs/Overview.md`
+- "How is the system put together?" -> `docs/Architecture.md`
+- "How is the Django + SvelteKit web app structured?" -> `docs/WebArchitecture.md`
+- "What are the backend app dependency rules?" -> `docs/AppBoundaries.md`
+- "What is Pinbase's business/domain model of pinball?" -> [DomainModel.md](../DomainModel.md)
+- "What do `Title`, `Model`, `Variant`, and related terms mean?" -> [DomainModel.md](../DomainModel.md)
+- "How do provenance and claims work?" -> [Provenance.md](../Provenance.md)
+- "How does ingest work?" -> [Ingest.md](../Ingest.md)
+- "How does media work?" -> `docs/Media.md`
+- "How do I work on this codebase?" -> `docs/Development.md`
+- "What is the lower-level technical/entity model?" -> `docs/DataModel.md` (if needed)
+- "How should we model new schema?" -> [DataModeling.md](../DataModeling.md)
+- "How should we test changes?" -> `docs/Testing.md`
+- "How is this deployed?" -> [Hosting.md](../Hosting.md)

--- a/docs/plans/Phase5-FandomWikidata.md
+++ b/docs/plans/Phase5-FandomWikidata.md
@@ -1,0 +1,374 @@
+# Phase 5: Fandom & Wikidata Adapter Conversion
+
+Convert `ingest_fandom`, `ingest_wikidata`, and `ingest_wikidata_manufacturers` from legacy imperative commands to plan/apply adapters.
+
+## Context
+
+Phases 1–4 of [ClaimsNextGen.md](ClaimsNextGen.md) are complete. The apply layer, OPDB adapter, IPDB adapter, entity lifecycle, DB-level validation, and relationship claim PK migration are all implemented. Two adapters remain before `ingest_pinbase` (the compound plan).
+
+Reference implementations:
+
+- **IPDB** (`catalog/ingestion/ipdb/adapter.py`) — multi-entity, `identity_refs`, most complex
+- **OPDB** (`catalog/ingestion/opdb/adapter.py`) — single-entity, simpler
+
+## Design Decisions
+
+### Three separate plans for Fandom (not one combined plan)
+
+The Fandom command currently processes three independent data streams (games/credits, persons, manufacturers) from separate source pages with separate dump files. Rather than combining them into one `IngestPlan`, each becomes its own `build_fandom_*_plan()` → `apply_plan()` cycle.
+
+**Why three plans wins:**
+
+1. **Fixes the credit gap bug.** The current command processes credits first (only matching existing persons), then creates new persons — so newly-created persons never get credit claims in the same run. With three plans applied in order (persons → credits → manufacturers), person creation commits before the credits plan runs. The credits plan sees the freshly-created persons and emits their credit claims. No `identity_refs` needed, no second run required.
+
+2. **Simpler to reason about.** Each plan has one entity type or one concern. No coordinating three unrelated datasets in a single plan.
+
+3. **Independent failure.** If the manufacturer phase fails, credits and persons already committed. These are independent data streams, so partial success is acceptable.
+
+**Drawback:** Three `IngestRun` audit records instead of one. Three transactions instead of one (but partial success is fine for independent streams).
+
+### Plan ordering within the command
+
+The management command applies plans in this order:
+
+1. **Persons plan** — parse games data to learn which person names appear in credits. Create missing Person records. Assert name/slug/bio claims on all matched+created persons. Apply. Persons now exist in DB.
+2. **Credits plan** — all persons (including freshly created ones) are findable. Build credit claims on MachineModel for matched (game, person, role) triples. Apply.
+3. **Manufacturers plan** — match manufacturers, assert scalar claims. Independent of 1 and 2. Apply.
+
+### Sweep removal (additive-only)
+
+Both Fandom and Wikidata currently use `sweep_field="credit"` + `authoritative_scope` for credit claims. Per the [additive-only design principle](ClaimsNextGen.md#additive-only-ingest-near-term), sweep is dropped. Stale credits from these sources won't be automatically deactivated. This matches the IPDB conversion.
+
+### `wikidata_id` via claims only (no direct writes)
+
+Both Wikidata commands currently do a dual write: assert a `wikidata_id` claim AND set `person.wikidata_id` / `mfr.wikidata_id` directly. The Person model even comments "direct field, not a claim" — but `wikidata_id` is NOT in `claims_exempt`, so `get_claim_fields()` treats it as claim-controlled.
+
+The plan/apply conversion drops the direct write. `wikidata_id` is asserted as a claim; the resolver materialises it. This is consistent with the "one write path" principle and eliminates the dual-write inconsistency. Remove the misleading comment on `Person.wikidata_id`.
+
+### Wikidata person + manufacturer share a source
+
+Both `ingest_wikidata` and `ingest_wikidata_manufacturers` use the same `Source(slug="wikidata")`. They become two build functions in the same adapter module (`catalog/ingestion/wikidata/adapter.py`), each producing its own `IngestPlan`.
+
+## File Layout
+
+```text
+catalog/ingestion/
+  fandom/
+    __init__.py
+    adapter.py          # build_fandom_persons_plan(), build_fandom_credits_plan(), build_fandom_manufacturers_plan()
+  wikidata/
+    __init__.py
+    adapter.py          # build_wikidata_persons_plan(), build_wikidata_manufacturers_plan()
+  fandom_wiki.py        # Existing parsing code — untouched
+  wikidata_sparql.py    # Existing parsing code — untouched
+
+catalog/management/commands/
+  ingest_fandom.py      # Thin wrapper: fetch/dump, parse, build plans → apply_plan(), print report
+  ingest_wikidata.py    # Thin wrapper: fetch/dump, parse, build plan → apply_plan(), print report
+  ingest_wikidata_manufacturers.py  # Thin wrapper: fetch/dump, parse, build plan → apply_plan(), print report
+
+catalog/tests/
+  test_fandom_adapter.py              # NEW: plan-boundary tests
+  test_wikidata_adapter.py            # NEW: plan-boundary tests
+  test_wikidata_manufacturers_adapter.py  # NEW: plan-boundary tests
+  test_ingest_fandom.py               # Existing integration tests — updated
+  test_ingest_wikidata.py             # Existing integration tests — updated
+  test_ingest_wikidata_manufacturers.py  # Existing integration tests — updated
+```
+
+## Adapter Details
+
+### 1. `ingest_wikidata_manufacturers` (simplest — implement first)
+
+**Entity types:** Manufacturer (match-only, no creation)
+
+**Reconciliation:** `ManufacturerResolver` chain: QID match → exact name → corporate entity → normalized name. Same as current.
+
+**Claims asserted on Manufacturer:**
+
+- `wikidata_id` (scalar)
+- `wikidata.description` (extra-data)
+- `logo_url` (scalar)
+- `website` (scalar)
+- `name` (scalar — needed so resolver doesn't blank it)
+
+**What changes from current:**
+
+- No direct `mfr.wikidata_id = wm.qid` write — claim-only
+- No `resolve_all_entities()` call — apply layer handles resolution
+- `IngestRun` audit trail created automatically
+- `--dry-run` flag added
+
+**`build_wikidata_manufacturers_plan()` signature:**
+
+```python
+def build_wikidata_manufacturers_plan(
+    wikidata_manufacturers: list[WikidataManufacturer],
+    source: Source,
+    input_fingerprint: str,
+) -> IngestPlan:
+```
+
+### 2. `ingest_wikidata` (persons + credits)
+
+**Entity types:** Person (match-only, no creation), MachineModel (match-only for credits)
+
+**Reconciliation:** `build_person_lookup()` for exact name match. Same as current. Confidence scoring is logging-only — not used for claim decisions.
+
+**Claims asserted on Person:**
+
+- `wikidata_id`, `name` (scalar)
+- `wikidata.description` (extra-data)
+- `birth_year`, `birth_month`, `birth_day` (scalar, precision-gated)
+- `death_year`, `death_month`, `death_day` (scalar, precision-gated)
+- `birth_place`, `nationality`, `photo_url` (scalar)
+
+**Claims asserted on MachineModel:**
+
+- `credit` (relationship: `{person: PK, role: PK}`)
+
+**What changes from current:**
+
+- No direct `person.wikidata_id = wp.qid` write — claim-only
+- No `resolve_all_entities()` / `resolve_all_credits()` calls — apply layer handles resolution
+- Sweep dropped for credit claims (additive-only)
+- `IngestRun` audit trail created automatically
+- `--dry-run` flag added
+
+**Resolve hooks:** The plan registers `resolve_all_credits` as a resolve hook for `MachineModel` content type, so credit claims get materialised into `Credit` rows.
+
+**`build_wikidata_persons_plan()` signature:**
+
+```python
+def build_wikidata_persons_plan(
+    wikidata_persons: list[WikidataPerson],
+    source: Source,
+    input_fingerprint: str,
+) -> IngestPlan:
+```
+
+Credit claims are included in the same plan as person claims (they share a source and apply atomically). This is one plan, not two — the person claims and credit claims reference existing entities only (no `identity_refs` needed).
+
+### 3. `ingest_fandom` (most complex — three plans)
+
+#### Plan A: Persons
+
+**Entity types:** Person (match + create)
+
+**Reconciliation:**
+
+1. Parse games data to build `fandom_credits_by_name` (which person names appear in credits)
+2. Skip persons with no game credits (not useful to create)
+3. Exact name match via `build_person_lookup()`
+4. Near-duplicate detection (same last name + shared game credit) — skip with warning
+5. Safe to create → `PlannedEntityCreate`
+
+**Claims asserted on Person (new + matched):**
+
+- `name` (scalar)
+- `slug` (scalar)
+- `status` (for new entities: `active`)
+- `fandom.bio` (extra-data, if non-empty)
+
+**`build_fandom_persons_plan()` signature:**
+
+```python
+def build_fandom_persons_plan(
+    fandom_persons: list[FandomPerson],
+    fandom_credits_by_name: dict[str, set[str]],
+    source: Source,
+    input_fingerprint: str,
+) -> IngestPlan:
+```
+
+The games data is parsed first by the management command to derive `fandom_credits_by_name`, then passed to this function. The adapter itself doesn't parse games.
+
+#### Plan B: Credits
+
+**Entity types:** MachineModel (match-only), Person (match-only via lookup), CreditRole (match-only)
+
+Runs after Plan A is applied, so freshly-created persons are findable.
+
+**Claims asserted on MachineModel:**
+
+- `credit` (relationship: `{person: PK, role: PK}`)
+
+**Reconciliation:**
+
+- Games matched by `name.lower()` against `MachineModel.objects.all()`
+- Persons matched by `build_person_lookup()` (refreshed after Plan A apply)
+- CreditRoles matched by slug
+
+**`build_fandom_credits_plan()` signature:**
+
+```python
+def build_fandom_credits_plan(
+    games: list[FandomGame],
+    source: Source,
+    input_fingerprint: str,
+) -> IngestPlan:
+```
+
+**Resolve hooks:** Registers `resolve_all_credits` for MachineModel content type.
+
+#### Plan C: Manufacturers
+
+**Entity types:** Manufacturer (match-only, no creation)
+
+**Reconciliation:** `ManufacturerResolver` chain (same as current).
+
+**Claims asserted on Manufacturer:**
+
+- `name` (scalar)
+- `fandom.description` (extra-data)
+- `website` (scalar)
+
+**`build_fandom_manufacturers_plan()` signature:**
+
+```python
+def build_fandom_manufacturers_plan(
+    fandom_manufacturers: list[FandomManufacturer],
+    source: Source,
+    input_fingerprint: str,
+) -> IngestPlan:
+```
+
+### Management Command Structure
+
+Each command becomes a thin wrapper. Example for `ingest_fandom`:
+
+```python
+def handle(self, *args, **options):
+    # 1. Fetch/dump (unchanged — same CLI flags)
+    # 2. Parse all three datasets
+    games = parse_game_pages(raw_games)
+    fandom_persons = parse_person_pages(raw_persons)
+    fandom_mfrs = parse_manufacturer_pages(raw_mfrs)
+
+    # 3. Source setup
+    source = get_or_create_source()
+
+    # 4. Compute fingerprints (hash of each dataset)
+
+    # 5. Derive credits-by-name from games (needed by persons plan)
+    fandom_credits_by_name = _build_credits_by_name(games)
+
+    # 6. Apply plans in order
+    persons_plan = build_fandom_persons_plan(fandom_persons, fandom_credits_by_name, source, fp1)
+    persons_report = apply_plan(persons_plan, dry_run=options["dry_run"])
+
+    credits_plan = build_fandom_credits_plan(games, source, fp2)
+    credits_report = apply_plan(credits_plan, dry_run=options["dry_run"])
+
+    mfrs_plan = build_fandom_manufacturers_plan(fandom_mfrs, source, fp3)
+    mfrs_report = apply_plan(mfrs_plan, dry_run=options["dry_run"])
+
+    # 7. Print combined report
+```
+
+## Testing Strategy
+
+### Plan-boundary tests (new)
+
+One test file per adapter module. Test `build_*_plan()` directly: given parsed records and specific DB state, assert the plan contains the expected entities, assertions, and warnings. No `apply_plan()` calls.
+
+**Pattern (from IPDB):**
+
+```python
+class TestWikidataManufacturerPlan:
+    def test_matched_manufacturer_gets_claims(self, ...):
+        plan = build_wikidata_manufacturers_plan(records, source, "fp")
+        fields = _assertion_fields(plan, object_id=mfr.pk)
+        assert fields >= {"wikidata_id", "name", "logo_url", "website"}
+
+    def test_unmatched_manufacturer_skipped(self, ...):
+        plan = build_wikidata_manufacturers_plan(records, source, "fp")
+        assert len(plan.assertions) == 0
+
+    def test_wikidata_description_is_extra_data(self, ...):
+        plan = build_wikidata_manufacturers_plan(records, source, "fp")
+        value = _assertion_value(plan, "wikidata.description", object_id=mfr.pk)
+        assert value == "American manufacturer..."
+```
+
+**Fandom persons plan tests should cover:**
+
+- Matched person gets name/slug/bio claims
+- Person with no credits skipped (no entity create, no claims)
+- Near-duplicate detected → warning, no entity create
+- New person gets `PlannedEntityCreate` + name/slug/status claims
+- Records parsed/matched counts are correct
+
+**Fandom credits plan tests should cover:**
+
+- Matched game + matched person + known role → credit assertion
+- Unmatched game → skipped (no assertion, counted in warnings or records_parsed)
+- Unmatched person → skipped
+- Unknown role slug → warning
+
+### Integration tests (updated)
+
+Existing integration tests in `test_ingest_fandom.py`, `test_ingest_wikidata.py`, `test_ingest_wikidata_manufacturers.py` are updated to:
+
+- Add `--dry-run` test (creates nothing)
+- Verify `IngestRun` audit records exist after a real run
+- Remove any assertions about sweep behavior
+- Keep all existing correctness assertions (credits created, idempotency, etc.)
+
+### Dry-run tests
+
+Each command gets a dry-run integration test:
+
+```python
+def test_dry_run_creates_nothing(self, ...):
+    call_command("ingest_wikidata_manufacturers", from_dump=SAMPLE, dry_run=True)
+    assert Claim.objects.count() == initial_claims
+    assert IngestRun.objects.count() == 0
+```
+
+## Implementation Order
+
+Three commits, simplest first:
+
+### Commit 1: `ingest_wikidata_manufacturers`
+
+1. Create `catalog/ingestion/wikidata/__init__.py` and `adapter.py`
+2. Implement `build_wikidata_manufacturers_plan()` + `get_or_create_source()` + `compute_fingerprint()`
+3. Slim down management command to thin wrapper
+4. Write plan-boundary tests (`test_wikidata_manufacturers_adapter.py`)
+5. Update integration tests (`test_ingest_wikidata_manufacturers.py`)
+6. Remove the misleading "direct field, not a claim" comment on `Manufacturer.wikidata_id` if present
+7. Run tests: `make test`
+
+### Commit 2: `ingest_wikidata`
+
+1. Add `build_wikidata_persons_plan()` to `catalog/ingestion/wikidata/adapter.py`
+2. Register `resolve_all_credits` as resolve hook for credit claims
+3. Slim down management command
+4. Write plan-boundary tests (`test_wikidata_adapter.py`)
+5. Update integration tests (`test_ingest_wikidata.py`)
+6. Remove the "direct field, not a claim" comment on `Person.wikidata_id`
+7. Run tests: `make test`
+
+### Commit 3: `ingest_fandom`
+
+1. Create `catalog/ingestion/fandom/__init__.py` and `adapter.py`
+2. Implement three build functions: persons, credits, manufacturers
+3. Slim down management command (three `apply_plan()` calls in order)
+4. Write plan-boundary tests (`test_fandom_adapter.py`)
+5. Update integration tests (`test_ingest_fandom.py`)
+6. Run tests: `make test`
+
+## What Does NOT Change
+
+- Parsing code: `fandom_wiki.py`, `wikidata_sparql.py` — untouched
+- Source priorities: Fandom=20, Wikidata=75
+- Reconciliation strategies: same matching logic, same resolver chains
+- CLI flags: `--dump`, `--from-dump`, `--dump-persons`, etc. all preserved
+- Test fixtures: same JSON sample files
+
+## Risks
+
+- **Resolve hook for credits.** The IPDB adapter registers `resolve_all_credits` as a resolve hook. Wikidata and Fandom credits need the same. Verify the resolve hook mechanism works for claims on existing entities (not just planned entities). If `apply.py._resolve()` only runs hooks for content types that had claims created, this should work — but verify.
+
+- **`wikidata_id` via resolver.** Dropping the direct write means `wikidata_id` must be handled by the resolver. Verify that `resolve_all_entities(Person, ...)` and `resolve_all_entities(Manufacturer, ...)` correctly materialise `wikidata_id` from claims. If the resolver skips it or resets it, the integration tests will catch it.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,7 @@
+# Plans
+
+This directory contains historical planning documents.
+
+These docs are useful for understanding prior design thinking, tradeoffs, and implementation sequencing, but they are not canonical product or system documentation. A plan doc may become outdated as soon as implementation lands.
+
+Use the stable docs in `docs/` for the current description of how the system works. Use `docs/plans/` when you need historical context, rationale, or the state of thinking at a particular moment in time.

--- a/docs/plans/auth/Auth.md
+++ b/docs/plans/auth/Auth.md
@@ -1,0 +1,235 @@
+# SSO
+
+This describes the authentication and authorization requirements and strategy for The Flip's web properties.
+
+## Background
+
+The Flip, Chicago's playable pinball musueum, has a growing collection of web properties.
+
+### The Properties
+
+Right now they are:
+
+#### WWW
+
+The public website. So far it's entirely public, no login. Dunno if that will change or not.
+
+- Lives at https://www.theflip.museum/
+- Built in Next.js
+- Code a https://github.com/The-Flip/www.theflip.museum
+
+#### Flipfix
+
+The web app used to coordinate maintenance. There are public read-only users, museum staff who can make edits, and Django superuser admins. Users are created by a superuser sending out an invite.
+
+- Lives at https://flipfix.theflip.museum/
+- Built in Django
+- Code at https://github.com/The-Flip/flipfix
+
+#### Pinbase
+
+An interactive, collaborative wiki-style catalog of all pinball machines in existence. It hasn't gone live yet. It will have public read-only access, public user registration, trusted museum staff roles, and Django superuser admin roles.
+
+- Will live at something like https://pinbase.theflip.museum/
+- Built in Django on the back end and Sveltekit on the front end
+- Code at https://github.com/deanmoses/pinbase/ but it will be moving under the The-Flip's account
+
+#### Juice
+
+An internal app used to monitor and reboot the pinball machines and other electronics in the musem. This is a tiny little internal application only available to the most trusted museum staff.
+
+- Lives at https://juice.theflip.museum/
+- Built in Python
+- Code at https://github.com/The-Flip/juice
+
+### Railway Hosting
+
+All of these are currently hosted on Railway, which we like well enough, though we don't want to make decisions that lock us in to Railway.
+
+## SSO Via Flipfix
+
+The first property to need authentication was Flipfix. We used the standard Djanog auth model. Now we need a single login to the other properties, so we implemented OAuth SSO on top of Flipfix; it serves as the OAuth provider right now. The Juice gets its identity through that.
+
+We're not locked in to this arrangement; if there's a better SSO system, we would consider migrating. There's maybe 30? users, it'd be a pain but we could do it.
+
+## The Challenge
+
+Now we need authentication and authorization for Pinbase. Since the public can self-register, this involves a new set of requirements.
+
+### Forgot password
+
+Forgot password is a must.
+
+We have not yet built Forgot Password functionality for Flipfix. For one, we haven't hooked up an email server to send the forgot password messages. I know from past experience that it can be difficult to not be classified as junk mail, so I'm skittish. And then customizing the email HTML so that it displays nicely on all browsers is notoriously tricky. We've already had users forget their password, so it'd be nice to have this, but not critical.
+
+### Email verification
+
+Verify that the person registering owns the email address. Otherwise you get spam accounts and people squatting on addresses. This is a must-have.
+
+If we're doing a system where people can also register with phone numbers, we'd need to verify the phone number. But I don't think we are... seems difficult?
+
+### Social Login
+
+Register/login using your Google/Apple/Facebook/etc identity. I'd kind of like this for Flipfix too, but that's a nice to have.
+
+#### Email & social logins work seamlessly
+
+When someone registers with email/password, then later tries to log in with Google using the same email, that should be treated as the same account, and work seamlessly.
+
+They can they still log in with their password.
+
+### Carry over Flipfix identity
+
+Nice to have: if you are already registered with Flipfix, you are already authenticated to Pinbase and your username and full name are carried over.
+
+If someone already has a Flipfix account, is not logged in to the SSO system, then attempts to register on Pinbase with the same email, it says 'account already taken'... just like it would on Flipfix.
+
+### Account deactivation / banning
+
+#### Admin-initiated deleting
+
+If an admin of a property deactivates / bans a user, it only applies to that property. Deactivating a Flipfix staff account does not deactivate that person's Pinbase account.
+
+Each property will have their own way of dealing with the deactivated user's contributions on that property.
+
+Deleting/banning a truly abusive user will take going to each property.
+
+#### User-initiated deleting
+
+We'd like to support GDPR-style "delete my account", but that may not be in scope for v1. Depends on how hard it is.
+
+### Username and display name
+
+Users should have the same username across all properties.
+
+Their display name should flow to each property, it's a nice to have to override that display name on a per-property basis.
+
+### Authorization / Roles
+
+#### Newly registered public user
+
+When a member of the public registers, I imagine each site will put them in their lowest tier of capability.
+
+**Pinbase**. Right now Pinbase has categories for 'registered user', 'staff' (has access to admin) roles, and superuser. Publicly registered users would be assigned the 'registered user' role. It's up to Pinbase what a registered user can do; that's not the scope of this doc.
+
+**Flipfix**. Will NOT allow any escalated privileges for publicly registered users; they will be treated like unregistered guests.
+
+**Juice**. Will NOT allow publicly registered users (or guest access) in any capacity.
+
+**www**. Has no authentication or authorization requirements at this time.
+
+#### Museum staff identity across apps
+
+If someone is staff on Flipfix, I'd like to be able to use that information on Pinbase to give them escalated privileges. But the Pinbase role model has not yet been figured out. I don't believe there should be a staff role that goes across all properties. If this creates a lot of complexity, I'll probably drop this requirement.
+
+#### Role escalation
+
+On Pinbase, a self-registered user can only become more trusted via some sort of admin action. That will be internal to Pinbase, not visible to the SSO system.
+
+#### No shared authorization
+
+Basically, we're saying is that we should have SSO -- one identity -- but not unified permissions. Unless it's somehow easy to flag a user as museum staff, to enable different properties to use that information in different ways.
+
+### Security
+
+- Rate limiting on registration: yes
+- CAPTCHA: no
+- Password policy: I guess some sort of minimum complexity, I don't feel strongly on this.
+- Multi-factor authentication: nice to have, depends on how hard it is
+
+#### Sessions
+
+- **Session Duration**. Ideally sessions last months, unless that's really a security no-no
+- **User revocation**. Users seeing and revoking sessions is a nice to have. Probably not for v1.
+
+### Logout
+
+I don't have a strong opinion on how logout needs to work; either one of these is fine:
+
+- Logging out of one app logs you out of all apps.
+- Logging out of one app only logs you out of that app.
+
+### Non-functional Requirements
+
+#### Don't build it ourselves
+
+Building a full SSO system sounds complicated; it's not our core competency; it's yet another service to keep running. My bias is to use a vendor for this, unless there's a good reason not to, or maybe unless there's an off-the-shelf system that is SUPER easy to run.
+
+#### Avoid Vendor Lock-in
+
+I'm nervous about picking a vendor and not being able to migrate. Meaning migrate the actual users with their authentication.
+
+#### Cost
+
+We don't want to spend a lot of ongoing money for this. A vendor with a free tier? $5/mo? Hopefully that's the ballpark we're talking about.
+
+The Flip is a registered Non Profit and all the software that SSO would integrate with is open source, if that changes the cost structure that vendors charge.
+
+#### Initial User Migration
+
+How hard is the initial migration of ~30 Flipfix users into the new system?
+
+- It would be great if existing Flipfix users could keep their passwords... but if this means not using a hosted service provider, I'd drop the requirement.
+- Some providers have bulk import tools. That's a nice to have.
+
+#### Ease of Migrating Off
+
+How hard would it be to switch providers? Does the provider allow us to download the user data, including password seeds, so that we can upload them to a different system?
+
+#### Ease of integration
+
+How easy is it to wire up each property?
+
+We strongly prefer a provider that exposes standard OIDC/OAuth2 endpoints (including `/.well-known/openid-configuration` discovery) so that each backend can integrate with a generic OIDC library (`mozilla-django-oidc`, `authlib`, etc.) rather than a vendor-specific SDK.
+
+Our architecture is session-based: the frontend redirects to the IdP, the IdP redirects back, and Django creates a server-side session. This is a standard OIDC authorization code flow. A provider that requires its own JavaScript SDK on the frontend — replacing the redirect flow with client-side JWT verification on every API call — would be a poor fit because:
+
+- It changes our auth model from server-side sessions to per-request JWT verification
+- It couples the frontend to the vendor (Clerk components, Clerk API calls) instead of a simple redirect
+- Every backend (Django, Python) needs vendor-specific token verification code instead of standard OIDC middleware
+- It's more integration surface area to get right across a mixed stack (Django, SvelteKit, Next.js, Python)
+
+#### Hosting location
+
+The properties are all hosted in US/East or US/Chicago, I'd prefer a SSO system that has services there, because perf/lantency.
+
+### Non-Requirements
+
+- **Data residency**
+- **Uptime**. These are not mission-critical systems.
+
+## The Options
+
+See [AuthProviders.md](AuthProviders.md)
+
+## The Decision
+
+I don't want to run an auth service ourselves:
+
+- I don't want to build it and own that code
+- I don't want to occupy us with the ongoing hosting of it
+
+This pushes us to a hosted vendor.
+
+After reviewing the hosted vendors (see [AuthProviders.md](AuthProviders.md)), WorkOS AuthKit is the leading candidate.
+
+The key reason is sessions. We want users to stay signed in for months. Auth0's self-service plans cap sessions at 3 days idle and 30 days absolute, and the longer session limits appear to require Enterprise pricing, which is out of budget even with nonprofit discounts. By contrast, in a real WorkOS AuthKit account we verified that:
+
+- Maximum session length can be set to 365 days
+- Inactivity timeout defaults to 2 days and can be increased to at least 100 days
+- Access token duration is configurable
+
+WorkOS also remains strong on the other important requirements:
+
+- Hosted vendor, not self-hosted
+- Standard OIDC/OAuth2 integration
+- Email/password, social login, email verification, forgot password, MFA, and account linking on the free tier
+- Built-in auth email sending, so we do not need a separate email provider for v1 unless we want a custom sending domain
+
+The main downside is branding: custom auth and email domains cost $99/mo. At this point, I would rather give up custom domains than long-lived sessions, so that tradeoff appears acceptable.
+
+So the current direction is:
+
+- Choose WorkOS AuthKit as the SSO provider
+- Accept WorkOS-hosted auth and email domains for v1
+- Revisit custom domains later only if they become important enough to justify the extra cost

--- a/docs/plans/auth/AuthMail.md
+++ b/docs/plans/auth/AuthMail.md
@@ -1,0 +1,96 @@
+# SSO Mail Provider
+
+This describes the mail provider requirements for authentication emails for The Flip's web properties.
+
+## Background
+
+The Flip, Chicago's playable pinball musueum, is implementing SSO across all its web properties. See [Auth.md](Auth.md).
+
+Some hosted auth providers require a separate email provider for production auth mail. Others can send the auth emails themselves. WorkOS AuthKit, for example, can send auth emails by default from a WorkOS domain, which may let us avoid choosing a separate email provider for v1.
+
+## Requirements
+
+### Deliverability
+
+I know from past experience that it can be difficult to not be classified as junk mail, so I'm skittish.
+
+### Reliability
+
+Reliable transactional deliverability for low-volume auth mail
+
+### Email customization
+
+#### Custom Text
+
+We should be able to change the text of the emails.
+
+#### Branding
+
+The emails must be branded with The Flip's branding.
+
+#### Portability
+
+Generating an email such that it displays nicely on all browsers is notoriously tricky. The email provider should somehow make this easy for us.
+
+We don't need a rich email authoring experience.
+
+### Cost
+
+Ideally, somewhere between free and $5/mo. But we'll go higher if it makes our life easier.
+
+### Custom Domain
+
+We want the emails coming from a The Flip domain, something like `authmail.the-flip.museum`.
+
+### Ease
+
+We're looking to minimize hassle. Email is not our core competencey.
+
+#### Hosted Provider
+
+We don't want to host an email server ourselves, we want a hosted provider.
+
+#### Works Well With Selected Auth Provider
+
+It would be great to find one that has super easy integration with our [Auth.md](Auth.md) provider.
+
+#### Easy DNS setup
+
+Hopefully, DNS configuration and domain verification is not too tortuous.
+
+## Non-Requirements
+
+- We do not need a general marketing/newsletter platform
+
+## Options
+
+### Mailgun
+
+### Sendgrid
+
+### Postmark
+
+### Resend
+
+### Amazon Simple Email Service (AWS SES)
+
+Cons:
+
+- We're not in the AWS ecosystem. I don't want to be in the AWS ecosystem because it's difficult to work with.
+
+## Current Direction
+
+For v1, the simplest path is probably to let WorkOS AuthKit send the auth emails itself.
+
+That means:
+
+- No separate email provider to configure for launch
+- Less operational hassle
+- Verification, password reset, and other auth emails work out of the box
+
+The downside is that the emails would come from a WorkOS domain rather than a The Flip domain.
+
+So the current tradeoff is:
+
+- Easiest v1: let WorkOS send auth emails from its own domain
+- More branded future option: later add a separate email provider or paid WorkOS custom email domain support if custom sender branding becomes important enough

--- a/docs/plans/auth/AuthProviders.md
+++ b/docs/plans/auth/AuthProviders.md
@@ -1,0 +1,195 @@
+# Auth Provider Options
+
+## Requirements
+
+See [Auth.md](Auth.md).
+
+## Options
+
+Note: we also need to choose an email provider. See [AuthMail.md](AuthMail.md).
+
+### Managed Service: Auth0
+
+Auth0 is third-party hosted IdP service. All properties redirect to Auth0 for login. Auth0 provides a "Universal Login" page that can be themed to match your branding, hosted on a custom domain like `auth.theflip.museum`.
+
+At ~30 users (growing to perhaps a few hundred with public registration), this falls well within Auth0's free tier (25,000 MAU). The free tier includes unlimited social login providers and 1 custom domain.
+
+**Pros:**
+
+- Registration, forgot password, email verification, social login, account linking, rate limiting, and session management all come out of the box
+- OIDC client libraries (e.g. Authlib) exist for every framework in our stack
+- Custom user metadata (e.g. `is_museum_staff`) supported natively
+- OIDC is a standard — if Auth0 ever becomes a problem, you can migrate to another OIDC provider without changing your apps' integration code
+- GDPR account deletion and user self-service profile management available
+- Supports bulk user import with PBKDF2 password hashes on the free tier. Django's `pbkdf2_sha256$iterations$salt$hash` format would need a conversion script to Auth0's PHC format, but existing Flipfix users could keep their passwords.
+- Password hash export is available (requires a support ticket; may not be available on the free tier), which reduces vendor lock-in for password-based users
+- Attack protection for signup and login flows is built in
+- 1 custom domain on the free tier means we can host login at something like `auth.theflip.museum`
+
+**Cons:**
+
+- **Session lifetime on free tier is short** — max 3-day idle timeout and 30-day absolute session lifetime. A user who doesn't visit for 4 days gets logged out. We want sessions lasting months. Longer sessions require Enterprise pricing (~$30k/year). This is a significant UX concern for a casual wiki-style site like Pinbase.
+- **MFA is not available on the free tier.** Essentials plan ($35/mo B2C) gets basic TOTP; Professional ($240/mo) adds SMS/email/push.
+- **Custom email templates need more verification** — Auth0 definitely requires an external email provider for production email and branded transactional email, but it is not yet clear from the docs whether template customization itself is gated behind a paid plan.
+- Login UI is hosted by Auth0 (customizable, but not fully yours)
+- Still requires us to configure an external email provider for production email sending; Auth0's built-in email provider is for testing only
+- True OIDC back-channel logout exists, but Auth0 documents it as an Enterprise feature, so we should not count on that for v1
+- User data lives on Auth0's servers (US or EU region selectable)
+
+Auth0 also has startup and nonprofit programs, which may matter if we later need paid features.
+
+However, this does not solve the session-lifetime problem. Auth0's public nonprofit discount is 50% off paid plans, which would bring Essentials to about $17.50/mo and Professional to about $120/mo. But the long-session capability appears to require Enterprise, and Enterprise would therefore still cost more than Professional and remain out of budget.
+
+### Managed Service: WorkOS AuthKit
+
+WorkOS AuthKit is a third-party hosted auth platform with hosted login/signup flows, password auth, social login, MFA, email verification, user management, and a branded authentication UI. Free tier covers up to 1 million MAU.
+
+WorkOS sends auth emails itself by default (from `workos-mail.com`), which eliminates the need for a separate email provider — unless we want a custom sending domain.
+
+WorkOS exposes standard OIDC/OAuth2 endpoints, so we can integrate with any OIDC library (`mozilla-django-oidc`, `authlib`, etc.) — not locked into their SDK.
+
+**Pros:**
+
+- Hosted service with no auth infrastructure for us to run
+- 1 million MAU on the free tier (vastly more generous than Auth0's 25k)
+- Password auth, social login, email verification, forgot password, MFA, and account linking all included on the free tier (Auth0 charges $35/mo for MFA alone)
+- WorkOS sends auth emails itself by default — no separate email provider to configure
+- Standard OIDC/OAuth2 — not SDK-locked like Clerk; works with any OIDC client library
+- Hosted UI supports logo and brand color customization on the free tier
+- Session configuration is available on the free tier. In the dashboard we verified:
+  - Maximum session length can be set to 365 days
+  - Access token duration defaults to 5 minutes and the UI appears to allow much longer values
+  - Inactivity timeout defaults to 2 days and we successfully increased it to 100 days
+- Supports bulk user import with PBKDF2 password hashes. Django 5.1+ (which the Flipfix system was born on) uses 870,000 iterations, which is within WorkOS's accepted range (600k–1M). Requires a format conversion script from Django's format to PHC format. Import is one API call per user (no bulk endpoint).
+- User metadata for custom attributes (e.g. `is_museum_staff`) supported
+- If we later decide to bring our own email provider, WorkOS supports SES, Mailgun, Postmark, Resend, and SendGrid
+
+**Cons:**
+
+- **No password hash export** — WorkOS does not allow exporting password hashes. If we migrate away, every password-based user must reset their password. (WorkOS imports hashes willingly but won't give them back.) Social login users are unaffected since their identity is anchored to the external provider.
+- **Custom domains (auth UI + email sending) are $99/mo** — a single bundle that covers auth domain, admin portal domain, and email sending domain. Without this, the login UI lives on WorkOS's domain and emails come from `workos-mail.com`.
+- **Email customization is limited compared to a full template editor** — WorkOS supports branding assets, brand colors, localized copy, and custom email-provider integrations, but if we need full control over email HTML/text we may still need to disable WorkOS emails and send our own.
+
+If we relax the custom domain requirement, WorkOS's free tier is significantly more capable than Auth0's for our use case — MFA, generous MAU limits, built-in email sending, and long-lived sessions that can be configured up to 365 days.
+
+### Managed Service: Clerk
+
+Clerk is a hosted auth and user-management platform with passwords, social login, automatic account linking, user metadata, hosted UI components, and a free tier that includes a custom domain.
+
+Its pricing is attractive: free for small apps, custom domain included, unlimited applications, and up to 50,000 monthly retained users per app. If this were a pure Next.js or React estate, it would be a stronger contender.
+
+**Pros:**
+
+- Hosted service with no auth infrastructure to run
+- Custom domain available on Pro plan ($20–25/mo)
+- Unlimited applications on one account
+- Password auth, social login, automatic account linking, usernames, and user metadata are all supported
+- Device/session management is built in
+- Shared auth across subdomains is a first-class Clerk concept
+- Clerk can act as an OAuth/OIDC identity provider for external apps
+- Self-service password hash export from the dashboard (CSV), no support ticket needed — the most migration-friendly option
+
+**Cons:**
+
+- **OIDC discovery is non-standard** — Clerk publishes `/.well-known/oauth-authorization-server` (RFC 8414), not `/.well-known/openid-configuration` (the OIDC standard). Libraries like `mozilla-django-oidc` and `authlib` expect the latter and won't auto-discover Clerk's endpoints. You'd need to manually configure each endpoint URL.
+- **No standard Django integration path** — every Django + Clerk integration in the wild uses Clerk-specific JWT verification, not standard OIDC. Clerk has a Python SDK (`clerk-backend-api`) and a community `clerk-django` package, but both are vendor-specific. There are zero documented examples of anyone using a generic OIDC library with Clerk on Django.
+- Clerk is much more SDK- and component-centric than OIDC-centric; its sweet spot is Next.js / React, whereas our estate is a mix of Django, SvelteKit, Next.js, and Python
+- MFA, custom email templates, and custom session lifetime are paid features
+- Hobby plan session duration is fixed at 7 days; Pro plan max is not documented (practical ceiling is Chrome's 400-day cookie limit)
+- Multi-domain and advanced shared-session docs are heavily oriented around Clerk-managed frontend apps, which makes this feel like a less natural fit for Flipfix and Juice than a more conventional OIDC provider
+
+Clerk is interesting on price, but looks less aligned with our mixed-stack, standards-first integration needs than Auth0.
+
+### Rejected Options
+
+#### Managed Service: Amazon Cognito
+
+Rejected because I already know from experience that Cognito is difficult to work with, hard to debug, hard to configure, and I do not want to bring AWS complexity into this project.
+
+#### Managed Service: Descope
+
+Rejected because custom domain support starts at the Pro plan, and Descope Pro starts at `$249/mo`, which is too expensive.
+
+#### Self-Hosted IdP: Authentik
+
+Rejected because I do not want to run an auth service ourselves.
+
+Authentik is a self-hosted identity provider. We'd run it ourselves on Railway alongside our existing services. Authentik is built on Django under the hood, so it's culturally familiar. It provides a full admin UI, OIDC/OAuth2/SAML support, social login, email verification, MFA, and user management.
+
+**Pros:**
+
+- Full control over all auth infrastructure and user data
+- No vendor dependency or pricing risk
+- Feature-rich: social login, MFA, email verification, forgot password, account linking, user self-service, admin UI
+- Built on Django/Python — familiar stack for debugging and customization
+- Supports custom attributes for the "museum staff" flag
+- No limits on social providers or login customizations
+- Can be themed to match your branding completely
+
+**Cons:**
+
+- Another Railway service to host, monitor, update, and back up
+- You still need to configure SMTP for transactional email (e.g. Postmark, Mailgun, SES) — email deliverability is your problem
+- More moving parts: Authentik needs a database, Redis, and a worker process
+- Operational burden on a small team — security patches, version upgrades, etc.
+- More initial setup and configuration compared to a managed service
+
+#### Build It Ourselves: django-allauth
+
+Rejected because I do not want to build and own an auth system ourselves.
+
+Create a dedicated Django auth service (or extend Flipfix) using django-allauth, which provides social login, email verification, forgot password, and account management as Django views and forms.
+
+**Pros:**
+
+- Stays entirely within your existing tech stack — it's just Django
+- Maximum control and customization over every flow and UI element
+- No external dependency or additional service to host (if built into Flipfix)
+- django-allauth is mature and widely used
+- No vendor costs at any scale
+
+**Cons:**
+
+- Most engineering effort of the three options — you're building auth UI, registration flows, and security hardening yourself
+- You still need email infrastructure (SMTP via Postmark, SES, etc.) — deliverability is your problem
+- Flipfix remains the IdP, preserving the coupling between a maintenance app and critical identity infrastructure — or you spin up yet another Django service
+- Account linking (email + social for same user) requires careful implementation
+- MFA, rate limiting, session management, and global logout all need to be built or wired up manually
+- Ongoing maintenance burden: security patches, keeping up with OAuth spec changes, social provider API changes
+
+## How they Integrate
+
+Regardless of which option we pick, the integration pattern is the same for each property:
+
+- **Pinbase**: User clicks login → redirect to IdP → authenticate → redirect back → Django creates session. Fits your existing same-origin proxy architecture perfectly.
+- **Flipfix**: Switches from being the OAuth provider to being an OAuth client. django-allauth or mozilla-django-oidc on the client side. Existing ~30 users migrated to the new IdP.
+- **Juice**: Swaps Flipfix's OAuth endpoint for the new IdP's. Minimal change.
+- **www**: No change now. If needed later, NextAuth.js speaks OIDC natively.
+
+### The "Museum Staff" Flag
+
+The requirement for optionally knowing "this person is museum staff" across properties maps cleanly to OIDC claims or user metadata. All three options support this — the IdP stores a custom attribute like is_museum_staff: true, and each property can read it from the token and decide what to do with it locally. It's not complex in any of the options.
+
+## Comparison
+
+Only the three actively considered managed services are compared. ✅ = included on free tier, 💰 = paid, ❌ = not available.
+
+|                                                                         | Auth0             | WorkOS AuthKit    | Clerk                              |
+| ----------------------------------------------------------------------- | ----------------- | ----------------- | ---------------------------------- |
+| [Standard OIDC/OAuth2](Auth.md#ease-of-integration)                     | ✅                | ✅                | ❌❌❌ SDK-only, no OIDC discovery |
+| [Forgot password](Auth.md#forgot-password)                              | ✅                | ✅                | ✅                                 |
+| [Email verification](Auth.md#email-verification)                        | ✅                | ✅                | ✅                                 |
+| [Social login](Auth.md#social-login)                                    | ✅                | ✅                | ✅                                 |
+| [Account linking](Auth.md#email--social-logins-work-seamlessly)         | ✅                | ✅                | ✅                                 |
+| [MFA](Auth.md#security)                                                 | 💰 $35/mo         | ✅                | 💰 $20/mo                          |
+| [Long-lived sessions](Auth.md#sessions)                                 | 💰 Enterprise     | ✅ up to 365 days | 💰 $20/mo (free = 7 days)          |
+| [User metadata / staff flag](Auth.md#museum-staff-identity-across-apps) | ✅                | ✅                | ✅                                 |
+| [GDPR account deletion](Auth.md#user-initiated-deleting)                | ✅                | ✅                | ✅                                 |
+| [Rate limiting](Auth.md#security)                                       | ✅                | ✅                | ✅                                 |
+| [Hosted vendor](Auth.md#dont-build-it-ourselves)                        | ✅                | ✅                | ✅                                 |
+| [Cost](Auth.md#cost)                                                    | Free (25k MAU)    | Free (1M MAU)     | Free (50k MAU)                     |
+| [Initial user migration](Auth.md#initial-user-migration)                | PBKDF2 import ✅  | PBKDF2 import ✅  | PBKDF2 import ✅                   |
+| [Password hash export](Auth.md#ease-of-migrating-off)                   | 💰 support ticket | ❌                | ✅ self-service                    |
+| Custom domain                                                           | ✅ (free tier)    | 💰 $99/mo         | 💰 $20/mo                          |
+| Built-in email sending                                                  | ❌ testing only   | ✅                | ✅                                 |
+| Custom email templates                                                  | unclear           | Limited           | 💰 $20/mo                          |


### PR DESCRIPTION
## Summary
- Add new docs: Overview, Architecture, WebArchitecture, AppBoundaries, Development, Testing
- Add planning docs: DocRefresh, Phase 5 (Fandom/Wikidata), auth design (Auth, AuthMail, AuthProviders)
- Update README with revised project description, ingest commands, and links to further reading

## Test plan
- [ ] Verify all doc links in README resolve correctly
- [ ] Spot-check markdown renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)