### PR TITLE
feat(auth): integrate WorkOS AuthKit for SSO login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ DJANGO_SUPERUSER_PASSWORD=change-me
 # DATABASE_URL          Auto-set by Railway Postgres plugin
 # PORT                  Auto-set by Railway
 
+# ── WorkOS AuthKit ────────────────────────────────────────────────
+# Required for SSO login. Get these from your WorkOS dashboard.
+# Local dev uses the WorkOS Sandbox environment.
+WORKOS_API_KEY=
+WORKOS_CLIENT_ID=
+WORKOS_REDIRECT_URI=http://localhost:8000/api/auth/callback/
+
 # ── Cloudflare R2 (ingest source storage) ────────────────────────────
 # Public read URL (no auth needed — used by pull_ingest_sources):
 R2_PUBLIC_URL=https://pub-8f33ea1ac628450298edd0d3243ecf5a.r2.dev

--- a/backend/apps/accounts/admin.py
+++ b/backend/apps/accounts/admin.py
@@ -8,7 +8,8 @@ from .models import UserProfile
 class UserProfileInline(admin.StackedInline):
     model = UserProfile
     extra = 0
-    fields = ("priority",)
+    fields = ("priority", "workos_user_id")
+    readonly_fields = ("workos_user_id",)
 
 
 class UserAdmin(BaseUserAdmin):

--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -1,13 +1,30 @@
-"""Auth API endpoints: status, login, logout."""
+"""Auth API endpoints: status, login (WorkOS redirect), callback, logout."""
 
 from __future__ import annotations
 
+import base64
+import json
+import logging
+import secrets
 from typing import Optional
 
-from django.contrib.auth import authenticate, login, logout
+from django.conf import settings
+from django.contrib.auth import get_user_model, login, logout
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.utils.http import url_has_allowed_host_and_scheme
 from ninja import Router, Schema
 
+from .models import UserProfile
+from .workos_client import get_workos_client
+
+log = logging.getLogger(__name__)
+
+User = get_user_model()
+
 auth_router = Router(tags=["auth", "private"])
+
+
+# ── Schemas ──────────────────────────────────────────────────────────
 
 
 class AuthStatusSchema(Schema):
@@ -16,13 +33,80 @@ class AuthStatusSchema(Schema):
     username: Optional[str] = None
 
 
-class LoginSchema(Schema):
-    username: str
-    password: str
+class LogoutResponseSchema(Schema):
+    is_authenticated: bool = False
+    logout_url: str = ""
 
 
 class ErrorSchema(Schema):
     detail: str
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _extract_session_id(access_token: str) -> str:
+    """Extract the ``sid`` claim from a WorkOS access token JWT."""
+    try:
+        payload = access_token.split(".")[1]
+        payload += "=" * (4 - len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+        return claims.get("sid", "")
+    except IndexError, ValueError, json.JSONDecodeError:
+        return ""
+
+
+def _generate_username(email: str) -> str:
+    """Derive a unique username from an email address."""
+    base = email.split("@")[0]
+    username = base
+    counter = 1
+    while User.objects.filter(username=username).exists():
+        username = f"{base}{counter}"
+        counter += 1
+    return username
+
+
+def get_or_create_django_user(workos_user):
+    """Match or create a Django User from a WorkOS user profile.
+
+    Matching priority:
+    1. By workos_user_id on UserProfile (returning user)
+    2. By verified email if exactly one local user matches (links accounts)
+    3. Create new user (self-registration)
+    """
+    # 1. Exact match on WorkOS user ID
+    try:
+        profile = UserProfile.objects.select_related("user").get(
+            workos_user_id=workos_user.id,
+        )
+        return profile.user
+    except UserProfile.DoesNotExist:
+        pass
+
+    # 2. Match by verified email — only if unambiguous
+    if workos_user.email_verified:
+        matches = User.objects.filter(email=workos_user.email)
+        if matches.count() == 1:
+            user = matches.get()
+            user.profile.workos_user_id = workos_user.id
+            user.profile.save(update_fields=["workos_user_id"])
+            return user
+
+    # 3. Create new user
+    user = User.objects.create_user(
+        username=_generate_username(workos_user.email),
+        email=workos_user.email,
+        first_name=workos_user.first_name or "",
+        last_name=workos_user.last_name or "",
+    )
+    # Profile auto-created by post_save signal
+    user.profile.workos_user_id = workos_user.id
+    user.profile.save(update_fields=["workos_user_id"])
+    return user
+
+
+# ── Endpoints ────────────────────────────────────────────────────────
 
 
 @auth_router.get("/me/", response=AuthStatusSchema)
@@ -41,28 +125,90 @@ def auth_me(request):
     return {"is_authenticated": False}
 
 
-@auth_router.post(
-    "/login/",
-    response={200: AuthStatusSchema, 400: ErrorSchema},
-)
-def auth_login(request, payload: LoginSchema):
-    """Authenticate with username and password.
+@auth_router.get("/login/", url_name="workos_login", include_in_schema=False)
+def auth_login(request):
+    """Redirect to WorkOS AuthKit hosted login UI."""
+    if not settings.WORKOS_API_KEY or not settings.WORKOS_CLIENT_ID:
+        return HttpResponse(
+            "WorkOS is not configured. Set WORKOS_API_KEY and WORKOS_CLIENT_ID.",
+            status=503,
+        )
 
-    Creates a session on success. Returns 400 with detail message on failure.
-    """
-    user = authenticate(request, username=payload.username, password=payload.password)
-    if user is None:
-        return 400, {"detail": "Invalid username or password."}
-    login(request, user)
-    return {
-        "is_authenticated": True,
-        "id": user.id,
-        "username": user.username,
-    }
+    next_url = request.GET.get("next", "/")
+    if not url_has_allowed_host_and_scheme(
+        next_url, allowed_hosts={request.get_host()}
+    ):
+        next_url = "/"
+
+    state = secrets.token_urlsafe(32)
+    request.session[f"auth_{state}"] = next_url
+
+    try:
+        client = get_workos_client()
+        authorization_url = client.user_management.get_authorization_url(
+            provider="authkit",
+            redirect_uri=settings.WORKOS_REDIRECT_URI,
+            client_id=settings.WORKOS_CLIENT_ID,
+            state=state,
+        )
+    except Exception:
+        log.exception("Failed to generate WorkOS authorization URL")
+        return HttpResponse(
+            "Sign-in is temporarily unavailable. Please try again later.",
+            status=503,
+        )
+    return HttpResponseRedirect(authorization_url)
 
 
-@auth_router.post("/logout/", response=AuthStatusSchema)
+@auth_router.get("/callback/", url_name="workos_callback", include_in_schema=False)
+def auth_callback(request):
+    """Handle the OAuth callback from WorkOS."""
+    code = request.GET.get("code")
+    state = request.GET.get("state")
+    if not code or not state:
+        return HttpResponseBadRequest("Missing code or state parameter.")
+
+    next_url = request.session.pop(f"auth_{state}", None)
+    if next_url is None:
+        return HttpResponseBadRequest("Invalid or expired state parameter.")
+
+    try:
+        client = get_workos_client()
+        auth_response = client.user_management.authenticate_with_code(
+            code=code,
+            client_id=settings.WORKOS_CLIENT_ID,
+        )
+    except Exception:
+        log.exception("WorkOS code exchange failed")
+        return HttpResponseBadRequest(
+            "Authentication failed. The login link may have expired — please try again."
+        )
+
+    user = get_or_create_django_user(auth_response.user)
+
+    # Store WorkOS session ID in the Django session (per-browser, not per-user)
+    sid = _extract_session_id(auth_response.access_token)
+    if sid:
+        request.session["workos_session_id"] = sid
+
+    login(request, user, backend="apps.accounts.backends.WorkOSBackend")
+    return HttpResponseRedirect(next_url)
+
+
+@auth_router.post("/logout/", response=LogoutResponseSchema)
 def auth_logout(request):
-    """End the current session."""
+    """End the current session and return the WorkOS logout URL if available."""
+    workos_session_id = request.session.get("workos_session_id", "")
     logout(request)
-    return {"is_authenticated": False}
+
+    logout_url = ""
+    if workos_session_id and settings.WORKOS_API_KEY and settings.WORKOS_CLIENT_ID:
+        try:
+            client = get_workos_client()
+            logout_url = client.user_management.get_logout_url(
+                session_id=workos_session_id,
+            )
+        except Exception:
+            log.exception("Failed to generate WorkOS logout URL")
+
+    return {"is_authenticated": False, "logout_url": logout_url}

--- a/backend/apps/accounts/backends.py
+++ b/backend/apps/accounts/backends.py
@@ -1,0 +1,24 @@
+"""Authentication backend for users authenticated via WorkOS AuthKit.
+
+This backend does not implement authenticate() because the actual
+authentication happens via the WorkOS SDK in the callback view.
+It only implements get_user() so Django's session framework can
+reload the user from the session.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class WorkOSBackend:
+    def authenticate(self, request, **kwargs):  # noqa: ARG002
+        return None
+
+    def get_user(self, user_id):
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None

--- a/backend/apps/accounts/migrations/0001_initial.py
+++ b/backend/apps/accounts/migrations/0001_initial.py
@@ -27,6 +27,17 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
+                    "workos_user_id",
+                    models.CharField(
+                        blank=True,
+                        default=None,
+                        help_text="WorkOS user ID (e.g. user_01ABC...). Null until first SSO login, then auto-linked by email.",
+                        max_length=64,
+                        null=True,
+                        unique=True,
+                    ),
+                ),
+                (
                     "priority",
                     models.PositiveSmallIntegerField(
                         default=10000,

--- a/backend/apps/accounts/models.py
+++ b/backend/apps/accounts/models.py
@@ -11,6 +11,14 @@ class UserProfile(models.Model):
         on_delete=models.CASCADE,
         related_name="profile",
     )
+    workos_user_id = models.CharField(
+        max_length=64,
+        null=True,
+        blank=True,
+        default=None,
+        unique=True,
+        help_text="WorkOS user ID (e.g. user_01ABC...). Null until first SSO login, then auto-linked by email.",
+    )
     priority = models.PositiveSmallIntegerField(
         default=10000,
         help_text="Claim priority for conflict resolution. Higher beats lower.",

--- a/backend/apps/accounts/tests/test_models.py
+++ b/backend/apps/accounts/tests/test_models.py
@@ -9,22 +9,46 @@ User = get_user_model()
 @pytest.mark.django_db
 class TestUserProfileAutoCreate:
     def test_profile_created_on_user_save(self):
-        user = User.objects.create_user(username="testuser", password="pass")
+        user = User.objects.create_user(username="testuser")
         assert UserProfile.objects.filter(user=user).exists()
 
     def test_profile_default_priority(self):
-        user = User.objects.create_user(username="testuser2", password="pass")
+        user = User.objects.create_user(username="testuser2")
         assert user.profile.priority == 10000
 
     def test_profile_deleted_with_user(self):
-        user = User.objects.create_user(username="testuser3", password="pass")
+        user = User.objects.create_user(username="testuser3")
         user_id = user.pk
         user.delete()
         assert not UserProfile.objects.filter(user_id=user_id).exists()
 
     def test_priority_is_configurable(self):
-        user = User.objects.create_user(username="editor", password="pass")
+        user = User.objects.create_user(username="editor")
         user.profile.priority = 200
         user.profile.save()
         user.profile.refresh_from_db()
         assert user.profile.priority == 200
+
+
+@pytest.mark.django_db
+class TestWorkOSFields:
+    def test_workos_user_id_default_null(self):
+        user = User.objects.create_user(username="testuser")
+        assert user.profile.workos_user_id is None
+
+    def test_workos_user_id_uniqueness(self, db):
+        u1 = User.objects.create_user(username="user1")
+        u1.profile.workos_user_id = "user_01ABC"
+        u1.profile.save()
+
+        u2 = User.objects.create_user(username="user2")
+        u2.profile.workos_user_id = "user_01ABC"
+        with pytest.raises(Exception):  # IntegrityError
+            u2.profile.save()
+
+    def test_multiple_null_workos_user_id_allowed(self):
+        """Legacy users can all have null workos_user_id."""
+        User.objects.create_user(username="legacy1")
+        User.objects.create_user(username="legacy2")
+        # Both profiles have workos_user_id=None — no uniqueness violation
+        assert UserProfile.objects.filter(workos_user_id=None).count() >= 2

--- a/backend/apps/accounts/tests/test_workos_auth.py
+++ b/backend/apps/accounts/tests/test_workos_auth.py
@@ -1,0 +1,324 @@
+"""Tests for the WorkOS AuthKit integration (login, callback, logout)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+User = get_user_model()
+
+
+def _make_workos_user(
+    *,
+    id="user_01ABC",
+    email="alice@example.com",
+    email_verified=True,
+    first_name="Alice",
+    last_name="Smith",
+):
+    return SimpleNamespace(
+        id=id,
+        email=email,
+        email_verified=email_verified,
+        first_name=first_name,
+        last_name=last_name,
+    )
+
+
+def _make_auth_response(workos_user=None, sid="sess_01XYZ"):
+    """Build a fake WorkOS authenticate_with_code response."""
+    if workos_user is None:
+        workos_user = _make_workos_user()
+
+    # Build a minimal JWT with a sid claim (header.payload.signature)
+    import base64
+    import json
+
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"sid": sid}).encode())
+        .rstrip(b"=")
+        .decode()
+    )
+    fake_jwt = f"header.{payload}.signature"
+
+    return SimpleNamespace(
+        user=workos_user,
+        access_token=fake_jwt,
+        refresh_token="rt_fake",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _workos_settings(settings):
+    """Ensure WorkOS settings are populated for all tests in this module."""
+    settings.WORKOS_API_KEY = "sk_test_fake"  # pragma: allowlist secret
+    settings.WORKOS_CLIENT_ID = "client_fake"
+    settings.WORKOS_REDIRECT_URI = "http://localhost:8000/api/auth/callback/"
+
+
+def _start_login(client: Client, next_url: str = "/") -> tuple[str, str]:
+    """Hit the login endpoint and return (state, redirect_url).
+
+    Follows the redirect to extract the state parameter that was stored
+    in the session.
+    """
+    resp = client.get(f"/api/auth/login/?next={next_url}")
+    assert resp.status_code == 302
+
+    # The state is embedded in the WorkOS redirect URL as a query param
+    from urllib.parse import parse_qs, urlparse
+
+    parsed = urlparse(resp["Location"])
+    state = parse_qs(parsed.query).get("state", [""])[0]
+    assert state, "Expected state parameter in WorkOS redirect URL"
+    return state, resp["Location"]
+
+
+@pytest.mark.django_db
+class TestAuthLogin:
+    def test_login_redirects_to_workos(self, client):
+        with patch("apps.accounts.api.get_workos_client") as mock:
+            mock.return_value.user_management.get_authorization_url.return_value = (
+                "https://auth.workos.com/authorize?state=abc"
+            )
+            resp = client.get("/api/auth/login/?next=/titles/")
+
+        assert resp.status_code == 302
+        assert "workos.com" in resp["Location"]
+
+    def test_login_stores_state_in_session(self, client):
+        with patch("apps.accounts.api.get_workos_client") as mock:
+            mock.return_value.user_management.get_authorization_url.return_value = (
+                "https://auth.workos.com/authorize?state=test123"
+            )
+            client.get("/api/auth/login/?next=/titles/foo")
+
+        # Session should have an auth_{state} key
+        session = client.session
+        auth_keys = [k for k in session.keys() if k.startswith("auth_")]
+        assert len(auth_keys) == 1
+        assert session[auth_keys[0]] == "/titles/foo"
+
+    def test_login_sanitizes_next_url(self, client):
+        with patch("apps.accounts.api.get_workos_client") as mock:
+            mock.return_value.user_management.get_authorization_url.return_value = (
+                "https://auth.workos.com/authorize?state=abc"
+            )
+            client.get("/api/auth/login/?next=https://evil.com")
+
+        session = client.session
+        auth_keys = [k for k in session.keys() if k.startswith("auth_")]
+        assert len(auth_keys) == 1
+        assert session[auth_keys[0]] == "/"
+
+    def test_login_returns_503_when_not_configured(self, client, settings):
+        settings.WORKOS_API_KEY = ""
+        settings.WORKOS_CLIENT_ID = ""
+        resp = client.get("/api/auth/login/")
+        assert resp.status_code == 503
+
+
+@pytest.mark.django_db
+class TestAuthCallback:
+    def _do_callback(self, client, *, workos_user=None, sid="sess_01XYZ"):
+        """Run the full login→callback flow with mocked WorkOS."""
+        auth_response = _make_auth_response(workos_user=workos_user, sid=sid)
+
+        with patch("apps.accounts.api.get_workos_client") as mock:
+            mock_client = mock.return_value
+            # Echo back the real state so _start_login can parse it
+            mock_client.user_management.get_authorization_url.side_effect = (
+                lambda **kwargs: (
+                    f"https://auth.workos.com/authorize?state={kwargs['state']}"
+                )
+            )
+            # Start the login to populate session state
+            state, _ = _start_login(client, next_url="/")
+
+            # Now mock the code exchange
+            mock_client.user_management.authenticate_with_code.return_value = (
+                auth_response
+            )
+            resp = client.get(f"/api/auth/callback/?code=fake&state={state}")
+
+        return resp
+
+    def test_callback_creates_new_user(self, client):
+        resp = self._do_callback(client)
+        assert resp.status_code == 302
+
+        user = User.objects.get(email="alice@example.com")
+        assert user.profile.workos_user_id == "user_01ABC"
+        assert user.first_name == "Alice"
+
+    def test_callback_links_existing_user_by_email(self, client):
+        existing = User.objects.create_user(username="alice", email="alice@example.com")
+        resp = self._do_callback(client)
+        assert resp.status_code == 302
+
+        existing.profile.refresh_from_db()
+        assert existing.profile.workos_user_id == "user_01ABC"
+        # No new user should have been created
+        assert User.objects.filter(email="alice@example.com").count() == 1
+
+    def test_callback_refuses_link_unverified_email(self, client):
+        existing = User.objects.create_user(username="alice", email="alice@example.com")
+        workos_user = _make_workos_user(email_verified=False)
+        self._do_callback(client, workos_user=workos_user)
+
+        # Should have created a NEW user, not linked the existing one
+        existing.profile.refresh_from_db()
+        assert existing.profile.workos_user_id is None
+        assert User.objects.filter(email="alice@example.com").count() == 2
+
+    def test_callback_refuses_link_ambiguous_email(self, client):
+        User.objects.create_user(username="alice1", email="alice@example.com")
+        User.objects.create_user(username="alice2", email="alice@example.com")
+        self._do_callback(client)
+
+        # Should have created a third user, not linked either existing one
+        assert User.objects.filter(email="alice@example.com").count() == 3
+
+    def test_callback_recognizes_returning_user(self, client):
+        user = User.objects.create_user(username="alice", email="alice@example.com")
+        user.profile.workos_user_id = "user_01ABC"
+        user.profile.save(update_fields=["workos_user_id"])
+
+        self._do_callback(client)
+
+        # Same user, no new user created
+        assert User.objects.filter(email="alice@example.com").count() == 1
+
+    def test_callback_preserves_next_url(self, client):
+        auth_response = _make_auth_response()
+
+        with patch("apps.accounts.api.get_workos_client") as mock:
+            mock_client = mock.return_value
+            mock_client.user_management.get_authorization_url.side_effect = (
+                lambda **kwargs: (
+                    f"https://auth.workos.com/authorize?state={kwargs['state']}"
+                )
+            )
+            state, _ = _start_login(client, next_url="/titles/medieval-madness")
+            mock_client.user_management.authenticate_with_code.return_value = (
+                auth_response
+            )
+            resp = client.get(f"/api/auth/callback/?code=fake&state={state}")
+
+        assert resp.status_code == 302
+        assert resp["Location"] == "/titles/medieval-madness"
+
+    def test_callback_rejects_missing_code(self, client):
+        resp = client.get("/api/auth/callback/")
+        assert resp.status_code == 400
+
+    def test_callback_rejects_invalid_state(self, client):
+        resp = client.get("/api/auth/callback/?code=fake&state=bogus")
+        assert resp.status_code == 400
+
+    def test_callback_stores_workos_session_id(self, client):
+        self._do_callback(client, sid="sess_test_123")
+        assert client.session.get("workos_session_id") == "sess_test_123"
+
+    def test_callback_handles_code_exchange_failure(self, client):
+        with patch("apps.accounts.api.get_workos_client") as mock:
+            mock_client = mock.return_value
+            mock_client.user_management.get_authorization_url.side_effect = (
+                lambda **kwargs: (
+                    f"https://auth.workos.com/authorize?state={kwargs['state']}"
+                )
+            )
+            state, _ = _start_login(client, next_url="/")
+            mock_client.user_management.authenticate_with_code.side_effect = Exception(
+                "expired code"
+            )
+            resp = client.get(f"/api/auth/callback/?code=expired&state={state}")
+
+        assert resp.status_code == 400
+        assert b"please try again" in resp.content.lower()
+
+
+def _set_session_value(client, key, value):
+    """Persist a value into the test client's server-side session.
+
+    Django's test client returns a *new* SessionStore each time you
+    access ``client.session``, so you must save through the store
+    retrieved from the session key in the cookie.
+    """
+    from django.contrib.sessions.backends.db import SessionStore
+
+    session_key = client.cookies["sessionid"].value
+    s = SessionStore(session_key=session_key)
+    s[key] = value
+    s.save()
+
+
+@pytest.mark.django_db
+class TestAuthLogout:
+    def test_logout_returns_workos_logout_url(self, client):
+        user = User.objects.create_user(username="alice")
+        client.force_login(user)
+        _set_session_value(client, "workos_session_id", "sess_abc")
+
+        with patch("apps.accounts.api.get_workos_client") as mock:
+            mock.return_value.user_management.get_logout_url.return_value = (
+                "https://auth.workos.com/logout?sid=sess_abc"
+            )
+            resp = client.post("/api/auth/logout/")
+
+        data = resp.json()
+        assert data["is_authenticated"] is False
+        assert "workos.com/logout" in data["logout_url"]
+
+    def test_logout_without_workos_session(self, client):
+        user = User.objects.create_user(username="alice")
+        client.force_login(user)
+
+        resp = client.post("/api/auth/logout/")
+        data = resp.json()
+        assert data["is_authenticated"] is False
+        assert data["logout_url"] == ""
+
+    def test_logout_multi_device(self, client):
+        """Two browser sessions for the same user get independent logout URLs."""
+        user = User.objects.create_user(username="alice")
+
+        # Browser A
+        client_a = Client()
+        client_a.force_login(user)
+        _set_session_value(client_a, "workos_session_id", "sess_A")
+
+        # Browser B
+        client_b = Client()
+        client_b.force_login(user)
+        _set_session_value(client_b, "workos_session_id", "sess_B")
+
+        with patch("apps.accounts.api.get_workos_client") as mock:
+            mock.return_value.user_management.get_logout_url.side_effect = (
+                lambda session_id: f"https://auth.workos.com/logout?sid={session_id}"
+            )
+            resp_a = client_a.post("/api/auth/logout/")
+            resp_b = client_b.post("/api/auth/logout/")
+
+        assert "sess_A" in resp_a.json()["logout_url"]
+        assert "sess_B" in resp_b.json()["logout_url"]
+
+
+@pytest.mark.django_db
+class TestAuthMe:
+    def test_me_anonymous(self, client):
+        resp = client.get("/api/auth/me/")
+        data = resp.json()
+        assert data["is_authenticated"] is False
+
+    def test_me_authenticated(self, client):
+        user = User.objects.create_user(username="alice")
+        client.force_login(user)
+        resp = client.get("/api/auth/me/")
+        data = resp.json()
+        assert data["is_authenticated"] is True
+        assert data["username"] == "alice"

--- a/backend/apps/accounts/workos_client.py
+++ b/backend/apps/accounts/workos_client.py
@@ -1,0 +1,10 @@
+"""WorkOS client factory — centralised so tests can mock one import."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from workos import WorkOSClient
+
+
+def get_workos_client() -> WorkOSClient:
+    return WorkOSClient(api_key=settings.WORKOS_API_KEY)

--- a/backend/apps/catalog/tests/test_api_claims.py
+++ b/backend/apps/catalog/tests/test_api_claims.py
@@ -12,7 +12,7 @@ User = get_user_model()
 
 @pytest.fixture
 def user(db):
-    return User.objects.create_user(username="editor", password="testpass")  # pragma: allowlist secret  # fmt: skip
+    return User.objects.create_user(username="editor")
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_api_claims_additional_entities.py
+++ b/backend/apps/catalog/tests/test_api_claims_additional_entities.py
@@ -33,7 +33,7 @@ User = get_user_model()
 
 @pytest.fixture
 def user(db):
-    return User.objects.create_user(username="editor", password="testpass")  # pragma: allowlist secret  # fmt: skip
+    return User.objects.create_user(username="editor")
 
 
 def _patch(client, path: str, body: dict):

--- a/backend/apps/catalog/tests/test_api_claims_manufacturer_person.py
+++ b/backend/apps/catalog/tests/test_api_claims_manufacturer_person.py
@@ -11,7 +11,7 @@ User = get_user_model()
 
 @pytest.fixture
 def user(db):
-    return User.objects.create_user(username="editor", password="testpass")  # pragma: allowlist secret  # fmt: skip
+    return User.objects.create_user(username="editor")
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_api_claims_model_relationships.py
+++ b/backend/apps/catalog/tests/test_api_claims_model_relationships.py
@@ -22,7 +22,7 @@ User = get_user_model()
 
 @pytest.fixture
 def user(db):
-    return User.objects.create_user(username="editor", password="testpass")  # pragma: allowlist secret  # fmt: skip
+    return User.objects.create_user(username="editor")
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_api_claims_title.py
+++ b/backend/apps/catalog/tests/test_api_claims_title.py
@@ -18,7 +18,7 @@ User = get_user_model()
 
 @pytest.fixture
 def user(db):
-    return User.objects.create_user(username="editor", password="testpass")  # pragma: allowlist secret  # fmt: skip
+    return User.objects.create_user(username="editor")
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_api_edit_history.py
+++ b/backend/apps/catalog/tests/test_api_edit_history.py
@@ -11,7 +11,7 @@ User = get_user_model()
 
 @pytest.fixture
 def user(db):
-    return User.objects.create_user(username="editor", password="testpass")  # pragma: allowlist secret  # fmt: skip
+    return User.objects.create_user(username="editor")
 
 
 @pytest.fixture
@@ -124,7 +124,7 @@ class TestEditHistoryMultipleFields:
 class TestEditHistoryMultiUser:
     def test_old_value_scoped_to_same_user(self, client, user, pm, db):
         """User B editing after User A should not show User A's value as old."""
-        user_b = User.objects.create_user(username="other", password="testpass")  # pragma: allowlist secret  # fmt: skip
+        user_b = User.objects.create_user(username="other")
 
         client.force_login(user)
         client.patch(

--- a/backend/apps/catalog/tests/test_db_constraints.py
+++ b/backend/apps/catalog/tests/test_db_constraints.py
@@ -274,7 +274,7 @@ class TestProvenanceConstraints:
         from apps.provenance.models import ChangeSet
 
         User = get_user_model()
-        user = User.objects.create_user(username="tester", password="test")
+        user = User.objects.create_user(username="tester")
         source = Source.objects.create(name="Test", source_type="database")
         mfr = Manufacturer.objects.create(name="Test", slug="test-mfr")
         claim = Claim.objects.assert_claim(mfr, "name", "Test", source=source)
@@ -353,7 +353,7 @@ class TestValidateCheckConstraints:
         from django.test import Client
 
         User = get_user_model()
-        user = User.objects.create_user(username="editor", password="pw")
+        user = User.objects.create_user(username="editor")
         from apps.accounts.models import UserProfile
 
         UserProfile.objects.get_or_create(user=user, defaults={"priority": 10000})

--- a/backend/apps/catalog/tests/test_description_html.py
+++ b/backend/apps/catalog/tests/test_description_html.py
@@ -192,7 +192,7 @@ class TestApiPatchConversion:
         from django.test import Client
 
         User = get_user_model()
-        user = User.objects.create_user(username="testuser", password="testpass")
+        user = User.objects.create_user(username="testuser")
         mfr = Manufacturer.objects.create(name="Williams", slug="williams")
         system = System.objects.create(name="WPC-95", slug="wpc-95", manufacturer=mfr)
 

--- a/backend/apps/catalog/tests/test_source_enabled.py
+++ b/backend/apps/catalog/tests/test_source_enabled.py
@@ -108,7 +108,7 @@ class TestIsEnabledUserClaims:
         from django.contrib.auth import get_user_model
 
         User = get_user_model()
-        user = User.objects.create_user(username="testuser", password="test")
+        user = User.objects.create_user(username="testuser")
 
         mfr = Manufacturer.objects.create(name="Test Mfr", slug="test-mfr")
         Claim.objects.assert_claim(mfr, "name", "User Claim", user=user)

--- a/backend/apps/core/tests/test_validators.py
+++ b/backend/apps/core/tests/test_validators.py
@@ -67,7 +67,7 @@ class TestMojibakeClaimsApiIntegration:
     def user(self):
         from django.contrib.auth import get_user_model
 
-        return get_user_model().objects.create_user(username="editor", password="testpass")  # pragma: allowlist secret  # fmt: skip
+        return get_user_model().objects.create_user(username="editor")
 
     @pytest.fixture
     def pm(self):

--- a/backend/apps/media/tests/test_media_claims.py
+++ b/backend/apps/media/tests/test_media_claims.py
@@ -27,10 +27,7 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def user(db):
-    return User.objects.create_user(
-        "editor",
-        password="testpass",  # pragma: allowlist secret
-    )
+    return User.objects.create_user("editor")
 
 
 @pytest.fixture

--- a/backend/apps/media/tests/test_upload_api.py
+++ b/backend/apps/media/tests/test_upload_api.py
@@ -72,10 +72,7 @@ def _media_settings(settings):
 
 @pytest.fixture
 def user(db):
-    return User.objects.create_user(
-        "uploader",
-        password="testpass",  # pragma: allowlist secret
-    )
+    return User.objects.create_user("uploader")
 
 
 @pytest.fixture

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -187,6 +187,22 @@ LOGGING = {
     },
 }
 
+# ── WorkOS AuthKit ────────────────────────────────────────────────
+WORKOS_API_KEY = os.environ.get("WORKOS_API_KEY", "")
+WORKOS_CLIENT_ID = os.environ.get("WORKOS_CLIENT_ID", "")
+WORKOS_REDIRECT_URI = os.environ.get(
+    "WORKOS_REDIRECT_URI", "http://localhost:8000/api/auth/callback/"
+)
+
+AUTHENTICATION_BACKENDS = [
+    "apps.accounts.backends.WorkOSBackend",
+    "django.contrib.auth.backends.ModelBackend",  # Django admin password login
+]
+
+# ── Sessions ─────────────────────────────────────────────────────
+SESSION_COOKIE_AGE = 60 * 60 * 24 * 90  # 90 days
+SESSION_SAVE_EVERY_REQUEST = True  # sliding window — reset expiry on each request
+
 # CSRF — allow JS to read the cookie for X-CSRFToken header
 CSRF_COOKIE_HTTPONLY = False
 CSRF_TRUSTED_ORIGINS = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "Pillow>=11.0",
     "pillow-heif>=1.2",
     "django-storages[s3]>=1.14",
+    "workos>=5.0",
 ]
 
 [dependency-groups]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -12,6 +12,18 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -37,6 +49,7 @@ dependencies = [
     { name = "pillow-heif" },
     { name = "psycopg", extra = ["binary"] },
     { name = "whitenoise" },
+    { name = "workos" },
 ]
 
 [package.dev-dependencies]
@@ -62,6 +75,7 @@ requires-dist = [
     { name = "pillow-heif", specifier = ">=1.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "whitenoise", specifier = ">=6.8" },
+    { name = "workos", specifier = ">=5.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -124,6 +138,39 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -155,6 +202,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759", size = 750542, upload-time = "2026-03-25T23:34:53.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8", size = 7176401, upload-time = "2026-03-25T23:33:22.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/e61f8f13950ab6195b31913b42d39f0f9afc7d93f76710f299b5ec286ae6/cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30", size = 4275275, upload-time = "2026-03-25T23:33:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a", size = 4425320, upload-time = "2026-03-25T23:33:25.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175", size = 4278082, upload-time = "2026-03-25T23:33:27.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ba/d5e27f8d68c24951b0a484924a84c7cdaed7502bac9f18601cd357f8b1d2/cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463", size = 4926514, upload-time = "2026-03-25T23:33:29.206Z" },
+    { url = "https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97", size = 4457766, upload-time = "2026-03-25T23:33:30.834Z" },
+    { url = "https://files.pythonhosted.org/packages/01/59/562be1e653accee4fdad92c7a2e88fced26b3fdfce144047519bbebc299e/cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c", size = 3986535, upload-time = "2026-03-25T23:33:33.02Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/b1ebfeb788bf4624d36e45ed2662b8bd43a05ff62157093c1539c1288a18/cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507", size = 4277618, upload-time = "2026-03-25T23:33:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/52/a005f8eabdb28df57c20f84c44d397a755782d6ff6d455f05baa2785bd91/cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19", size = 4890802, upload-time = "2026-03-25T23:33:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4d/8e7d7245c79c617d08724e2efa397737715ca0ec830ecb3c91e547302555/cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738", size = 4457425, upload-time = "2026-03-25T23:33:38.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5c/f6c3596a1430cec6f949085f0e1a970638d76f81c3ea56d93d564d04c340/cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c", size = 4405530, upload-time = "2026-03-25T23:33:40.842Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c9/9f9cea13ee2dbde070424e0c4f621c091a91ffcc504ffea5e74f0e1daeff/cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f", size = 4667896, upload-time = "2026-03-25T23:33:42.781Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b5/1895bc0821226f129bc74d00eccfc6a5969e2028f8617c09790bf89c185e/cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2", size = 3026348, upload-time = "2026-03-25T23:33:45.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124", size = 3483896, upload-time = "2026-03-25T23:33:46.649Z" },
+    { url = "https://files.pythonhosted.org/packages/01/41/3a578f7fd5c70611c0aacba52cd13cb364a5dee895a5c1d467208a9380b0/cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275", size = 7117147, upload-time = "2026-03-25T23:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/87/887f35a6fca9dde90cad08e0de0c89263a8e59b2d2ff904fd9fcd8025b6f/cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4", size = 4266221, upload-time = "2026-03-25T23:33:49.874Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a8/0a90c4f0b0871e0e3d1ed126aed101328a8a57fd9fd17f00fb67e82a51ca/cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b", size = 4408952, upload-time = "2026-03-25T23:33:52.128Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0b/b239701eb946523e4e9f329336e4ff32b1247e109cbab32d1a7b61da8ed7/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707", size = 4270141, upload-time = "2026-03-25T23:33:54.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/976acdd4f0f30df7b25605f4b9d3d89295351665c2091d18224f7ad5cdbf/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361", size = 4904178, upload-time = "2026-03-25T23:33:55.725Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/bf0e01a88efd0e59679b69f42d4afd5bced8700bb5e80617b2d63a3741af/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b", size = 4441812, upload-time = "2026-03-25T23:33:57.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/8b/11df86de2ea389c65aa1806f331cae145f2ed18011f30234cc10ca253de8/cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca", size = 3963923, upload-time = "2026-03-25T23:33:59.361Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e0/207fb177c3a9ef6a8108f234208c3e9e76a6aa8cf20d51932916bd43bda0/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013", size = 4269695, upload-time = "2026-03-25T23:34:00.909Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5e/19f3260ed1e95bced52ace7501fabcd266df67077eeb382b79c81729d2d3/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4", size = 4869785, upload-time = "2026-03-25T23:34:02.796Z" },
+    { url = "https://files.pythonhosted.org/packages/10/38/cd7864d79aa1d92ef6f1a584281433419b955ad5a5ba8d1eb6c872165bcb/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a", size = 4441404, upload-time = "2026-03-25T23:34:04.35Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/4fe7a8d25fed74419f91835cf5829ade6408fd1963c9eae9c4bce390ecbb/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d", size = 4397549, upload-time = "2026-03-25T23:34:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a0/7d738944eac6513cd60a8da98b65951f4a3b279b93479a7e8926d9cd730b/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736", size = 4651874, upload-time = "2026-03-25T23:34:07.916Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f1/c2326781ca05208845efca38bf714f76939ae446cd492d7613808badedf1/cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed", size = 3001511, upload-time = "2026-03-25T23:34:09.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/57/fe4a23eb549ac9d903bd4698ffda13383808ef0876cc912bcb2838799ece/cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4", size = 3471692, upload-time = "2026-03-25T23:34:11.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cc/f330e982852403da79008552de9906804568ae9230da8432f7496ce02b71/cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a", size = 7162776, upload-time = "2026-03-25T23:34:13.308Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b3/dc27efd8dcc4bff583b3f01d4a3943cd8b5821777a58b3a6a5f054d61b79/cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8", size = 4270529, upload-time = "2026-03-25T23:34:15.019Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/05/e8d0e6eb4f0d83365b3cb0e00eb3c484f7348db0266652ccd84632a3d58d/cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77", size = 4414827, upload-time = "2026-03-25T23:34:16.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/daba0f5d2dc6d855e2dcb70733c812558a7977a55dd4a6722756628c44d1/cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290", size = 4271265, upload-time = "2026-03-25T23:34:18.586Z" },
+    { url = "https://files.pythonhosted.org/packages/89/06/fe1fce39a37ac452e58d04b43b0855261dac320a2ebf8f5260dd55b201a9/cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410", size = 4916800, upload-time = "2026-03-25T23:34:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8a/b14f3101fe9c3592603339eb5d94046c3ce5f7fc76d6512a2d40efd9724e/cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d", size = 4448771, upload-time = "2026-03-25T23:34:22.406Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b3/0796998056a66d1973fd52ee89dc1bb3b6581960a91ad4ac705f182d398f/cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70", size = 3978333, upload-time = "2026-03-25T23:34:24.281Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3d/db200af5a4ffd08918cd55c08399dc6c9c50b0bc72c00a3246e099d3a849/cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d", size = 4271069, upload-time = "2026-03-25T23:34:25.895Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/18/61acfd5b414309d74ee838be321c636fe71815436f53c9f0334bf19064fa/cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa", size = 4878358, upload-time = "2026-03-25T23:34:27.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/65/5bf43286d566f8171917cae23ac6add941654ccf085d739195a4eacf1674/cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58", size = 4448061, upload-time = "2026-03-25T23:34:29.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/7e49c0fa7205cf3597e525d156a6bce5b5c9de1fd7e8cb01120e459f205a/cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb", size = 4399103, upload-time = "2026-03-25T23:34:32.036Z" },
+    { url = "https://files.pythonhosted.org/packages/44/46/466269e833f1c4718d6cd496ffe20c56c9c8d013486ff66b4f69c302a68d/cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72", size = 4659255, upload-time = "2026-03-25T23:34:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/09/ddc5f630cc32287d2c953fc5d32705e63ec73e37308e5120955316f53827/cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c", size = 3010660, upload-time = "2026-03-25T23:34:35.418Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/ca4893968aeb2709aacfb57a30dec6fa2ab25b10fa9f064b8882ce33f599/cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f", size = 3471160, upload-time = "2026-03-25T23:34:37.191Z" },
 ]
 
 [[package]]
@@ -232,6 +332,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/13/ef67f59f6a7896fdc2c1d62b5665c5219d6b0a9a1784938eb9a28e55e128/gunicorn-25.1.0.tar.gz", hash = "sha256:1426611d959fa77e7de89f8c0f32eed6aa03ee735f98c01efba3e281b1c47616", size = 594377, upload-time = "2026-02-13T11:09:58.989Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/73/4ad5b1f6a2e21cf1e85afdaad2b7b1a933985e2f5d679147a1953aaa192c/gunicorn-25.1.0-py3-none-any.whl", hash = "sha256:d0b1236ccf27f72cfe14bce7caadf467186f19e865094ca84221424e839b8b8b", size = 197067, upload-time = "2026-02-13T11:09:57.146Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -445,6 +582,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -505,6 +651,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]
@@ -681,4 +836,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
+]
+
+[[package]]
+name = "workos"
+version = "5.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/c7/8eb6f513a39a24544f28d0fd764db1c4a54b897885b9f0aede0b4a28d436/workos-5.46.0.tar.gz", hash = "sha256:db6ce0fa6924bfd7a790c2bdae97cf7be8a970eaaef04156ae554157d24376f2", size = 65693, upload-time = "2026-03-16T20:49:13.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/8f/43b2345c7d0283660db4c205e93134c4a57406ee896782e7384431906493/workos-5.46.0-py3-none-any.whl", hash = "sha256:b83704d4d6fcafa57439e232f62944b619aabc1c632b0ced9f71501298be0c78", size = 121032, upload-time = "2026-03-16T20:49:11.905Z" },
 ]

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -27,20 +27,14 @@ function createAuthStore() {
 		if (data) set(data);
 	}
 
-	async function login(username: string, password: string): Promise<string | null> {
-		const { data, error } = await client.POST('/api/auth/login/', {
-			body: { username, password }
-		});
-		if (data) {
-			set(data);
-			return null;
-		}
-		return (error as { detail?: string })?.detail ?? 'Login failed.';
-	}
-
 	async function logout() {
 		const { data } = await client.POST('/api/auth/logout/');
-		if (data) set(data);
+		if (data) {
+			set({ is_authenticated: false });
+			if (data.logout_url) {
+				window.location.href = data.logout_url;
+			}
+		}
 	}
 
 	return {
@@ -57,7 +51,6 @@ function createAuthStore() {
 			return loaded;
 		},
 		load,
-		login,
 		logout
 	};
 }

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -91,7 +91,7 @@
 					<button class="auth-link" onclick={handleLogout}>Sign out</button>
 				{:else}
 					<a
-						href={resolveHref(`/login?next=${encodeURIComponent(page.url.pathname)}`)}
+						href={`/api/auth/login/?next=${encodeURIComponent(page.url.pathname)}`}
 						class="auth-link">Sign in</a
 					>
 				{/if}

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,67 +1,20 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { auth } from '$lib/auth.svelte';
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
 	import { SITE_NAME } from '$lib/constants';
-	import { resolveHref } from '$lib/utils';
 
-	let username = $state('');
-	let password = $state('');
-	let error = $state<string | null>(null);
-	let submitting = $state(false);
-
-	async function handleSubmit(e: SubmitEvent) {
-		e.preventDefault();
-		error = null;
-		submitting = true;
-		const err = await auth.login(username, password);
-		submitting = false;
-		if (err) {
-			error = err;
-			return;
-		}
-		const next = new URLSearchParams(window.location.search).get('next');
-		await goto(next || resolveHref('/'));
-	}
+	onMount(() => {
+		const next = page.url.searchParams.get('next') || '/';
+		window.location.href = `/api/auth/login/?next=${encodeURIComponent(next)}`;
+	});
 </script>
 
 <svelte:head>
-	<title>Sign in — {SITE_NAME}</title>
+	<title>Redirecting to sign in — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="login-page">
-	<form class="login-form" onsubmit={handleSubmit}>
-		<h1>Sign in</h1>
-
-		{#if error}
-			<p class="error">{error}</p>
-		{/if}
-
-		<label>
-			<span>Username</span>
-			<input
-				type="text"
-				bind:value={username}
-				autocomplete="username"
-				required
-				disabled={submitting}
-			/>
-		</label>
-
-		<label>
-			<span>Password</span>
-			<input
-				type="password"
-				bind:value={password}
-				autocomplete="current-password"
-				required
-				disabled={submitting}
-			/>
-		</label>
-
-		<button type="submit" disabled={submitting}>
-			{submitting ? 'Signing in...' : 'Sign in'}
-		</button>
-	</form>
+	<p>Redirecting to sign in...</p>
 </div>
 
 <style>
@@ -69,73 +22,6 @@
 		display: flex;
 		justify-content: center;
 		padding: var(--size-8) 0;
-	}
-
-	.login-form {
-		width: 100%;
-		max-width: 24rem;
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-4);
-	}
-
-	h1 {
-		font-size: var(--font-size-5);
-		font-weight: 700;
-		margin: 0 0 var(--size-2);
-	}
-
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: var(--size-1);
-		font-size: var(--font-size-2);
-		font-weight: 500;
 		color: var(--color-text-muted);
-	}
-
-	input {
-		padding: var(--size-2) var(--size-3);
-		border: 1px solid var(--color-border);
-		border-radius: var(--radius-2);
-		font-size: var(--font-size-2);
-		background: var(--color-surface);
-		color: var(--color-text-primary);
-	}
-
-	input:focus {
-		outline: 2px solid var(--color-accent);
-		outline-offset: -1px;
-		border-color: var(--color-accent);
-	}
-
-	button {
-		padding: var(--size-2) var(--size-4);
-		background: var(--color-accent);
-		color: white;
-		border: none;
-		border-radius: var(--radius-2);
-		font-size: var(--font-size-2);
-		font-weight: 600;
-		cursor: pointer;
-		transition: background 0.15s var(--ease-2);
-	}
-
-	button:hover:not(:disabled) {
-		background: var(--color-accent-hover);
-	}
-
-	button:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.error {
-		color: var(--color-error);
-		font-size: var(--font-size-2);
-		margin: 0;
-		padding: var(--size-2) var(--size-3);
-		background: color-mix(in srgb, var(--color-error) 10%, transparent);
-		border-radius: var(--radius-2);
 	}
 </style>


### PR DESCRIPTION
## Summary

- Replace username/password login with WorkOS AuthKit redirect-based OAuth 2.0 flow
- WorkOS handles the hosted login UI (email/password, Google, Apple); Django sessions remain the auth mechanism
- Auto-links existing users by verified email on first SSO login; new users are created automatically (self-registration)
- OAuth state nonce prevents CSRF and tab-race on redirect targets
- WorkOS session ID stored per Django session for correct multi-device logout
- Error handling on all WorkOS SDK calls (no unhandled 500s)
- Removes unnecessary `password=` from `create_user` calls across all test files

## Setup required

After merge, configure in WorkOS dashboard:
1. Sign-in redirect URI: `http://localhost:8000/api/auth/callback/` (Sandbox) and production URL
2. Sign-out redirect URI: `http://localhost:5173/` (Sandbox) and production home URL
3. Enable Email + Password, Google OAuth, Apple OAuth

Add env vars: `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, `WORKOS_REDIRECT_URI`

## Test plan

- [x] 19 new backend tests covering login redirect, callback (user creation, email linking, unverified/ambiguous email rejection, state validation, error handling), logout (with/without WorkOS session, multi-device), and /me endpoint
- [x] All 1395 backend tests pass
- [x] All 238 frontend tests pass
- [x] All linters pass (ruff, eslint, prettier)
- [ ] Manual: configure WorkOS Sandbox credentials, click Sign in → WorkOS UI → authenticate → redirected back authenticated
- [ ] Manual: click Sign out → Django session cleared → redirected to WorkOS logout
- [ ] Manual: Django admin still accessible via /admin/login/ with local password

🤖 Generated with [Claude Code](https://claude.com/claude-code)