### PR TITLE
fix(auth): correct WorkOS client init, redirect URI, and simplify logout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ DJANGO_SUPERUSER_PASSWORD=change-me
 # Local dev uses the WorkOS Sandbox environment.
 WORKOS_API_KEY=
 WORKOS_CLIENT_ID=
-WORKOS_REDIRECT_URI=http://localhost:8000/api/auth/callback/
+WORKOS_REDIRECT_URI=http://localhost:5173/api/auth/callback/
 
 # ── Cloudflare R2 (ingest source storage) ────────────────────────────
 # Public read URL (no auth needed — used by pull_ingest_sources):

--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import base64
-import json
 import logging
 import secrets
 from typing import Optional
@@ -33,27 +31,11 @@ class AuthStatusSchema(Schema):
     username: Optional[str] = None
 
 
-class LogoutResponseSchema(Schema):
-    is_authenticated: bool = False
-    logout_url: str = ""
-
-
 class ErrorSchema(Schema):
     detail: str
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
-
-
-def _extract_session_id(access_token: str) -> str:
-    """Extract the ``sid`` claim from a WorkOS access token JWT."""
-    try:
-        payload = access_token.split(".")[1]
-        payload += "=" * (4 - len(payload) % 4)
-        claims = json.loads(base64.urlsafe_b64decode(payload))
-        return claims.get("sid", "")
-    except IndexError, ValueError, json.JSONDecodeError:
-        return ""
 
 
 def _generate_username(email: str) -> str:
@@ -148,7 +130,6 @@ def auth_login(request):
         authorization_url = client.user_management.get_authorization_url(
             provider="authkit",
             redirect_uri=settings.WORKOS_REDIRECT_URI,
-            client_id=settings.WORKOS_CLIENT_ID,
             state=state,
         )
     except Exception:
@@ -176,7 +157,6 @@ def auth_callback(request):
         client = get_workos_client()
         auth_response = client.user_management.authenticate_with_code(
             code=code,
-            client_id=settings.WORKOS_CLIENT_ID,
         )
     except Exception:
         log.exception("WorkOS code exchange failed")
@@ -185,30 +165,12 @@ def auth_callback(request):
         )
 
     user = get_or_create_django_user(auth_response.user)
-
-    # Store WorkOS session ID in the Django session (per-browser, not per-user)
-    sid = _extract_session_id(auth_response.access_token)
-    if sid:
-        request.session["workos_session_id"] = sid
-
     login(request, user, backend="apps.accounts.backends.WorkOSBackend")
     return HttpResponseRedirect(next_url)
 
 
-@auth_router.post("/logout/", response=LogoutResponseSchema)
+@auth_router.post("/logout/", response=AuthStatusSchema)
 def auth_logout(request):
-    """End the current session and return the WorkOS logout URL if available."""
-    workos_session_id = request.session.get("workos_session_id", "")
+    """End the current session."""
     logout(request)
-
-    logout_url = ""
-    if workos_session_id and settings.WORKOS_API_KEY and settings.WORKOS_CLIENT_ID:
-        try:
-            client = get_workos_client()
-            logout_url = client.user_management.get_logout_url(
-                session_id=workos_session_id,
-            )
-        except Exception:
-            log.exception("Failed to generate WorkOS logout URL")
-
-    return {"is_authenticated": False, "logout_url": logout_url}
+    return {"is_authenticated": False}

--- a/backend/apps/accounts/tests/test_workos_auth.py
+++ b/backend/apps/accounts/tests/test_workos_auth.py
@@ -29,26 +29,15 @@ def _make_workos_user(
     )
 
 
-def _make_auth_response(workos_user=None, sid="sess_01XYZ"):
+def _make_auth_response(workos_user=None):
     """Build a fake WorkOS authenticate_with_code response."""
     if workos_user is None:
         workos_user = _make_workos_user()
 
-    # Build a minimal JWT with a sid claim (header.payload.signature)
-    import base64
-    import json
-
-    payload = (
-        base64.urlsafe_b64encode(json.dumps({"sid": sid}).encode())
-        .rstrip(b"=")
-        .decode()
-    )
-    fake_jwt = f"header.{payload}.signature"
-
     return SimpleNamespace(
         user=workos_user,
-        access_token=fake_jwt,
-        refresh_token="rt_fake",
+        access_token="fake",
+        refresh_token="fake",
     )
 
 
@@ -57,7 +46,7 @@ def _workos_settings(settings):
     """Ensure WorkOS settings are populated for all tests in this module."""
     settings.WORKOS_API_KEY = "sk_test_fake"  # pragma: allowlist secret
     settings.WORKOS_CLIENT_ID = "client_fake"
-    settings.WORKOS_REDIRECT_URI = "http://localhost:8000/api/auth/callback/"
+    settings.WORKOS_REDIRECT_URI = "http://localhost:5173/api/auth/callback/"
 
 
 def _start_login(client: Client, next_url: str = "/") -> tuple[str, str]:
@@ -124,9 +113,9 @@ class TestAuthLogin:
 
 @pytest.mark.django_db
 class TestAuthCallback:
-    def _do_callback(self, client, *, workos_user=None, sid="sess_01XYZ"):
+    def _do_callback(self, client, *, workos_user=None):
         """Run the full login→callback flow with mocked WorkOS."""
-        auth_response = _make_auth_response(workos_user=workos_user, sid=sid)
+        auth_response = _make_auth_response(workos_user=workos_user)
 
         with patch("apps.accounts.api.get_workos_client") as mock:
             mock_client = mock.return_value
@@ -164,6 +153,21 @@ class TestAuthCallback:
         assert existing.profile.workos_user_id == "user_01ABC"
         # No new user should have been created
         assert User.objects.filter(email="alice@example.com").count() == 1
+
+    def test_callback_linking_preserves_superuser_flags(self, client):
+        """Linking a WorkOS login to an existing superuser must not reset is_staff/is_superuser."""
+        existing = User.objects.create_superuser(
+            username="moses", email="alice@example.com"
+        )
+        assert existing.is_staff is True
+        assert existing.is_superuser is True
+
+        self._do_callback(client)
+
+        existing.refresh_from_db()
+        assert existing.profile.workos_user_id == "user_01ABC"
+        assert existing.is_staff is True, "is_staff was reset during linking"
+        assert existing.is_superuser is True, "is_superuser was reset during linking"
 
     def test_callback_refuses_link_unverified_email(self, client):
         existing = User.objects.create_user(username="alice", email="alice@example.com")
@@ -220,10 +224,6 @@ class TestAuthCallback:
         resp = client.get("/api/auth/callback/?code=fake&state=bogus")
         assert resp.status_code == 400
 
-    def test_callback_stores_workos_session_id(self, client):
-        self._do_callback(client, sid="sess_test_123")
-        assert client.session.get("workos_session_id") == "sess_test_123"
-
     def test_callback_handles_code_exchange_failure(self, client):
         with patch("apps.accounts.api.get_workos_client") as mock:
             mock_client = mock.return_value
@@ -242,70 +242,19 @@ class TestAuthCallback:
         assert b"please try again" in resp.content.lower()
 
 
-def _set_session_value(client, key, value):
-    """Persist a value into the test client's server-side session.
-
-    Django's test client returns a *new* SessionStore each time you
-    access ``client.session``, so you must save through the store
-    retrieved from the session key in the cookie.
-    """
-    from django.contrib.sessions.backends.db import SessionStore
-
-    session_key = client.cookies["sessionid"].value
-    s = SessionStore(session_key=session_key)
-    s[key] = value
-    s.save()
-
-
 @pytest.mark.django_db
 class TestAuthLogout:
-    def test_logout_returns_workos_logout_url(self, client):
-        user = User.objects.create_user(username="alice")
-        client.force_login(user)
-        _set_session_value(client, "workos_session_id", "sess_abc")
-
-        with patch("apps.accounts.api.get_workos_client") as mock:
-            mock.return_value.user_management.get_logout_url.return_value = (
-                "https://auth.workos.com/logout?sid=sess_abc"
-            )
-            resp = client.post("/api/auth/logout/")
-
-        data = resp.json()
-        assert data["is_authenticated"] is False
-        assert "workos.com/logout" in data["logout_url"]
-
-    def test_logout_without_workos_session(self, client):
+    def test_logout_clears_session(self, client):
         user = User.objects.create_user(username="alice")
         client.force_login(user)
 
         resp = client.post("/api/auth/logout/")
         data = resp.json()
         assert data["is_authenticated"] is False
-        assert data["logout_url"] == ""
 
-    def test_logout_multi_device(self, client):
-        """Two browser sessions for the same user get independent logout URLs."""
-        user = User.objects.create_user(username="alice")
-
-        # Browser A
-        client_a = Client()
-        client_a.force_login(user)
-        _set_session_value(client_a, "workos_session_id", "sess_A")
-
-        # Browser B
-        client_b = Client()
-        client_b.force_login(user)
-        _set_session_value(client_b, "workos_session_id", "sess_B")
-
-        with patch("apps.accounts.api.get_workos_client") as mock:
-            mock.return_value.user_management.get_logout_url.side_effect = (
-                lambda session_id: f"https://auth.workos.com/logout?sid={session_id}"
-            )
-            resp_a = client_a.post("/api/auth/logout/")
-            resp_b = client_b.post("/api/auth/logout/")
-
-        assert "sess_A" in resp_a.json()["logout_url"]
-        assert "sess_B" in resp_b.json()["logout_url"]
+        # Verify session is actually cleared
+        resp = client.get("/api/auth/me/")
+        assert resp.json()["is_authenticated"] is False
 
 
 @pytest.mark.django_db

--- a/backend/apps/accounts/workos_client.py
+++ b/backend/apps/accounts/workos_client.py
@@ -7,4 +7,7 @@ from workos import WorkOSClient
 
 
 def get_workos_client() -> WorkOSClient:
-    return WorkOSClient(api_key=settings.WORKOS_API_KEY)
+    return WorkOSClient(
+        api_key=settings.WORKOS_API_KEY,
+        client_id=settings.WORKOS_CLIENT_ID,
+    )

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -191,7 +191,7 @@ LOGGING = {
 WORKOS_API_KEY = os.environ.get("WORKOS_API_KEY", "")
 WORKOS_CLIENT_ID = os.environ.get("WORKOS_CLIENT_ID", "")
 WORKOS_REDIRECT_URI = os.environ.get(
-    "WORKOS_REDIRECT_URI", "http://localhost:8000/api/auth/callback/"
+    "WORKOS_REDIRECT_URI", "http://localhost:5173/api/auth/callback/"
 )
 
 AUTHENTICATION_BACKENDS = [

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -29,12 +29,7 @@ function createAuthStore() {
 
 	async function logout() {
 		const { data } = await client.POST('/api/auth/logout/');
-		if (data) {
-			set({ is_authenticated: false });
-			if (data.logout_url) {
-				window.location.href = data.logout_url;
-			}
-		}
+		if (data) set({ is_authenticated: false });
 	}
 
 	return {

--- a/scripts/dev-backend
+++ b/scripts/dev-backend
@@ -1,6 +1,14 @@
 #!/usr/bin/env sh
 set -e
-cd "$(dirname "$0")/../backend"
+cd "$(dirname "$0")/.."
 
+# Load .env if present (exports vars for Django's os.environ.get)
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+cd backend
 pkill -f "manage.py runserver" 2>/dev/null || true
 uv run python manage.py runserver 127.0.0.1:8000


### PR DESCRIPTION
## Summary

- Pass `client_id` to `WorkOSClient` constructor (was causing 503 on every login attempt)
- Change redirect URI default to port 5173 (Vite proxy) so post-login redirects stay on the frontend origin in dev
- Load `.env` in `dev-backend` script so Django picks up environment variables
- Remove WorkOS logout redirect — just clear Django session and stay on current page
- Remove all dead code from the abandoned logout redirect: `LogoutResponseSchema`, `_extract_session_id`, `workos_session_id` session storage, `get_logout_url` call
- Add test verifying superuser flags survive email-based account linking

## Test plan

- [x] 15 backend auth tests pass (login, callback, logout, user matching, superuser preservation)
- [x] Full suite: 1393 backend + 238 frontend tests pass
- [x] All linters pass
- [ ] Manual: `make dev`, click Sign in → Google → redirected back to frontend (port 5173), authenticated
- [ ] Manual: click Sign out → stays on current page, UI updates to signed-out state
- [ ] Manual: create superuser, log in via Google with same email → admin access preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)