### PR TITLE
docs(auth): add WorkOS cost estimate examples

### DIFF
--- a/docs/plans/auth/Auth.md
+++ b/docs/plans/auth/Auth.md
@@ -226,6 +226,8 @@ WorkOS also remains strong on the other important requirements:
 - Email/password, social login, email verification, forgot password, MFA, and account linking on the free tier
 - Built-in auth email sending, so we do not need a separate email provider for v1 unless we want a custom sending domain
 
+On current pricing, the expected monthly cost is still effectively zero at our projected scale. Even if Pinbase grows from 20 users in month 1 to 100 users in month 2 and 500 users by month 6, that is still far below WorkOS AuthKit's free-tier limit of 1 million monthly active users.
+
 The main downside is branding: custom auth and email domains cost $99/mo. At this point, I would rather give up custom domains than long-lived sessions, so that tradeoff appears acceptable.
 
 So the current direction is:

--- a/docs/plans/auth/AuthProviders.md
+++ b/docs/plans/auth/AuthProviders.md
@@ -44,6 +44,8 @@ However, this does not solve the session-lifetime problem. Auth0's public nonpro
 
 WorkOS AuthKit is a third-party hosted auth platform with hosted login/signup flows, password auth, social login, MFA, email verification, user management, and a branded authentication UI. Free tier covers up to 1 million MAU.
 
+At the currently expected scale, cost is not a meaningful factor. If we have roughly 20 monthly active users in month 1, 100 in month 2, and 500 by month 6, the monthly WorkOS AuthKit charge still appears to be $0 unless we opt into paid add-ons like custom domains.
+
 WorkOS sends auth emails itself by default (from `workos-mail.com`), which eliminates the need for a separate email provider — unless we want a custom sending domain.
 
 WorkOS exposes standard OIDC/OAuth2 endpoints, so we can integrate with any OIDC library (`mozilla-django-oidc`, `authlib`, etc.) — not locked into their SDK.


### PR DESCRIPTION
## Summary

Document the expected WorkOS AuthKit monthly cost at projected growth levels.

- Note that 20 MAU in month 1, 100 in month 2, and 500 in month 6 all remain within the free AuthKit tier
- Keep the existing custom-domain caveat explicit at /mo

## Test plan

- [x] Review the updated auth planning docs for consistency
- [x] Confirm only the auth docs files were included in this change