### PR TITLE
Add plan docs for uniqueness, renditions, and video

### DIFF
--- a/docs/plans/NameAliasUniqueness.md
+++ b/docs/plans/NameAliasUniqueness.md
@@ -1,0 +1,72 @@
+# Name + Alias Cross Uniqueness
+
+## The Problem
+
+Some catalog entity types have unique names — Manufacturer, Theme, GameplayFeature, RewardType — meaning the name alone can resolve to exactly one entity during ingest and lookup. Each of these entities also has zero or more aliases that serve the same resolution purpose. If the same string appears as an entity's name and as another entity's alias (or as aliases on two different entities), resolution becomes ambiguous: which entity did the source mean?
+
+This does not apply to entity types with non-unique names (Person, Location, CorporateEntity), where two records can have the same name -- two people can have the same name -- and are used for search but not for unambiguous resolution.
+
+Today there are no collisions in the data. But as the system opens to end-user editing, fat-fingered entries will create them. The question is whether the system catches those mistakes before they land, or discovers them later as confusing search results.
+
+## Current State
+
+Application-level validation prevents collisions through four independent code paths:
+
+1. **Model `clean()` methods** — reject name↔alias collisions on `full_clean()`
+2. **API validation** — reject collisions in the edit claims endpoints
+3. **Resolver filtering** — silently skip colliding aliases during batch ingestion
+4. **Per-table DB constraints** — enforce name uniqueness within a single entity type, and alias uniqueness within a single alias table
+
+The gap: nothing prevents a name in one table from matching an alias in another table at the database level. The checks are application-only, which means `bulk_create`, raw SQL, concurrent writes, or any future code path that doesn't know about the rule can introduce collisions silently.
+
+## Proposed Architecture: NameRegistry
+
+Add a single shared table that indexes every name and alias across all entity types:
+
+| Column        | Purpose                                       |
+| ------------- | --------------------------------------------- |
+| `value`       | Lowercased string (unique)                    |
+| `entity_type` | ContentType FK — which model owns this string |
+| `entity_id`   | PK of the owning entity                       |
+| `role`        | `"name"` or `"alias"`                         |
+
+The `UNIQUE` constraint on `value` makes cross-table collisions impossible at the database level.
+
+### What it is
+
+An index table. Names and aliases still live on their respective models — the registry is a projection that the DB can enforce uniqueness on. It could be rebuilt from scratch by scanning the name fields and alias tables.
+
+### What it replaces
+
+The four independent application-level checks collapse into one mechanism. Model `clean()` methods, API cross-checks, and resolver name-set filtering all become unnecessary — the DB constraint does the work. The code simplifies from "check the rule in four places" to "write to the registry; the DB enforces the rule."
+
+### How it stays in sync
+
+Writes to name fields and alias tables must create/update/delete registry rows in the same transaction. This can be done via:
+
+- The resolver (which already manages alias rows in bulk)
+- The edit claims execute path (which already writes in a transaction)
+- A post-save signal as a safety net
+
+A periodic sweep (management command) can detect and report drift.
+
+### What it enables beyond uniqueness
+
+- **Conflict preview in the UI** — "is this string taken?" becomes a single indexed query
+- **Global search** — one table to search for any entity by name or alias
+- **Namespace reservations** — if needed later, reserve strings before an entity exists
+
+## Migration Path
+
+1. Ship the current application-level checks (already written, tested, passing) — they provide immediate protection for end-user editing.
+2. Add the `NameRegistry` model and populate it from existing data.
+3. Wire up the write paths (resolver + edit claims) to maintain the registry.
+4. Remove the redundant application-level cross-checks, keeping only the registry.
+
+Step 1 is ready now. Steps 2-4 can happen in a follow-up when the cost of the current approach (maintaining four code paths) outweighs the cost of the migration.
+
+## Open Questions
+
+- Should the registry include entity types that don't have aliases today (Series, Franchise)? Reserving their names in the shared namespace would prevent a future alias from colliding with them.
+- Should the registry span across entity types? Today "Gottlieb" as a Manufacturer name and "Gottlieb" as a Theme name are allowed. Is that a problem?
+- Is the registry the right place to enforce alias-to-alias uniqueness within a type, replacing the per-table `UniqueConstraint(Lower("value"))` constraints?

--- a/docs/plans/Renditions.md
+++ b/docs/plans/Renditions.md
@@ -1,0 +1,134 @@
+# Image Renditions Plan
+
+Plan date: 2026-04-03
+
+This document describes the product and architecture direction for Pinbase-owned image delivery after the initial media support work. It focuses on uploaded images that Pinbase has the right to store and display. Third-party image references remain external.
+
+## Background
+
+Pinbase's current image system stores uploaded originals in R2 and also stores fixed derived files for the main UI use cases. Today that means the application decides in advance which sizes exist, generates those files during upload, and stores them as separate physical renditions.
+
+That approach is simple and it was the right first step. It kept the initial media feature synchronous, easy to reason about, and independent of a background worker system.
+
+It also has an obvious downside: image size becomes part of the storage model. If the product wants a different thumbnail size, a different card crop, or a new hero treatment, that is no longer just a presentation change. It becomes a media regeneration problem.
+
+## Justification
+
+Image dimensions are primarily a delivery concern, not catalog truth.
+
+Pinbase's real source of truth is:
+
+- which uploaded asset exists
+- which entity it is attached to
+- which category it belongs to
+- which image is primary
+
+Those facts belong in Pinbase and in the claims-based media model. By contrast, "400px thumbnail" versus "480px thumbnail" is not a piece of catalog truth. It is a presentation choice that should be cheap to change.
+
+Cloudflare is well suited to that delivery layer. It can resize Pinbase-owned originals on demand, cache the generated result at the edge, and let the application change image presets without regenerating a library of stored files. That gives Pinbase more product flexibility while reducing application-owned image processing work.
+
+This is also a cleaner operational split:
+
+- Pinbase owns uploads, permissions, attachments, provenance, and editorial choices.
+- Cloudflare owns delivery-time resizing, format negotiation, caching, and global distribution.
+
+## Decision
+
+Pinbase should move toward a model where the uploaded original is the canonical stored image and Cloudflare generates delivery variants for Pinbase-owned images.
+
+The plan is not to let arbitrary sizes leak throughout the product. Instead, Pinbase should define a small vocabulary of named image presets such as thumbnail, card, detail, and hero. Product and frontend code should request those logical presets. Cloudflare should turn those preset requests into resized cached assets.
+
+This keeps the product flexible without turning image delivery into an unbounded free-for-all.
+
+## Goals
+
+- Make image size and format a configuration concern rather than a migration concern.
+- Keep Pinbase's claims-based attachment model unchanged.
+- Keep Pinbase-owned originals in storage that Pinbase controls.
+- Use Cloudflare for resizing, optimization, and CDN caching.
+- Preserve the rule that third-party media stays external.
+- Give product and frontend teams a stable set of named image variants.
+
+## Non-Goals
+
+- No re-hosting or proxying of OPDB, IPDB, Fandom, Wikidata, or other third-party images.
+- No attempt to expose arbitrary width and height combinations across the product.
+- No migration to Cloudflare Images managed storage as a prerequisite for this plan.
+- No change to the editorial model for categories, primaries, or attachment claims.
+
+## Product Shape
+
+From a product perspective, Pinbase should stop thinking in terms of "files we pre-generated during upload" and start thinking in terms of "approved ways the product may present an image".
+
+That means:
+
+- the UI asks for named presets, not hard-coded one-off sizes
+- changing a preset is a product decision, not a data migration
+- new surfaces can reuse an existing preset or introduce a new one intentionally
+- the same uploaded original can support multiple presentation contexts without extra ingest work
+
+This keeps image behavior consistent across cards, lists, detail pages, and future layouts.
+
+## Architecture Shape
+
+At a high level, the architecture should be:
+
+1. Pinbase accepts and validates uploads for Pinbase-owned images.
+2. Pinbase stores the canonical original in R2 and records the media asset and attachment truth in its existing media models.
+3. Cloudflare sits in front of that storage on a Pinbase media domain.
+4. Cloudflare generates and caches approved delivery variants from the original when requested.
+5. APIs and frontend code use stable preset-based URLs or helpers rather than treating stored derived files as first-class data.
+
+The important boundary is that Pinbase still owns media truth, while Cloudflare owns rendition delivery.
+
+## Why Not Keep Pre-Generated Renditions
+
+Keeping pre-generated renditions is still viable for a very small system, but it locks presentation choices into stored artifacts. Over time that creates avoidable friction:
+
+- every new image surface pressures the storage model
+- old rendition sizes linger after the UI moves on
+- changing a preset becomes a backfill or dual-support problem
+- the application does work that the CDN layer is better positioned to do
+
+That is not a good long-term fit for a product that will continue refining its presentation layer.
+
+## Why Not Move Fully Into Cloudflare Images Storage
+
+The main opportunity here is delivery, not a storage migration.
+
+Pinbase already has an R2-backed media model and clear ownership boundaries around which files it stores. Moving to Cloudflare-hosted image storage would be a larger system change with less product benefit than simply adopting Cloudflare's resizing and caching layer in front of the originals Pinbase already stores.
+
+The simpler plan is the better one: keep Pinbase's owned originals, put Cloudflare in charge of delivery.
+
+## Relationship To Existing Media Architecture
+
+This plan does not change the claims-based media attachment model.
+
+`MediaAsset` remains the logical owned upload. `EntityMedia` remains the resolved attachment truth. What changes is how Pinbase thinks about delivery variants. The system should gradually move away from treating fixed stored thumbnails and display files as the long-term source of truth for presentation.
+
+In other words:
+
+- attachment truth stays in Pinbase
+- canonical originals stay in Pinbase-controlled storage
+- rendition generation moves to Cloudflare
+
+## Rollout Direction
+
+The rollout should be incremental:
+
+1. Put a Cloudflare-served custom domain in front of Pinbase media storage.
+2. Introduce named delivery presets for uploaded images.
+3. Route those presets through Cloudflare resizing and caching.
+4. Simplify Pinbase's own rendition generation once the new delivery path is established.
+
+This keeps the migration low-risk. Pinbase can adopt the new delivery model before it fully removes old assumptions.
+
+## Success Criteria
+
+This plan is successful when:
+
+- product can change thumbnail and hero sizing without a media migration
+- frontend code uses a small stable preset vocabulary
+- Pinbase stores fewer presentation-specific artifacts
+- uploaded images are delivered faster and more consistently through Cloudflare
+- the legal and editorial boundary around third-party media remains intact

--- a/docs/plans/Video.md
+++ b/docs/plans/Video.md
@@ -1,0 +1,156 @@
+# Video Plan
+
+Plan date: 2026-04-03
+
+This document describes the product and architecture direction for user-uploaded video in Pinbase. It covers Pinbase-owned video uploads only. Third-party videos remain external.
+
+## Background
+
+Video is not an image with a larger file size. It introduces a different class of product and operational concerns:
+
+- uploads are much larger
+- processing takes longer
+- playback must adapt to device and network conditions
+- users expect posters, scrubbing, and reliable streaming
+- failures and long-running states are normal rather than exceptional
+
+Pinbase's current media architecture is intentionally simple for images. Upload happens in one request, processing is synchronous, and the request either succeeds or fails immediately. That model is a poor fit for video.
+
+If Pinbase handled video entirely itself, it would need a more complex ingestion pipeline: direct uploads, background processing, transcoding workers, status transitions, retries, monitoring, and streaming delivery concerns. That is a substantial amount of infrastructure for a feature that is not Pinbase's core product.
+
+## Justification
+
+Pinbase should own the product truth around video, but it should not own the transcoding platform.
+
+The important things Pinbase must control are:
+
+- who uploaded the video
+- which catalog entity it is attached to
+- which category it belongs to
+- whether it is primary
+- whether it is published, visible, or moderated
+
+Those are product and editorial concerns, and they fit naturally into Pinbase's existing media and claims architecture.
+
+Encoding pipelines, adaptive bitrate packaging, playback manifests, and streaming delivery are infrastructure concerns. They are expensive to build, easy to get partly wrong, and not where Pinbase should spend its complexity budget.
+
+Cloudflare Stream is a better fit for that layer. It provides direct uploads, asynchronous processing, managed playback formats, and globally distributed delivery without requiring Pinbase to build and operate its own transcoding queue.
+
+## Decision
+
+Pinbase should use Cloudflare Stream for Pinbase-owned video uploads and playback.
+
+The key distinction is:
+
+- Pinbase remains the system of record for media ownership, attachment, moderation, and editorial decisions.
+- Cloudflare Stream becomes the managed service for video ingestion, transcoding, storage, and playback delivery.
+
+This is not "transcode on every request." Stream's model is upload first, process asynchronously, then serve the prepared video once ready. That is the right shape for user-uploaded video.
+
+## Goals
+
+- Support user-uploaded Pinbase-owned video without building a Pinbase-operated transcoding stack.
+- Keep media attachment truth claims-based and consistent with the rest of the media system.
+- Provide a clear processing lifecycle for video assets.
+- Support reliable playback across devices and connection qualities.
+- Keep direct upload and large-file handling out of the main Django request path.
+- Preserve the legal rule that third-party media stays external.
+
+## Non-Goals
+
+- No self-hosted transcoding worker system in Pinbase.
+- No re-hosting or proxying of third-party videos.
+- No live streaming product in the initial plan.
+- No in-app video editing suite, clipping workflow, or creator tools beyond upload and playback.
+- No attempt to make video behave like synchronous image upload.
+
+## Product Shape
+
+From the user's perspective, video should behave like a managed asset with a visible lifecycle:
+
+- uploading
+- processing
+- ready
+- failed
+
+That state is part of the product, not an implementation leak. Video cannot honestly promise the instant, atomic behavior that images can.
+
+The UI should set that expectation clearly. Users upload a file, Pinbase records the intended attachment, and the video becomes playable once processing is complete. Posters and playback should feel native to Pinbase, but the system should not pretend that video is immediate when it is not.
+
+## Architecture Shape
+
+At a high level, the architecture should be:
+
+1. Pinbase creates the logical media asset and attachment intent.
+2. The client uploads the video directly to Cloudflare Stream using a one-time upload flow.
+3. Cloudflare Stream processes the video asynchronously.
+4. Pinbase learns the processing result through callbacks or status synchronization and updates the asset lifecycle.
+5. Once ready, Pinbase serves video metadata and playback references as part of its normal media APIs.
+
+That keeps the heavy transfer and processing path out of the application server while preserving Pinbase's control over product truth.
+
+## Why Not Build This In-House
+
+An in-house video pipeline would force Pinbase to own several concerns that are not central to the product:
+
+- large-file upload infrastructure
+- resumable or direct-to-storage upload flows
+- background job orchestration
+- transcoding reliability
+- poster generation
+- stream packaging
+- playback compatibility
+- operational monitoring for long-running media jobs
+
+That is a lot of surface area for a feature that can be delivered more safely through a managed service.
+
+The result would not just be more code. It would be more operational burden, more failure modes, and more product delay.
+
+## Relationship To Existing Media Architecture
+
+This plan extends the current media model rather than replacing it.
+
+`MediaAsset` still represents the logical uploaded item. `EntityMedia` still represents the resolved attachment truth. The difference is that video assets have a meaningful processing lifecycle and rely on an external managed video backend for their derived outputs and playback delivery.
+
+That means the application model stays coherent:
+
+- Pinbase owns the asset record
+- Pinbase owns the attachment record
+- Cloudflare Stream owns the video processing and delivery machinery
+
+## Ownership Boundary
+
+The same ownership rule used for images applies here.
+
+Pinbase video support is for media that Pinbase has the right to store and display, such as videos uploaded by users under Pinbase's terms or videos owned by The Flip Museum. Third-party videos remain references, not ingested assets.
+
+This boundary matters for both legal reasons and system design. The managed video pipeline should only be used for content Pinbase is actually entitled to host.
+
+## Delivery and Access
+
+Playback should be treated as a delivery concern, not a catalog-truth concern.
+
+Pinbase should decide which viewers are allowed to access a given video and what metadata the UI should see. Cloudflare Stream should handle the mechanics of delivering a playable video efficiently. If Pinbase later needs signed playback, restricted access, or more nuanced publication states, that can be layered on top without changing the basic division of responsibility.
+
+## Rollout Direction
+
+The rollout should be staged:
+
+1. Introduce video as a new media kind in the Pinbase media model.
+2. Add a product-visible processing lifecycle for video assets.
+3. Integrate direct uploads to Cloudflare Stream.
+4. Connect Stream processing results back into Pinbase's asset status.
+5. Add playback surfaces once the ingest and status model are stable.
+
+This sequence keeps the work honest. Pinbase should model the lifecycle first and only then expose polished playback on top of it.
+
+## Success Criteria
+
+This plan is successful when:
+
+- Pinbase can support user-uploaded video without a Pinbase-operated transcoding queue
+- large uploads do not flow through the normal application request path
+- the UI can accurately show upload, processing, ready, and failed states
+- playback is reliable across devices
+- video remains consistent with Pinbase's claims-based media attachment model
+- third-party video remains outside Pinbase-hosted storage


### PR DESCRIPTION
## Summary

- **NameAliasUniqueness.md** — documents the problem of name↔alias collisions in unique-name entity types, the current application-level enforcement, and a proposed NameRegistry table for DB-level uniqueness
- **Renditions.md** — on-demand media rendition architecture (deferred)
- **Video.md** — video support planning

## Test plan

- [ ] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning documentation for future infrastructure and architecture improvements.

*Note: This PR contains internal planning documents with no immediate user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->