### PR TITLE
chore(ci)/Disable CodeRabbit auto review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,6 +2,8 @@
 # https://docs.coderabbit.ai/reference/configuration
 
 reviews:
+  auto_review:
+    enabled: false
   tools:
     languagetool:
       enabled: false


### PR DESCRIPTION
## Summary
Disables CodeRabbit automatic reviews for this repository by setting reviews.auto_review.enabled: false in .coderabbit.yaml.

## Why
CodeRabbit was reviewing every pull request by default. This change makes reviews opt-in instead of automatic.

## Impact
Pull requests will no longer be reviewed automatically by CodeRabbit. Manual review requests still remain available through CodeRabbit commands when needed.

## Validation
- Pre-commit hooks passed during commit
- YAML validation passed