### PR TITLE
fix(docker): install libavif for AVIF image support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ RUN pnpm build
 # ── Stage 2: Django application ────────────────────────────────────
 FROM python:3.14-slim AS base
 
+# Image codec libraries (AVIF support for Pillow)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libavif-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 


### PR DESCRIPTION
## Summary
- Install `libavif-dev` in the Docker production image so Pillow's AVIF codec is available at runtime
- Fixes the "AVIF codec unavailable" warning on Railway

## Test plan
- [ ] Deploy to Railway and verify AVIF warning no longer appears in logs
- [ ] Upload an AVIF image and confirm it processes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)