### PR TITLE
fix(docker): force Pillow source build for AVIF codec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ RUN pnpm build
 # ── Stage 2: Django application ────────────────────────────────────
 FROM python:3.14-slim AS base
 
-# Image codec libraries (AVIF support for Pillow)
+# Build deps + AVIF library so Pillow compiles with AVIF support
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
     libavif-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -30,8 +31,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 # Install dependencies (cached layer)
+# --no-binary-package pillow forces source build against system libavif
 COPY backend/pyproject.toml backend/uv.lock ./
-RUN uv sync --frozen --no-dev --no-install-project
+RUN uv sync --frozen --no-dev --no-install-project --no-binary-package pillow
 
 # Copy application code
 COPY backend/ .


### PR DESCRIPTION
## Summary
- Pre-built Pillow wheels bundle their own codecs and ignore the system `libavif` — that's why #134 didn't work
- Add `build-essential` so Pillow can compile from source
- Use `--no-binary-package pillow` in `uv sync` to force source build against system `libavif-dev`

## Test plan
- [ ] Deploy to Railway and verify AVIF warning no longer appears in logs
- [ ] Upload an AVIF image and confirm it processes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)