### PR TITLE
fix(docker): add Pillow build deps for AVIF source compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,15 @@ RUN pnpm build
 # ── Stage 2: Django application ────────────────────────────────────
 FROM python:3.14-slim AS base
 
-# Build deps + AVIF library so Pillow compiles with AVIF support
+# Build deps so Pillow compiles from source with AVIF support
+# (python:3.14-slim pre-built wheels lack AVIF codec)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    zlib1g-dev \
+    libjpeg62-turbo-dev \
+    libfreetype-dev \
+    liblcms2-dev \
+    libwebp-dev \
     libavif-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Adds `zlib1g-dev`, `libjpeg62-turbo-dev`, `libfreetype-dev`, `liblcms2-dev`, `libwebp-dev` alongside the existing `build-essential` and `libavif-dev`
- These are all required when Pillow compiles from source (which `--no-binary-package pillow` forces)
- Previous attempt (#135) failed because only `libavif-dev` was present — zlib was the first missing dep

## Test plan
- [ ] Railway build succeeds (no `zlib` header error)
- [ ] AVIF warning no longer appears in deploy logs
- [ ] AVIF image upload works

🤖 Generated with [Claude Code](https://claude.com/claude-code)