### PR TITLE
fix: hide coffee stains in dark mode, show processing state on upload

### DIFF
--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -109,36 +109,38 @@
 	</div>
 
 	<!-- Coffee stain overlays — three strips covering full width -->
-	<CoffeeStain
-		seed={stainSeed1}
-		frequency={0.03}
-		opacity={0.12}
-		blur={4}
-		threshold="0 0 0 0 0 0 0.5 0.7"
-		x="0%"
-		width="40%"
-	/>
-	<CoffeeStain
-		seed={stainSeed2}
-		frequency={0.04}
-		octaves={4}
-		opacity={0.08}
-		blur={5}
-		threshold="0 0 0 0 0 0 0 0.4"
-		color="rgb(100, 65, 20)"
-		x="30%"
-		width="40%"
-	/>
-	<CoffeeStain
-		seed={stainSeed3}
-		frequency={0.025}
-		opacity={0.1}
-		blur={3}
-		threshold="0 0 0 0 0 0.4 0.6 0.8"
-		color="rgb(130, 90, 35)"
-		x="60%"
-		width="40%"
-	/>
+	<div class="header-stains">
+		<CoffeeStain
+			seed={stainSeed1}
+			frequency={0.03}
+			opacity={0.12}
+			blur={4}
+			threshold="0 0 0 0 0 0 0.5 0.7"
+			x="0%"
+			width="40%"
+		/>
+		<CoffeeStain
+			seed={stainSeed2}
+			frequency={0.04}
+			octaves={4}
+			opacity={0.08}
+			blur={5}
+			threshold="0 0 0 0 0 0 0 0.4"
+			color="rgb(100, 65, 20)"
+			x="30%"
+			width="40%"
+		/>
+		<CoffeeStain
+			seed={stainSeed3}
+			frequency={0.025}
+			opacity={0.1}
+			blur={3}
+			threshold="0 0 0 0 0 0.4 0.6 0.8"
+			color="rgb(130, 90, 35)"
+			x="60%"
+			width="40%"
+		/>
+	</div>
 
 	<!-- Torn bottom edge -->
 	<div class="torn-edge" style:filter="url(#{tornId})"></div>
@@ -324,6 +326,19 @@
 
 		.site-nav.open {
 			display: flex;
+		}
+	}
+
+	.header-stains {
+		display: none;
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+	}
+
+	@media (prefers-color-scheme: light) {
+		.header-stains {
+			display: block;
 		}
 	}
 

--- a/frontend/src/lib/components/media/MediaUploadZone.svelte
+++ b/frontend/src/lib/components/media/MediaUploadZone.svelte
@@ -135,7 +135,9 @@
 				<li class="file-entry" class:error={entry.status === 'error'}>
 					<span class="file-name">{entry.file.name}</span>
 					<span class="file-status">
-						{#if entry.status === 'uploading'}
+						{#if entry.status === 'uploading' && entry.progress >= 100}
+							Processing...
+						{:else if entry.status === 'uploading'}
 							<span class="progress-bar">
 								<span class="progress-fill" style:width="{entry.progress}%"></span>
 							</span>


### PR DESCRIPTION
## Summary
- **Nav**: Wrap coffee stain overlays in a container that's hidden by default and only displayed in light mode, preventing brown textures from bleeding through on dark backgrounds
- **MediaUploadZone**: Show "Processing..." text when file upload progress reaches 100% but the server is still processing

## Test plan
- [ ] Toggle dark mode — coffee stains should not appear
- [ ] Toggle light mode — coffee stains should appear as before
- [ ] Upload a file and observe "Processing..." appears when progress bar fills before server responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)