### PR TITLE
refactor: rename Activity to Sources across frontend and backend

### DIFF
--- a/backend/apps/catalog/api/corporate_entities.py
+++ b/backend/apps/catalog/api/corporate_entities.py
@@ -16,7 +16,7 @@ from ninja.security import django_auth
 
 from .edit_claims import execute_claims, plan_alias_claims, validate_scalar_fields
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -62,7 +62,7 @@ class CorporateEntityDetailSchema(Schema):
     aliases: list[str] = []
     locations: list[CorporateEntityLocationSchema] = []
     titles: list[RelatedTitleSchema]
-    activity: list[ClaimSchema] = []
+    sources: list[ClaimSchema] = []
 
 
 # ---------------------------------------------------------------------------
@@ -109,7 +109,7 @@ def _serialize_detail(ce) -> dict:
         "aliases": [a.value for a in ce.aliases.all()],
         "locations": _serialize_locations(ce),
         "titles": _collect_titles(ce.models.all()),
-        "activity": _build_activity(getattr(ce, "active_claims", [])),
+        "sources": _build_sources(getattr(ce, "active_claims", [])),
     }
 
 

--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -15,7 +15,7 @@ from ninja.security import django_auth
 
 from .edit_claims import execute_claims
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -50,7 +50,7 @@ class FranchiseDetailSchema(Schema):
     slug: str
     description: RichTextSchema = RichTextSchema()
     titles: list[TitleRefSchema]
-    activity: list[ClaimSchema] = []
+    sources: list[ClaimSchema] = []
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +154,7 @@ def get_franchise(request, slug: str):
             franchise, "description", getattr(franchise, "active_claims", [])
         ),
         "titles": [_serialize_title_list(t) for t in franchise.titles.all()],
-        "activity": _build_activity(getattr(franchise, "active_claims", [])),
+        "sources": _build_sources(getattr(franchise, "active_claims", [])),
     }
 
 
@@ -187,7 +187,7 @@ def patch_franchise_claims(request, slug: str, data: ClaimPatchSchema):
             franchise, "description", getattr(franchise, "active_claims", [])
         ),
         "titles": [_serialize_title_list(t) for t in franchise.titles.all()],
-        "activity": _build_activity(getattr(franchise, "active_claims", [])),
+        "sources": _build_sources(getattr(franchise, "active_claims", [])),
     }
 
 

--- a/backend/apps/catalog/api/gameplay_features.py
+++ b/backend/apps/catalog/api/gameplay_features.py
@@ -17,7 +17,7 @@ from .edit_claims import (
     validate_scalar_fields,
 )
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -53,7 +53,7 @@ class GameplayFeatureDetailSchema(Schema):
     parents: list[GameplayFeatureSchema] = []
     children: list[GameplayFeatureSchema] = []
     uploaded_media: list[UploadedMediaSchema] = []
-    activity: list[ClaimSchema] = []
+    sources: list[ClaimSchema] = []
 
 
 # ---------------------------------------------------------------------------
@@ -88,7 +88,7 @@ def _serialize_detail(feature) -> dict:
         "uploaded_media": _serialize_uploaded_media(
             getattr(feature, "all_media", None) or []
         ),
-        "activity": _build_activity(getattr(feature, "active_claims", [])),
+        "sources": _build_sources(getattr(feature, "active_claims", [])),
     }
 
 

--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -5,19 +5,19 @@ from __future__ import annotations
 from django.db.models import Case, F, IntegerField, Prefetch, Value, When
 
 
-def _build_activity(active_claims) -> list[dict]:
-    """Serialize pre-fetched active claims into the activity list format.
+def _build_sources(active_claims) -> list[dict]:
+    """Serialize pre-fetched active claims into the sources list format.
 
     Claims should be ordered by claim_key, -priority, -created_at. The first
     claim seen per claim_key is marked as the winner.
     """
     winners: set[str] = set()
-    activity: list[dict] = []
+    sources: list[dict] = []
     for claim in active_claims:
         is_winner = claim.claim_key not in winners
         if is_winner:
             winners.add(claim.claim_key)
-        activity.append(
+        sources.append(
             {
                 "source_name": claim.source.name if claim.source else None,
                 "source_slug": claim.source.slug if claim.source else None,
@@ -30,8 +30,8 @@ def _build_activity(active_claims) -> list[dict]:
                 "changeset_note": claim.changeset.note if claim.changeset else None,
             }
         )
-    activity.sort(key=lambda c: c["created_at"], reverse=True)
-    return activity
+    sources.sort(key=lambda c: c["created_at"], reverse=True)
+    return sources
 
 
 def _build_edit_history(entity) -> list[dict]:

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -16,7 +16,7 @@ from ninja.security import django_auth
 from ..cache import MODELS_ALL_KEY
 from .constants import DEFAULT_PAGE_SIZE
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -129,7 +129,7 @@ class MachineModelDetailSchema(Schema):
     abbreviations: list[str] = []
     extra_data: dict
     credits: list[CreditSchema]
-    activity: list[ClaimSchema]
+    sources: list[ClaimSchema]
     thumbnail_url: Optional[str] = None
     hero_image_url: Optional[str] = None
     image_attribution: Optional[AttributionSchema] = None
@@ -304,9 +304,9 @@ def _serialize_model_detail(pm) -> dict:
         for c in pm.credits.all()
     ]
 
-    activity_claims = getattr(pm, "active_claims", None)
-    if activity_claims is None:
-        activity_claims = list(
+    active_claims = getattr(pm, "active_claims", None)
+    if active_claims is None:
+        active_claims = list(
             pm.claims.filter(is_active=True)
             .exclude(source__is_enabled=False)
             .select_related("source", "user")
@@ -320,7 +320,7 @@ def _serialize_model_detail(pm) -> dict:
             )
             .order_by("claim_key", "-effective_priority", "-created_at")
         )
-    activity = _build_activity(activity_claims)
+    sources = _build_sources(active_claims)
 
     all_media = getattr(pm, "all_media", None) or []
     primary_media = [em for em in all_media if em.is_primary]
@@ -331,7 +331,7 @@ def _serialize_model_detail(pm) -> dict:
         pm.extra_data or {}, primary_media or None
     )
     uploaded_media = _serialize_uploaded_media(all_media)
-    description = _build_rich_text(pm, "description", activity_claims)
+    description = _build_rich_text(pm, "description", active_claims)
     variant_features = _extract_variant_features(pm.extra_data or {})
 
     variants = [
@@ -419,7 +419,7 @@ def _serialize_model_detail(pm) -> dict:
         "abbreviations": [a.value for a in pm.abbreviations.all()],
         "extra_data": pm.extra_data or {},
         "credits": credits,
-        "activity": activity,
+        "sources": sources,
         "thumbnail_url": thumbnail_url,
         "hero_image_url": hero_image_url,
         "image_attribution": image_attribution,

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -19,7 +19,7 @@ from apps.core.models import active_status_q
 from ..cache import MANUFACTURERS_ALL_KEY
 from .constants import DEFAULT_PAGE_SIZE
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -110,7 +110,7 @@ class ManufacturerDetailSchema(Schema):
     systems: list[SystemSchema]
     persons: list[ManufacturerPersonSchema] = []
     uploaded_media: list[UploadedMediaSchema] = []
-    activity: list[ClaimSchema]
+    sources: list[ClaimSchema]
 
 
 # ---------------------------------------------------------------------------
@@ -183,7 +183,7 @@ def _serialize_manufacturer_detail(mfr) -> dict:
         "uploaded_media": _serialize_uploaded_media(
             getattr(mfr, "all_media", None) or []
         ),
-        "activity": _build_activity(getattr(mfr, "active_claims", [])),
+        "sources": _build_sources(getattr(mfr, "active_claims", [])),
     }
 
 

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -16,7 +16,7 @@ from ninja.security import django_auth
 from ..cache import PEOPLE_ALL_KEY
 from .constants import DEFAULT_PAGE_SIZE
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -70,7 +70,7 @@ class PersonDetailSchema(Schema):
     photo_url: str | None = None
     titles: list[PersonTitleSchema]
     uploaded_media: list[UploadedMediaSchema] = []
-    activity: list[ClaimSchema]
+    sources: list[ClaimSchema]
 
 
 # ---------------------------------------------------------------------------
@@ -132,7 +132,7 @@ def _serialize_person_detail(person) -> dict:
         "uploaded_media": _serialize_uploaded_media(
             getattr(person, "all_media", None) or []
         ),
-        "activity": _build_activity(getattr(person, "active_claims", [])),
+        "sources": _build_sources(getattr(person, "active_claims", [])),
     }
 
 

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -15,7 +15,7 @@ from ninja.security import django_auth
 
 from .edit_claims import execute_claims
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -53,7 +53,7 @@ class SeriesDetailSchema(Schema):
     description: RichTextSchema = RichTextSchema()
     titles: list[TitleRefSchema]
     credits: list[CreditSchema] = []
-    activity: list[ClaimSchema] = []
+    sources: list[ClaimSchema] = []
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +145,7 @@ def _serialize_series_detail(series) -> dict:
             }
             for c in series.credits.all()
         ],
-        "activity": _build_activity(getattr(series, "active_claims", [])),
+        "sources": _build_sources(getattr(series, "active_claims", [])),
     }
 
 

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -15,7 +15,7 @@ from ninja.security import django_auth
 
 from .edit_claims import execute_claims
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -54,7 +54,7 @@ class SystemDetailSchema(Schema):
     manufacturer: Optional[Ref] = None
     titles: list[RelatedTitleSchema]
     sibling_systems: list[SiblingSystemSchema] = []
-    activity: list[ClaimSchema] = []
+    sources: list[ClaimSchema] = []
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +131,7 @@ def _serialize_system_detail(system) -> dict:
         ),
         "titles": list(titles.values()),
         "sibling_systems": sibling_systems,
-        "activity": _build_activity(getattr(system, "active_claims", [])),
+        "sources": _build_sources(getattr(system, "active_claims", [])),
     }
 
 

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -10,7 +10,7 @@ from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
 from .edit_claims import execute_claims, plan_scalar_field_claims
-from .helpers import _build_activity, _build_rich_text, _claims_prefetch
+from .helpers import _build_rich_text, _build_sources, _claims_prefetch
 from .schemas import ClaimPatchSchema, ClaimSchema, RichTextSchema, TitleMachineSchema
 
 
@@ -27,7 +27,7 @@ def _serialize_taxonomy(obj) -> dict:
         "description": _build_rich_text(
             obj, "description", getattr(obj, "active_claims", [])
         ),
-        "activity": _build_activity(getattr(obj, "active_claims", [])),
+        "sources": _build_sources(getattr(obj, "active_claims", [])),
     }
 
 
@@ -56,7 +56,7 @@ class TaxonomySchema(Schema):
     slug: str
     display_order: int
     description: RichTextSchema = RichTextSchema()
-    activity: list[ClaimSchema] = []
+    sources: list[ClaimSchema] = []
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -17,7 +17,7 @@ from .edit_claims import (
     validate_scalar_fields,
 )
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -51,7 +51,7 @@ class ThemeDetailSchema(Schema):
     parents: list[ThemeSchema] = []
     children: list[ThemeSchema] = []
     machines: list[TitleMachineSchema]
-    activity: list[ClaimSchema] = []
+    sources: list[ClaimSchema] = []
 
 
 # ---------------------------------------------------------------------------
@@ -90,7 +90,7 @@ def _serialize_detail(theme) -> dict:
             {"name": t.name, "slug": t.slug} for t in theme.children.order_by("name")
         ],
         "machines": [_serialize_title_machine(pm) for pm in theme.machine_models.all()],
-        "activity": _build_activity(getattr(theme, "active_claims", [])),
+        "sources": _build_sources(getattr(theme, "active_claims", [])),
     }
 
 

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -21,7 +21,7 @@ from .edit_claims import (
     plan_abbreviation_claims,
 )
 from .helpers import (
-    _build_activity,
+    _build_sources,
     _build_edit_history,
     _build_rich_text,
     _claims_prefetch,
@@ -111,7 +111,7 @@ class TitleDetailSchema(Schema):
     credits: list[CreditSchema] = []
     agreed_specs: AgreedSpecsSchema = AgreedSpecsSchema()
     model_detail: Optional[MachineModelDetailSchema] = None
-    activity: list[ClaimSchema] = []
+    sources: list[ClaimSchema] = []
 
 
 class TitleClaimPatchSchema(Schema):
@@ -432,7 +432,7 @@ def _serialize_title_detail(title) -> dict:
         "credits": credits,
         "agreed_specs": agreed_specs,
         "model_detail": model_detail,
-        "activity": _build_activity(getattr(title, "active_claims", [])),
+        "sources": _build_sources(getattr(title, "active_claims", [])),
     }
 
 

--- a/backend/apps/catalog/tests/test_api_claims_additional_entities.py
+++ b/backend/apps/catalog/tests/test_api_claims_additional_entities.py
@@ -283,7 +283,7 @@ class TestAdditionalPatchClaimEndpoints:
         ("path_template", "factory", "field_name", "field_value", "resource_name"),
         PATCH_CASES,
     )
-    def test_creates_claim_changeset_and_activity(
+    def test_creates_claim_changeset_and_sources(
         self,
         client,
         user,
@@ -307,7 +307,7 @@ class TestAdditionalPatchClaimEndpoints:
         assert data["description"]["text"] == field_value
         assert any(
             claim["field_name"] == field_name and claim["is_winner"]
-            for claim in data["activity"]
+            for claim in data["sources"]
         ), resource_name
 
         entity.refresh_from_db()

--- a/backend/apps/catalog/tests/test_api_claims_gameplay_feature.py
+++ b/backend/apps/catalog/tests/test_api_claims_gameplay_feature.py
@@ -126,14 +126,13 @@ class TestPatchGameplayFeaturePersistence:
         assert inactive.count() == 1
         assert active.first().value == "Second"
 
-    def test_response_includes_activity(self, client, user, feature):
+    def test_response_includes_sources(self, client, user, feature):
         client.force_login(user)
         resp = _patch(client, feature.slug, {"fields": {"description": "Updated"}})
         data = resp.json()
-        assert "activity" in data
+        assert "sources" in data
         assert any(
-            c["field_name"] == "description" and c["is_winner"]
-            for c in data["activity"]
+            c["field_name"] == "description" and c["is_winner"] for c in data["sources"]
         )
 
 
@@ -173,7 +172,7 @@ class TestPatchGameplayFeatureChangeSet:
         cs = ChangeSet.objects.first()
         assert cs.note == "Corrected from IPDB listing"
 
-    def test_changeset_note_in_activity_response(self, client, user, feature):
+    def test_changeset_note_in_sources_response(self, client, user, feature):
         client.force_login(user)
         resp = _patch(
             client,
@@ -185,7 +184,7 @@ class TestPatchGameplayFeatureChangeSet:
         )
         data = resp.json()
         desc_claim = next(
-            c for c in data["activity"] if c["field_name"] == "description"
+            c for c in data["sources"] if c["field_name"] == "description"
         )
         assert desc_claim["changeset_note"] == "My edit note"
 

--- a/backend/apps/catalog/tests/test_api_claims_manufacturer_person.py
+++ b/backend/apps/catalog/tests/test_api_claims_manufacturer_person.py
@@ -185,7 +185,7 @@ class TestPatchManufacturerClaimsPersistence:
         assert resp.status_code == 200
         assert resp.json()["description"]["text"] == "User Name"
 
-    def test_response_includes_activity(self, client, user, mfr):
+    def test_response_includes_sources(self, client, user, mfr):
         client.force_login(user)
         resp = client.patch(
             f"/api/manufacturers/{mfr.slug}/claims/",
@@ -193,10 +193,9 @@ class TestPatchManufacturerClaimsPersistence:
             content_type="application/json",
         )
         data = resp.json()
-        assert "activity" in data
+        assert "sources" in data
         assert any(
-            c["field_name"] == "description" and c["is_winner"]
-            for c in data["activity"]
+            c["field_name"] == "description" and c["is_winner"] for c in data["sources"]
         )
 
 
@@ -281,7 +280,7 @@ class TestPatchPersonClaimsPersistence:
         assert resp.status_code == 422
         assert "unique" in resp.json()["detail"].lower()
 
-    def test_response_includes_activity(self, client, user, person):
+    def test_response_includes_sources(self, client, user, person):
         client.force_login(user)
         resp = client.patch(
             f"/api/people/{person.slug}/claims/",
@@ -289,8 +288,7 @@ class TestPatchPersonClaimsPersistence:
             content_type="application/json",
         )
         data = resp.json()
-        assert "activity" in data
+        assert "sources" in data
         assert any(
-            c["field_name"] == "description" and c["is_winner"]
-            for c in data["activity"]
+            c["field_name"] == "description" and c["is_winner"] for c in data["sources"]
         )

--- a/backend/apps/catalog/tests/test_api_claims_title.py
+++ b/backend/apps/catalog/tests/test_api_claims_title.py
@@ -89,7 +89,7 @@ class TestPatchTitleClaims:
         resp = _patch(client, title.slug, {"fields": {}})
         assert resp.status_code == 422
 
-    def test_scalar_edit_updates_title_and_returns_activity(
+    def test_scalar_edit_updates_title_and_returns_sources(
         self, client, user, title, franchise
     ):
         client.force_login(user)
@@ -111,7 +111,7 @@ class TestPatchTitleClaims:
         assert data["franchise"]["slug"] == franchise.slug
         assert any(
             claim["field_name"] == "description" and claim["is_winner"]
-            for claim in data["activity"]
+            for claim in data["sources"]
         )
 
         title.refresh_from_db()
@@ -228,7 +228,7 @@ class TestPatchTitleClaims:
             "abbreviation",
         }
 
-    def test_changeset_note_is_returned_in_activity(self, client, user, title):
+    def test_changeset_note_is_returned_in_sources(self, client, user, title):
         client.force_login(user)
         resp = _patch(
             client,
@@ -242,5 +242,5 @@ class TestPatchTitleClaims:
         assert resp.status_code == 200
         assert any(
             claim["changeset_note"] == "Editorial cleanup"
-            for claim in resp.json()["activity"]
+            for claim in resp.json()["sources"]
         )

--- a/backend/apps/catalog/tests/test_api_models.py
+++ b/backend/apps/catalog/tests/test_api_models.py
@@ -118,7 +118,7 @@ class TestModelsAPI:
         assert data["name"] == "Medieval Madness"
         assert len(data["credits"]) == 1
         assert data["credits"][0]["person"]["name"] == "Pat Lawlor"
-        year_claims = [c for c in data["activity"] if c["field_name"] == "year"]
+        year_claims = [c for c in data["sources"] if c["field_name"] == "year"]
         assert len(year_claims) == 1
         assert year_claims[0]["source_name"] == "IPDB"
         assert year_claims[0]["is_winner"] is True

--- a/backend/apps/catalog/tests/test_api_titles.py
+++ b/backend/apps/catalog/tests/test_api_titles.py
@@ -70,7 +70,7 @@ class TestTitlesAPI:
         data = resp.json()
         assert data["name"] == "Medieval Madness"
         assert len(data["machines"]) == 2
-        assert data["activity"] == []
+        assert data["sources"] == []
 
     def test_get_title_detail_excludes_variants(self, client, title_with_machines):
         parent = MachineModel.objects.get(name="Medieval Madness")
@@ -102,10 +102,10 @@ class TestTitlesAPI:
         resp = client.get("/api/titles/nonexistent")
         assert resp.status_code == 404
 
-    def test_get_title_detail_includes_activity(self, client, title):
+    def test_get_title_detail_includes_sources(self, client, title):
         resp = client.get(f"/api/titles/{title.slug}")
         assert resp.status_code == 200
-        assert "activity" in resp.json()
+        assert "sources" in resp.json()
 
 
 class TestTitlesAllFacets:

--- a/backend/apps/catalog/tests/test_source_enabled.py
+++ b/backend/apps/catalog/tests/test_source_enabled.py
@@ -179,7 +179,7 @@ class TestIsEnabledRelationshipResolution:
 
 
 @pytest.mark.django_db
-class TestIsEnabledActivityPrefetch:
+class TestIsEnabledSourcesPrefetch:
     def test_claims_prefetch_excludes_disabled_source(self, source_a, source_b):
         """_claims_prefetch() should not include claims from disabled sources."""
         from apps.catalog.api.helpers import _claims_prefetch

--- a/docs/plans/user_engagement/RichText.md
+++ b/docs/plans/user_engagement/RichText.md
@@ -1,0 +1,75 @@
+# Rich Text Editing: How Much Editor Do Contributors Need?
+
+## Background
+
+The [UserEngagement](UserEngagement.md) plan bets that Pinbase wins contributors by being a better partner than the alternatives. IPDB has an opaque editorial queue. Wikipedia has intimidating bureaucracy — sourcing standards, notability guidelines, editorial norms. Pinbase's opening is: write something, it's live. No queue, no notability debate, no editorial norms to internalize.
+
+The editor is a separate question from the engagement model. Contributors write in Markdown, which is itself a markup language — a simple one, but invisible to anyone who hasn't used it. Even basic formatting (bold, links, headings) is hidden behind keyboard shortcuts that a new contributor won't know exist. How much tooling is worth building to make that easier?
+
+The answer depends on who the contributors actually are and where the real friction lies. Wikipedia's own research (below) found that removing markup was not the intervention that moved the engagement needle — the social and bureaucratic barriers mattered far more. Pinbase won't have those barriers, so the editor experience could matter more in relative terms, but it's not clear it's the highest-value investment right now.
+
+## The Options
+
+### 1. Current state: wikilinks autocomplete + keyboard shortcuts
+
+The editor already supports `[[wikilink]]` autocomplete (type `[[` and get suggestions) and standard keyboard shortcuts for formatting (Ctrl+B for bold, etc.). Contributors write in Markdown but don't need to know the syntax if they use the shortcuts.
+
+**Pros:** Already built. Zero additional engineering cost. Sufficient for technically comfortable contributors.
+
+**Cons:** Formatting is completely undiscoverable. A contributor who doesn't already know Ctrl+B exists will type plain text and never realize formatting is available. The wikilink syntax (`[[Page Name]]`) is itself a markup convention that has to be learned.
+
+### 2. Toolbar
+
+A formatting toolbar above the editor with buttons for bold, italic, headings, links, wikilinks, and lists. Clicking a button inserts the corresponding Markdown. The contributor still sees Markdown in the editing area, but doesn't need to memorize syntax.
+
+**Pros:** Makes formatting discoverable. Relatively cheap to build (a row of buttons that insert text). Keeps Markdown as the source format, avoiding the complexity of a separate document model. Familiar pattern — GitHub, Stack Overflow, and Discourse all use this approach.
+
+**Cons:** Contributors still see raw Markdown while editing, which can be confusing if they're not expecting it. Doesn't fully deliver on the "no markup language" promise.
+
+### 3. WYSIWYG editor
+
+A full rich text editor (e.g. TipTap, ProseMirror, Lexical) where the editing surface looks like the final output. Bold text appears bold, headings appear large, links are clickable. No Markdown visible.
+
+**Pros:** Fully delivers on the "no markup" promise. Lowest possible barrier to entry for non-technical contributors. The approach used by Notion, Confluence, and modern wiki products.
+
+**Cons:** Significant engineering investment to build and maintain. Requires a document model that round-trips cleanly to/from Markdown storage. Ongoing maintenance burden as editor libraries evolve. Can introduce subtle formatting bugs that are hard to debug.
+
+## Research
+
+### Wikipedia VisualEditor: WYSIWYG didn't move the needle
+
+Wikipedia shipped VisualEditor in 2013 — a full WYSIWYG editor built on a custom engine (Parsoid + OOjs UI) that lets contributors edit without seeing wikitext markup. It was a massive, multi-year engineering investment motivated by declining editor numbers.
+
+The Wikimedia Foundation ran controlled studies on its impact:
+
+- **May 2015 study:** Making VisualEditor the default for new editors showed no significant difference in first-edit rates, editor retention, or total contributions compared to the control group.
+- **Earlier studies:** New editors using VisualEditor weren't reverted or blocked more often (good), but showed a measurable productivity loss — they edited less, likely because the editor was slower than the wikitext editor at the time.
+- The overall measured impact was effectively zero on the metrics that mattered most: getting new people to make a first edit and getting them to come back.
+
+**What this means for Pinbase:** Wikipedia's finding was that the editor wasn't the bottleneck — social barriers were (intimidating norms, reverts of newcomer edits, notability policies, editorial bureaucracy). Pinbase won't have those barriers, so the editor might matter more in relative terms. But the Wikipedia case is strong evidence that a WYSIWYG editor alone doesn't drive engagement, and the engineering cost is high.
+
+Sources: [Wikimedia May 2015 study](https://meta.wikimedia.org/wiki/Research:VisualEditor%27s_effect_on_newly_registered_editors/May_2015_study), [VisualEditor research overview](https://meta.wikimedia.org/wiki/Research:VisualEditor), [VisualEditor/Why](https://en.wikipedia.org/wiki/Wikipedia:VisualEditor/Why)
+
+### Notion vs. Confluence: the whole experience matters more than the editor
+
+An often-cited anecdote: one organization that switched from Confluence to Notion saw their wiki grow from 200 to 800 pages in six months. But this was a complete product switch, not an editor change. Notion's advantage is the overall writing experience — clean interface, fast response, slash commands, drag-and-drop blocks — not any single editor feature.
+
+Confluence has a WYSIWYG editor too, and it didn't prevent the engagement problem. The lesson: a pleasant, responsive writing experience matters more than the specific editor paradigm (WYSIWYG vs. toolbar vs. raw markup). A sluggish WYSIWYG is worse than a fast, clean Markdown editor.
+
+Sources: [Notion vs Confluence 2026 comparison](https://saascrmreview.com/notion-vs-confluence/)
+
+### Stack Overflow: toolbar + preview as the pragmatic middle
+
+Stack Overflow uses a Markdown editor with a formatting toolbar and live preview (Stacks-Editor). They found that real-time preview — seeing the rendered output as you type — was the feature that mattered most for writing quality. They later built a hybrid editor that renders Markdown inline, closer to a WYSIWYG experience but without the complexity of a separate document model.
+
+This is the approach GitHub, Discourse, and most developer-facing community platforms settled on. No controlled engagement studies are publicly available, but the convergence of multiple large platforms on this pattern is signal.
+
+Sources: [Stacks-Editor (GitHub)](https://github.com/StackExchange/Stacks-Editor), [Stack Overflow editor design blog](https://stackoverflow.blog/2008/05/22/potential-markup-and-editing-choices/)
+
+### The missing data: Pinbase's actual contributors
+
+No external study directly answers the question for Pinbase, because the answer depends on who the contributors are. The [UserEngagement](UserEngagement.md) plan describes the initial contributor base as museum-connected pinball enthusiasts — a small, known, motivated group. Key unknowns:
+
+- **Technical comfort.** Do these contributors use Markdown regularly, or is it foreign? If the former, keyboard shortcuts may be sufficient. If the latter, even a toolbar is a meaningful improvement.
+- **Where the drop-off is.** Are people failing to start contributions, or starting and producing poorly-formatted content? The editor choice addresses the second problem, not the first.
+- **What else the engineering time could buy.** Watchlists, recent changes feed, better photo upload, talk pages — features from the UserEngagement plan that might move the engagement needle more than editor polish.

--- a/docs/plans/user_engagement/TargetUsers.md
+++ b/docs/plans/user_engagement/TargetUsers.md
@@ -7,12 +7,12 @@ The core user is someone driven by curiosity and love of the subject, not by a t
 - Historians/archivists who care about preservation for its own sake.
 - People just getting into pinball and wanting the authoritative encyclopedia of all the concepts.
 - Casual fans who just played something cool at a bar and want to know more.
-- Collectors wanting to learn more about the history of their machines, their signifigance, the industry context, ideas for other machines to collect.
+- Collectors wanting to learn more about the history of their machines, their significance, the industry context, ideas for other machines to collect.
 - The general public of the museum, which is probably mostly casual fans, wanting to explore more about what they've seen, are seeing at the moment (via a kiosk at the museum or their phone) or are about to see before they come.
 
 ## Who They Might Be In The Future
 
-- Restorers looking for specs, schematics, parts info. We already have a public read-only version of the Flipfix maintenance site that we hope to grow into a deep resource of repair information for the particular models that the musem owns: the entire maintenance history and conversations around maintenance are public. So there's deep interest from the museum in supporting this community. Adding specs, schematics, parts info to Pinbase would absolutely be right in the museum's mission. Dunno, though, whether we can improve on existing sites around this.
+- Restorers looking for specs, schematics, parts info. We already have a public read-only version of the Flipfix maintenance site that we hope to grow into a deep resource of repair information for the particular models that the museum owns: the entire maintenance history and conversations around maintenance are public. So there's deep interest from the museum in supporting this community. Adding specs, schematics, parts info to Pinbase would absolutely be right in the museum's mission. Dunno, though, whether we can improve on existing sites around this.
 
 ## Who They Are Not
 
@@ -20,34 +20,36 @@ The core user is someone driven by curiosity and love of the subject, not by a t
 - Collectors wanting to value what they own.
 - Operators managing routes and tracking machine performance.
 
-## The Two Modes: Explore and Contribute
+## The Two Profiles: Explore and Contribute
 
-Users roughly fall into two modes:
+Users roughly fall into two profiles:
 
-- **Explore mode**: "I just played Medieval Madness and now I want to fall down a rabbit hole about Williams in the 90s." This is the casual fan, the museum visitor, the person just getting into pinball.
-- **Contribute mode**: "I know things about pinball history that aren't captured anywhere, and I want to help build the definitive record." This is the historian/archivist, and your data entry gaming nerds.
+- **Explorer**: "I just played Medieval Madness and now I want to fall down a rabbit hole about Williams in the 90s." This is the casual fan, the museum visitor, the person just getting into pinball.
+- **Contributor**: "I know things about pinball history that aren't captured anywhere, and I want to help build the definitive record." This is the historian/archivist and the museum-connected enthusiasts.
 
-### The Contribute People
+## The Contributors
 
-According to the museum director, there's pent-up demand among amateur writers/historians because the existing major encyclopedia site, IPDB, has been difficult to work with for years. So I think there's an opportunity here.
+### The opportunity
 
-#### What are they entering
+We suspect there's pent-up demand among amateur pinball writers and historians becuase IPDB, the existing major encyclopedia, has been difficult to work with for years.
 
-- Primarily photos and descriptions
-- For descriptions it's historical context, meditations on gameplay features like interesting quirks in the history of star rollovers, the history of different manufacturers and titles and series and people and locations (like Chicago specifically) etc.
-- For photos it's the museum has their own collection of high-quality photos, people attached to the museum have collections of high-quality photos. I don't think it's someone who happens to have a Gorgar machine that's going to upload, I suspect there are super-uploaders that will upload their entire collection, if we can give them an easy way to do so.
-- They probably won't enter too much structured catalog data because that's pretty complete already.
+This is Pinbase's contributor acquisition strategy: give frustrated IPDB contributors a better home.
 
-#### What makes it meaningful to them
+### What they contribute
 
-What makes them feel like they're building something meaningful vs. doing data entry for someone else's project?
+Two distinct activities that attract different people and need different recognition:
 
-How some sites in the same general ballpark do it:
+**Writing** — original descriptions, historical context, essays on gameplay features (like the evolution of star rollovers), histories of manufacturers, titles, series, people, and places. This is creative, high-effort, high-reward work. It's what makes a page great. A 2,000-word history of Williams' System 11 platform needs to feel like that author's contribution to a shared project, not something that disappeared into the site.
 
-- Wikipedia figured this out — the sense of shared ownership is what sustains it. At Wikipedia, the gamification is subtle — edit counts, barnstar awards, admin status. The primary motivator for most sustained Wikipedia editors is stewardship: "I am the person who maintains the article on Bally Manufacturing, and that matters. On Wikipedia, there's an unspoken understanding that certain editors are the stewards of certain articles.
-- On a subreddit, moderators own the space. Again, ownership.
-- Pinside figured it out differently — reputation and social status.
+**Uploading** — photos, documents, media. The museum has its own collection of high-quality photos, and people attached to the museum have personal collections. Expect super-uploaders who will upload their entire collection if given an easy way to do so, rather than one-off uploads from random owners. Lower effort per item than writing, more mechanical, but still valuable. Batch upload and bulk tagging are core needs, not nice-to-haves. These people may enjoy having more control over how their photos are presented, giving them more control over layouts... just a hypothesis. We know some of these people and can both ask them and user-test features with them.
 
-I think both the ownership and reputation are important planks.
+Contributors probably won't enter that much structured catalog data — that's already fairly complete for historical models. This may be the way that new models get entered, or we may automate scraping manufacturer sites to get this information.
 
-If someone writes a beautiful 2,000-word history of Williams' System 11 platform, they have to feel like that's their contribution to a shared project, that it doesn't just disappear into the site.
+### What makes it meaningful to them
+
+Both ownership and reputation matter:
+
+- **Stewardship**: The Wikipedia model. "I am the person who maintains the article on Bally Manufacturing, and that matters." The identity comes first; game mechanics (edit counts, awards) reinforce it. Contributors need to feel like stewards of a shared project, not data entry workers for someone else's site.
+- **Visibility**: The Pinside model. Contributors are recognized community members. Their name appears on their work, they build a visible contribution history, and the community acknowledges their expertise.
+
+The museum director's background at Wikipedia informs the approach: knowledge as a side-product of well-designed incentives, with stewardship as the foundation and reputation mechanics as reinforcement.

--- a/docs/plans/user_engagement/UserAttribution.md
+++ b/docs/plans/user_engagement/UserAttribution.md
@@ -1,6 +1,18 @@
-# UGC Photo Attribution
+# User Attribution
 
-## Problem Statement
+How Pinbase credits contributors — on articles, on photos, and on profiles.
+
+## Article Attribution
+
+Wikipedia deliberately does not show author credit on articles. There's no byline. Attribution is buried in the edit history tab, where you'd have to scroll through potentially thousands of edits to see who wrote what. Wikipedia's explicit policy is "no one owns an article," and suppressing visible credit reinforces that norm. This works at Wikipedia's scale because the mission and community are strong enough to sustain contribution without personal recognition.
+
+Pinbase is not Wikipedia. At Pinbase's scale — dozens of contributors, not hundreds of thousands — recognition is personal rather than statistical. A contributor who writes a definitive history of the System 11 platform should see evidence of that contribution without digging through an edit log. One approach worth exploring: a "Contributors to this article" line on the article itself, listing the people who've meaningfully edited it. This makes contribution visible without implying single authorship, and it's compatible with the open wiki model — anyone can still edit, and their name joins the list.
+
+The details of how this works (how many names to show, what threshold of contribution earns a listing, how to handle minor edits vs. substantial ones) are design problems to work through. The principle is: contribution to an article should be visible on the article.
+
+## Photo Attribution
+
+### Problem Statement
 
 Pinbase now accepts user-uploaded photos. When a user uploads a photo of a pinball machine, we know internally who uploaded it — but we haven't decided what to show publicly.
 

--- a/docs/plans/user_engagement/UserEngagement.md
+++ b/docs/plans/user_engagement/UserEngagement.md
@@ -1,0 +1,84 @@
+# User Engagement: How Pinbase Builds a Self-Sustaining Knowledge Base
+
+## The Problem
+
+Pinball has a rich, deep history — and it's slowly being lost. The people who know it best are aging out. The existing reference sites are either frozen (IPDB hasn't evolved in years) or noisy (Pinside buries knowledge in forum threads). There's no place where a passionate amateur historian can write a careful essay about the evolution of pop bumpers and have it live alongside authoritative catalog data, credited to them, improvable by others, and durable enough to outlive them.
+
+That last part matters. The goal isn't just to collect knowledge — it's to build something that endures. A contribution to Pinbase should still be useful in 20 years, even if the person who wrote it has moved on. This means the knowledge can't be locked to its original author. It has to be a living document that the community maintains, corrects, and deepens over time.
+
+## The Constraints
+
+Pinbase is a project of The Flip, a volunteer-run museum. This means:
+
+- **No dedicated moderation staff.** The museum director is motivated but time-limited. There is no team sitting in a queue approving edits. Any model that requires a human bottleneck will die the first week the bottleneck is busy.
+- **Small initial contributor base.** At launch, contributors are a known group of museum-connected pinball enthusiasts. The community is small enough that people know each other.
+- **Museum brand attached.** The site carries the museum's credibility. Content that's sloppy, wrong, or vandalized reflects on the institution. The quality floor matters even without paid staff to enforce it.
+
+These constraints rule out two common models:
+
+- **Pre-publication review** (Atlas Obscura, MusicBrainz) requires staff to process a queue. With volunteers, the queue becomes a graveyard.
+- **Single-author content** (blogs, authored contributions) means pages die when their author loses interest. An encyclopedia for future generations can't afford that.
+
+## The Model: Open Wiki, Community-Corrected
+
+Edits go live immediately. No approval queue. No voting. The community self-corrects.
+
+This is Wikipedia's model, and it works because of a counterintuitive insight: **you don't need gatekeepers if you make bad edits cheaper to fix than to prevent.** A one-click revert takes five seconds. A moderation queue takes days and demoralizes the contributor waiting in it.
+
+### Why this works for Pinbase specifically
+
+**The vandalism risk is near zero.** Wikipedia needs semi-protection on articles about politicians and mass shootings because millions of people visit those pages with agendas. Nobody is edit-warring over the Gorgar page. If this ever changes, protection can be added reactively — building for today's actual threat level is smarter than building for Wikipedia's.
+
+**The contributor base is self-selecting.** People who seek out a pinball encyclopedia to write about star rollovers are not the same population that vandalizes Wikipedia. The niche itself is a filter.
+
+**The real risk is quality dilution, not vandalism.** A well-meaning but less skilled editor making a good essay worse. This is a real concern, but it's addressed by visibility and reversibility, not by gates.
+
+## The Bet: Be a Great Partner to Contributors
+
+Before stewardship, before watchlists, before any engagement mechanics — the first thing Pinbase has to get right is the contribution experience itself. The hypothesis is simple: there are people who want to write about pinball history and upload their photo collections, and the existing options are bad enough that a good one wins by default.
+
+IPDB requires submitting to an editorial team. You send in your contribution and wait. Maybe it gets published, maybe it doesn't. You have no control over how it's presented. The process is opaque and slow, and it's been this way for years. There's pent-up frustration among amateur historians who have knowledge to share and no good place to share it.
+
+Wikipedia has the opposite problem: you can publish, but the bureaucracy around formatting, sourcing standards, notability guidelines, and editorial norms is intimidating. Writing a Wikipedia article is a skill in itself, separate from actually knowing the subject.
+
+Pinbase's opening is to be neither. Write something, it's live. Upload photos, they're on the page. No queue, no notability debate, no editorial norms to internalize. The contribution experience should feel like the site is a willing partner — it wants your knowledge and makes it easy to share. (For analysis of how much editor tooling is needed to deliver on this, see [RichText.md](RichText.md).)
+
+This is the MVP of engagement. If the first contribution feels good enough that someone wants to do a second one, everything else follows. If it doesn't, no amount of gamification or community features will compensate.
+
+## Why People Contribute: Stewardship and Visibility
+
+An open wiki only works if people actually show up and write. Two motivations sustain long-term contribution:
+
+### Stewardship
+
+The primary motivator for sustained Wikipedia editors isn't edit counts or badges — it's identity. "I am the person who maintains the article on Bally Manufacturing, and that matters." The steward doesn't own the page, but they feel responsible for it. They watch it, they improve it, they defend it against bad edits. Game mechanics (contribution counts, awards) reinforce this identity, but the identity comes first.
+
+Pinbase needs to foster this. A contributor who writes a definitive history of Williams should feel like the steward of that page — not through exclusive control, but through visible association and the tools to maintain it (watchlists, edit history, their name in the contribution record).
+
+### Visibility
+
+Contributors need to feel recognized for their work. How this works in practice — what's shown on articles, on profiles, on photos — is a design problem with real tradeoffs. See [UserAttribution.md](UserAttribution.md) for the detailed analysis.
+
+## How Quality Sustains Itself: The Correction Flywheel
+
+Stewardship explains why people contribute. But an open wiki also needs mechanisms that make the community self-correcting — so that quality holds without moderators. These mechanisms form a progression, each handling a harder class of problem than the last:
+
+### Edit history
+
+Every version of every page is preserved. Nothing is ever truly lost. This is the foundation that makes everything else possible — contributors are braver about letting others edit their work when they know the original is one click away.
+
+### Recent changes feed
+
+A single page showing every edit across the site, in real time. This is the most underrated feature in Wikipedia's arsenal. Experienced Wikipedia editors are genuinely addicted to the recent changes page — it's how they find problems, discover new content, and feel the pulse of the project. At Pinbase's scale, this feed is small enough to be browsable by anyone who cares. It turns passive readers into active stewards: "I just saw someone edited the Bally page — let me check if it's good."
+
+### Watchlists
+
+Contributors opt in to notifications when pages they care about are edited. This is how stewardship becomes operational: the person who wrote the System 11 essay doesn't approve edits to it, but they _notice_ them and can revert bad ones. The community polices itself because the people who care most are watching.
+
+### One-click revert
+
+Rolling back to any previous version is trivial. This changes the calculus of open editing: the worst case isn't "someone ruins the page," it's "someone ruins the page and it takes 5 seconds to fix." That's an acceptable risk.
+
+### Talk pages
+
+A discussion space attached to each article. Reverts handle clear-cut problems — vandalism, obvious errors. But some disagreements are genuine: "I think the Bally/Williams merger timeline is wrong, here's my source." That's not a revert, it's a conversation. Without a place for that conversation, disagreements become edit wars — two people reverting each other until one gives up. Talk pages turn conflicts into collaborative research. They're also where the community's shared understanding of accuracy develops over time: "We agreed last year that the primary source for this is the 1988 RePlay Magazine interview, not the Rogowski book." That institutional memory is what makes an encyclopedia authoritative rather than just editable.

--- a/frontend/src/lib/components/EntityProvenance.svelte
+++ b/frontend/src/lib/components/EntityProvenance.svelte
@@ -4,11 +4,11 @@
 	type Claim = components['schemas']['ClaimSchema'];
 	type FieldGroup = { field: string; claims: Claim[] };
 
-	let { activity }: { activity: Claim[] } = $props();
+	let { sources }: { sources: Claim[] } = $props();
 
-	let activityGroups = $derived.by(() => {
+	let sourceGroups = $derived.by(() => {
 		const byField: Record<string, Claim[]> = {};
-		for (const claim of activity) {
+		for (const claim of sources) {
 			(byField[claim.field_name] ??= []).push(claim);
 		}
 
@@ -52,23 +52,23 @@
 	{/if}
 {/snippet}
 
-{#if activity.length > 0}
-	{@const { conflicts, agreed, single } = activityGroups}
+{#if sources.length > 0}
+	{@const { conflicts, agreed, single } = sourceGroups}
 	{@const contributorNames = [
 		...new Set(
-			activity
+			sources
 				.map((c) => c.source_name ?? (c.user_display ? `@${c.user_display}` : null))
 				.filter(Boolean)
 		)
 	]}
-	<section class="activity">
+	<section class="sources">
 		<h2>Sources</h2>
-		<p class="activity-summary">
+		<p class="sources-summary">
 			{contributorNames.join(' and ')} contributed to this record.
 		</p>
 
 		{#if conflicts.length > 0}
-			<details class="activity-group" open>
+			<details class="sources-group" open>
 				<summary>
 					<h3>
 						Conflicts resolved ({conflicts.length} field{conflicts.length === 1 ? '' : 's'})
@@ -92,7 +92,7 @@
 		{/if}
 
 		{#if agreed.length > 0}
-			<details class="activity-group">
+			<details class="sources-group">
 				<summary>
 					<h3>Sources agree ({agreed.length} field{agreed.length === 1 ? '' : 's'})</h3>
 				</summary>
@@ -115,7 +115,7 @@
 		{/if}
 
 		{#if single.length > 0}
-			<details class="activity-group">
+			<details class="sources-group">
 				<summary>
 					<h3>Single source ({single.length} field{single.length === 1 ? '' : 's'})</h3>
 				</summary>
@@ -135,7 +135,7 @@
 		{/if}
 	</section>
 {:else}
-	<p class="no-activity">No source data recorded yet.</p>
+	<p class="no-sources">No source data recorded yet.</p>
 {/if}
 
 <style>
@@ -146,29 +146,29 @@
 		margin-bottom: var(--size-3);
 	}
 
-	.activity-summary {
+	.sources-summary {
 		font-size: var(--font-size-1);
 		color: var(--color-text-muted);
 		margin-bottom: var(--size-4);
 	}
 
-	.activity-group {
+	.sources-group {
 		margin-bottom: var(--size-4);
 	}
 
-	.activity-group h3 {
+	.sources-group h3 {
 		font-size: var(--font-size-1);
 		font-weight: 600;
 		color: var(--color-text-primary);
 		margin-bottom: var(--size-2);
 	}
 
-	.activity-group summary {
+	.sources-group summary {
 		cursor: pointer;
 		list-style: revert;
 	}
 
-	.activity-group summary h3 {
+	.sources-group summary h3 {
 		display: inline;
 	}
 
@@ -245,7 +245,7 @@
 		color: var(--color-text-muted);
 	}
 
-	.no-activity {
+	.no-sources {
 		font-size: var(--font-size-1);
 		color: var(--color-text-muted);
 	}

--- a/frontend/src/routes/cabinets/[slug]/+layout.svelte
+++ b/frontend/src/routes/cabinets/[slug]/+layout.svelte
@@ -18,10 +18,10 @@
 	});
 
 	let isDetail = $derived(
-		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/activity')
+		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/sources')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 </script>
 
 <svelte:head>
@@ -46,7 +46,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/cabinets/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/cabinets/${slug}/activity`)}>Activity</Tab>
+		<Tab active={isSources} href={resolve(`/cabinets/${slug}/sources`)}>Sources</Tab>
 	</TabNav>
 
 	{@render children()}

--- a/frontend/src/routes/cabinets/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/cabinets/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.profile.activity} />

--- a/frontend/src/routes/cabinets/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/cabinets/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.profile.activity} />
+<EntityProvenance sources={data.profile.sources} />

--- a/frontend/src/routes/cabinets/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/cabinets/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.profile.activity} />

--- a/frontend/src/routes/corporate-entities/[slug]/+layout.svelte
+++ b/frontend/src/routes/corporate-entities/[slug]/+layout.svelte
@@ -25,11 +25,11 @@
 
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/edit-history')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 </script>
 
@@ -63,9 +63,7 @@
 				{#if auth.isAuthenticated}
 					<Tab active={isEdit} href={resolve(`/corporate-entities/${slug}/edit`)}>Edit</Tab>
 				{/if}
-				<Tab active={isActivity} href={resolve(`/corporate-entities/${slug}/activity`)}
-					>Activity</Tab
-				>
+				<Tab active={isSources} href={resolve(`/corporate-entities/${slug}/sources`)}>Sources</Tab>
 				<Tab active={isEditHistory} href={resolve(`/corporate-entities/${slug}/edit-history`)}
 					>Edit History</Tab
 				>

--- a/frontend/src/routes/corporate-entities/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/corporate-entities/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.corporateEntity.activity} />

--- a/frontend/src/routes/corporate-entities/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/corporate-entities/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.corporateEntity.activity} />
+<EntityProvenance sources={data.corporateEntity.sources} />

--- a/frontend/src/routes/corporate-entities/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/corporate-entities/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.corporateEntity.activity} />

--- a/frontend/src/routes/display-subtypes/[slug]/+layout.svelte
+++ b/frontend/src/routes/display-subtypes/[slug]/+layout.svelte
@@ -18,10 +18,10 @@
 	});
 
 	let isDetail = $derived(
-		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/activity')
+		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/sources')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 </script>
 
 <svelte:head>
@@ -49,7 +49,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/display-subtypes/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/display-subtypes/${slug}/activity`)}>Activity</Tab>
+		<Tab active={isSources} href={resolve(`/display-subtypes/${slug}/sources`)}>Sources</Tab>
 	</TabNav>
 
 	{@render children()}

--- a/frontend/src/routes/display-subtypes/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/display-subtypes/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.profile.activity} />

--- a/frontend/src/routes/display-subtypes/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/display-subtypes/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.profile.activity} />
+<EntityProvenance sources={data.profile.sources} />

--- a/frontend/src/routes/display-subtypes/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/display-subtypes/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.profile.activity} />

--- a/frontend/src/routes/display-types/[slug]/+layout.svelte
+++ b/frontend/src/routes/display-types/[slug]/+layout.svelte
@@ -18,10 +18,10 @@
 	});
 
 	let isDetail = $derived(
-		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/activity')
+		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/sources')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 </script>
 
 <svelte:head>
@@ -49,7 +49,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/display-types/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/display-types/${slug}/activity`)}>Activity</Tab>
+		<Tab active={isSources} href={resolve(`/display-types/${slug}/sources`)}>Sources</Tab>
 	</TabNav>
 
 	{@render children()}

--- a/frontend/src/routes/display-types/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/display-types/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.profile.activity} />

--- a/frontend/src/routes/display-types/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/display-types/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.profile.activity} />
+<EntityProvenance sources={data.profile.sources} />

--- a/frontend/src/routes/display-types/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/display-types/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.profile.activity} />

--- a/frontend/src/routes/franchises/[slug]/+layout.svelte
+++ b/frontend/src/routes/franchises/[slug]/+layout.svelte
@@ -19,11 +19,11 @@
 
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/edit-history')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 </script>
 
@@ -49,7 +49,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/franchises/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/franchises/${slug}/activity`)}>Activity</Tab>
+		<Tab active={isSources} href={resolve(`/franchises/${slug}/sources`)}>Sources</Tab>
 		<Tab active={isEditHistory} href={resolve(`/franchises/${slug}/edit-history`)}>Edit History</Tab
 		>
 	</TabNav>

--- a/frontend/src/routes/franchises/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/franchises/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.franchise.activity} />

--- a/frontend/src/routes/franchises/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/franchises/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.franchise.activity} />
+<EntityProvenance sources={data.franchise.sources} />

--- a/frontend/src/routes/franchises/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/franchises/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.franchise.activity} />

--- a/frontend/src/routes/game-formats/[slug]/+layout.svelte
+++ b/frontend/src/routes/game-formats/[slug]/+layout.svelte
@@ -18,10 +18,10 @@
 	});
 
 	let isDetail = $derived(
-		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/activity')
+		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/sources')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 </script>
 
 <svelte:head>
@@ -49,7 +49,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/game-formats/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/game-formats/${slug}/activity`)}>Activity</Tab>
+		<Tab active={isSources} href={resolve(`/game-formats/${slug}/sources`)}>Sources</Tab>
 	</TabNav>
 
 	{@render children()}

--- a/frontend/src/routes/game-formats/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/game-formats/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.profile.activity} />

--- a/frontend/src/routes/game-formats/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/game-formats/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.profile.activity} />
+<EntityProvenance sources={data.profile.sources} />

--- a/frontend/src/routes/game-formats/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/game-formats/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.profile.activity} />

--- a/frontend/src/routes/gameplay-features/[slug]/+layout.svelte
+++ b/frontend/src/routes/gameplay-features/[slug]/+layout.svelte
@@ -38,12 +38,12 @@
 	);
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/edit-history') &&
 			!isMedia
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 </script>
 
@@ -75,8 +75,7 @@
 				{#if auth.isAuthenticated}
 					<Tab active={isEdit} href={resolve(`/gameplay-features/${slug}/edit`)}>Edit</Tab>
 				{/if}
-				<Tab active={isActivity} href={resolve(`/gameplay-features/${slug}/activity`)}>Activity</Tab
-				>
+				<Tab active={isSources} href={resolve(`/gameplay-features/${slug}/sources`)}>Sources</Tab>
 				<Tab active={isEditHistory} href={resolve(`/gameplay-features/${slug}/edit-history`)}
 					>Edit History</Tab
 				>

--- a/frontend/src/routes/gameplay-features/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/gameplay-features/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.profile.activity} />

--- a/frontend/src/routes/gameplay-features/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/gameplay-features/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.profile.activity} />
+<EntityProvenance sources={data.profile.sources} />

--- a/frontend/src/routes/gameplay-features/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/gameplay-features/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.profile.activity} />

--- a/frontend/src/routes/manufacturers/[slug]/+layout.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+layout.svelte
@@ -33,13 +33,13 @@
 	);
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/systems') &&
 			!page.url.pathname.endsWith('/edit-history') &&
 			!isMedia
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 
 	function websiteHostname(url: string): string {
@@ -76,7 +76,7 @@
 				{#if auth.isAuthenticated}
 					<Tab active={isEdit} href={resolve(`/manufacturers/${slug}/edit`)}>Edit</Tab>
 				{/if}
-				<Tab active={isActivity} href={resolve(`/manufacturers/${slug}/activity`)}>Activity</Tab>
+				<Tab active={isSources} href={resolve(`/manufacturers/${slug}/sources`)}>Sources</Tab>
 				<Tab active={isEditHistory} href={resolve(`/manufacturers/${slug}/edit-history`)}
 					>Edit History</Tab
 				>

--- a/frontend/src/routes/manufacturers/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.manufacturer.activity} />

--- a/frontend/src/routes/manufacturers/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.manufacturer.activity} />
+<EntityProvenance sources={data.manufacturer.sources} />

--- a/frontend/src/routes/manufacturers/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.manufacturer.activity} />

--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -30,12 +30,12 @@
 	);
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/edit-history') &&
 			!isMedia
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 
 	let parentLink = $derived(
@@ -92,7 +92,7 @@
 				{#if auth.isAuthenticated}
 					<Tab active={isEdit} href={resolve(`/models/${slug}/edit`)}>Edit</Tab>
 				{/if}
-				<Tab active={isActivity} href={resolve(`/models/${slug}/activity`)}>Activity</Tab>
+				<Tab active={isSources} href={resolve(`/models/${slug}/sources`)}>Sources</Tab>
 				<Tab active={isEditHistory} href={resolve(`/models/${slug}/edit-history`)}>Edit History</Tab
 				>
 			</TabNav>

--- a/frontend/src/routes/models/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/models/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.model.activity} />

--- a/frontend/src/routes/models/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/models/[slug]/edit/+page.svelte
@@ -186,7 +186,7 @@
 			</p>
 			<div class="merged-actions">
 				<a href={resolveHref(`/titles/${model.title.slug}/edit`)}>Edit title facts</a>
-				<a href={resolveHref(`/titles/${model.title.slug}/activity`)}>Title activity</a>
+				<a href={resolveHref(`/titles/${model.title.slug}/sources`)}>Title sources</a>
 			</div>
 		</section>
 	{/if}

--- a/frontend/src/routes/models/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/models/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.model.activity} />
+<EntityProvenance sources={data.model.sources} />

--- a/frontend/src/routes/models/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/models/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.model.activity} />

--- a/frontend/src/routes/people/[slug]/+layout.svelte
+++ b/frontend/src/routes/people/[slug]/+layout.svelte
@@ -20,12 +20,12 @@
 	);
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/edit-history') &&
 			!isMedia
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 </script>
 
@@ -45,7 +45,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/people/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/people/${slug}/activity`)}>Activity</Tab>
+		<Tab active={isSources} href={resolve(`/people/${slug}/sources`)}>Sources</Tab>
 		<Tab active={isEditHistory} href={resolve(`/people/${slug}/edit-history`)}>Edit History</Tab>
 	</TabNav>
 

--- a/frontend/src/routes/people/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/people/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.person.activity} />

--- a/frontend/src/routes/people/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/people/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.person.activity} />
+<EntityProvenance sources={data.person.sources} />

--- a/frontend/src/routes/people/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/people/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.person.activity} />

--- a/frontend/src/routes/reward-types/[slug]/+layout.svelte
+++ b/frontend/src/routes/reward-types/[slug]/+layout.svelte
@@ -18,10 +18,10 @@
 	});
 
 	let isDetail = $derived(
-		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/activity')
+		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/sources')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 </script>
 
 <svelte:head>
@@ -49,7 +49,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/reward-types/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/reward-types/${slug}/activity`)}>Activity</Tab>
+		<Tab active={isSources} href={resolve(`/reward-types/${slug}/sources`)}>Sources</Tab>
 	</TabNav>
 
 	{@render children()}

--- a/frontend/src/routes/reward-types/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/reward-types/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.profile.activity} />

--- a/frontend/src/routes/reward-types/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/reward-types/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.profile.activity} />
+<EntityProvenance sources={data.profile.sources} />

--- a/frontend/src/routes/reward-types/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/reward-types/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.profile.activity} />

--- a/frontend/src/routes/series/[slug]/+layout.svelte
+++ b/frontend/src/routes/series/[slug]/+layout.svelte
@@ -19,11 +19,11 @@
 
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/edit-history')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 </script>
 
@@ -49,7 +49,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/series/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/series/${slug}/activity`)}>Activity</Tab>
+		<Tab active={isSources} href={resolve(`/series/${slug}/sources`)}>Sources</Tab>
 		<Tab active={isEditHistory} href={resolve(`/series/${slug}/edit-history`)}>Edit History</Tab>
 	</TabNav>
 

--- a/frontend/src/routes/series/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/series/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.series.activity} />

--- a/frontend/src/routes/series/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/series/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.series.activity} />
+<EntityProvenance sources={data.series.sources} />

--- a/frontend/src/routes/series/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/series/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.series.activity} />

--- a/frontend/src/routes/systems/[slug]/+layout.svelte
+++ b/frontend/src/routes/systems/[slug]/+layout.svelte
@@ -23,11 +23,11 @@
 
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/edit-history')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 </script>
 
@@ -55,7 +55,7 @@
 				{#if auth.isAuthenticated}
 					<Tab active={isEdit} href={resolve(`/systems/${slug}/edit`)}>Edit</Tab>
 				{/if}
-				<Tab active={isActivity} href={resolve(`/systems/${slug}/activity`)}>Activity</Tab>
+				<Tab active={isSources} href={resolve(`/systems/${slug}/sources`)}>Sources</Tab>
 				<Tab active={isEditHistory} href={resolve(`/systems/${slug}/edit-history`)}
 					>Edit History</Tab
 				>

--- a/frontend/src/routes/systems/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/systems/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.system.activity} />

--- a/frontend/src/routes/systems/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/systems/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.system.activity} />
+<EntityProvenance sources={data.system.sources} />

--- a/frontend/src/routes/systems/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/systems/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.system.activity} />

--- a/frontend/src/routes/tags/[slug]/+layout.svelte
+++ b/frontend/src/routes/tags/[slug]/+layout.svelte
@@ -18,10 +18,10 @@
 	});
 
 	let isDetail = $derived(
-		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/activity')
+		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/sources')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 </script>
 
 <svelte:head>
@@ -46,7 +46,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/tags/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/tags/${slug}/activity`)}>Activity</Tab>
+		<Tab active={isSources} href={resolve(`/tags/${slug}/sources`)}>Sources</Tab>
 	</TabNav>
 
 	{@render children()}

--- a/frontend/src/routes/tags/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/tags/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.profile.activity} />

--- a/frontend/src/routes/tags/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/tags/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.profile.activity} />
+<EntityProvenance sources={data.profile.sources} />

--- a/frontend/src/routes/tags/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/tags/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.profile.activity} />

--- a/frontend/src/routes/technology-generations/[slug]/+layout.svelte
+++ b/frontend/src/routes/technology-generations/[slug]/+layout.svelte
@@ -18,10 +18,10 @@
 	});
 
 	let isDetail = $derived(
-		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/activity')
+		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/sources')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 </script>
 
 <svelte:head>
@@ -49,9 +49,7 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/technology-generations/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/technology-generations/${slug}/activity`)}
-			>Activity</Tab
-		>
+		<Tab active={isSources} href={resolve(`/technology-generations/${slug}/sources`)}>Sources</Tab>
 	</TabNav>
 
 	{@render children()}

--- a/frontend/src/routes/technology-generations/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/technology-generations/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.profile.activity} />

--- a/frontend/src/routes/technology-generations/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/technology-generations/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.profile.activity} />
+<EntityProvenance sources={data.profile.sources} />

--- a/frontend/src/routes/technology-generations/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/technology-generations/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.profile.activity} />

--- a/frontend/src/routes/technology-subgenerations/[slug]/+layout.svelte
+++ b/frontend/src/routes/technology-subgenerations/[slug]/+layout.svelte
@@ -18,10 +18,10 @@
 	});
 
 	let isDetail = $derived(
-		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/activity')
+		!page.url.pathname.endsWith('/edit') && !page.url.pathname.endsWith('/sources')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 </script>
 
 <svelte:head>
@@ -49,8 +49,8 @@
 		{#if auth.isAuthenticated}
 			<Tab active={isEdit} href={resolve(`/technology-subgenerations/${slug}/edit`)}>Edit</Tab>
 		{/if}
-		<Tab active={isActivity} href={resolve(`/technology-subgenerations/${slug}/activity`)}
-			>Activity</Tab
+		<Tab active={isSources} href={resolve(`/technology-subgenerations/${slug}/sources`)}
+			>Sources</Tab
 		>
 	</TabNav>
 

--- a/frontend/src/routes/technology-subgenerations/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/technology-subgenerations/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.profile.activity} />

--- a/frontend/src/routes/technology-subgenerations/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/technology-subgenerations/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.profile.activity} />
+<EntityProvenance sources={data.profile.sources} />

--- a/frontend/src/routes/technology-subgenerations/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/technology-subgenerations/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.profile.activity} />

--- a/frontend/src/routes/themes/[slug]/+layout.svelte
+++ b/frontend/src/routes/themes/[slug]/+layout.svelte
@@ -23,11 +23,11 @@
 
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/edit-history')
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 </script>
 
@@ -55,7 +55,7 @@
 				{#if auth.isAuthenticated}
 					<Tab active={isEdit} href={resolve(`/themes/${slug}/edit`)}>Edit</Tab>
 				{/if}
-				<Tab active={isActivity} href={resolve(`/themes/${slug}/activity`)}>Activity</Tab>
+				<Tab active={isSources} href={resolve(`/themes/${slug}/sources`)}>Sources</Tab>
 				<Tab active={isEditHistory} href={resolve(`/themes/${slug}/edit-history`)}>Edit History</Tab
 				>
 			</TabNav>

--- a/frontend/src/routes/themes/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/themes/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.theme.activity} />

--- a/frontend/src/routes/themes/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/themes/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.theme.activity} />
+<EntityProvenance sources={data.theme.sources} />

--- a/frontend/src/routes/themes/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/themes/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.theme.activity} />

--- a/frontend/src/routes/titles/[slug]/+layout.svelte
+++ b/frontend/src/routes/titles/[slug]/+layout.svelte
@@ -33,12 +33,12 @@
 	);
 	let isDetail = $derived(
 		!page.url.pathname.endsWith('/edit') &&
-			!page.url.pathname.endsWith('/activity') &&
+			!page.url.pathname.endsWith('/sources') &&
 			!page.url.pathname.endsWith('/edit-history') &&
 			!isMedia
 	);
 	let isEdit = $derived(page.url.pathname.endsWith('/edit'));
-	let isActivity = $derived(page.url.pathname.endsWith('/activity'));
+	let isSources = $derived(page.url.pathname.endsWith('/sources'));
 	let isEditHistory = $derived(page.url.pathname.endsWith('/edit-history'));
 
 	let metaItems = $derived.by(() => {
@@ -93,7 +93,7 @@
 				{#if auth.isAuthenticated}
 					<Tab active={isEdit} href={resolve(`/titles/${slug}/edit`)}>Edit</Tab>
 				{/if}
-				<Tab active={isActivity} href={resolve(`/titles/${slug}/activity`)}>Activity</Tab>
+				<Tab active={isSources} href={resolve(`/titles/${slug}/sources`)}>Sources</Tab>
 				<Tab active={isEditHistory} href={resolve(`/titles/${slug}/edit-history`)}>Edit History</Tab
 				>
 			</TabNav>

--- a/frontend/src/routes/titles/[slug]/activity/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/activity/+page.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
-
-	let { data } = $props();
-</script>
-
-<EntityProvenance activity={data.title.activity} />

--- a/frontend/src/routes/titles/[slug]/edit/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/edit/+page.svelte
@@ -81,7 +81,7 @@
 			</p>
 			<div class="merged-actions">
 				<a href={resolveHref(boundary.singleModelActions.editHref)}>Edit model facts</a>
-				<a href={resolveHref(boundary.singleModelActions.activityHref)}>Model activity</a>
+				<a href={resolveHref(boundary.singleModelActions.sourcesHref)}>Model sources</a>
 			</div>
 		</section>
 	{/if}

--- a/frontend/src/routes/titles/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/sources/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EntityProvenance sources={data.title.activity} />
+<EntityProvenance sources={data.title.sources} />

--- a/frontend/src/routes/titles/[slug]/sources/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/sources/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import EntityProvenance from '$lib/components/EntityProvenance.svelte';
+
+	let { data } = $props();
+</script>
+
+<EntityProvenance sources={data.title.activity} />

--- a/frontend/src/routes/titles/[slug]/title-edit.test.ts
+++ b/frontend/src/routes/titles/[slug]/title-edit.test.ts
@@ -85,12 +85,12 @@ describe('buildTitlePatchBody', () => {
 });
 
 describe('buildModelBoundary', () => {
-	it('shows direct model edit and activity links for single-model titles', () => {
+	it('shows direct model edit and sources links for single-model titles', () => {
 		expect(buildModelBoundary(singleModelTitle)).toEqual({
 			modelLinks: [],
 			singleModelActions: {
 				editHref: '/models/attack-from-mars/edit',
-				activityHref: '/models/attack-from-mars/activity'
+				sourcesHref: '/models/attack-from-mars/sources'
 			}
 		});
 	});

--- a/frontend/src/routes/titles/[slug]/title-edit.ts
+++ b/frontend/src/routes/titles/[slug]/title-edit.ts
@@ -102,7 +102,7 @@ export function buildTitlePatchBody(
 
 export function buildModelBoundary(title: TitleEditView): {
 	modelLinks: Array<{ slug: string; name: string }>;
-	singleModelActions: { editHref: string; activityHref: string } | null;
+	singleModelActions: { editHref: string; sourcesHref: string } | null;
 } {
 	const singleModelSlug = title.model_detail?.slug ?? null;
 	const modelLinks = singleModelSlug
@@ -123,7 +123,7 @@ export function buildModelBoundary(title: TitleEditView): {
 		singleModelActions: singleModelSlug
 			? {
 					editHref: `/models/${singleModelSlug}/edit`,
-					activityHref: `/models/${singleModelSlug}/activity`
+					sourcesHref: `/models/${singleModelSlug}/sources`
 				}
 			: null
 	};


### PR DESCRIPTION
## Summary

Renames the "Activity" concept to "Sources" across the entire stack — frontend routes/tabs and backend API response fields — to better describe what the tab shows (provenance claims from data sources, not an edit timeline).

- Frontend: renamed `/activity` routes to `/sources`, updated tab labels, updated component prop reads from `.activity` to `.sources`
- Backend: renamed `_build_activity()` → `_build_sources()`, `activity` schema fields → `sources`, updated all serializer dicts and tests
- No model or migration changes — purely a serialization-layer rename

## Test plan

- [x] All 1393 backend tests pass
- [x] All 238 frontend tests pass
- [x] `svelte-check` passes with 0 type errors
- [x] Pre-commit hooks pass (ruff, eslint, prettier, type checks, full test suite)
- [ ] Verify `/titles/{slug}/sources` tab loads and shows claim data
- [ ] Verify `/models/{slug}/sources` tab loads and shows claim data

🤖 Generated with [Claude Code](https://claude.com/claude-code)