### PR TITLE
feat: add user contributions page and inline edit diffs

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -1,16 +1,22 @@
-"""Auth API endpoints: status, login (WorkOS redirect), callback, logout."""
+"""Auth & user API endpoints."""
 
 from __future__ import annotations
 
 import logging
 import secrets
+from collections import defaultdict
 from typing import Optional
 
 from django.conf import settings
 from django.contrib.auth import get_user_model, login, logout
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Count, Max
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.utils.http import url_has_allowed_host_and_scheme
 from ninja import Router, Schema
+
+from apps.provenance.models import ChangeSet, Claim
 
 from .models import UserProfile
 from .workos_client import get_workos_client
@@ -20,6 +26,7 @@ log = logging.getLogger(__name__)
 User = get_user_model()
 
 auth_router = Router(tags=["auth", "private"])
+users_router = Router(tags=["users"])
 
 
 # ── Schemas ──────────────────────────────────────────────────────────
@@ -174,3 +181,162 @@ def auth_logout(request):
     """End the current session."""
     logout(request)
     return {"is_authenticated": False}
+
+
+# ── User profile schemas ───────────────────────────────────────────
+
+
+class EntityContributionSchema(Schema):
+    entity_href: str
+    entity_name: str
+    entity_type_label: str
+    edit_count: int
+    last_edited_at: str
+
+
+class UserChangeSetSchema(Schema):
+    id: int
+    note: str
+    created_at: str
+    entity_href: str
+    entity_name: str
+    entity_type_label: str
+
+
+class UserProfileSchema(Schema):
+    username: str
+    member_since: str
+    edit_count: int
+    entities_edited: list[EntityContributionSchema]
+    recent_edits: list[UserChangeSetSchema]
+
+
+# ── User profile helpers ───────────────────────────────────────────
+
+
+def _resolve_entity_href(model_class, entity) -> str | None:
+    """Build the frontend URL for a catalog entity from its link_url_pattern."""
+    pattern = getattr(model_class, "link_url_pattern", None)
+    if not pattern or not hasattr(entity, "slug"):
+        return None
+    return pattern.format(slug=entity.slug)
+
+
+def _batch_resolve_entities(entity_rows):
+    """Resolve entity metadata from (content_type_id, object_id) pairs.
+
+    Returns a dict mapping (content_type_id, object_id) to
+    {"href": str, "name": str, "type_label": str}, skipping unresolvable
+    entities.
+    """
+    # Group by content_type_id, deduplicating object_ids
+    by_ct: dict[int, set[int]] = defaultdict(set)
+    for row in entity_rows:
+        by_ct[row["content_type_id"]].add(row["object_id"])
+
+    resolved: dict[tuple[int, int], dict] = {}
+    for ct_id, obj_ids in by_ct.items():
+        ct = ContentType.objects.get_for_id(ct_id)
+        model_class = ct.model_class()
+        if not model_class:
+            continue
+        entities = model_class.objects.in_bulk(list(obj_ids))
+        type_label = model_class._meta.verbose_name.title()
+        for obj_id, entity in entities.items():
+            href = _resolve_entity_href(model_class, entity)
+            if href is None:
+                continue
+            resolved[(ct_id, obj_id)] = {
+                "href": href,
+                "name": getattr(entity, "name", str(entity)),
+                "type_label": type_label,
+            }
+    return resolved
+
+
+# ── User profile endpoint ──────────────────────────────────────────
+
+
+@users_router.get("/{username}/", response={200: UserProfileSchema, 404: ErrorSchema})
+def user_profile(request, username: str):
+    """Public profile showing a user's contributions."""
+    user = get_object_or_404(User, username=username)
+
+    edit_count = ChangeSet.objects.filter(user=user).count()
+    member_since = user.profile.created_at.isoformat()
+
+    # Entities edited: distinct (content_type, object_id) from user's claims
+    entity_rows = list(
+        Claim.objects.filter(user=user, changeset__isnull=False)
+        .values("content_type_id", "object_id")
+        .annotate(
+            edit_count=Count("changeset", distinct=True),
+            last_edited_at=Max("changeset__created_at"),
+        )
+        .order_by("-last_edited_at")
+    )
+
+    resolved = _batch_resolve_entities(entity_rows)
+
+    entities_edited = []
+    for row in entity_rows:
+        meta = resolved.get((row["content_type_id"], row["object_id"]))
+        if not meta:
+            continue
+        entities_edited.append(
+            {
+                "entity_href": meta["href"],
+                "entity_name": meta["name"],
+                "entity_type_label": meta["type_label"],
+                "edit_count": row["edit_count"],
+                "last_edited_at": row["last_edited_at"].isoformat(),
+            }
+        )
+
+    # Recent edits: last 50 changesets with entity context
+    recent_changesets = (
+        ChangeSet.objects.filter(user=user)
+        .prefetch_related("claims")
+        .order_by("-created_at")[:50]
+    )
+
+    # Collect entity refs from changesets for batch resolution.
+    # Access the prefetch cache via .all() without slicing to avoid N+1.
+    cs_entity_refs: list[dict] = []
+    cs_first_claim: dict[int, tuple[int, int]] = {}
+    for cs in recent_changesets:
+        prefetched_claims = cs.claims.all()
+        if prefetched_claims:
+            c = prefetched_claims[0]
+            key = (c.content_type_id, c.object_id)
+            cs_first_claim[cs.pk] = key
+            cs_entity_refs.append({"content_type_id": key[0], "object_id": key[1]})
+
+    cs_resolved = _batch_resolve_entities(cs_entity_refs)
+
+    recent_edits = []
+    for cs in recent_changesets:
+        ref = cs_first_claim.get(cs.pk)
+        if not ref:
+            continue
+        meta = cs_resolved.get(ref)
+        if not meta:
+            continue
+        recent_edits.append(
+            {
+                "id": cs.pk,
+                "note": cs.note,
+                "created_at": cs.created_at.isoformat(),
+                "entity_href": meta["href"],
+                "entity_name": meta["name"],
+                "entity_type_label": meta["type_label"],
+            }
+        )
+
+    return {
+        "username": user.username,
+        "member_since": member_since,
+        "edit_count": edit_count,
+        "entities_edited": entities_edited,
+        "recent_edits": recent_edits,
+    }

--- a/backend/apps/accounts/tests/test_user_profile.py
+++ b/backend/apps/accounts/tests/test_user_profile.py
@@ -1,0 +1,232 @@
+"""Tests for GET /api/users/{username}/ endpoint."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from apps.catalog.models import MachineModel, Manufacturer
+from apps.provenance.models import Claim, Source
+
+User = get_user_model()
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="historian")
+
+
+@pytest.fixture
+def bootstrap_source(db):
+    return Source.objects.create(
+        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
+    )
+
+
+@pytest.fixture
+def manufacturer(db, bootstrap_source):
+    mfr = Manufacturer.objects.create(name="Williams", slug="williams")
+    Claim.objects.assert_claim(mfr, "name", "Williams", source=bootstrap_source)
+    return mfr
+
+
+@pytest.fixture
+def model_a(db, bootstrap_source):
+    pm = MachineModel.objects.create(
+        name="Medieval Madness", slug="medieval-madness", year=1997
+    )
+    Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
+    return pm
+
+
+@pytest.fixture
+def model_b(db, bootstrap_source):
+    pm = MachineModel.objects.create(
+        name="Attack from Mars", slug="attack-from-mars", year=1995
+    )
+    Claim.objects.assert_claim(pm, "name", "Attack from Mars", source=bootstrap_source)
+    return pm
+
+
+@pytest.mark.django_db
+class TestUserProfileNotFound:
+    def test_nonexistent_user_returns_404(self, client):
+        resp = client.get("/api/users/nonexistent/")
+        assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+class TestUserProfileEmpty:
+    def test_user_with_no_edits(self, client, user):
+        resp = client.get(f"/api/users/{user.username}/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "historian"
+        assert data["edit_count"] == 0
+        assert data["entities_edited"] == []
+        assert data["recent_edits"] == []
+        assert "member_since" in data
+
+
+@pytest.mark.django_db
+class TestUserProfileWithEdits:
+    def test_single_entity_edit(self, client, user, model_a):
+        """Editing one entity shows up in both entities_edited and recent_edits."""
+        client.force_login(user)
+        client.patch(
+            f"/api/models/{model_a.slug}/claims/",
+            data='{"fields": {"year": 1998}}',
+            content_type="application/json",
+        )
+
+        resp = client.get(f"/api/users/{user.username}/")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["edit_count"] == 1
+        assert len(data["entities_edited"]) == 1
+
+        entity = data["entities_edited"][0]
+        assert entity["entity_href"] == "/models/medieval-madness"
+        assert entity["entity_name"] == "Medieval Madness"
+        assert entity["entity_type_label"] == "Machine Model"
+        assert entity["edit_count"] == 1
+
+        assert len(data["recent_edits"]) == 1
+        edit = data["recent_edits"][0]
+        assert edit["entity_href"] == "/models/medieval-madness"
+        assert edit["entity_name"] == "Medieval Madness"
+
+    def test_multiple_entity_edits_ordered_by_recency(
+        self, client, user, model_a, model_b
+    ):
+        """Entities are ordered by most recently edited."""
+        client.force_login(user)
+        # Edit model_a first
+        client.patch(
+            f"/api/models/{model_a.slug}/claims/",
+            data='{"fields": {"year": 1998}}',
+            content_type="application/json",
+        )
+        # Edit model_b second (more recent)
+        client.patch(
+            f"/api/models/{model_b.slug}/claims/",
+            data='{"fields": {"year": 1996}}',
+            content_type="application/json",
+        )
+
+        resp = client.get(f"/api/users/{user.username}/")
+        data = resp.json()
+
+        assert data["edit_count"] == 2
+        assert len(data["entities_edited"]) == 2
+        # Most recently edited first
+        assert data["entities_edited"][0]["entity_name"] == "Attack from Mars"
+        assert data["entities_edited"][1]["entity_name"] == "Medieval Madness"
+
+        # Recent edits also newest first
+        assert len(data["recent_edits"]) == 2
+        assert data["recent_edits"][0]["entity_name"] == "Attack from Mars"
+        assert data["recent_edits"][1]["entity_name"] == "Medieval Madness"
+
+    def test_multiple_edits_same_entity(self, client, user, model_a):
+        """Multiple edits to one entity count correctly."""
+        client.force_login(user)
+        client.patch(
+            f"/api/models/{model_a.slug}/claims/",
+            data='{"fields": {"year": 1998}}',
+            content_type="application/json",
+        )
+        client.patch(
+            f"/api/models/{model_a.slug}/claims/",
+            data='{"fields": {"year": 1999}}',
+            content_type="application/json",
+        )
+
+        resp = client.get(f"/api/users/{user.username}/")
+        data = resp.json()
+
+        assert data["edit_count"] == 2
+        assert len(data["entities_edited"]) == 1
+        assert data["entities_edited"][0]["edit_count"] == 2
+        assert len(data["recent_edits"]) == 2
+
+    def test_cross_entity_type_edits(self, client, user, model_a, manufacturer):
+        """Edits to different entity types are all included."""
+        client.force_login(user)
+        client.patch(
+            f"/api/models/{model_a.slug}/claims/",
+            data='{"fields": {"year": 1998}}',
+            content_type="application/json",
+        )
+        client.patch(
+            f"/api/manufacturers/{manufacturer.slug}/claims/",
+            data='{"fields": {"description": "A pinball manufacturer."}}',
+            content_type="application/json",
+        )
+
+        resp = client.get(f"/api/users/{user.username}/")
+        data = resp.json()
+
+        assert data["edit_count"] == 2
+        assert len(data["entities_edited"]) == 2
+        entity_types = {e["entity_type_label"] for e in data["entities_edited"]}
+        assert "Machine Model" in entity_types
+        assert "Manufacturer" in entity_types
+
+    def test_other_users_edits_not_included(self, client, user, model_a, db):
+        """Only the requested user's edits appear."""
+        other = User.objects.create_user(username="other")
+        client.force_login(other)
+        client.patch(
+            f"/api/models/{model_a.slug}/claims/",
+            data='{"fields": {"year": 1998}}',
+            content_type="application/json",
+        )
+
+        resp = client.get(f"/api/users/{user.username}/")
+        data = resp.json()
+        assert data["edit_count"] == 0
+        assert data["entities_edited"] == []
+        assert data["recent_edits"] == []
+
+
+@pytest.mark.django_db
+class TestEditHistoryUserDisplayNull:
+    """Verify that _build_edit_history returns null for non-user changesets."""
+
+    def test_ingest_changeset_has_null_user_display(self, client, db):
+        from apps.provenance.models import ChangeSet, IngestRun
+
+        source = Source.objects.create(
+            name="IPDB", slug="ipdb", source_type="database", priority=10
+        )
+        pm = MachineModel.objects.create(name="Gorgar", slug="gorgar", year=1979)
+
+        # Create an ingest changeset with a claim — this is the non-user path
+        ingest_run = IngestRun.objects.create(source=source, input_fingerprint="abc123")
+        ingest_cs = ChangeSet.objects.create(ingest_run=ingest_run)
+        Claim.objects.assert_claim(pm, "year", 1979, source=source, changeset=ingest_cs)
+
+        # Create a user changeset with a claim — this is the user path
+        user = User.objects.create_user(username="tester")
+        user_cs = ChangeSet.objects.create(user=user)
+        Claim.objects.assert_claim(
+            pm,
+            "description",
+            "First talking pinball machine",
+            user=user,
+            changeset=user_cs,
+        )
+
+        resp = client.get(f"/api/models/{pm.slug}/edit-history/")
+        data = resp.json()
+        # Find entries by user_display to avoid ordering assumptions
+        user_entries = [e for e in data if e["user_display"] == "tester"]
+        ingest_entries = [e for e in data if e["user_display"] is None]
+        assert len(user_entries) == 1
+        assert len(ingest_entries) == 1

--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -106,7 +106,7 @@ def _build_edit_history(entity) -> list[dict]:
         result.append(
             {
                 "id": cs.pk,
-                "user_display": cs.user.username if cs.user else "system",
+                "user_display": cs.user.username if cs.user else None,
                 "note": cs.note,
                 "created_at": cs.created_at.isoformat(),
                 "changes": changes,

--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -173,7 +173,7 @@ class ChangeSetSchema(Schema):
     """A grouped edit session with per-field diffs."""
 
     id: int
-    user_display: str
+    user_display: Optional[str] = None
     note: str
     created_at: str
     changes: list[FieldChangeSchema]

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError
 
-from apps.accounts.api import auth_router
+from apps.accounts.api import auth_router, users_router
 from apps.catalog.api import (
     cabinets_router,
     corporate_entities_router,
@@ -72,6 +72,7 @@ def health(request):
 
 
 api.add_router("/auth/", auth_router)
+api.add_router("/users/", users_router)
 api.add_router("/corporate-entities/", corporate_entities_router)
 api.add_router("/display-types/", display_types_router)
 api.add_router("/technology-generations/", technology_generations_router)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
 		"@fortawesome/fontawesome-svg-core": "^7.2.0",
 		"@fortawesome/free-regular-svg-icons": "^7.2.0",
 		"@fortawesome/free-solid-svg-icons": "^7.2.0",
+		"diff": "^8.0.4",
 		"open-props": "^1.7.23",
 		"openapi-fetch": "^0.17.0",
 		"postcss-jit-props": "^1.0.16"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@fortawesome/free-solid-svg-icons':
         specifier: ^7.2.0
         version: 7.2.0
+      diff:
+        specifier: ^8.0.4
+        version: 8.0.4
       open-props:
         specifier: ^1.7.23
         version: 1.7.23
@@ -740,6 +743,10 @@ packages:
 
   devalue@5.6.4:
     resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -1909,6 +1916,8 @@ snapshots:
   deepmerge@4.3.1: {}
 
   devalue@5.6.4: {}
+
+  diff@8.0.4: {}
 
   es-module-lexer@2.0.0: {}
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -44,6 +44,10 @@ html {
 	--color-warning: #b45309;
 	--color-link: #2563eb;
 
+	/* Diff */
+	--color-diff-ins-bg: rgba(22, 163, 74, 0.15);
+	--color-diff-del-bg: rgba(220, 38, 38, 0.15);
+
 	/* Inputs */
 	--color-input-bg: #ffffff;
 	--color-input-border: #d1d5db;
@@ -77,6 +81,10 @@ html {
 		--color-error: #f85149;
 		--color-warning: #fbbf24;
 		--color-link: #4daafc;
+
+		/* Diff */
+		--color-diff-ins-bg: rgba(46, 160, 67, 0.25);
+		--color-diff-del-bg: rgba(248, 81, 73, 0.25);
 
 		/* Inputs */
 		--color-input-bg: #2b2b2b;

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { components } from '$lib/api/schema';
+	import UserBadge from './UserBadge.svelte';
 
 	type ChangeSet = components['schemas']['ChangeSetSchema'];
 
@@ -30,7 +31,7 @@
 			{#each changesets as cs (cs.id)}
 				<li class="changeset">
 					<div class="changeset-header">
-						<span class="user-badge">@{cs.user_display}</span>
+						<UserBadge username={cs.user_display} />
 						<time datetime={cs.created_at}>{formatDate(cs.created_at)}</time>
 					</div>
 					{#if cs.note}
@@ -86,19 +87,6 @@
 		align-items: center;
 		gap: var(--size-2);
 		margin-bottom: var(--size-2);
-	}
-
-	.user-badge {
-		display: inline-block;
-		padding: 1px var(--size-2);
-		font-size: var(--font-size-00, 0.7rem);
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		border-radius: var(--radius-1);
-		background-color: var(--color-surface);
-		border: 1px solid var(--color-border-soft);
-		color: var(--color-text-muted);
 	}
 
 	time {

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
 	import type { components } from '$lib/api/schema';
+	import InlineDiff from './InlineDiff.svelte';
 	import UserBadge from './UserBadge.svelte';
 
 	type ChangeSet = components['schemas']['ChangeSetSchema'];
+	type FieldChange = components['schemas']['FieldChangeSchema'];
 
 	let { changesets }: { changesets: ChangeSet[] } = $props();
+
+	function isDiffable(
+		change: FieldChange
+	): change is FieldChange & { old_value: string; new_value: string } {
+		return (
+			typeof change.old_value === 'string' &&
+			typeof change.new_value === 'string' &&
+			(change.old_value.length > 80 || change.new_value.length > 80)
+		);
+	}
 
 	function formatValue(v: unknown): string {
 		if (v === null || v === undefined || v === '') return '—';
@@ -39,16 +51,25 @@
 					{/if}
 					<dl class="field-list">
 						{#each cs.changes as change (change.claim_key)}
-							<div class="field-row">
-								<dt>{change.field_name}</dt>
-								<dd>
-									{#if change.old_value !== null && change.old_value !== undefined}
-										<span class="old-value">{formatValue(change.old_value)}</span>
-										<span class="arrow">&rarr;</span>
-									{/if}
-									<span class="new-value">{formatValue(change.new_value)}</span>
-								</dd>
-							</div>
+							{#if isDiffable(change)}
+								<div class="field-row field-row-diff">
+									<dt>{change.field_name}</dt>
+									<dd>
+										<InlineDiff oldValue={change.old_value} newValue={change.new_value} />
+									</dd>
+								</div>
+							{:else}
+								<div class="field-row">
+									<dt>{change.field_name}</dt>
+									<dd>
+										{#if change.old_value !== null && change.old_value !== undefined}
+											<span class="old-value">{formatValue(change.old_value)}</span>
+											<span class="arrow">&rarr;</span>
+										{/if}
+										<span class="new-value">{formatValue(change.new_value)}</span>
+									</dd>
+								</div>
+							{/if}
 						{/each}
 					</dl>
 				</li>
@@ -132,6 +153,15 @@
 		gap: var(--size-1);
 		color: var(--color-text-primary);
 		word-break: break-word;
+	}
+
+	.field-row-diff {
+		flex-wrap: wrap;
+	}
+
+	.field-row-diff dd {
+		flex-basis: 100%;
+		display: block;
 	}
 
 	.old-value {

--- a/frontend/src/lib/components/EntityProvenance.svelte
+++ b/frontend/src/lib/components/EntityProvenance.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { components } from '$lib/api/schema';
+	import UserBadge from './UserBadge.svelte';
 
 	type Claim = components['schemas']['ClaimSchema'];
 	type FieldGroup = { field: string; claims: Claim[] };
@@ -42,7 +43,11 @@
 </script>
 
 {#snippet claimDetail(claim: Claim)}
-	<span class="source-badge">{claimAttribution(claim)}</span>
+	{#if claim.user_display}
+		<UserBadge username={claim.user_display} />
+	{:else}
+		<span class="source-badge">{claim.source_name ?? 'Unknown'}</span>
+	{/if}
 	{formatValue(claim.value)}
 	{#if claim.is_winner}
 		<span class="badge-used">used</span>

--- a/frontend/src/lib/components/InlineDiff.svelte
+++ b/frontend/src/lib/components/InlineDiff.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { computeWordDiff } from '$lib/diff';
+
+	let { oldValue, newValue }: { oldValue: string; newValue: string } = $props();
+
+	let segments = $derived(computeWordDiff(oldValue, newValue));
+
+	let container: HTMLDivElement | undefined = $state();
+	let expanded = $state(false);
+	let needsExpansion = $state(false);
+
+	const COLLAPSED_HEIGHT = 200;
+
+	$effect(() => {
+		// Read segments.length to re-fire when diff content changes.
+		void segments.length;
+		if (container) {
+			needsExpansion = container.scrollHeight > COLLAPSED_HEIGHT;
+		}
+	});
+</script>
+
+<div class="diff-container" class:collapsed={needsExpansion && !expanded} bind:this={container}>
+	{#each segments as seg, i (i)}
+		{#if seg.type === 'added'}
+			<ins>{seg.text}</ins>
+		{:else if seg.type === 'removed'}
+			<del>{seg.text}</del>
+		{:else}
+			<span>{seg.text}</span>
+		{/if}
+	{/each}
+</div>
+{#if needsExpansion}
+	<button class="diff-toggle" onclick={() => (expanded = !expanded)}>
+		{expanded ? 'Show less' : 'Show full diff'}
+	</button>
+{/if}
+
+<style>
+	.diff-container {
+		font-size: var(--font-size-0);
+		line-height: var(--font-lineheight-3);
+		word-break: break-word;
+		white-space: pre-wrap;
+	}
+
+	.collapsed {
+		max-height: 200px;
+		overflow: hidden;
+		mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+		-webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+	}
+
+	ins {
+		background-color: var(--color-diff-ins-bg);
+		text-decoration: none;
+		border-radius: 2px;
+		padding: 0 1px;
+	}
+
+	del {
+		background-color: var(--color-diff-del-bg);
+		text-decoration: line-through;
+		border-radius: 2px;
+		padding: 0 1px;
+		opacity: 0.7;
+	}
+
+	.diff-toggle {
+		background: none;
+		border: none;
+		color: var(--color-accent);
+		font-size: var(--font-size-0);
+		padding: var(--size-1) 0 0;
+		cursor: pointer;
+	}
+
+	.diff-toggle:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/frontend/src/lib/components/UserBadge.svelte
+++ b/frontend/src/lib/components/UserBadge.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { resolveHref } from '$lib/utils';
+
+	let { username }: { username: string | null | undefined } = $props();
+</script>
+
+{#if username}
+	<a href={resolveHref(`/users/${username}`)} class="user-badge">@{username}</a>
+{:else}
+	<span class="user-badge">system</span>
+{/if}
+
+<style>
+	.user-badge {
+		display: inline-block;
+		padding: 1px var(--size-2);
+		font-size: var(--font-size-00, 0.7rem);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		border-radius: var(--radius-1);
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-soft);
+		color: var(--color-text-muted);
+		text-decoration: none;
+	}
+
+	a.user-badge {
+		color: var(--color-accent);
+		border-color: var(--color-accent);
+	}
+
+	a.user-badge:hover {
+		background-color: var(--color-accent);
+		color: var(--color-surface);
+	}
+</style>

--- a/frontend/src/lib/diff.test.ts
+++ b/frontend/src/lib/diff.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { computeWordDiff } from './diff';
+
+describe('computeWordDiff', () => {
+	it('returns a single unchanged segment for identical strings', () => {
+		const segments = computeWordDiff('hello world', 'hello world');
+		expect(segments.every((s) => s.type === 'unchanged')).toBe(true);
+		expect(segments.map((s) => s.text).join('')).toBe('hello world');
+	});
+
+	it('detects a word insertion', () => {
+		const segments = computeWordDiff('hello world', 'hello brave world');
+		const added = segments.filter((s) => s.type === 'added');
+		expect(added.length).toBeGreaterThan(0);
+		expect(added.map((s) => s.text).join('')).toContain('brave');
+	});
+
+	it('detects a word deletion', () => {
+		const segments = computeWordDiff('hello brave world', 'hello world');
+		const removed = segments.filter((s) => s.type === 'removed');
+		expect(removed.length).toBeGreaterThan(0);
+		expect(removed.map((s) => s.text).join('')).toContain('brave');
+	});
+
+	it('detects a word replacement', () => {
+		const segments = computeWordDiff('the quick fox', 'the slow fox');
+		const removed = segments.filter((s) => s.type === 'removed');
+		const added = segments.filter((s) => s.type === 'added');
+		expect(removed.map((s) => s.text).join('')).toContain('quick');
+		expect(added.map((s) => s.text).join('')).toContain('slow');
+	});
+
+	it('handles empty old string (full insertion)', () => {
+		const segments = computeWordDiff('', 'new content');
+		expect(segments.every((s) => s.type === 'added')).toBe(true);
+		expect(segments.map((s) => s.text).join('')).toBe('new content');
+	});
+
+	it('handles empty new string (full deletion)', () => {
+		const segments = computeWordDiff('old content', '');
+		expect(segments.every((s) => s.type === 'removed')).toBe(true);
+		expect(segments.map((s) => s.text).join('')).toBe('old content');
+	});
+
+	it('preserves newline characters in segment text', () => {
+		const old = 'line one\nline two';
+		const next = 'line one\nline two\nline three';
+		const segments = computeWordDiff(old, next);
+		const allText = segments.map((s) => s.text).join('');
+		expect(allText).toContain('\n');
+		expect(allText).toBe('line one\nline two\nline three');
+	});
+
+	it('detects whitespace-only edits (added paragraph break)', () => {
+		const old = 'paragraph one\nparagraph two';
+		const next = 'paragraph one\n\nparagraph two';
+		const segments = computeWordDiff(old, next);
+		const added = segments.filter((s) => s.type === 'added');
+		expect(added.length).toBeGreaterThan(0);
+	});
+
+	it('handles a realistic markdown description change', () => {
+		const old =
+			'The Gorgar was a groundbreaking machine released by Williams in 1979. It was the first pinball machine to feature synthesized speech.';
+		const next =
+			'The Gorgar was a groundbreaking machine released by Williams in 1979. It was the first pinball machine to feature synthesized speech, using a vocabulary of seven words.';
+		const segments = computeWordDiff(old, next);
+		const added = segments.filter((s) => s.type === 'added');
+		expect(added.map((s) => s.text).join('')).toContain('vocabulary');
+		// Original text is still present in unchanged segments
+		const unchanged = segments.filter((s) => s.type === 'unchanged');
+		expect(unchanged.map((s) => s.text).join('')).toContain('groundbreaking');
+	});
+});

--- a/frontend/src/lib/diff.ts
+++ b/frontend/src/lib/diff.ts
@@ -1,0 +1,20 @@
+import { diffWordsWithSpace } from 'diff';
+
+export type DiffSegment = {
+	text: string;
+	type: 'added' | 'removed' | 'unchanged';
+};
+
+/**
+ * Compute a word-level diff between two strings.
+ *
+ * Uses diffWordsWithSpace (not diffWords) so whitespace-only changes
+ * like added paragraph breaks are visible in the output.
+ */
+export function computeWordDiff(oldText: string, newText: string): DiffSegment[] {
+	const changes = diffWordsWithSpace(oldText, newText);
+	return changes.map((c) => ({
+		text: c.value,
+		type: c.added ? 'added' : c.removed ? 'removed' : 'unchanged'
+	}));
+}

--- a/frontend/src/routes/users/[username]/+page.svelte
+++ b/frontend/src/routes/users/[username]/+page.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+	import { SITE_NAME } from '$lib/constants';
+	import { resolveHref } from '$lib/utils';
+
+	let { data } = $props();
+	let { profile } = data;
+
+	function formatDate(iso: string): string {
+		return new Date(iso).toLocaleDateString('en', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		});
+	}
+
+	function formatDateTime(iso: string): string {
+		return new Date(iso).toLocaleDateString('en', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit'
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>@{profile.username} — {SITE_NAME}</title>
+</svelte:head>
+
+<div class="profile-page">
+	<header class="profile-header">
+		<h1>@{profile.username}</h1>
+		<p class="meta">
+			Member since {formatDate(profile.member_since)} · {profile.edit_count}
+			{profile.edit_count === 1 ? 'edit' : 'edits'}
+		</p>
+	</header>
+
+	{#if profile.entities_edited.length > 0}
+		<section class="section">
+			<h2>Entities edited</h2>
+			<ul class="entity-list">
+				{#each profile.entities_edited as entity (entity.entity_href)}
+					<li class="entity-item">
+						<a href={resolveHref(entity.entity_href)} class="entity-link">
+							<span class="entity-name">{entity.entity_name}</span>
+							<span class="entity-type">{entity.entity_type_label}</span>
+						</a>
+						<span class="entity-meta">
+							{entity.edit_count}
+							{entity.edit_count === 1 ? 'edit' : 'edits'} · last {formatDate(
+								entity.last_edited_at
+							)}
+						</span>
+					</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
+
+	{#if profile.recent_edits.length > 0}
+		<section class="section">
+			<h2>Recent edits</h2>
+			<ol class="edit-list">
+				{#each profile.recent_edits as edit (edit.id)}
+					<li class="edit-item">
+						<div class="edit-header">
+							<a href={resolveHref(edit.entity_href)} class="entity-link">
+								<span class="entity-name">{edit.entity_name}</span>
+								<span class="entity-type">{edit.entity_type_label}</span>
+							</a>
+							<time datetime={edit.created_at}>{formatDateTime(edit.created_at)}</time>
+						</div>
+						{#if edit.note}
+							<p class="edit-note">{edit.note}</p>
+						{/if}
+					</li>
+				{/each}
+			</ol>
+		</section>
+	{/if}
+
+	{#if profile.entities_edited.length === 0 && profile.recent_edits.length === 0}
+		<p class="no-edits">No contributions yet.</p>
+	{/if}
+</div>
+
+<style>
+	.profile-page {
+		padding: var(--size-5) 0;
+	}
+
+	.profile-header {
+		margin-bottom: var(--size-6);
+	}
+
+	.profile-header h1 {
+		font-size: var(--font-size-5);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin: 0 0 var(--size-1) 0;
+	}
+
+	.meta {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+		margin: 0;
+	}
+
+	.section {
+		margin-bottom: var(--size-6);
+	}
+
+	.section h2 {
+		font-size: var(--font-size-3);
+		font-weight: 600;
+		color: var(--color-text-primary);
+		margin-bottom: var(--size-3);
+	}
+
+	.entity-list,
+	.edit-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+	}
+
+	.entity-item,
+	.edit-item {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: var(--size-2);
+		padding: var(--size-2) 0;
+		border-bottom: 1px solid var(--color-border-soft);
+	}
+
+	.entity-item:last-child,
+	.edit-item:last-child {
+		border-bottom: none;
+	}
+
+	.entity-link {
+		display: inline-flex;
+		align-items: baseline;
+		gap: var(--size-2);
+		text-decoration: none;
+		color: var(--color-text-primary);
+	}
+
+	.entity-link:hover .entity-name {
+		color: var(--color-accent);
+	}
+
+	.entity-name {
+		font-weight: 500;
+	}
+
+	.entity-type {
+		font-size: var(--font-size-00, 0.7rem);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--color-text-muted);
+		padding: 1px var(--size-2);
+		border-radius: var(--radius-1);
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border-soft);
+	}
+
+	.entity-meta {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+	}
+
+	.edit-header {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: var(--size-2);
+		width: 100%;
+	}
+
+	.edit-header time {
+		font-size: var(--font-size-0);
+		color: var(--color-text-muted);
+		margin-left: auto;
+	}
+
+	.edit-note {
+		width: 100%;
+		font-size: var(--font-size-0);
+		font-style: italic;
+		color: var(--color-text-muted);
+		margin: var(--size-1) 0 0 0;
+	}
+
+	.no-edits {
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+	}
+</style>

--- a/frontend/src/routes/users/[username]/+page.ts
+++ b/frontend/src/routes/users/[username]/+page.ts
@@ -1,0 +1,19 @@
+import client from '$lib/api/client';
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const prerender = false;
+export const ssr = false;
+
+export const load: PageLoad = async ({ params }) => {
+	const { data, response } = await client.GET('/api/users/{username}/', {
+		params: { path: { username: params.username } }
+	});
+
+	if (!data) {
+		if (response?.status === 404) error(404, 'User not found');
+		error(500, 'Failed to load user profile');
+	}
+
+	return { profile: data };
+};


### PR DESCRIPTION
## Summary

Add a public user contributions page at `/users/{username}` showing edit history across all entities, plus inline word-level diffs in the Edit History tab.

- New backend endpoint `GET /api/users/{username}/` returns contribution summary with resolved entity hrefs
- New `UserBadge` component makes `@username` references clickable links to profile pages
- Edit History tab now shows highlighted word-level insertions/deletions for long text fields instead of truncated old/new values
- Backend tests and frontend diff unit tests included

## Test plan

- [ ] Visit `/users/{username}` for a user with edits — verify entity list and recent edits display
- [ ] Visit `/users/{username}` for a non-existent user — verify 404 handling
- [ ] Check Edit History tab on any entity with text field edits — verify inline diffs render correctly
- [ ] Click a `@username` badge in edit history or provenance — verify it links to the user's contributions page
- [ ] Run `make test` — all backend and frontend tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)