### PR TITLE
feat(media): show user attribution in lightbox

### DIFF
--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -13,7 +13,7 @@ def _media_prefetch():
         "entity_media",
         queryset=EntityMedia.objects.filter(
             asset__status="ready",
-        ).select_related("asset"),
+        ).select_related("asset", "asset__uploaded_by"),
         to_attr="all_media",
     )
 
@@ -27,6 +27,9 @@ def _serialize_uploaded_media(all_media) -> list[dict]:
             "asset_uuid": str(em.asset.uuid),
             "category": em.category,
             "is_primary": em.is_primary,
+            "uploaded_by_username": (
+                em.asset.uploaded_by.username if em.asset.uploaded_by else None
+            ),
             "renditions": {
                 "thumb": build_public_url(build_storage_key(em.asset.uuid, "thumb")),
                 "display": build_public_url(

--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -174,4 +174,5 @@ class UploadedMediaSchema(Schema):
     asset_uuid: str
     category: Optional[str] = None
     is_primary: bool
+    uploaded_by_username: Optional[str] = None
     renditions: MediaRenditionsSchema

--- a/backend/apps/media/tests/test_api_response.py
+++ b/backend/apps/media/tests/test_api_response.py
@@ -294,6 +294,7 @@ class TestModelDetailApiResponse:
             assert "display" in item["renditions"]
             assert "category" in item
             assert "is_primary" in item
+            assert item["uploaded_by_username"] == user.username
 
     def test_detail_uploaded_media_empty(self, client, machine_model):
         resp = client.get(f"/api/models/{machine_model.slug}")

--- a/docs/plans/user_engagement/UserAttribution.md
+++ b/docs/plans/user_engagement/UserAttribution.md
@@ -86,3 +86,20 @@ Always record who the photographer is (required, defaults to the uploader's name
 
 - **Why it could work:** Cleanest data — always knows the photographer, separately from the display preference. No ambiguity between "didn't fill it in" and "wants to be anonymous." Closest to the Wikimedia model.
 - **Why it might not:** Two controls on an upload form is more friction than one. The distinction between "who took this" and "should we show it" is meaningful at Wikimedia's scale but probably over-engineered for Pinbase's current stage. A required credit field adds friction even when the uploader is the photographer (the common case).
+
+## Decision
+
+**Option A now, with a path to C later.**
+
+Start by always showing the uploader's display name on the photo detail/lightbox view. No new fields, no configuration — just surface what we already track (`uploaded_by`). Gallery thumbnails stay clean with no attribution.
+
+This is the right first step because:
+
+- It's the simplest thing that works. No new data model, no upload UX changes.
+- It establishes attribution as a norm from day one, before habits form around anonymity.
+- Every photo uploaded under Option A remains correctly attributed if we later add opt-out or photographer override — no backfill needed.
+
+**Future additions (not committed, just preserved as options):**
+
+- **Opt-out:** Add an optional mechanism for uploaders to hide their name. Could be per-photo or account-wide. Only worth adding if users actually request it.
+- **Photographer credit:** Add an optional field for crediting someone other than the uploader. Only worth adding if the "uploader ≠ photographer" case turns out to be common in practice.

--- a/frontend/src/lib/components/media/MediaLightbox.svelte
+++ b/frontend/src/lib/components/media/MediaLightbox.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolveHref } from '$lib/utils';
 	import type { components } from '$lib/api/schema';
 
 	type UploadedMedia = components['schemas']['UploadedMediaSchema'];
@@ -61,6 +62,14 @@
 			<div class="lightbox-footer">
 				{#if item.category}
 					<span class="category">{item.category}</span>
+				{/if}
+				{#if item.uploaded_by_username}
+					<span class="uploader">
+						Uploaded by <a
+							href={resolveHref(`/users/${item.uploaded_by_username}`)}
+							class="uploader-link">{item.uploaded_by_username}</a
+						>
+					</span>
 				{/if}
 				<span class="counter">{index + 1} / {media.length}</span>
 			</div>
@@ -150,11 +159,17 @@
 
 	.lightbox-footer {
 		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
+		justify-content: center;
 		gap: var(--size-3);
 		margin-top: var(--size-2);
 		color: rgba(255, 255, 255, 0.7);
 		font-size: var(--font-size-1);
+	}
+
+	.uploader-link {
+		color: var(--color-link);
 	}
 
 	@media (max-width: 640px) {


### PR DESCRIPTION
## Summary

- Add `uploaded_by_username` to the media API response (via `UploadedMediaSchema`)
- Prefetch uploader in `_media_prefetch()` to avoid N+1 queries
- Display "Uploaded by {username}" in the photo lightbox footer, with username linking to `/users/{username}`
- Gallery thumbnails remain clean with no attribution
- Document the Option A decision in UserAttribution.md

## Test plan

- [x] Backend test asserts `uploaded_by_username` is present and correct in API response
- [ ] Manual: open a machine model's media tab, click a photo, confirm lightbox shows "Uploaded by {username}" with a working profile link
- [ ] Manual: confirm gallery thumbnails show no attribution
- [ ] Manual: on a narrow viewport, confirm the footer wraps gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)