### PR TITLE
feat: resolution boundary + per-field revert

### DIFF
--- a/backend/apps/catalog/_alias_registry.py
+++ b/backend/apps/catalog/_alias_registry.py
@@ -1,0 +1,37 @@
+"""Alias-type discovery from AliasBase subclasses.
+
+Shared module that both ``claims.py`` and ``resolve/`` can import without
+creating circular dependencies — it only touches ``core.models.AliasBase``.
+"""
+
+from __future__ import annotations
+
+import functools
+
+
+@functools.lru_cache(maxsize=1)
+def discover_alias_types() -> tuple[tuple[type, str], ...]:
+    """Return ``((parent_model, claim_field_name), ...)`` for every AliasBase subclass.
+
+    Must be called after Django's app registry is ready (i.e. not at import
+    time).  Results are cached after the first call.
+    """
+    from apps.core.models import AliasBase
+
+    result: list[tuple[type, str]] = []
+    for alias_cls in AliasBase.__subclasses__():
+        # Each AliasBase subclass has exactly one FK to its parent model.
+        fks = [
+            f
+            for f in alias_cls._meta.get_fields()
+            if hasattr(f, "related_model") and f.many_to_one
+        ]
+        if len(fks) != 1:
+            raise RuntimeError(
+                f"{alias_cls.__name__} has {len(fks)} ForeignKeys; expected exactly 1"
+            )
+        parent_model = fks[0].related_model
+        claim_field = f"{parent_model._meta.verbose_name.replace(' ', '_')}_alias"
+        result.append((parent_model, claim_field))
+
+    return tuple(sorted(result, key=lambda pair: pair[1]))

--- a/backend/apps/catalog/api/corporate_entities.py
+++ b/backend/apps/catalog/api/corporate_entities.py
@@ -177,7 +177,6 @@ def patch_corporate_entity_claims(
 ):
     """Assert per-field claims from the authenticated user, then re-resolve."""
     from ..models import CorporateEntity
-    from ..resolve._relationships import resolve_corporate_entity_aliases
 
     if not data.fields and data.aliases is None:
         raise HttpError(422, "No changes provided.")
@@ -186,21 +185,19 @@ def patch_corporate_entity_claims(
 
     specs = validate_scalar_fields(CorporateEntity, data.fields, entity=ce)
 
-    resolvers = []
     if data.aliases is not None:
-        alias_specs = plan_alias_claims(
-            ce,
-            data.aliases,
-            claim_field_name="corporate_entity_alias",
+        specs.extend(
+            plan_alias_claims(
+                ce,
+                data.aliases,
+                claim_field_name="corporate_entity_alias",
+            )
         )
-        specs.extend(alias_specs)
-        if alias_specs:
-            resolvers.append(resolve_corporate_entity_aliases)
 
     if not specs:
         raise HttpError(422, "No changes provided.")
 
-    execute_claims(ce, specs, user=request.user, note=data.note, resolvers=resolvers)
+    execute_claims(ce, specs, user=request.user, note=data.note)
 
     ce = get_object_or_404(_detail_qs(), slug=ce.slug)
     return _serialize_detail(ce)

--- a/backend/apps/catalog/api/edit_claims.py
+++ b/backend/apps/catalog/api/edit_claims.py
@@ -7,13 +7,10 @@ build a list of ClaimSpecs, then execute them atomically in a ChangeSet.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
 
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from ninja.errors import HttpError
-
-from ..cache import invalidate_all
 
 
 @dataclass(frozen=True)
@@ -609,26 +606,18 @@ def execute_claims(
     *,
     user,
     note: str = "",
-    resolvers: list[Callable] | None = None,
-    resolve_fn: Callable | None = None,
 ) -> None:
     """Create a ChangeSet + claims atomically, resolve, and invalidate cache.
 
-    ``resolvers`` is an optional list of callables to run inside the
-    transaction before the entity resolver — e.g., relationship resolvers
-    like ``resolve_gameplay_feature_parents``.
-
-    ``resolve_fn`` overrides the default ``resolve_entity`` — used by
-    MachineModel which needs ``resolve_model`` instead.
+    Resolution is handled by :func:`resolve_after_mutation` which routes
+    to the correct resolver(s) based on entity type and the claim field
+    names in *specs*.
 
     Raises HttpError 422 on IntegrityError (unique constraint violations).
     """
     from apps.provenance.models import ChangeSet, Claim
 
-    if resolve_fn is None:
-        from ..resolve import resolve_entity
-
-        resolve_fn = resolve_entity
+    from ..resolve import resolve_after_mutation
 
     try:
         with transaction.atomic():
@@ -642,12 +631,9 @@ def execute_claims(
                     claim_key=spec.claim_key,
                     changeset=cs,
                 )
-            for resolver in resolvers or []:
-                resolver()
-            resolve_fn(entity)
+            field_names = list({s.field_name for s in specs})
+            resolve_after_mutation(entity, field_names=field_names)
     except ValidationError as exc:
         raise HttpError(422, "; ".join(exc.messages)) from exc
     except IntegrityError as exc:
         raise HttpError(422, f"Unique constraint violation: {exc}") from exc
-
-    invalidate_all()

--- a/backend/apps/catalog/api/gameplay_features.py
+++ b/backend/apps/catalog/api/gameplay_features.py
@@ -168,10 +168,6 @@ def get_gameplay_feature(request, slug: str):
 def patch_gameplay_feature_claims(request, slug: str, data: HierarchyClaimPatchSchema):
     """Assert per-field claims from the authenticated user, then re-resolve."""
     from ..models import GameplayFeature
-    from ..resolve._relationships import (
-        resolve_gameplay_feature_aliases,
-        resolve_gameplay_feature_parents,
-    )
 
     if not data.fields and data.parents is None and data.aliases is None:
         raise HttpError(422, "No changes provided.")
@@ -180,34 +176,29 @@ def patch_gameplay_feature_claims(request, slug: str, data: HierarchyClaimPatchS
 
     specs = validate_scalar_fields(GameplayFeature, data.fields, entity=feature)
 
-    resolvers = []
     if data.parents is not None:
-        parent_specs = plan_parent_claims(
-            feature,
-            set(data.parents),
-            model_class=GameplayFeature,
-            claim_field_name="gameplay_feature_parent",
+        specs.extend(
+            plan_parent_claims(
+                feature,
+                set(data.parents),
+                model_class=GameplayFeature,
+                claim_field_name="gameplay_feature_parent",
+            )
         )
-        specs.extend(parent_specs)
-        if parent_specs:
-            resolvers.append(resolve_gameplay_feature_parents)
 
     if data.aliases is not None:
-        alias_specs = plan_alias_claims(
-            feature,
-            data.aliases,
-            claim_field_name="gameplay_feature_alias",
+        specs.extend(
+            plan_alias_claims(
+                feature,
+                data.aliases,
+                claim_field_name="gameplay_feature_alias",
+            )
         )
-        specs.extend(alias_specs)
-        if alias_specs:
-            resolvers.append(resolve_gameplay_feature_aliases)
 
     if not specs:
         raise HttpError(422, "No changes provided.")
 
-    execute_claims(
-        feature, specs, user=request.user, note=data.note, resolvers=resolvers
-    )
+    execute_claims(feature, specs, user=request.user, note=data.note)
 
     feature = get_object_or_404(_detail_qs(), slug=feature.slug)
     return _serialize_detail(feature)

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -854,7 +854,6 @@ def patch_model_claims(request, slug: str, data: ModelClaimPatchSchema):
     )
 
     from ..models import MachineModel, RewardType, Tag, Theme
-    from ..resolve import resolve_model
 
     pm = get_object_or_404(
         MachineModel.objects.active().prefetch_related(
@@ -921,11 +920,7 @@ def patch_model_claims(request, slug: str, data: ModelClaimPatchSchema):
     if not specs:
         raise HttpError(422, "No changes provided.")
 
-    # MachineModel uses resolve_model (handles relationship claims + opdb_id
-    # conflicts) instead of the generic resolve_entity.
-    execute_claims(
-        pm, specs, user=request.user, note=data.note, resolve_fn=resolve_model
-    )
+    execute_claims(pm, specs, user=request.user, note=data.note)
 
     pm = get_object_or_404(_model_detail_qs(), slug=pm.slug)
     return _serialize_model_detail(pm)

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -135,7 +135,6 @@ def get_theme(request, slug: str):
 def patch_theme_claims(request, slug: str, data: HierarchyClaimPatchSchema):
     """Assert per-field claims from the authenticated user, then re-resolve."""
     from ..models import Theme
-    from ..resolve._relationships import resolve_theme_aliases, resolve_theme_parents
 
     if not data.fields and data.parents is None and data.aliases is None:
         raise HttpError(422, "No changes provided.")
@@ -144,32 +143,29 @@ def patch_theme_claims(request, slug: str, data: HierarchyClaimPatchSchema):
 
     specs = validate_scalar_fields(Theme, data.fields, entity=theme)
 
-    resolvers = []
     if data.parents is not None:
-        parent_specs = plan_parent_claims(
-            theme,
-            set(data.parents),
-            model_class=Theme,
-            claim_field_name="theme_parent",
+        specs.extend(
+            plan_parent_claims(
+                theme,
+                set(data.parents),
+                model_class=Theme,
+                claim_field_name="theme_parent",
+            )
         )
-        specs.extend(parent_specs)
-        if parent_specs:
-            resolvers.append(resolve_theme_parents)
 
     if data.aliases is not None:
-        alias_specs = plan_alias_claims(
-            theme,
-            data.aliases,
-            claim_field_name="theme_alias",
+        specs.extend(
+            plan_alias_claims(
+                theme,
+                data.aliases,
+                claim_field_name="theme_alias",
+            )
         )
-        specs.extend(alias_specs)
-        if alias_specs:
-            resolvers.append(resolve_theme_aliases)
 
     if not specs:
         raise HttpError(422, "No changes provided.")
 
-    execute_claims(theme, specs, user=request.user, note=data.note, resolvers=resolvers)
+    execute_claims(theme, specs, user=request.user, note=data.note)
 
     theme = get_object_or_404(_detail_qs(), slug=theme.slug)
     return _serialize_detail(theme)

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -562,7 +562,6 @@ def get_title(request, slug: str):
 def patch_title_claims(request, slug: str, data: TitleClaimPatchSchema):
     """Assert title-owned claims and return the refreshed title detail."""
     from ..models import Title
-    from ..resolve._relationships import resolve_all_title_abbreviations
     from .edit_claims import plan_scalar_field_claims
 
     if not data.fields and data.abbreviations is None:
@@ -577,19 +576,13 @@ def patch_title_claims(request, slug: str, data: TitleClaimPatchSchema):
         else []
     )
 
-    resolvers = []
     if data.abbreviations is not None:
-        abbreviation_specs = plan_abbreviation_claims(title, data.abbreviations)
-        specs.extend(abbreviation_specs)
-        if abbreviation_specs:
-            resolvers.append(
-                lambda: resolve_all_title_abbreviations(model_ids={title.pk})
-            )
+        specs.extend(plan_abbreviation_claims(title, data.abbreviations))
 
     if not specs:
         raise HttpError(422, "No changes provided.")
 
-    execute_claims(title, specs, user=request.user, note=data.note, resolvers=resolvers)
+    execute_claims(title, specs, user=request.user, note=data.note)
 
     title = get_object_or_404(_detail_qs(), slug=title.slug)
     return _serialize_title_detail(title)

--- a/backend/apps/catalog/claims.py
+++ b/backend/apps/catalog/claims.py
@@ -81,19 +81,23 @@ def _get_entity_ref_targets() -> dict[str, list[RefKey]]:
     return _entity_ref_targets
 
 
-LITERAL_SCHEMAS: dict[str, LiteralKey] = {
-    "abbreviation": LiteralKey("value", "value"),
-    "theme_alias": LiteralKey("alias_value", "alias"),
-    "manufacturer_alias": LiteralKey("alias_value", "alias"),
-    "person_alias": LiteralKey("alias_value", "alias"),
-    "gameplay_feature_alias": LiteralKey("alias_value", "alias"),
-    "reward_type_alias": LiteralKey("alias_value", "alias"),
-    "corporate_entity_alias": LiteralKey("alias_value", "alias"),
-    "location_alias": LiteralKey("alias_value", "alias"),
-}
+_literal_schemas: dict[str, LiteralKey] | None = None
 
-# Eagerly computable — literal namespace names are string constants.
-_LITERAL_NAMESPACES = frozenset(LITERAL_SCHEMAS)
+
+def _get_literal_schemas() -> dict[str, LiteralKey]:
+    """Return literal namespace schemas, auto-discovering alias types.
+
+    Lazy — safe to call at any time; caches after first call.
+    Follows the same pattern as ``_get_entity_ref_targets()``.
+    """
+    global _literal_schemas  # noqa: PLW0603
+    if _literal_schemas is None:
+        from ._alias_registry import discover_alias_types
+
+        _literal_schemas = {"abbreviation": LiteralKey("value", "value")}
+        for _model, claim_field in discover_alias_types():
+            _literal_schemas[claim_field] = LiteralKey("alias_value", "alias")
+    return _literal_schemas
 
 
 _relationship_namespaces: frozenset[str] | None = None
@@ -106,8 +110,8 @@ def get_relationship_namespaces() -> frozenset[str]:
     """
     global _relationship_namespaces  # noqa: PLW0603
     if _relationship_namespaces is None:
-        _relationship_namespaces = (
-            frozenset(_get_entity_ref_targets()) | _LITERAL_NAMESPACES
+        _relationship_namespaces = frozenset(_get_entity_ref_targets()) | frozenset(
+            _get_literal_schemas()
         )
     return _relationship_namespaces
 
@@ -141,7 +145,7 @@ def get_all_namespace_keys() -> dict[str, list[str]]:
     result: dict[str, list[str]] = {}
     for ns, ref_keys in _get_entity_ref_targets().items():
         result[ns] = [rk.name for rk in ref_keys]
-    for ns, lit in LITERAL_SCHEMAS.items():
+    for ns, lit in _get_literal_schemas().items():
         result[ns] = [lit.value_key]
     return result
 
@@ -169,7 +173,7 @@ def build_relationship_claim(
                 raise ValueError(f"Missing required key {key!r} for {field_name!r}")
         identity_parts = {k: identity[k] for k in expected}
     else:
-        literal = LITERAL_SCHEMAS.get(field_name)
+        literal = _get_literal_schemas().get(field_name)
         if literal is None:
             raise ValueError(f"Unknown relationship namespace: {field_name!r}")
         # Literal namespace: map value_key → identity_key.

--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -66,6 +66,8 @@ from ._entities import (  # noqa: F401
     resolve_entity as resolve_entity,
 )
 
+from ._dispatch import resolve_after_mutation as resolve_after_mutation  # noqa: F401
+
 logger = logging.getLogger(__name__)
 
 

--- a/backend/apps/catalog/resolve/_dispatch.py
+++ b/backend/apps/catalog/resolve/_dispatch.py
@@ -1,0 +1,203 @@
+"""Centralised resolution dispatch after claim mutations.
+
+Provides :func:`resolve_after_mutation` — a single entry-point that any
+module (including provenance) can call after mutating claims on an entity.
+Internally it routes to the correct resolver(s) based on entity type and
+the claim field names that changed, then invalidates cached endpoint data.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+
+from ..cache import invalidate_all
+from .._alias_registry import discover_alias_types
+
+if TYPE_CHECKING:
+    from django.db import models
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tables — built lazily to avoid import-time model access
+# ---------------------------------------------------------------------------
+
+_alias_dispatch: dict[str, type] | None = None
+
+
+def _get_alias_dispatch() -> dict[str, type]:
+    """field_name → parent model class for alias resolvers."""
+    global _alias_dispatch  # noqa: PLW0603
+    if _alias_dispatch is None:
+        _alias_dispatch = {
+            field_name: model for model, field_name in discover_alias_types()
+        }
+    return _alias_dispatch
+
+
+_parent_dispatch: dict[str, tuple[type, str | None]] | None = None
+
+
+def _get_parent_dispatch() -> dict[str, tuple[type, str | None]]:
+    """field_name → (model, claim_field_prefix) for _resolve_parents()."""
+    global _parent_dispatch  # noqa: PLW0603
+    if _parent_dispatch is None:
+        from ..models import GameplayFeature, Theme
+
+        _parent_dispatch = {
+            "theme_parent": (Theme, None),
+            "gameplay_feature_parent": (GameplayFeature, "gameplay_feature"),
+        }
+    return _parent_dispatch
+
+
+_custom_dispatch: dict[str, tuple[type, str, str]] | None = None
+
+
+def _get_custom_dispatch() -> dict[str, tuple[type, str, str]]:
+    """field_name → (entity_model, resolver_function_name, id_kwarg_name).
+
+    Each entry specifies which model type it applies to, which
+    ``resolve_all_*`` function to call, and which keyword argument
+    receives the scoped ID set.
+    """
+    global _custom_dispatch  # noqa: PLW0603
+    if _custom_dispatch is None:
+        from ..models import CorporateEntity, Series, Title
+
+        _custom_dispatch = {
+            "abbreviation": (Title, "resolve_all_title_abbreviations", "model_ids"),
+            "location": (
+                CorporateEntity,
+                "resolve_all_corporate_entity_locations",
+                "entity_ids",
+            ),
+            "series_title": (Series, "resolve_all_series_titles", "model_ids"),
+        }
+    return _custom_dispatch
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve_after_mutation(
+    entity: models.Model,
+    field_names: list[str] | None = None,
+) -> None:
+    """Re-resolve an entity after its claims have been mutated.
+
+    Call this inside a ``transaction.atomic()`` block after creating,
+    deactivating, or modifying claims.  Resolution runs synchronously
+    inside the caller's transaction.  Cache invalidation runs after
+    resolution completes.
+
+    Parameters
+    ----------
+    entity:
+        The catalog entity whose claims changed.
+    field_names:
+        The claim ``field_name`` values that were mutated.  When ``None``,
+        all applicable resolvers run (safe but less efficient).
+    """
+    from ..models import MachineModel
+
+    if isinstance(entity, MachineModel):
+        _resolve_machine_model(entity)
+    else:
+        _resolve_non_machine_model(entity, field_names)
+
+    transaction.on_commit(invalidate_all)
+
+
+# ---------------------------------------------------------------------------
+# Internal routing
+# ---------------------------------------------------------------------------
+
+
+def _resolve_machine_model(entity: models.Model) -> None:
+    """MachineModel path — resolve_model() handles everything."""
+    from . import resolve_model
+
+    resolve_model(entity)
+
+
+def _resolve_non_machine_model(
+    entity: models.Model,
+    field_names: list[str] | None,
+) -> None:
+    """Non-MachineModel path — dispatch relationship resolvers then scalars."""
+    from ..claims import get_relationship_namespaces
+    from ._entities import resolve_entity
+    from ._media import resolve_media_attachments
+    from ._relationships import _resolve_aliases, _resolve_parents
+
+    relationship_ns = get_relationship_namespaces()
+    entity_type = type(entity)
+
+    if field_names is not None:
+        rel_fields = [fn for fn in field_names if fn in relationship_ns]
+    else:
+        rel_fields = None  # signals "run all applicable"
+
+    # --- Alias resolvers ---
+    alias_dispatch = _get_alias_dispatch()
+    if rel_fields is not None:
+        for fn in rel_fields:
+            if fn in alias_dispatch and alias_dispatch[fn] is entity_type:
+                _resolve_aliases(alias_dispatch[fn], fn)
+    else:
+        for fn, parent_model in alias_dispatch.items():
+            if parent_model is entity_type:
+                _resolve_aliases(parent_model, fn)
+
+    # --- Parent hierarchy resolvers ---
+    parent_dispatch = _get_parent_dispatch()
+    if rel_fields is not None:
+        for fn in rel_fields:
+            if fn in parent_dispatch:
+                model, prefix = parent_dispatch[fn]
+                if model is entity_type:
+                    _resolve_parents(model, claim_field_prefix=prefix)
+    else:
+        for fn, (model, prefix) in parent_dispatch.items():
+            if model is entity_type:
+                _resolve_parents(model, claim_field_prefix=prefix)
+
+    # --- Custom resolvers (abbreviation, location, series_title) ---
+    custom_dispatch = _get_custom_dispatch()
+    if rel_fields is not None:
+        for fn in rel_fields:
+            if fn in custom_dispatch and custom_dispatch[fn][0] is entity_type:
+                _call_custom_resolver(custom_dispatch[fn], entity.pk)
+    else:
+        for fn, spec in custom_dispatch.items():
+            if spec[0] is entity_type:
+                _call_custom_resolver(spec, entity.pk)
+
+    # --- Media attachments ---
+    from apps.core.models import MediaSupported
+
+    if isinstance(entity, MediaSupported):
+        if rel_fields is None or "media_attachment" in rel_fields:
+            from django.contrib.contenttypes.models import ContentType
+
+            ct = ContentType.objects.get_for_model(entity_type)
+            resolve_media_attachments(content_type_id=ct.id, entity_ids={entity.pk})
+
+    # --- Scalar fields ---
+    resolve_entity(entity)
+
+
+def _call_custom_resolver(spec: tuple[type, str, str], entity_pk: int) -> None:
+    """Call a custom resolver by name with scoped IDs."""
+    from . import _relationships
+
+    _model, func_name, id_kwarg = spec
+    func = getattr(_relationships, func_name)
+    func(**{id_kwarg: {entity_pk}})

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from apps.provenance.models import Claim
 
 from ._helpers import _annotate_priority
+from .._alias_registry import discover_alias_types
 
 from ..models import (
     CorporateEntity,
@@ -755,19 +756,14 @@ def _resolve_aliases(
 
 
 # ---------------------------------------------------------------------------
-# Alias registry — drives resolve_all_aliases()
+# Alias registry — drives resolve_all_aliases() and dispatch
 # ---------------------------------------------------------------------------
-# Each tuple: (parent_model, claim_field_name)
-
-ALIAS_TYPES: list[tuple[type, str]] = [
-    (Theme, "theme_alias"),
-    (Manufacturer, "manufacturer_alias"),
-    (Person, "person_alias"),
-    (GameplayFeature, "gameplay_feature_alias"),
-    (RewardType, "reward_type_alias"),
-    (CorporateEntity, "corporate_entity_alias"),
-    (Location, "location_alias"),
-]
+# Auto-discovered from AliasBase subclasses.  Safe to compute at module level
+# because this module already imports Django models at the top, so the app
+# registry is guaranteed to be ready.  ``ALIAS_TYPES`` is kept as a public
+# binding (same shape as before) so that existing callers — including the
+# test suite — continue to work.
+ALIAS_TYPES: list[tuple[type, str]] = list(discover_alias_types())
 
 
 def resolve_theme_aliases() -> None:
@@ -795,8 +791,8 @@ def resolve_corporate_entity_aliases() -> None:
 
 
 def resolve_all_aliases() -> None:
-    """Resolve all alias types from the registry."""
-    for parent_model, claim_field in ALIAS_TYPES:
+    """Resolve all alias types from the auto-discovered registry."""
+    for parent_model, claim_field in discover_alias_types():
         _resolve_aliases(parent_model, claim_field)
 
 
@@ -916,11 +912,16 @@ def resolve_all_location_aliases() -> None:
 # ------------------------------------------------------------------
 
 
-def resolve_all_corporate_entity_locations() -> dict[str, int]:
+def resolve_all_corporate_entity_locations(
+    *,
+    entity_ids: set[int] | None = None,
+) -> dict[str, int]:
     """Sync CorporateEntityLocation rows from active 'location' claims on CorporateEntity.
 
-    Loads ALL existing CorporateEntityLocation rows so that CEs whose claims
-    were all deactivated also have their stale rows removed.
+    When *entity_ids* is ``None`` (the default), processes ALL CorporateEntity
+    rows so that CEs whose claims were all deactivated also have their stale
+    rows removed.  When scoped to a set of entity PKs, only those CEs are
+    considered.
     """
     from collections import defaultdict
 
@@ -929,11 +930,13 @@ def resolve_all_corporate_entity_locations() -> dict[str, int]:
     ce_ct = ContentType.objects.get_for_model(CorporateEntity)
     valid_loc_pks = set(Location.objects.values_list("pk", flat=True))
 
-    active_claims = (
-        Claim.objects.filter(content_type=ce_ct, field_name="location", is_active=True)
-        .exclude(source__is_enabled=False)
-        .values("object_id", "value")
-    )
+    claims_qs = Claim.objects.filter(
+        content_type=ce_ct, field_name="location", is_active=True
+    ).exclude(source__is_enabled=False)
+    if entity_ids is not None:
+        claims_qs = claims_qs.filter(object_id__in=entity_ids)
+
+    active_claims = claims_qs.values("object_id", "value")
 
     desired: dict[int, set[int]] = defaultdict(set)
     for row in active_claims:
@@ -943,10 +946,12 @@ def resolve_all_corporate_entity_locations() -> dict[str, int]:
 
     created = deleted = 0
 
-    # Load ALL existing rows so stale rows for CEs with no active claims are cleaned up.
-    all_existing = CorporateEntityLocation.objects.all()
+    existing_qs = CorporateEntityLocation.objects.all()
+    if entity_ids is not None:
+        existing_qs = existing_qs.filter(corporate_entity_id__in=entity_ids)
+
     current: dict[int, dict[int, CorporateEntityLocation]] = defaultdict(dict)
-    for cel in all_existing:
+    for cel in existing_qs:
         current[cel.corporate_entity_id][cel.location_id] = cel
 
     # Create missing rows.

--- a/backend/apps/catalog/tests/test_resolve_dispatch.py
+++ b/backend/apps/catalog/tests/test_resolve_dispatch.py
@@ -1,0 +1,216 @@
+"""Tests for resolve_after_mutation() dispatch and alias auto-discovery."""
+
+import pytest
+
+from apps.catalog._alias_registry import discover_alias_types
+from apps.catalog.claims import _get_literal_schemas, build_relationship_claim
+from apps.catalog.models import (
+    MachineModel,
+    Manufacturer,
+    TechnologyGeneration,
+    Theme,
+    Title,
+)
+from apps.catalog.resolve._dispatch import resolve_after_mutation
+from apps.provenance.models import Claim, Source
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def source(db):
+    return Source.objects.create(
+        name="Test Source", source_type="editorial", priority=100
+    )
+
+
+@pytest.fixture
+def theme(db):
+    return Theme.objects.create(name="Placeholder Theme", slug="placeholder-theme")
+
+
+@pytest.fixture
+def title(db):
+    return Title.objects.create(name="Placeholder Title", slug="placeholder-title")
+
+
+@pytest.fixture
+def manufacturer(db):
+    return Manufacturer.objects.create(name="Placeholder Mfr", slug="placeholder-mfr")
+
+
+@pytest.fixture
+def pm(db):
+    return MachineModel.objects.create(name="Placeholder", slug="placeholder")
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovery tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverAliasTypes:
+    def test_discovers_all_seven_alias_types(self):
+        result = discover_alias_types()
+        assert len(result) == 7
+
+    def test_known_types_present(self):
+        field_names = {fn for _, fn in discover_alias_types()}
+        expected = {
+            "theme_alias",
+            "manufacturer_alias",
+            "person_alias",
+            "gameplay_feature_alias",
+            "reward_type_alias",
+            "corporate_entity_alias",
+            "location_alias",
+        }
+        assert field_names == expected
+
+
+class TestLiteralSchemasAutoPopulated:
+    def test_contains_abbreviation(self):
+        schemas = _get_literal_schemas()
+        assert "abbreviation" in schemas
+
+    def test_contains_all_alias_types(self):
+        schemas = _get_literal_schemas()
+        for _, field_name in discover_alias_types():
+            assert field_name in schemas
+            assert schemas[field_name].value_key == "alias_value"
+            assert schemas[field_name].identity_key == "alias"
+
+
+# ---------------------------------------------------------------------------
+# resolve_after_mutation() routing tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestMachineModelRouting:
+    def test_scalars_resolved(self, pm, source):
+        ss = TechnologyGeneration.objects.create(name="Solid State", slug="solid-state")
+        Claim.objects.assert_claim(pm, "name", "Test Machine", source=source)
+        Claim.objects.assert_claim(
+            pm, "technology_generation", "solid-state", source=source
+        )
+
+        resolve_after_mutation(pm, field_names=["name", "technology_generation"])
+
+        pm.refresh_from_db()
+        assert pm.name == "Test Machine"
+        assert pm.technology_generation == ss
+
+    def test_m2m_resolved(self, pm, source):
+        Claim.objects.assert_claim(pm, "name", "Test Machine", source=source)
+        theme = Theme.objects.create(name="Adventure", slug="adventure")
+        ck, val = build_relationship_claim("theme", {"theme": theme.pk})
+        Claim.objects.assert_claim(pm, "theme", val, source=source, claim_key=ck)
+
+        resolve_after_mutation(pm, field_names=["name", "theme"])
+
+        assert theme in pm.themes.all()
+
+
+@pytest.mark.django_db
+class TestScalarResolution:
+    def test_non_machine_model_scalars(self, theme, source):
+        Claim.objects.assert_claim(theme, "name", "Updated Theme", source=source)
+
+        resolve_after_mutation(theme, field_names=["name"])
+
+        theme.refresh_from_db()
+        assert theme.name == "Updated Theme"
+
+
+@pytest.mark.django_db
+class TestAliasDispatch:
+    def test_theme_alias(self, theme, source):
+        ck, val = build_relationship_claim("theme_alias", {"alias_value": "test-alias"})
+        Claim.objects.assert_claim(
+            theme, "theme_alias", val, source=source, claim_key=ck
+        )
+
+        resolve_after_mutation(theme, field_names=["theme_alias"])
+
+        assert theme.aliases.filter(value="test-alias").exists()
+
+    def test_manufacturer_alias(self, manufacturer, source):
+        ck, val = build_relationship_claim(
+            "manufacturer_alias", {"alias_value": "mfr-alias"}
+        )
+        Claim.objects.assert_claim(
+            manufacturer, "manufacturer_alias", val, source=source, claim_key=ck
+        )
+
+        resolve_after_mutation(manufacturer, field_names=["manufacturer_alias"])
+
+        assert manufacturer.aliases.filter(value="mfr-alias").exists()
+
+
+@pytest.mark.django_db
+class TestParentDispatch:
+    def test_theme_parent(self, source):
+        parent_theme = Theme.objects.create(name="Parent", slug="parent")
+        child_theme = Theme.objects.create(name="Child", slug="child")
+
+        ck, val = build_relationship_claim("theme_parent", {"parent": parent_theme.pk})
+        Claim.objects.assert_claim(
+            child_theme, "theme_parent", val, source=source, claim_key=ck
+        )
+
+        resolve_after_mutation(child_theme, field_names=["theme_parent"])
+
+        assert parent_theme in child_theme.parents.all()
+
+
+@pytest.mark.django_db
+class TestCustomDispatch:
+    def test_abbreviation(self, title, source):
+        Claim.objects.assert_claim(title, "name", title.name, source=source)
+        ck, val = build_relationship_claim("abbreviation", {"value": "TST"})
+        Claim.objects.assert_claim(
+            title, "abbreviation", val, source=source, claim_key=ck
+        )
+
+        resolve_after_mutation(title, field_names=["abbreviation"])
+
+        assert title.abbreviations.filter(value="TST").exists()
+
+
+@pytest.mark.django_db
+class TestEntityTypeGuard:
+    def test_mismatched_alias_namespace_ignored(self, manufacturer, source):
+        """theme_alias on a Manufacturer should not call the Theme alias resolver."""
+        resolve_after_mutation(manufacturer, field_names=["theme_alias"])
+        # No error, no side effects — the namespace is silently skipped.
+
+    def test_mismatched_custom_namespace_ignored(self, theme, source):
+        """abbreviation on a Theme should not call the Title abbreviation resolver."""
+        resolve_after_mutation(theme, field_names=["abbreviation"])
+
+
+@pytest.mark.django_db
+class TestFieldNamesNone:
+    def test_resolves_scalars(self, theme, source):
+        Claim.objects.assert_claim(theme, "name", "Fallback Theme", source=source)
+
+        resolve_after_mutation(theme, field_names=None)
+
+        theme.refresh_from_db()
+        assert theme.name == "Fallback Theme"
+
+    def test_resolves_aliases(self, theme, source):
+        ck, val = build_relationship_claim(
+            "theme_alias", {"alias_value": "fallback-alias"}
+        )
+        Claim.objects.assert_claim(
+            theme, "theme_alias", val, source=source, claim_key=ck
+        )
+
+        resolve_after_mutation(theme, field_names=None)
+
+        assert theme.aliases.filter(value="fallback-alias").exists()

--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -18,6 +18,7 @@ from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.responses import Status
+from ninja.security import django_auth
 
 
 class FieldChangeSchema(Schema):
@@ -27,6 +28,11 @@ class FieldChangeSchema(Schema):
     claim_key: str
     old_value: Optional[object] = None
     new_value: object
+    claim_id: Optional[int] = None
+    claim_user_id: Optional[int] = None
+    is_active: Optional[bool] = None
+    is_winning: Optional[bool] = None
+    is_retracted: Optional[bool] = None
 
 
 class ChangeSetSchema(Schema):
@@ -37,6 +43,7 @@ class ChangeSetSchema(Schema):
     note: str
     created_at: str
     changes: list[FieldChangeSchema]
+    retractions: list["RetractionSchema"] = []
 
 
 class SourceSchema(Schema):
@@ -178,6 +185,7 @@ class RecentChangesListSchema(Schema):
 
 
 class RetractionSchema(Schema):
+    claim_id: int
     field_name: str
     claim_key: str
     old_value: object
@@ -396,6 +404,7 @@ def recent_change_detail(request, changeset_id: int):
 
     retractions = [
         {
+            "claim_id": c.pk,
             "field_name": c.field_name,
             "claim_key": c.claim_key,
             "old_value": c.value,
@@ -420,7 +429,29 @@ def recent_change_detail(request, changeset_id: int):
 
 # ── Edit History (generic, per-entity) ───────────────────────────
 
+
+class RevertClaimSchema(Schema):
+    claim_id: int
+    note: str
+
+
 edit_history_router = Router(tags=["edit-history"])
+
+
+def _resolve_catalog_entity(entity_type: str, slug: str):
+    """Look up a catalog entity by content-type name and slug.
+
+    Returns the entity instance, or a ``Status(404, ...)`` response if the
+    entity type is unknown or the slug doesn't exist.
+    """
+    try:
+        ct = ContentType.objects.get(app_label="catalog", model=entity_type)
+    except ContentType.DoesNotExist:
+        return Status(404, {"detail": f"Unknown entity type: {entity_type}"})
+    model_class = ct.model_class()
+    if not model_class or not hasattr(model_class, "link_url_pattern"):
+        return Status(404, {"detail": f"Unknown entity type: {entity_type}"})
+    return get_object_or_404(model_class, slug=slug)
 
 
 @edit_history_router.get(
@@ -432,12 +463,29 @@ def get_edit_history(request, entity_type: str, slug: str):
     """Return changeset-grouped edit history for any catalog entity."""
     from .history import build_edit_history
 
-    try:
-        ct = ContentType.objects.get(app_label="catalog", model=entity_type)
-    except ContentType.DoesNotExist:
-        return Status(404, {"detail": f"Unknown entity type: {entity_type}"})
-    model_class = ct.model_class()
-    if not model_class or not hasattr(model_class, "link_url_pattern"):
-        return Status(404, {"detail": f"Unknown entity type: {entity_type}"})
-    entity = get_object_or_404(model_class, slug=slug)
+    entity = _resolve_catalog_entity(entity_type, slug)
+    if isinstance(entity, Status):
+        return entity
     return build_edit_history(entity)
+
+
+@edit_history_router.post(
+    "/{entity_type}/{slug}/revert/",
+    auth=django_auth,
+    response={200: dict, 403: dict, 404: dict, 422: dict},
+    tags=["private"],
+)
+def revert_claim(request, entity_type: str, slug: str, data: RevertClaimSchema):
+    """Revert (deactivate) a single user claim and re-resolve the entity."""
+    from .revert import RevertError, execute_revert
+
+    entity = _resolve_catalog_entity(entity_type, slug)
+    if isinstance(entity, Status):
+        return entity
+    try:
+        execute_revert(
+            entity, claim_id=data.claim_id, user=request.user, note=data.note
+        )
+    except RevertError as exc:
+        return Status(exc.status_code, {"detail": str(exc)})
+    return {"ok": True}

--- a/backend/apps/provenance/constants.py
+++ b/backend/apps/provenance/constants.py
@@ -1,0 +1,3 @@
+"""Provenance constants."""
+
+REVERT_OTHERS_MIN_EDITS = 5

--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -5,9 +5,43 @@ from __future__ import annotations
 from collections import defaultdict
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Prefetch
+from django.db.models import Case, F, IntegerField, Prefetch, Q, Value, When
 
 from .models import ChangeSet, Claim
+
+
+def _compute_winning_claim_ids(ct, entity_pk: int) -> set[int]:
+    """Return the set of claim PKs that are current winners for the entity.
+
+    For each ``claim_key``, the winner is the active claim with the highest
+    ``effective_priority``, breaking ties by most recent ``created_at``, then
+    highest ``pk``.
+    """
+    active_claims = (
+        Claim.objects.filter(
+            content_type=ct,
+            object_id=entity_pk,
+            is_active=True,
+        )
+        .exclude(source__is_enabled=False)
+        .annotate(
+            effective_priority=Case(
+                When(source__isnull=False, then=F("source__priority")),
+                When(user__isnull=False, then=F("user__profile__priority")),
+                default=Value(0),
+                output_field=IntegerField(),
+            )
+        )
+        .order_by("claim_key", "-effective_priority", "-created_at", "-pk")
+    )
+
+    winners: set[int] = set()
+    seen_keys: set[str] = set()
+    for claim in active_claims:
+        if claim.claim_key not in seen_keys:
+            seen_keys.add(claim.claim_key)
+            winners.add(claim.pk)
+    return winners
 
 
 def build_edit_history(entity) -> list[dict]:
@@ -19,11 +53,14 @@ def build_edit_history(entity) -> list[dict]:
     """
     ct = ContentType.objects.get_for_model(entity)
 
-    # 1. Fetch changesets that have claims for this entity.
+    # 1. Fetch changesets that have claims OR retracted_claims for this entity.
     changesets = (
         ChangeSet.objects.filter(
-            claims__content_type=ct,
-            claims__object_id=entity.pk,
+            Q(claims__content_type=ct, claims__object_id=entity.pk)
+            | Q(
+                retracted_claims__content_type=ct,
+                retracted_claims__object_id=entity.pk,
+            )
         )
         .distinct()
         .select_related("user")
@@ -33,7 +70,13 @@ def build_edit_history(entity) -> list[dict]:
                 queryset=Claim.objects.filter(
                     content_type=ct, object_id=entity.pk
                 ).order_by("field_name"),
-            )
+            ),
+            Prefetch(
+                "retracted_claims",
+                queryset=Claim.objects.filter(
+                    content_type=ct, object_id=entity.pk
+                ).order_by("field_name"),
+            ),
         )
         .order_by("-created_at")
     )
@@ -53,7 +96,10 @@ def build_edit_history(entity) -> list[dict]:
     for c in all_user_claims:
         history[(c.claim_key, c.user_id)].append(c)
 
-    # 3. Build response.
+    # 3. Compute winning claims for is_winning.
+    winning_ids = _compute_winning_claim_ids(ct, entity.pk)
+
+    # 4. Build response.
     result: list[dict] = []
     for cs in changesets:
         changes: list[dict] = []
@@ -70,8 +116,24 @@ def build_edit_history(entity) -> list[dict]:
                     "claim_key": claim.claim_key,
                     "old_value": old_value,
                     "new_value": claim.value,
+                    "claim_id": claim.pk,
+                    "claim_user_id": claim.user_id,
+                    "is_active": claim.is_active,
+                    "is_winning": claim.pk in winning_ids,
+                    "is_retracted": claim.retracted_by_changeset_id is not None,
                 }
             )
+
+        retractions = [
+            {
+                "claim_id": c.pk,
+                "field_name": c.field_name,
+                "claim_key": c.claim_key,
+                "old_value": c.value,
+            }
+            for c in cs.retracted_claims.all()
+        ]
+
         result.append(
             {
                 "id": cs.pk,
@@ -79,6 +141,7 @@ def build_edit_history(entity) -> list[dict]:
                 "note": cs.note,
                 "created_at": cs.created_at.isoformat(),
                 "changes": changes,
+                "retractions": retractions,
             }
         )
     return result

--- a/backend/apps/provenance/models/changeset.py
+++ b/backend/apps/provenance/models/changeset.py
@@ -12,8 +12,8 @@ class ChangeSet(models.Model):
 
     A ChangeSet is a thin grouping record, not a snapshot of entity state.
     Truth is always derived from claim resolution (highest priority wins).
-    Reverting a ChangeSet means creating inverse claims, not restoring a
-    snapshot.
+    Reverting a claim means deactivating it and re-resolving — the
+    resolution machinery picks the correct winner from whatever remains.
 
     All claims in a ChangeSet must share the same actor (same user or same
     source). A CheckConstraint enforces that exactly one of user or

--- a/backend/apps/provenance/models/claim.py
+++ b/backend/apps/provenance/models/claim.py
@@ -303,7 +303,7 @@ class Claim(models.Model):
         related_name="retracted_claims",
         null=True,
         blank=True,
-        help_text="The changeset that deactivated this claim (full_sync retraction).",
+        help_text="The changeset that deactivated this claim (user revert or full_sync retraction).",
     )
     value = models.JSONField()
     citation = models.TextField(blank=True, default="", db_default="")

--- a/backend/apps/provenance/revert.py
+++ b/backend/apps/provenance/revert.py
@@ -1,0 +1,97 @@
+"""Per-field claim revert logic."""
+
+from __future__ import annotations
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError, transaction
+from django.core.exceptions import ValidationError
+
+from .constants import REVERT_OTHERS_MIN_EDITS
+from .models import ChangeSet, Claim
+
+
+class RevertError(Exception):
+    """Domain error raised by execute_revert().
+
+    Carries a ``status_code`` so the calling view can translate to the
+    appropriate HTTP response without coupling revert logic to Django Ninja.
+    """
+
+    def __init__(self, message: str, *, status_code: int = 422):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def execute_revert(entity, *, claim_id: int, user, note: str) -> None:
+    """Deactivate a single user claim and re-resolve the entity.
+
+    Creates a new ChangeSet recording the revert, deactivates the target
+    claim, and delegates to ``resolve_after_mutation()`` for resolution
+    and cache invalidation.
+
+    If the same user had a previous (superseded) claim for the same
+    claim_key, it is re-activated so the field falls back to their
+    prior value rather than dropping to the source default.
+
+    Raises ``RevertError`` on validation or authorisation failures.
+    """
+    if not note or not note.strip():
+        raise RevertError("A note is required when reverting.")
+
+    ct = ContentType.objects.get_for_model(entity)
+
+    try:
+        target = Claim.objects.get(pk=claim_id, content_type=ct, object_id=entity.pk)
+    except Claim.DoesNotExist:
+        raise RevertError("Claim not found for this entity.", status_code=404)
+
+    if target.source_id is not None:
+        raise RevertError("Source-attributed claims cannot be reverted.")
+
+    if not target.is_active:
+        raise RevertError("This claim is already inactive.")
+
+    if target.user_id != user.pk:
+        edit_count = ChangeSet.objects.filter(user=user).count()
+        if edit_count < REVERT_OTHERS_MIN_EDITS:
+            raise RevertError(
+                f"You need at least {REVERT_OTHERS_MIN_EDITS} edits to revert other users' changes.",
+                status_code=403,
+            )
+
+    from apps.catalog.resolve import resolve_after_mutation
+
+    try:
+        with transaction.atomic():
+            cs = ChangeSet.objects.create(user=user, note=note)
+            target.is_active = False
+            target.retracted_by_changeset = cs
+            target.save(update_fields=["is_active", "retracted_by_changeset"])
+
+            # Re-activate the most recent superseded (not retracted) claim
+            # from the same user for the same claim_key.  Without this,
+            # reverting a user's latest edit would leave ALL their previous
+            # edits for the field inactive (because assert_claim deactivates
+            # the predecessor when creating a new claim).
+            predecessor = (
+                Claim.objects.filter(
+                    content_type=ct,
+                    object_id=entity.pk,
+                    user_id=target.user_id,
+                    claim_key=target.claim_key,
+                    is_active=False,
+                    retracted_by_changeset__isnull=True,
+                )
+                .exclude(pk=target.pk)
+                .order_by("-created_at", "-pk")
+                .first()
+            )
+            if predecessor:
+                predecessor.is_active = True
+                predecessor.save(update_fields=["is_active"])
+
+            resolve_after_mutation(entity, field_names=[target.field_name])
+    except ValidationError as exc:
+        raise RevertError("; ".join(exc.messages)) from exc
+    except IntegrityError as exc:
+        raise RevertError(f"Unique constraint violation: {exc}") from exc

--- a/backend/apps/provenance/tests/test_revert.py
+++ b/backend/apps/provenance/tests/test_revert.py
@@ -1,0 +1,407 @@
+"""Tests for per-field claim revert via POST /api/edit-history/{entity_type}/{slug}/revert/."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+
+from apps.catalog.models import MachineModel
+from apps.provenance.models import ChangeSet, Claim, Source
+
+User = get_user_model()
+
+REVERT_URL = "/api/edit-history/machinemodel/{slug}/revert/"
+
+
+@pytest.fixture
+def _bootstrap_source(db):
+    return Source.objects.create(
+        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
+    )
+
+
+@pytest.fixture
+def source(db):
+    return Source.objects.create(
+        name="IPDB", slug="ipdb", source_type="database", priority=10
+    )
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="editor")
+
+
+@pytest.fixture
+def pm(db, _bootstrap_source):
+    pm = MachineModel.objects.create(
+        name="Medieval Madness", slug="medieval-madness", year=1997
+    )
+    Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    return pm
+
+
+def _make_user_edit(client, user, pm, fields, note=""):
+    """Helper: log in, PATCH claims, return the response."""
+    client.force_login(user)
+    import json
+
+    return client.patch(
+        f"/api/models/{pm.slug}/claims/",
+        data=json.dumps({"fields": fields, "note": note}),
+        content_type="application/json",
+    )
+
+
+def _get_active_claim(pm, field_name, user):
+    ct = ContentType.objects.get_for_model(pm)
+    return Claim.objects.get(
+        content_type=ct,
+        object_id=pm.pk,
+        field_name=field_name,
+        user=user,
+        is_active=True,
+    )
+
+
+def _revert(client, slug, claim_id, note):
+    import json
+
+    return client.post(
+        REVERT_URL.format(slug=slug),
+        data=json.dumps({"claim_id": claim_id, "note": note}),
+        content_type="application/json",
+    )
+
+
+# ── Core revert behaviour ───────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestRevertScalar:
+    def test_revert_deactivates_claim_and_re_resolves(self, client, user, pm, source):
+        """Reverting a user's scalar claim deactivates it; source value surfaces."""
+        Claim.objects.assert_claim(pm, "year", 1998, source=source)
+        _make_user_edit(client, user, pm, {"year": 2002})
+
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "Wrong year")
+
+        assert resp.status_code == 200
+        claim.refresh_from_db()
+        assert claim.is_active is False
+        assert claim.retracted_by_changeset is not None
+
+        pm.refresh_from_db()
+        assert pm.year == 1998  # source value surfaces
+
+    def test_revert_only_user_claim_falls_to_source_or_default(self, client, user, pm):
+        """If no source claim exists, field falls to default/null."""
+        _make_user_edit(client, user, pm, {"year": 2005})
+
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "Removing year")
+
+        assert resp.status_code == 200
+        pm.refresh_from_db()
+        # year default is None on MachineModel
+        assert pm.year is None
+
+
+@pytest.mark.django_db
+class TestRevertPredecessor:
+    def test_revert_reactivates_predecessor_claim(self, client, user, pm):
+        """Reverting a user's latest edit re-activates their previous edit."""
+        _make_user_edit(client, user, pm, {"year": 2001})
+        _make_user_edit(client, user, pm, {"year": 2005})
+
+        claim = _get_active_claim(pm, "year", user)
+        assert claim.value == 2005
+
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "Wrong year")
+        assert resp.status_code == 200
+
+        pm.refresh_from_db()
+        assert pm.year == 2001
+
+        # The predecessor is now active and revertable.
+        predecessor = _get_active_claim(pm, "year", user)
+        assert predecessor.value == 2001
+
+    def test_revert_does_not_reactivate_retracted_predecessor(self, client, user, pm):
+        """A predecessor that was explicitly retracted should NOT be re-activated."""
+        _make_user_edit(client, user, pm, {"year": 2001})
+        first_claim = _get_active_claim(pm, "year", user)
+
+        _make_user_edit(client, user, pm, {"year": 2005})
+        second_claim = _get_active_claim(pm, "year", user)
+
+        # Manually retract the first claim (simulating an earlier revert).
+        cs = ChangeSet.objects.create(user=user, note="earlier revert")
+        first_claim.retracted_by_changeset = cs
+        first_claim.save(update_fields=["retracted_by_changeset"])
+
+        client.force_login(user)
+        resp = _revert(client, pm.slug, second_claim.pk, "Undo")
+        assert resp.status_code == 200
+
+        pm.refresh_from_db()
+        # First claim was retracted so it's not re-activated; field drops to default.
+        assert pm.year is None
+
+    def test_revert_chain_walks_back_through_edits(self, client, user, pm):
+        """Reverting twice walks back through the edit chain."""
+        _make_user_edit(client, user, pm, {"year": 2001})
+        _make_user_edit(client, user, pm, {"year": 2003})
+        _make_user_edit(client, user, pm, {"year": 2005})
+
+        # Revert 2005 → surfaces 2003
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        _revert(client, pm.slug, claim.pk, "Undo 2005")
+        pm.refresh_from_db()
+        assert pm.year == 2003
+
+        # Revert 2003 → surfaces 2001
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        _revert(client, pm.slug, claim.pk, "Undo 2003")
+        pm.refresh_from_db()
+        assert pm.year == 2001
+
+        # Revert 2001 → no predecessor, drops to default
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        _revert(client, pm.slug, claim.pk, "Undo 2001")
+        pm.refresh_from_db()
+        assert pm.year is None
+
+
+@pytest.mark.django_db
+class TestRevertNonWinning:
+    def test_revert_non_winning_claim_deactivates_without_changing_value(
+        self, client, user, pm, db
+    ):
+        """Reverting a lower-priority claim deactivates it; page value unchanged."""
+        # User profile default priority is 10000; use a source above that.
+        hi_source = Source.objects.create(
+            name="HiPri", slug="hipri", source_type="database", priority=20000
+        )
+        Claim.objects.assert_claim(pm, "year", 1998, source=hi_source)
+        from apps.catalog.resolve import resolve_after_mutation
+
+        resolve_after_mutation(pm, field_names=["year"])
+        pm.refresh_from_db()
+        assert pm.year == 1998  # source wins
+
+        _make_user_edit(client, user, pm, {"year": 1997})
+        pm.refresh_from_db()
+        assert pm.year == 1998  # source still wins (higher priority)
+
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "Not needed")
+
+        assert resp.status_code == 200
+        pm.refresh_from_db()
+        assert pm.year == 1998  # unchanged
+
+
+# ── Authorisation ────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestRevertAuth:
+    def test_self_revert_with_zero_edits_succeeds(self, client, user, pm):
+        """A user can always revert their own claims, even with 0 other edits."""
+        _make_user_edit(client, user, pm, {"year": 2005})
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "My mistake")
+        assert resp.status_code == 200
+
+    def test_revert_others_below_threshold_returns_403(self, client, user, pm, db):
+        """Users with <5 edits cannot revert another user's claims."""
+        _make_user_edit(client, user, pm, {"year": 2005})
+        claim = _get_active_claim(pm, "year", user)
+
+        other = User.objects.create_user(username="newbie", password="pw")
+        client.force_login(other)
+        resp = _revert(client, pm.slug, claim.pk, "Reverting you")
+        assert resp.status_code == 403
+        assert "5 edits" in resp.json()["detail"]
+
+    def test_revert_others_above_threshold_succeeds(self, client, user, pm, db):
+        """Users with 5+ edits can revert another user's claims."""
+        _make_user_edit(client, user, pm, {"year": 2005})
+        claim = _get_active_claim(pm, "year", user)
+
+        other = User.objects.create_user(username="veteran", password="pw")
+        # Create 5 changesets for other user
+        for _ in range(5):
+            ChangeSet.objects.create(user=other, note="edit")
+
+        client.force_login(other)
+        resp = _revert(client, pm.slug, claim.pk, "Correcting year")
+        assert resp.status_code == 200
+
+    def test_unauthenticated_returns_401(self, client, pm):
+        resp = _revert(client, pm.slug, 999, "nope")
+        assert resp.status_code == 401
+
+
+# ── Validation ───────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestRevertValidation:
+    def test_empty_note_returns_422(self, client, user, pm):
+        _make_user_edit(client, user, pm, {"year": 2005})
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "")
+        assert resp.status_code == 422
+        assert "note" in resp.json()["detail"].lower()
+
+    def test_whitespace_only_note_returns_422(self, client, user, pm):
+        _make_user_edit(client, user, pm, {"year": 2005})
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "   ")
+        assert resp.status_code == 422
+
+    def test_source_claim_returns_422(self, client, user, pm, source):
+        """Source-attributed claims cannot be reverted."""
+        Claim.objects.assert_claim(pm, "year", 1998, source=source)
+        ct = ContentType.objects.get_for_model(pm)
+        src_claim = Claim.objects.get(
+            content_type=ct,
+            object_id=pm.pk,
+            field_name="year",
+            source=source,
+            is_active=True,
+        )
+        client.force_login(user)
+        resp = _revert(client, pm.slug, src_claim.pk, "Trying")
+        assert resp.status_code == 422
+        assert "source" in resp.json()["detail"].lower()
+
+    def test_inactive_claim_returns_422(self, client, user, pm):
+        """Already-inactive claims cannot be reverted."""
+        _make_user_edit(client, user, pm, {"year": 2005})
+        claim = _get_active_claim(pm, "year", user)
+
+        # Deactivate manually
+        claim.is_active = False
+        claim.save(update_fields=["is_active"])
+
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "Double revert")
+        assert resp.status_code == 422
+        assert "inactive" in resp.json()["detail"].lower()
+
+    def test_claim_for_wrong_entity_returns_404(
+        self, client, user, pm, _bootstrap_source, db
+    ):
+        """Claim PK that doesn't belong to the URL entity returns 404."""
+        pm2 = MachineModel.objects.create(name="Other", slug="other")
+        Claim.objects.assert_claim(pm2, "name", "Other", source=_bootstrap_source)
+        _make_user_edit(client, user, pm2, {"year": 2000})
+        claim = _get_active_claim(pm2, "year", user)
+
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "Wrong entity")
+        assert resp.status_code == 404
+
+
+# ── Multi-user interleaving ──────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestRevertMultiUser:
+    def test_revert_surfaces_next_winner(self, client, user, pm, source, db):
+        """A:1998, C:2001, A:2002 → revert A:2002 → surfaces C:2001."""
+        Claim.objects.assert_claim(pm, "year", 1998, source=source)
+
+        user_c = User.objects.create_user(username="charlie", password="pw")
+        _make_user_edit(client, user_c, pm, {"year": 2001})
+        _make_user_edit(client, user, pm, {"year": 2002})
+
+        claim = _get_active_claim(pm, "year", user)
+        client.force_login(user)
+        resp = _revert(client, pm.slug, claim.pk, "Wrong")
+
+        assert resp.status_code == 200
+        pm.refresh_from_db()
+        # User profile default priority (10000) beats IPDB source (10),
+        # so charlie's claim wins.
+        assert pm.year == 2001
+
+
+# ── Edit history shows retractions ───────────────────────────────
+
+
+@pytest.mark.django_db
+class TestRevertInHistory:
+    def test_revert_appears_as_changeset_with_retraction(self, client, user, pm):
+        """After reverting, edit history includes the revert changeset with retractions."""
+        _make_user_edit(client, user, pm, {"year": 2005})
+        claim = _get_active_claim(pm, "year", user)
+
+        client.force_login(user)
+        _revert(client, pm.slug, claim.pk, "Reverting year")
+
+        resp = client.get(f"/api/edit-history/machinemodel/{pm.slug}/")
+        data = resp.json()
+
+        # Should have 2 changesets: the revert and the original edit
+        assert len(data) >= 2
+
+        # The newest changeset should be the revert
+        revert_cs = data[0]
+        assert revert_cs["note"] == "Reverting year"
+        assert len(revert_cs["retractions"]) == 1
+        assert revert_cs["retractions"][0]["field_name"] == "year"
+        assert revert_cs["retractions"][0]["old_value"] == 2005
+
+
+# ── Claim metadata in edit history ───────────────────────────────
+
+
+@pytest.mark.django_db
+class TestEditHistoryClaimMetadata:
+    def test_claim_metadata_populated(self, client, user, pm):
+        """Edit history includes claim_id, claim_user_id, is_active, is_winning."""
+        _make_user_edit(client, user, pm, {"year": 2005})
+
+        resp = client.get(f"/api/edit-history/machinemodel/{pm.slug}/")
+        data = resp.json()
+        change = data[0]["changes"][0]
+
+        assert change["claim_id"] is not None
+        assert change["claim_user_id"] == user.pk
+        assert change["is_active"] is True
+        assert change["is_winning"] is True
+
+    def test_reverted_claim_shows_inactive(self, client, user, pm):
+        """After revert, the original changeset's claim shows is_active=False."""
+        _make_user_edit(client, user, pm, {"year": 2005})
+        claim = _get_active_claim(pm, "year", user)
+
+        client.force_login(user)
+        _revert(client, pm.slug, claim.pk, "Undo")
+
+        resp = client.get(f"/api/edit-history/machinemodel/{pm.slug}/")
+        data = resp.json()
+
+        # Find the original edit changeset (the one with a year change, not the revert)
+        original = next(
+            cs
+            for cs in data
+            if cs["changes"] and cs["changes"][0].get("new_value") == 2005
+        )
+        change = original["changes"][0]
+        assert change["is_active"] is False
+        assert change["is_winning"] is False

--- a/docs/plans/ResolutionBoundary.md
+++ b/docs/plans/ResolutionBoundary.md
@@ -1,0 +1,162 @@
+# Resolution Boundary: Untangling Provenance and Catalog
+
+## The Problem
+
+Provenance owns claim data (Claim, ChangeSet, Source). Catalog owns what happens when claim data changes — resolving winning values into entity fields, materializing relationships, invalidating caches. But there's no clean boundary between them. Every claim mutation must trigger catalog-specific resolution, and the knowledge of _how_ to resolve is scattered across the codebase.
+
+This coupling was tolerable when claim mutations only happened in two places: interactive edits (catalog PATCH endpoints) and bulk ingestion (management commands). Both lived in catalog or were orchestrated by catalog-aware code. But as provenance gains its own write operations — such as one-click revert ( /Users/moses/.claude/plans/linked-mixing-piglet.md ) — the coupling becomes a real problem. Provenance can't deactivate a claim and trigger re-resolution without importing half of catalog.
+
+## Where the Coupling Lives
+
+### Interactive edits: caller-driven dispatch
+
+`execute_claims()` in `catalog/api/edit_claims.py` takes `resolve_fn` and `resolvers` as parameters. Each PATCH endpoint knows which entity type it's editing and which relationship resolvers to pass:
+
+```python
+# themes.py — caller knows to add parent/alias resolvers
+resolvers = []
+if data.parents is not None:
+    resolvers.append(resolve_theme_parents)
+if data.aliases is not None:
+    resolvers.append(resolve_theme_aliases)
+execute_claims(theme, specs, user=request.user, resolvers=resolvers)
+```
+
+This works because the caller always knows the entity type and which fields it's editing. The resolution knowledge stays in catalog.
+
+### Bulk ingestion: orchestrator-driven
+
+Management commands call `bulk_assert_claims()` (provenance), then explicitly call catalog resolution functions in the right order:
+
+```python
+# ingest_pinbase.py — orchestrator manually sequences resolution
+bulk_assert_claims(source=ipdb, pending=claims, ...)
+resolve_all_entities(MachineModel, object_ids=changed_ids)
+resolve_all_credits(model_ids=changed_ids)
+resolve_all_themes(model_ids=changed_ids)
+# ... etc
+```
+
+Again, catalog knowledge stays in catalog-aware code.
+
+### The problem case: provenance-initiated mutations
+
+One-click revert lives in provenance. It deactivates a claim, but then needs to:
+
+1. Determine whether the entity is a MachineModel (uses `resolve_model`) or anything else (uses `resolve_entity`)
+2. Look up which relationship resolver to call based on the claim's `field_name` (e.g., `theme_alias` needs `resolve_theme_aliases`)
+3. Call `invalidate_all()` from catalog's cache module
+
+This forces provenance to contain a dispatch table mapping claim namespaces to catalog resolver functions — hardcoded knowledge of every entity type and every relationship namespace. That's catalog's domain leaking into provenance.
+
+## Why It Matters
+
+Today it's revert. Tomorrow it could be:
+
+- Claim expiration (auto-deactivate claims older than N days from low-priority sources)
+- Moderation actions (admin deactivates a claim flagged for review)
+- Source disabling (deactivate all claims from a source that's been marked unreliable)
+
+Each of these is a provenance operation that needs catalog resolution afterward. Without a clean boundary, each one will need its own copy of the resolver dispatch table.
+
+## The Shape of the Coupling
+
+The coupling isn't symmetric. Provenance doesn't need to know _how_ resolution works — it just needs to say "claims changed for entity X, go figure it out." Catalog knows everything about resolution but has no way to offer that as a service.
+
+What's missing is a **resolution trigger interface**: something provenance can call that says "this entity's claims changed" and catalog handles the rest — picking the right resolver, running relationship resolvers, invalidating caches.
+
+The key inputs catalog needs:
+
+- **Which entity** (model class + PK, or the instance itself)
+- **Which fields changed** (optional — could just re-resolve everything, but targeted resolution is more efficient)
+
+The key thing catalog should encapsulate:
+
+- MachineModel vs everything else routing
+- Which relationship resolvers to run for which field names
+- Cache invalidation
+
+## Constraints
+
+- The bulk ingestion path resolves thousands of entities in optimized batches. Whatever interface we design must not force everything through a single-entity path. The batch path can remain orchestrator-driven — the problem is specifically single-entity mutations initiated by provenance.
+- `resolve_model()` does things `resolve_entity()` doesn't (M2M relationships, media attachments, abbreviations). This asymmetry is real and needs to be preserved, not papered over.
+- The relationship resolver dispatch depends on claim `field_name` values that are defined in `catalog/claims.py`. These are the canonical namespace strings (`theme_alias`, `gameplay_feature_parent`, etc.). Any registry-based approach would likely key on these.
+
+## Current Workarounds
+
+`execute_claims()` sidesteps the problem by making callers pass resolution details. This is fine for catalog-internal code (PATCH endpoints know their entity type). It doesn't work for provenance-initiated operations where the claim is fetched by PK and the entity type isn't known until runtime.
+
+## Direction
+
+### The resolution pipeline already exists — it just needs extracting
+
+`execute_claims()` already does exactly what provenance needs: run relationship resolvers, run entity resolver, invalidate cache. The problem is that this pipeline is fused to claim creation. The fix is extracting the bottom half of `execute_claims()` into a standalone function, not building something new.
+
+### `resolve_after_mutation(entity, field_names=None)`
+
+A single function in `catalog.resolve` that provenance (or anything else) can call after mutating claims. Internally it:
+
+1. Routes MachineModel to `resolve_model()` (which already handles all its own relationships)
+2. Routes everything else to the appropriate relationship resolver(s) + `resolve_entity()`
+3. Schedules cache invalidation via `transaction.on_commit(invalidate_all)`
+
+The function performs resolution synchronously (inside whatever transaction the caller has open) but defers cache invalidation until after successful commit. This preserves current semantics: if resolution fails, the transaction rolls back and no stale cache is served. Callers don't need to know about this — they call one function, inside their own `transaction.atomic()` block.
+
+`execute_claims()` itself becomes a thin wrapper: create claims, then call `resolve_after_mutation()`. Its existing `try/except` around `transaction.atomic()` continues to work unchanged — if resolution raises, the atomic block rolls back both the claims and the resolution, and `on_commit` never fires.
+
+### Dispatch: auto-discover aliases, explicit dicts for the rest
+
+`resolve_after_mutation()` needs to know which relationship resolver to run for a given `field_name`. The dispatch uses two strategies: auto-discovery where the pattern is universal and the type count is high, explicit dicts where the set is small and stable.
+
+#### Auto-discovered: aliases
+
+Walk `AliasBase.__subclasses__()` at import time. Each subclass has a FK to its parent model. Derive the claim field name as `{namespace}_alias` using `model._meta.verbose_name` with spaces replaced by underscores (Django auto-generates this from the class name: `GameplayFeature` → `"gameplay feature"` → `"gameplay_feature"`). Call `_resolve_aliases(model, field_name)` directly. This also auto-populates `LITERAL_SCHEMAS` (always `LiteralKey("alias_value", "alias")` for aliases) and replaces the hand-maintained `ALIAS_TYPES` list.
+
+This covers 7 alias types today and scales to new ones with zero registration — defining the `AliasBase` subclass is sufficient.
+
+#### Explicit dicts: everything else
+
+Parents (2 entries) and simple M2Ms (3 entries) are small, stable sets that rarely grow — new hierarchies and new M2M relationships on MachineModel are structural additions, not something that happens with every new entity type. Introspection machinery (self-referential M2M detection, through-model field analysis) to save a handful of one-liners isn't worth the debugging cost. Keep these as readable, greppable dicts inside `resolve_after_mutation()`.
+
+The full non-MachineModel dispatch:
+
+```python
+# Auto-discovered at import time from AliasBase subclasses
+ALIAS_RESOLVERS: dict[str, tuple[type, str]] = _discover_alias_types()
+
+# Explicit — small sets with stable membership
+PARENT_RESOLVERS: dict[str, tuple[type, str]] = {
+    "theme_parent": (Theme, "theme"),
+    "gameplay_feature_parent": (GameplayFeature, "gameplay_feature"),
+}
+SIMPLE_M2M_RESOLVERS: dict[str, M2MFieldSpec] = {
+    "theme": M2MFieldSpec("theme", "themes", Theme),
+    "reward_type": M2MFieldSpec("reward_type", "reward_types", RewardType),
+    "tag": M2MFieldSpec("tag", "tags", Tag),
+}
+# Custom resolvers — each accepts model_ids or entity_ids to scope
+# to the mutated entity. resolve_after_mutation() passes {entity.pk}.
+CUSTOM_RESOLVERS: dict[str, Callable[[set[int]], None]] = {
+    "abbreviation": lambda ids: resolve_all_title_abbreviations(model_ids=ids),
+    "corporate_entity_location": lambda ids: resolve_all_corporate_entity_locations(entity_ids=ids),
+    "series_title": lambda ids: resolve_all_series_titles(model_ids=ids),
+    "gameplay_feature": lambda ids: resolve_all_gameplay_features(model_ids=ids),
+    "credit": lambda ids: resolve_all_credits(model_ids=ids),
+}
+```
+
+Media attachments are handled by checking `isinstance(entity, MediaSupported)` when `field_name == "media_attachment"`. `resolve_media_attachments()` is already generic (takes content_type_id + entity_ids). Covers Manufacturer, Person, GameplayFeature, and MachineModel.
+
+For MachineModel, `resolve_model()` already handles all relationships internally, so this dispatch only matters for non-MachineModel entities.
+
+**Retiring old infrastructure:** Once `execute_claims()` calls `resolve_after_mutation()` internally, PATCH endpoints no longer pass resolvers. The per-entity wrapper functions (`resolve_theme_aliases()`, `resolve_theme_parents()`, etc.) become dead code and are removed. The hand-maintained `ALIAS_TYPES` list is replaced by auto-discovery. `M2M_FIELDS` stays as-is (it's already the right shape, just moves into the dispatch module).
+
+### What this means for the revert plan
+
+The revert plan's step 6 (determine `resolve_fn`) and step 7 (determine relationship resolvers) collapse into a single call: `resolve_after_mutation(entity, field_names=[target.field_name])`. The `isinstance` routing, resolver lookup, and cache invalidation all move inside that function.
+
+### Decisions
+
+- **Simple function, not events.** Direct call. Events add indirection and debugging cost with no second subscriber to justify them.
+- **Cache invalidation is internal, via `on_commit`.** The whole point is "call one thing." The caller doesn't manage cache invalidation. But invalidation is deferred to after commit via `transaction.on_commit()`, so it never fires if the transaction rolls back.
+- **Bulk path stays separate.** Bulk ingestion resolves thousands of entities in optimized batches with explicit sequencing. Forcing it through a single-entity interface would be a performance regression. The orchestrator-driven pattern is correct for bulk; this interface is for single-entity mutations initiated outside catalog.

--- a/docs/plans/user_engagement/RichText.md
+++ b/docs/plans/user_engagement/RichText.md
@@ -72,4 +72,3 @@ No external study directly answers the question for Pinbase, because the answer 
 
 - **Technical comfort.** Do these contributors use Markdown regularly, or is it foreign? If the former, keyboard shortcuts may be sufficient. If the latter, even a toolbar is a meaningful improvement.
 - **Where the drop-off is.** Are people failing to start contributions, or starting and producing poorly-formatted content? The editor choice addresses the second problem, not the first.
-- **What else the engineering time could buy.** Watchlists, recent changes feed, better photo upload, talk pages — features from the UserEngagement plan that might move the engagement needle more than editor polish.

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -1,12 +1,81 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import client from '$lib/api/client';
 	import type { components } from '$lib/api/schema';
+	import { auth } from '$lib/auth.svelte';
 	import InlineDiff from './InlineDiff.svelte';
 	import UserBadge from './UserBadge.svelte';
+	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { isDiffable, formatValue } from './change-display';
 
 	type ChangeSet = components['schemas']['ChangeSetSchema'];
+	type FieldChange = components['schemas']['FieldChangeSchema'];
 
-	let { changesets }: { changesets: ChangeSet[] } = $props();
+	let {
+		changesets,
+		entityType,
+		entitySlug
+	}: { changesets: ChangeSet[]; entityType: string; entitySlug: string } = $props();
+
+	let revertingClaimId = $state<number | null>(null);
+	let revertNote = $state('');
+	let revertError = $state<string | null>(null);
+	let revertLoading = $state(false);
+
+	interface RetractionInfo {
+		user_display: string | null | undefined;
+		created_at: string;
+		note: string;
+	}
+
+	/**
+	 * Build a lookup: claim_id → retraction info from the revert changeset.
+	 * Keyed by claim_id (not claim_key) so repeated reverts of the same
+	 * field each get their own attribution.
+	 */
+	let retractionLookup = $derived.by(() => {
+		const lookup = new SvelteMap<number, RetractionInfo>();
+		for (const cs of changesets) {
+			for (const r of cs.retractions ?? []) {
+				lookup.set(r.claim_id, {
+					user_display: cs.user_display,
+					created_at: cs.created_at,
+					note: cs.note
+				});
+			}
+		}
+		return lookup;
+	});
+
+	/** Set of claim_ids that appear in retractions (for suppressing revert cards). */
+	let matchedRetractionIds = $derived.by(() => {
+		const ids = new SvelteSet<number>();
+		for (const cs of changesets) {
+			for (const change of cs.changes) {
+				if (
+					change.is_retracted &&
+					change.claim_id != null &&
+					retractionLookup.has(change.claim_id)
+				) {
+					ids.add(change.claim_id);
+				}
+			}
+		}
+		return ids;
+	});
+
+	/**
+	 * A changeset is "empty" when all its visual content has been absorbed
+	 * elsewhere (retractions shown inline on original changes). Hide these
+	 * to avoid blank cards.
+	 */
+	function isEmptyChangeset(cs: ChangeSet): boolean {
+		const hasChanges = cs.changes.length > 0;
+		const hasUnmatchedRetractions = (cs.retractions ?? []).some(
+			(r) => !matchedRetractionIds.has(r.claim_id)
+		);
+		return !hasChanges && !hasUnmatchedRetractions;
+	}
 
 	function formatDate(iso: string): string {
 		const d = new Date(iso);
@@ -18,45 +87,179 @@
 			minute: '2-digit'
 		});
 	}
+
+	function canRevert(change: FieldChange): boolean {
+		return (
+			auth.isAuthenticated &&
+			change.is_active === true &&
+			change.claim_user_id !== null &&
+			change.claim_id !== null
+		);
+	}
+
+	function startRevert(claimId: number) {
+		revertingClaimId = claimId;
+		revertNote = '';
+		revertError = null;
+	}
+
+	function cancelRevert() {
+		revertingClaimId = null;
+		revertNote = '';
+		revertError = null;
+	}
+
+	async function submitRevert() {
+		if (!revertingClaimId || !revertNote.trim()) return;
+		revertLoading = true;
+		revertError = null;
+
+		const { error } = await client.POST('/api/edit-history/{entity_type}/{slug}/revert/', {
+			params: { path: { entity_type: entityType, slug: entitySlug } },
+			body: { claim_id: revertingClaimId, note: revertNote }
+		});
+
+		revertLoading = false;
+
+		if (error) {
+			revertError = (error as { detail?: string }).detail ?? 'Revert failed.';
+		} else {
+			revertingClaimId = null;
+			revertNote = '';
+			await invalidateAll();
+		}
+	}
 </script>
+
+{#snippet revertControls(change: FieldChange)}
+	{#if canRevert(change)}
+		<div class="revert-cell">
+			{#if revertingClaimId === change.claim_id}
+				<div class="revert-form">
+					<input
+						type="text"
+						bind:value={revertNote}
+						placeholder="Reason for reverting…"
+						class="revert-input"
+						disabled={revertLoading}
+					/>
+					<div class="revert-actions">
+						<button
+							class="btn-revert-submit"
+							onclick={submitRevert}
+							disabled={revertLoading || !revertNote.trim()}
+						>
+							{revertLoading ? 'Reverting…' : 'Confirm'}
+						</button>
+						<button class="btn-revert-cancel" onclick={cancelRevert} disabled={revertLoading}>
+							Cancel
+						</button>
+					</div>
+					{#if revertError}
+						<p class="revert-error">{revertError}</p>
+					{/if}
+				</div>
+			{:else}
+				<button
+					class="btn-revert"
+					class:btn-revert-dim={change.is_winning === false}
+					title={change.is_winning === false
+						? "This change doesn't affect the current page"
+						: 'Revert this change'}
+					onclick={() => startRevert(change.claim_id!)}
+				>
+					Revert
+				</button>
+			{/if}
+		</div>
+	{/if}
+{/snippet}
 
 {#if changesets.length > 0}
 	<section class="edit-history">
 		<h2>Edit History</h2>
 		<ol class="changeset-list">
 			{#each changesets as cs (cs.id)}
-				<li class="changeset">
-					<div class="changeset-header">
-						<UserBadge username={cs.user_display} />
-						<time datetime={cs.created_at}>{formatDate(cs.created_at)}</time>
-					</div>
-					{#if cs.note}
-						<p class="changeset-note">{cs.note}</p>
-					{/if}
-					<dl class="field-list">
-						{#each cs.changes as change (change.claim_key)}
-							{#if isDiffable(change)}
-								<div class="field-row field-row-diff">
-									<dt>{change.field_name}</dt>
-									<dd>
-										<InlineDiff oldValue={change.old_value} newValue={change.new_value} />
-									</dd>
-								</div>
-							{:else}
-								<div class="field-row">
-									<dt>{change.field_name}</dt>
-									<dd>
-										{#if change.old_value !== null && change.old_value !== undefined}
-											<span class="old-value">{formatValue(change.old_value)}</span>
-											<span class="arrow">&rarr;</span>
+				{#if !isEmptyChangeset(cs)}
+					<li class="changeset">
+						<div class="changeset-header">
+							<UserBadge username={cs.user_display} />
+							<time datetime={cs.created_at}>{formatDate(cs.created_at)}</time>
+						</div>
+						{#if cs.note}
+							<p class="changeset-note">{cs.note}</p>
+						{/if}
+						<dl class="field-list">
+							{#each cs.changes as change (change.claim_key)}
+								{#if change.is_retracted}
+									{@const info =
+										change.claim_id != null ? retractionLookup.get(change.claim_id) : undefined}
+									<div
+										class="field-row field-row-retraction"
+										class:field-row-diff={isDiffable(change)}
+									>
+										<dt>{change.field_name}</dt>
+										<dd>
+											<span class="reverted-badge">reverted</span>
+											{#if info}
+												by {#if info.user_display}<a href="/users/{info.user_display}"
+														>{info.user_display}</a
+													>{:else}system{/if}
+												on {formatDate(info.created_at)}{#if info.note}:
+													{info.note}{/if}
+											{/if}
+										</dd>
+										{#if isDiffable(change)}
+											<dd>
+												<InlineDiff oldValue={change.old_value} newValue={change.new_value} />
+											</dd>
+										{:else}
+											<dd>
+												{#if change.old_value !== null && change.old_value !== undefined}
+													<span class="old-value">{formatValue(change.old_value)}</span>
+													<span class="arrow">&rarr;</span>
+												{/if}
+												<span class="old-value">{formatValue(change.new_value)}</span>
+											</dd>
 										{/if}
-										<span class="new-value">{formatValue(change.new_value)}</span>
-									</dd>
-								</div>
-							{/if}
-						{/each}
-					</dl>
-				</li>
+									</div>
+								{:else if isDiffable(change)}
+									<div class="field-row field-row-diff">
+										<dt>{change.field_name}</dt>
+										<dd>
+											<InlineDiff oldValue={change.old_value} newValue={change.new_value} />
+										</dd>
+										{@render revertControls(change)}
+									</div>
+								{:else}
+									<div class="field-row">
+										<dt>{change.field_name}</dt>
+										<dd>
+											{#if change.old_value !== null && change.old_value !== undefined}
+												<span class="old-value">{formatValue(change.old_value)}</span>
+												<span class="arrow">&rarr;</span>
+											{/if}
+											<span class="new-value">{formatValue(change.new_value)}</span>
+										</dd>
+										{@render revertControls(change)}
+									</div>
+								{/if}
+							{/each}
+							<!-- Show retractions that couldn't be matched to an original change -->
+							{#each cs.retractions ?? [] as retraction (retraction.claim_key)}
+								{#if !matchedRetractionIds.has(retraction.claim_id)}
+									<div class="field-row field-row-retraction">
+										<dt>{retraction.field_name}</dt>
+										<dd>
+											<span class="reverted-badge">reverted</span>
+											<span class="old-value">{formatValue(retraction.old_value)}</span>
+										</dd>
+									</div>
+								{/if}
+							{/each}
+						</dl>
+					</li>
+				{/if}
 			{/each}
 		</ol>
 	</section>
@@ -118,6 +321,7 @@
 		padding: var(--size-1) 0;
 		border-bottom: 1px solid var(--color-border-soft);
 		font-size: var(--font-size-0);
+		flex-wrap: wrap;
 	}
 
 	.field-row:last-child {
@@ -137,6 +341,7 @@
 		gap: var(--size-1);
 		color: var(--color-text-primary);
 		word-break: break-word;
+		flex: 1;
 	}
 
 	.field-row-diff {
@@ -165,5 +370,98 @@
 	.no-history {
 		font-size: var(--font-size-1);
 		color: var(--color-text-muted);
+	}
+
+	/* Revert controls */
+	.revert-cell {
+		margin-left: auto;
+		flex-shrink: 0;
+	}
+
+	.btn-revert {
+		font-size: var(--font-size-00, 0.75rem);
+		padding: 0.15em 0.5em;
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-1);
+		background: transparent;
+		color: var(--color-text-muted);
+		cursor: pointer;
+	}
+
+	.btn-revert:hover {
+		border-color: var(--color-danger, #c00);
+		color: var(--color-danger, #c00);
+	}
+
+	.btn-revert-dim {
+		opacity: 0.5;
+	}
+
+	.revert-form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--size-1);
+		padding: var(--size-1) 0;
+	}
+
+	.revert-input {
+		font-size: var(--font-size-0);
+		padding: var(--size-1);
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-1);
+		width: 100%;
+		min-width: 16rem;
+	}
+
+	.revert-actions {
+		display: flex;
+		gap: var(--size-1);
+	}
+
+	.btn-revert-submit {
+		font-size: var(--font-size-00, 0.75rem);
+		padding: 0.25em 0.75em;
+		border: 1px solid var(--color-danger, #c00);
+		border-radius: var(--radius-1);
+		background: var(--color-danger, #c00);
+		color: white;
+		cursor: pointer;
+	}
+
+	.btn-revert-submit:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-revert-cancel {
+		font-size: var(--font-size-00, 0.75rem);
+		padding: 0.25em 0.75em;
+		border: 1px solid var(--color-border-soft);
+		border-radius: var(--radius-1);
+		background: transparent;
+		color: var(--color-text-muted);
+		cursor: pointer;
+	}
+
+	.revert-error {
+		font-size: var(--font-size-00, 0.75rem);
+		color: var(--color-danger, #c00);
+		margin: 0;
+	}
+
+	/* Retraction rows */
+	.field-row-retraction {
+		opacity: 0.6;
+	}
+
+	.reverted-badge {
+		font-size: var(--font-size-00, 0.75rem);
+		padding: 0.1em 0.4em;
+		border-radius: var(--radius-1);
+		background: var(--color-danger, #c00);
+		color: white;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
 	}
 </style>

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -88,7 +88,7 @@
 
 			{#if auth.loaded}
 				{#if auth.isAuthenticated}
-					<span class="auth-user">{auth.username}</span>
+					<a href={resolveHref(`/users/${auth.username}`)} class="auth-user">{auth.username}</a>
 					<button class="auth-link" onclick={handleLogout}>Sign out</button>
 				{:else}
 					<a
@@ -275,6 +275,12 @@
 	.auth-user {
 		font-size: var(--font-size-2);
 		color: var(--header-ink-muted);
+		text-decoration: none;
+		transition: color 0.15s var(--ease-2);
+	}
+
+	.auth-user:hover {
+		color: var(--header-ink);
 	}
 
 	.auth-link {

--- a/frontend/src/routes/corporate-entities/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/corporate-entities/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/corporate-entities/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/corporate-entities/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'corporateentity', slug: params.slug };
 };

--- a/frontend/src/routes/franchises/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/franchises/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/franchises/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/franchises/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'franchise', slug: params.slug };
 };

--- a/frontend/src/routes/gameplay-features/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/gameplay-features/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/gameplay-features/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/gameplay-features/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'gameplayfeature', slug: params.slug };
 };

--- a/frontend/src/routes/manufacturers/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/manufacturers/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/manufacturers/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'manufacturer', slug: params.slug };
 };

--- a/frontend/src/routes/models/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/models/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/models/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/models/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'machinemodel', slug: params.slug };
 };

--- a/frontend/src/routes/people/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/people/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/people/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/people/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'person', slug: params.slug };
 };

--- a/frontend/src/routes/series/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/series/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/series/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/series/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'series', slug: params.slug };
 };

--- a/frontend/src/routes/systems/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/systems/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/systems/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/systems/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'system', slug: params.slug };
 };

--- a/frontend/src/routes/themes/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/themes/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/themes/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/themes/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'theme', slug: params.slug };
 };

--- a/frontend/src/routes/titles/[slug]/edit-history/+page.svelte
+++ b/frontend/src/routes/titles/[slug]/edit-history/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props();
 </script>
 
-<EditHistory changesets={data.changesets} />
+<EditHistory changesets={data.changesets} entityType={data.entityType} entitySlug={data.slug} />

--- a/frontend/src/routes/titles/[slug]/edit-history/+page.ts
+++ b/frontend/src/routes/titles/[slug]/edit-history/+page.ts
@@ -9,5 +9,5 @@ export const load: PageLoad = async ({ params }) => {
 
 	if (!data) error(500, 'Failed to load edit history');
 
-	return { changesets: data };
+	return { changesets: data, entityType: 'title', slug: params.slug };
 };


### PR DESCRIPTION
## Summary

- **Centralise resolution dispatch** behind `resolve_after_mutation()` — a single entry-point that any module (including provenance) can call after mutating claims. Routes to the correct resolver(s) based on entity type and changed field names, with auto-discovery for alias types.
- **Per-field one-click revert** on edit history pages. Each user claim gets a "Revert" button that deactivates the claim, re-activates the user's predecessor if one exists, and re-resolves via `resolve_after_mutation()`. Reverting others' changes requires 5+ edits; reverting your own has no threshold. Required note on every revert.
- **Link username in nav** to user profile page.

## Key design decisions

- Revert = deactivate + re-resolve, not inverse claims. The resolution machinery picks the winner from whatever remains.
- Predecessor re-activation: reverting your latest edit surfaces your previous edit, not the source default. Repeatedly reverting walks back through the chain.
- Reverted changes shown inline on the original changeset card with attribution (who/when/why), not as a separate card.
- `RevertError` domain exception keeps HTTP concerns out of business logic.

## Test plan

- [ ] 19 new backend tests covering: scalar revert, predecessor re-activation/chain, non-winning revert, self-revert, threshold enforcement (403), validation (401/404/422), multi-user interleaving, retraction in history, claim metadata
- [ ] `make test` passes (1459 backend + 268 frontend)
- [ ] `make lint` clean
- [ ] Manual: edit a field, revert it, confirm previous value surfaces and retraction attribution appears inline
- [ ] Manual: verify reverting a non-winning claim deactivates it without changing the page value

🤖 Generated with [Claude Code](https://claude.com/claude-code)