### PR TITLE
feat: friendly relative timestamps (smart dates)

### DIFF
--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -7,6 +7,7 @@
 	import UserBadge from './UserBadge.svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { isDiffable, formatValue } from './change-display';
+	import SmartDate from './SmartDate.svelte';
 
 	type ChangeSet = components['schemas']['ChangeSetSchema'];
 	type FieldChange = components['schemas']['FieldChangeSchema'];
@@ -75,17 +76,6 @@
 			(r) => !matchedRetractionIds.has(r.claim_id)
 		);
 		return !hasChanges && !hasUnmatchedRetractions;
-	}
-
-	function formatDate(iso: string): string {
-		const d = new Date(iso);
-		return d.toLocaleDateString('en', {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric',
-			hour: 'numeric',
-			minute: '2-digit'
-		});
 	}
 
 	function canRevert(change: FieldChange): boolean {
@@ -184,7 +174,7 @@
 					<li class="changeset">
 						<div class="changeset-header">
 							<UserBadge username={cs.user_display} />
-							<time datetime={cs.created_at}>{formatDate(cs.created_at)}</time>
+							<span class="timestamp"><SmartDate iso={cs.created_at} /></span>
 						</div>
 						{#if cs.note}
 							<p class="changeset-note">{cs.note}</p>
@@ -205,7 +195,9 @@
 												by {#if info.user_display}<a href="/users/{info.user_display}"
 														>{info.user_display}</a
 													>{:else}system{/if}
-												on {formatDate(info.created_at)}{#if info.note}:
+												on
+												<span class="timestamp"><SmartDate iso={info.created_at} /></span
+												>{#if info.note}:
 													{info.note}{/if}
 											{/if}
 										</dd>
@@ -297,7 +289,7 @@
 		margin-bottom: var(--size-2);
 	}
 
-	time {
+	.timestamp {
 		font-size: var(--font-size-0);
 		color: var(--color-text-muted);
 	}

--- a/frontend/src/lib/components/SmartDate.svelte
+++ b/frontend/src/lib/components/SmartDate.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { smartDate, fullDateTime } from '$lib/dates';
+
+	let { iso }: { iso: string } = $props();
+</script>
+
+<time datetime={iso} title={fullDateTime(iso)}>{smartDate(iso)}</time>

--- a/frontend/src/lib/dates.test.ts
+++ b/frontend/src/lib/dates.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isSameDay, formatTime, smartDate, formatDate } from './dates';
+
+// ── isSameDay ───────────────────────────────────────────────────
+
+describe('isSameDay', () => {
+	it('returns true for same date at different times', () => {
+		const a = new Date(2025, 5, 15, 9, 0);
+		const b = new Date(2025, 5, 15, 21, 45);
+		expect(isSameDay(a, b)).toBe(true);
+	});
+
+	it('returns false for different days in same month', () => {
+		const a = new Date(2025, 5, 15, 12, 0);
+		const b = new Date(2025, 5, 16, 12, 0);
+		expect(isSameDay(a, b)).toBe(false);
+	});
+
+	it('returns false for same day in different months', () => {
+		const a = new Date(2025, 5, 15, 12, 0);
+		const b = new Date(2025, 6, 15, 12, 0);
+		expect(isSameDay(a, b)).toBe(false);
+	});
+
+	it('returns false for same month/day in different years', () => {
+		const a = new Date(2025, 5, 15, 12, 0);
+		const b = new Date(2026, 5, 15, 12, 0);
+		expect(isSameDay(a, b)).toBe(false);
+	});
+
+	it('handles midnight boundary (11:59 PM vs 12:00 AM next day)', () => {
+		const a = new Date(2025, 5, 15, 23, 59);
+		const b = new Date(2025, 5, 16, 0, 0);
+		expect(isSameDay(a, b)).toBe(false);
+	});
+});
+
+// ── formatTime ──────────────────────────────────────────────────
+
+describe('formatTime', () => {
+	it('returns a lowercase string', () => {
+		const result = formatTime(new Date(2025, 5, 15, 14, 30));
+		expect(result).toBe(result.toLowerCase());
+	});
+
+	it('includes minutes when they are non-zero', () => {
+		const result = formatTime(new Date(2025, 5, 15, 14, 30));
+		expect(result).toMatch(/30/);
+	});
+
+	it('omits minutes when they are zero', () => {
+		const result = formatTime(new Date(2025, 5, 15, 14, 0));
+		// Should not contain :00 — the Intl formatter omits minutes
+		expect(result).not.toMatch(/:00/);
+	});
+});
+
+// ── smartDate ───────────────────────────────────────────────────
+
+describe('smartDate', () => {
+	// Fixed "now": Wednesday, June 18, 2025 at 3:00 PM
+	const NOW = new Date(2025, 5, 18, 15, 0);
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('shows just the time for same day', () => {
+		const result = smartDate(new Date(2025, 5, 18, 9, 30).toISOString());
+		// Should contain the time digits but no day/date prefix
+		expect(result).toMatch(/9/);
+		expect(result).toMatch(/30/);
+		expect(result).not.toMatch(/yesterday/i);
+	});
+
+	it('shows a relative label (not a date) for yesterday', () => {
+		const result = smartDate(new Date(2025, 5, 17, 10, 0).toISOString());
+		// Should NOT contain a month name, day number, or year — just a
+		// locale-relative label ("Yesterday", "hier", "gestern", …) + time.
+		expect(result).not.toMatch(/2025/);
+		expect(result).not.toMatch(/17/);
+		expect(result.length).toBeGreaterThan(0);
+	});
+
+	it('shows weekday abbreviation within 7 days', () => {
+		// Saturday June 14 — 4 days before NOW (Wed June 18)
+		const result = smartDate(new Date(2025, 5, 14, 10, 0).toISOString());
+		expect(result).not.toMatch(/yesterday/i);
+		expect(result.length).toBeGreaterThan(0);
+		// Should not include year or month — just weekday + time
+		expect(result).not.toMatch(/2025/);
+		expect(result).not.toMatch(/jun/i);
+	});
+
+	it('shows month and day for same year beyond 7 days', () => {
+		// March 10, 2025 — same year, more than 7 days ago
+		const result = smartDate(new Date(2025, 2, 10, 14, 0).toISOString());
+		// Should contain day number and not the year
+		expect(result).toMatch(/10/);
+		expect(result).not.toMatch(/2025/);
+	});
+
+	it('shows month, day, and year for different year', () => {
+		const result = smartDate(new Date(2024, 11, 25, 9, 0).toISOString());
+		// Should contain the year and the day
+		expect(result).toMatch(/2024/);
+		expect(result).toMatch(/25/);
+	});
+
+	it('returns empty string for empty input', () => {
+		expect(smartDate('')).toBe('');
+	});
+
+	it('uses calendar days for the 7-day boundary, not elapsed time', () => {
+		// June 12 at 11pm — 6 calendar days before NOW (June 18 3pm),
+		// but more than 6*24h elapsed. Should still show weekday, not month+day.
+		const result = smartDate(new Date(2025, 5, 12, 23, 0).toISOString());
+		expect(result).not.toMatch(/jun/i);
+		expect(result).not.toMatch(/2025/);
+	});
+
+	it('shows month+day at exactly 7 calendar days ago', () => {
+		// June 11 — exactly 7 calendar days before June 18
+		const result = smartDate(new Date(2025, 5, 11, 10, 0).toISOString());
+		expect(result).toMatch(/11/);
+		expect(result).not.toMatch(/2025/);
+	});
+
+	it('falls through to absolute date for future dates', () => {
+		// July 20, 2025 — over a month in the future, same year
+		const result = smartDate(new Date(2025, 6, 20, 14, 0).toISOString());
+		expect(result).toMatch(/20/);
+		expect(result).not.toMatch(/2025/);
+	});
+
+	it('falls through to full date for future dates in a different year', () => {
+		const result = smartDate(new Date(2026, 0, 15, 10, 0).toISOString());
+		expect(result).toMatch(/2026/);
+		expect(result).toMatch(/15/);
+	});
+});
+
+// ── formatDate ──────────────────────────────────────────────────
+
+describe('formatDate', () => {
+	it('includes day and year', () => {
+		const result = formatDate(new Date(2024, 2, 10).toISOString());
+		expect(result).toMatch(/10/);
+		expect(result).toMatch(/2024/);
+	});
+
+	it('does not include a time component', () => {
+		const result = formatDate(new Date(2024, 2, 10, 14, 30).toISOString());
+		// Should not contain hour/minute indicators
+		expect(result).not.toMatch(/[AP]M/i);
+		expect(result).not.toMatch(/14/);
+		expect(result).not.toMatch(/30/);
+	});
+
+	it('returns empty string for empty input', () => {
+		expect(formatDate('')).toBe('');
+	});
+});

--- a/frontend/src/lib/dates.ts
+++ b/frontend/src/lib/dates.ts
@@ -1,0 +1,82 @@
+/** Friendly date formatting utilities. */
+
+export function isSameDay(a: Date, b: Date): boolean {
+	return (
+		a.getFullYear() === b.getFullYear() &&
+		a.getMonth() === b.getMonth() &&
+		a.getDate() === b.getDate()
+	);
+}
+
+export function formatTime(date: Date): string {
+	const minutes = date.getMinutes();
+	const formatter = new Intl.DateTimeFormat(undefined, {
+		hour: 'numeric',
+		minute: minutes === 0 ? undefined : '2-digit'
+	});
+	return formatter.format(date).toLowerCase();
+}
+
+export function smartDate(iso: string): string {
+	if (!iso) return '';
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) return '';
+
+	const now = new Date();
+	const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	const startOfDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+	const calendarDays = Math.round((startOfToday.getTime() - startOfDate.getTime()) / 86_400_000);
+
+	if (isSameDay(date, now)) {
+		return formatTime(date);
+	}
+
+	if (calendarDays === 1) {
+		const yesterday = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(-1, 'day');
+		return `${yesterday[0].toUpperCase()}${yesterday.slice(1)} ${formatTime(date)}`;
+	}
+
+	if (calendarDays > 0 && calendarDays < 7) {
+		const weekday = new Intl.DateTimeFormat(undefined, { weekday: 'short' }).format(date);
+		return `${weekday} ${formatTime(date)}`;
+	}
+
+	if (date.getFullYear() === now.getFullYear()) {
+		const monthDay = new Intl.DateTimeFormat(undefined, {
+			month: 'short',
+			day: 'numeric'
+		}).format(date);
+		return `${monthDay} ${formatTime(date)}`;
+	}
+
+	const full = new Intl.DateTimeFormat(undefined, {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric'
+	}).format(date);
+	return `${full} ${formatTime(date)}`;
+}
+
+export function fullDateTime(iso: string): string {
+	if (!iso) return '';
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) return '';
+	return new Intl.DateTimeFormat(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit'
+	}).format(date);
+}
+
+export function formatDate(iso: string): string {
+	if (!iso) return '';
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) return '';
+	return new Intl.DateTimeFormat(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric'
+	}).format(date);
+}

--- a/frontend/src/routes/recent-changes/+page.svelte
+++ b/frontend/src/routes/recent-changes/+page.svelte
@@ -4,6 +4,7 @@
 	import { ENTITY_TYPES } from '$lib/api/catalog-meta';
 	import { SITE_NAME } from '$lib/constants';
 	import { resolveHref } from '$lib/utils';
+	import SmartDate from '$lib/components/SmartDate.svelte';
 	import InlineDiff from '$lib/components/InlineDiff.svelte';
 	import UserBadge from '$lib/components/UserBadge.svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
@@ -130,16 +131,6 @@
 		}
 	}
 
-	function formatDateTime(iso: string): string {
-		return new Date(iso).toLocaleDateString('en', {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric',
-			hour: 'numeric',
-			minute: '2-digit'
-		});
-	}
-
 	// Reload on filter change
 	let filterKey = $derived(`${entityType}|${timeRange}|${includeIngest}`);
 
@@ -226,7 +217,7 @@
 								<span class="entity-type">{cs.entity_type_label}</span>
 							</a>
 						</div>
-						<time datetime={cs.created_at}>{formatDateTime(cs.created_at)}</time>
+						<span class="timestamp"><SmartDate iso={cs.created_at} /></span>
 					</div>
 
 					<div class="feed-body">
@@ -404,7 +395,7 @@
 		flex: 1;
 	}
 
-	.feed-header time {
+	.timestamp {
 		font-size: var(--font-size-0);
 		color: var(--color-text-muted);
 		margin-left: auto;
@@ -605,7 +596,7 @@
 			gap: var(--size-1);
 		}
 
-		.feed-header time {
+		.timestamp {
 			margin-left: 0;
 		}
 

--- a/frontend/src/routes/users/[username]/+page.svelte
+++ b/frontend/src/routes/users/[username]/+page.svelte
@@ -1,27 +1,10 @@
 <script lang="ts">
 	import { SITE_NAME } from '$lib/constants';
 	import { resolveHref } from '$lib/utils';
+	import SmartDate from '$lib/components/SmartDate.svelte';
 
 	let { data } = $props();
 	let { profile } = data;
-
-	function formatDate(iso: string): string {
-		return new Date(iso).toLocaleDateString('en', {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric'
-		});
-	}
-
-	function formatDateTime(iso: string): string {
-		return new Date(iso).toLocaleDateString('en', {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric',
-			hour: 'numeric',
-			minute: '2-digit'
-		});
-	}
 </script>
 
 <svelte:head>
@@ -32,7 +15,10 @@
 	<header class="profile-header">
 		<h1>@{profile.username}</h1>
 		<p class="meta">
-			Member since {formatDate(profile.member_since)} · {profile.edit_count}
+			Member since {new Date(profile.member_since).toLocaleDateString(undefined, {
+				month: 'short',
+				year: 'numeric'
+			})} · {profile.edit_count}
 			{profile.edit_count === 1 ? 'edit' : 'edits'}
 		</p>
 	</header>
@@ -49,9 +35,8 @@
 						</a>
 						<span class="entity-meta">
 							{entity.edit_count}
-							{entity.edit_count === 1 ? 'edit' : 'edits'} · last {formatDate(
-								entity.last_edited_at
-							)}
+							{entity.edit_count === 1 ? 'edit' : 'edits'} · last
+							<SmartDate iso={entity.last_edited_at} />
 						</span>
 					</li>
 				{/each}
@@ -70,7 +55,7 @@
 								<span class="entity-name">{edit.entity_name}</span>
 								<span class="entity-type">{edit.entity_type_label}</span>
 							</a>
-							<time datetime={edit.created_at}>{formatDateTime(edit.created_at)}</time>
+							<span class="timestamp"><SmartDate iso={edit.created_at} /></span>
 						</div>
 						{#if edit.note}
 							<p class="edit-note">{edit.note}</p>
@@ -185,7 +170,7 @@
 		width: 100%;
 	}
 
-	.edit-header time {
+	.timestamp {
 		font-size: var(--font-size-0);
 		color: var(--color-text-muted);
 		margin-left: auto;


### PR DESCRIPTION
## Summary
- Add `smartDate()` utility and `<SmartDate>` component for context-aware date formatting: time-only for today, localized "yesterday", weekday within 7 days, month/day or full date beyond that
- Replace duplicated inline `formatDate`/`formatDateTime` functions across EditHistory, recent-changes feed, and user profile with shared utility
- `<SmartDate>` renders a `<time>` element with full datetime in the `title` attribute for hover tooltip
- Uses `Intl.RelativeTimeFormat` for locale-aware "yesterday" label; all formatting via `Intl.DateTimeFormat(undefined, ...)` for i18n
- Calendar-day comparison for the 7-day boundary (not elapsed milliseconds)
- Future dates fall through to absolute format instead of incorrectly showing a weekday
- "Member since" on user profile changed to month+year only

## Test plan
- [x] 21 vitest tests in `dates.test.ts` covering `isSameDay`, `formatTime`, `smartDate`, and `formatDate`
- [x] Tests use fake timers and locale-independent assertions
- [x] `pnpm check` — 0 type errors
- [x] `pnpm lint` — 0 lint issues
- [x] All 289 frontend tests pass
- [ ] Manual: visit edit history, recent changes, and user profile pages — confirm friendly dates render
- [ ] Manual: hover over a smart date to see full datetime tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)