### PR TITLE
Fix Django settings for Caddy reverse proxy topology

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,9 +2,7 @@
 
 @django path /api /api/* /admin /admin/* /media/* /static /static/*
 handle @django {
-	reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000} {
-		header_up X-Forwarded-Proto https
-	}
+	reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000}
 }
 
 handle {

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-{$HOST:0.0.0.0}:{$PORT:8080}
+:{$PORT:8080}
 
 @django path /api /api/* /admin /admin/* /media/* /static /static/*
 handle @django {

--- a/Caddyfile
+++ b/Caddyfile
@@ -2,7 +2,9 @@
 
 @django path /api /api/* /admin /admin/* /media/* /static /static/*
 handle @django {
-	reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000}
+	reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000} {
+		header_up X-Forwarded-Proto https
+	}
 }
 
 handle {

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -199,8 +199,11 @@ if not DEBUG:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
     SESSION_COOKIE_SAMESITE = "Lax"
-    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-    SECURE_SSL_REDIRECT = True
+    # TLS is terminated by Railway's edge proxy and (in the container) by
+    # Caddy.  Django never receives external traffic directly, so SSL
+    # redirect and proxy-header sniffing are unnecessary.  Keeping them
+    # would break internal callers (SSR, health checks) that reach Django
+    # over plain HTTP on 127.0.0.1.
 
 # ---------------------------------------------------------------------------
 # Constance (runtime-configurable settings)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -19,6 +19,11 @@ ALLOWED_HOSTS = [
     for h in os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
     if h.strip()
 ]
+# SSR and health-check traffic reaches Django on 127.0.0.1 inside the
+# container, so localhost must always be allowed regardless of the env var.
+for _host in ("localhost", "127.0.0.1"):
+    if _host not in ALLOWED_HOSTS:
+        ALLOWED_HOSTS.append(_host)
 
 INSTALLED_APPS = [
     "django.contrib.admin",


### PR DESCRIPTION
## Summary

- Disable Caddy auto-HTTPS — Railway terminates TLS at the edge and forwards plain HTTP to the container
- Remove `SECURE_SSL_REDIRECT` and `SECURE_PROXY_SSL_HEADER` — Django is now an internal service behind Caddy, never receiving external traffic directly
- Always include `localhost` / `127.0.0.1` in `ALLOWED_HOSTS` — SSR load functions and health checks call Django at `127.0.0.1:8000`

## Test plan

- [x] Verified in production: public pages, SSR detail pages, CSR list pages, and `/__health` all return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)