### PR TITLE
perf: 6-54x faster cold-cache rebuild for /all/ endpoints

### DIFF
--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -70,6 +70,8 @@ def _uploaded_image_urls(primary_media) -> tuple[str | None, str | None]:
 def _extract_image_urls(
     extra_data: dict,
     primary_media=None,
+    *,
+    min_rank: int | None = None,
 ) -> tuple[str | None, str | None]:
     """Return (thumbnail_url, hero_image_url).
 
@@ -77,6 +79,8 @@ def _extract_image_urls(
     images, those are used unconditionally (no license gating — Pinbase owns
     them).  Otherwise falls back to third-party images in *extra_data*,
     respecting the global Constance display threshold.
+
+    Pass *min_rank* to avoid repeated Constance DB lookups in tight loops.
     """
     # Uploaded media always wins — no license gating.
     thumb, hero = _uploaded_image_urls(primary_media)
@@ -85,7 +89,8 @@ def _extract_image_urls(
 
     from apps.core.licensing import UNKNOWN_LICENSE_RANK, get_minimum_display_rank
 
-    min_rank = get_minimum_display_rank()
+    if min_rank is None:
+        min_rank = get_minimum_display_rank()
 
     def _rank_ok(key: str) -> bool:
         rank = extra_data.get(f"{key}.__permissiveness_rank")

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -700,62 +700,155 @@ def list_recent_models(request):
 @decorate_view(cache_control(no_cache=True))
 def list_all_models(request):
     """Return every model (including variants) with minimal fields (no pagination)."""
+    from collections import defaultdict
+
     from django.core.cache import cache
 
-    from ..models import Credit, MachineModel
+    from ..models import (
+        Credit,
+        CorporateEntity,
+        CorporateEntityLocation,
+        MachineModel,
+        ModelAbbreviation,
+    )
+
+    from apps.core.licensing import get_minimum_display_rank
 
     result = cache.get(MODELS_ALL_KEY)
     if result is not None:
         return result
-    qs = (
+
+    min_rank = get_minimum_display_rank()
+
+    # --- Main query: values_list avoids ORM object hydration for 6.8k rows ---
+    rows = list(
         MachineModel.objects.active()
-        .select_related(
-            "corporate_entity__manufacturer",
-            "technology_generation",
-            "technology_subgeneration",
-            "display_type",
-            "title",
-            "system",
-            "display_subtype",
-            "cabinet",
-            "game_format",
-        )
-        .prefetch_related(
-            "themes",
-            "tags",
-            "gameplay_features",
-            "variants",
-            "abbreviations",
-            "corporate_entity__manufacturer__entities__locations__location",
-            Prefetch(
-                "credits",
-                queryset=Credit.objects.filter(model__isnull=False).select_related(
-                    "person", "role"
-                ),
-            ),
+        .values_list(
+            "id",
+            "name",
+            "slug",
+            "year",
+            "extra_data",
+            "corporate_entity__manufacturer__id",
+            "corporate_entity__manufacturer__name",
+            "technology_generation__name",
+            "display_type__name",
+            "display_subtype__name",
+            "title__slug",
+            "system__name",
+            "cabinet__name",
+            "game_format__name",
         )
         .order_by("name")
     )
+    model_ids = {r[0] for r in rows}
+
+    # --- Bulk M2M queries for search_text ---
+    model_themes: dict[int, list[str]] = defaultdict(list)
+    for mid, name in MachineModel.themes.through.objects.filter(
+        machinemodel_id__in=model_ids
+    ).values_list("machinemodel_id", "theme__name"):
+        model_themes[mid].append(name)
+
+    model_tags: dict[int, list[str]] = defaultdict(list)
+    for mid, name in MachineModel.tags.through.objects.filter(
+        machinemodel_id__in=model_ids
+    ).values_list("machinemodel_id", "tag__name"):
+        model_tags[mid].append(name)
+
+    model_gf: dict[int, list[str]] = defaultdict(list)
+    for mid, name in MachineModel.gameplay_features.through.objects.filter(
+        machinemodel_id__in=model_ids
+    ).values_list("machinemodel_id", "gameplayfeature__name"):
+        model_gf[mid].append(name)
+
+    model_credits: dict[int, list[str]] = defaultdict(list)
+    for mid, name in Credit.objects.filter(model_id__in=model_ids).values_list(
+        "model_id", "person__name"
+    ):
+        model_credits[mid].append(name)
+
+    model_abbrevs: dict[int, list[str]] = defaultdict(list)
+    for mid, value in ModelAbbreviation.objects.filter(
+        machine_model_id__in=model_ids
+    ).values_list("machine_model_id", "value"):
+        model_abbrevs[mid].append(value)
+
+    # --- Bulk manufacturer search text (entity names, aliases, locations) ---
+    # Build manufacturer_id → search parts map
+    mfr_search_parts: dict[int, list[str]] = defaultdict(list)
+
+    # Entity names
+    for mfr_id, ename in CorporateEntity.objects.active().values_list(
+        "manufacturer_id", "name"
+    ):
+        if mfr_id:
+            mfr_search_parts[mfr_id].append(ename)
+
+    # Entity aliases
+    from ..models import CorporateEntityAlias
+
+    for mfr_id, aval in CorporateEntityAlias.objects.filter(
+        corporate_entity__manufacturer__isnull=False
+    ).values_list("corporate_entity__manufacturer_id", "value"):
+        mfr_search_parts[mfr_id].append(aval)
+
+    # Location names (walk hierarchy via pre-fetched chain)
+    for mfr_id, loc_name, p1, p2, p3, p4 in (
+        CorporateEntityLocation.objects.filter(
+            corporate_entity__manufacturer__isnull=False
+        )
+        .select_related("location__parent__parent__parent__parent")
+        .values_list(
+            "corporate_entity__manufacturer_id",
+            "location__name",
+            "location__parent__name",
+            "location__parent__parent__name",
+            "location__parent__parent__parent__name",
+            "location__parent__parent__parent__parent__name",
+        )
+    ):
+        for n in (loc_name, p1, p2, p3, p4):
+            if n:
+                mfr_search_parts[mfr_id].append(n)
+
+    # --- Assembly ---
+    # Row indices: 0=id, 1=name, 2=slug, 3=year, 4=extra_data,
+    # 5=mfr_id, 6=mfr_name, 7=tech_gen_name, 8=display_type_name,
+    # 9=display_subtype_name, 10=title_slug, 11=system_name,
+    # 12=cabinet_name, 13=game_format_name
     result = []
-    for pm in qs:
-        thumbnail_url, _ = _extract_image_urls(pm.extra_data or {})
+    for r in rows:
+        mid = r[0]
+        extra_data = r[4]
+        thumbnail_url, _ = _extract_image_urls(extra_data or {}, min_rank=min_rank)
+
+        # Build search_text from bulk maps
+        parts: list[str] = []
+        mfr_id, mfr_name = r[5], r[6]
+        if mfr_name:
+            parts.append(mfr_name)
+            parts.extend(mfr_search_parts.get(mfr_id, []))
+        for name in (r[11], r[7], r[8], r[9], r[12], r[13]):
+            if name:
+                parts.append(name)
+        parts.extend(model_themes.get(mid, []))
+        parts.extend(model_tags.get(mid, []))
+        parts.extend(model_gf.get(mid, []))
+        parts.extend(model_credits.get(mid, []))
+        parts.extend(model_abbrevs.get(mid, []))
+
         result.append(
             {
-                "name": pm.name,
-                "slug": pm.slug,
-                "year": pm.year,
-                "manufacturer_name": (
-                    pm.corporate_entity.manufacturer.name
-                    if pm.corporate_entity and pm.corporate_entity.manufacturer
-                    else None
-                ),
-                "technology_generation_name": (
-                    pm.technology_generation.name if pm.technology_generation else None
-                ),
+                "name": r[1],
+                "slug": r[2],
+                "year": r[3],
+                "manufacturer_name": mfr_name,
+                "technology_generation_name": r[7],
                 "thumbnail_url": thumbnail_url,
-                "abbreviations": [a.value for a in pm.abbreviations.all()],
-                "search_text": _build_search_text(pm),
-                "title_slug": pm.title.slug if pm.title else None,
+                "abbreviations": model_abbrevs.get(mid, []),
+                "search_text": " | ".join(parts) if parts else None,
+                "title_slug": r[10],
             }
         )
     cache.set(MODELS_ALL_KEY, result, timeout=None)

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -699,7 +699,13 @@ def list_recent_models(request):
 @models_router.get("/all/", response=list[MachineModelGridSchema])
 @decorate_view(cache_control(no_cache=True))
 def list_all_models(request):
-    """Return every model (including variants) with minimal fields (no pagination)."""
+    """Return every model (including variants) for client-side search/grid.
+
+    Performance-critical: serializes ~7k models with search_text built from
+    M2M relations.  Uses ``values_list`` to avoid ORM object hydration and
+    bulk through-table queries for M2M data.  See ``list_all_titles`` for
+    the full explanation of this pattern.
+    """
     from collections import defaultdict
 
     from django.core.cache import cache
@@ -720,7 +726,22 @@ def list_all_models(request):
 
     min_rank = get_minimum_display_rank()
 
-    # --- Main query: values_list avoids ORM object hydration for 6.8k rows ---
+    # Column indices for the values_list below.
+    M_ID = 0
+    M_NAME = 1
+    M_SLUG = 2
+    M_YEAR = 3
+    M_EXTRA_DATA = 4
+    M_MFR_ID = 5
+    M_MFR_NAME = 6
+    M_TECH_GEN_NAME = 7
+    M_DISPLAY_TYPE_NAME = 8
+    M_DISPLAY_SUBTYPE_NAME = 9
+    M_TITLE_SLUG = 10
+    M_SYSTEM_NAME = 11
+    M_CABINET_NAME = 12
+    M_GAME_FORMAT_NAME = 13
+
     rows = list(
         MachineModel.objects.active()
         .values_list(
@@ -741,7 +762,7 @@ def list_all_models(request):
         )
         .order_by("name")
     )
-    model_ids = {r[0] for r in rows}
+    model_ids = {r[M_ID] for r in rows}
 
     # --- Bulk M2M queries for search_text ---
     model_themes: dict[int, list[str]] = defaultdict(list)
@@ -813,23 +834,26 @@ def list_all_models(request):
                 mfr_search_parts[mfr_id].append(n)
 
     # --- Assembly ---
-    # Row indices: 0=id, 1=name, 2=slug, 3=year, 4=extra_data,
-    # 5=mfr_id, 6=mfr_name, 7=tech_gen_name, 8=display_type_name,
-    # 9=display_subtype_name, 10=title_slug, 11=system_name,
-    # 12=cabinet_name, 13=game_format_name
     result = []
     for r in rows:
-        mid = r[0]
-        extra_data = r[4]
+        mid = r[M_ID]
+        extra_data = r[M_EXTRA_DATA]
         thumbnail_url, _ = _extract_image_urls(extra_data or {}, min_rank=min_rank)
 
         # Build search_text from bulk maps
         parts: list[str] = []
-        mfr_id, mfr_name = r[5], r[6]
+        mfr_id, mfr_name = r[M_MFR_ID], r[M_MFR_NAME]
         if mfr_name:
             parts.append(mfr_name)
             parts.extend(mfr_search_parts.get(mfr_id, []))
-        for name in (r[11], r[7], r[8], r[9], r[12], r[13]):
+        for name in (
+            r[M_SYSTEM_NAME],
+            r[M_TECH_GEN_NAME],
+            r[M_DISPLAY_TYPE_NAME],
+            r[M_DISPLAY_SUBTYPE_NAME],
+            r[M_CABINET_NAME],
+            r[M_GAME_FORMAT_NAME],
+        ):
             if name:
                 parts.append(name)
         parts.extend(model_themes.get(mid, []))
@@ -840,15 +864,15 @@ def list_all_models(request):
 
         result.append(
             {
-                "name": r[1],
-                "slug": r[2],
-                "year": r[3],
+                "name": r[M_NAME],
+                "slug": r[M_SLUG],
+                "year": r[M_YEAR],
                 "manufacturer_name": mfr_name,
-                "technology_generation_name": r[7],
+                "technology_generation_name": r[M_TECH_GEN_NAME],
                 "thumbnail_url": thumbnail_url,
                 "abbreviations": model_abbrevs.get(mid, []),
                 "search_text": " | ".join(parts) if parts else None,
-                "title_slug": r[10],
+                "title_slug": r[M_TITLE_SLUG],
             }
         )
     cache.set(MODELS_ALL_KEY, result, timeout=None)

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from django.core.cache import cache
-from django.db.models import Count, F, Prefetch, Q
+from django.db.models import Count, F, Max, Min, Prefetch, Q
 from django.shortcuts import get_object_or_404
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
@@ -263,80 +263,185 @@ def list_manufacturers(request):
 @decorate_view(cache_control(no_cache=True))
 def list_all_manufacturers(request):
     """Return every manufacturer with model count and thumbnail (no pagination)."""
+    from collections import defaultdict
+
+    from apps.core.licensing import get_minimum_display_rank
+
     result = cache.get(MANUFACTURERS_ALL_KEY)
     if result is not None:
         return result
 
+    min_rank = get_minimum_display_rank()
+
     from ..models import (
         CorporateEntity,
+        CorporateEntityAlias,
         CorporateEntityLocation,
+        Credit,
         MachineModel,
         Manufacturer,
     )
 
-    qs = (
+    # --- Main query with annotations ---
+    manufacturers = list(
         Manufacturer.objects.active()
         .annotate(
             model_count=Count(
                 "entities__models",
                 filter=Q(entities__models__variant_of__isnull=True)
                 & active_status_q("entities__models"),
-            )
-        )
-        .prefetch_related(
-            Prefetch(
-                "entities",
-                queryset=CorporateEntity.objects.active().prefetch_related(
-                    Prefetch(
-                        "locations",
-                        queryset=CorporateEntityLocation.objects.select_related(
-                            "location__parent__parent__parent__parent"
-                        ),
-                    ),
-                    "aliases",
-                    Prefetch(
-                        "models",
-                        queryset=MachineModel.objects.active()
-                        .filter(variant_of__isnull=True)
-                        .select_related("technology_generation")
-                        .prefetch_related("credits__person")
-                        .order_by(F("year").desc(nulls_last=True)),
-                    ),
-                ),
+            ),
+            year_min=Min(
+                "entities__models__year",
+                filter=Q(entities__models__variant_of__isnull=True)
+                & active_status_q("entities__models"),
+            ),
+            year_max=Max(
+                "entities__models__year",
+                filter=Q(entities__models__variant_of__isnull=True)
+                & active_status_q("entities__models"),
             ),
         )
         .order_by("-model_count")
     )
 
+    # --- Batch thumbnail: newest model with extra_data per manufacturer ---
+    mfr_thumb_model: dict[int, int] = {}
+    for mfr_id, model_id in (
+        MachineModel.objects.active()
+        .filter(
+            variant_of__isnull=True,
+            extra_data__isnull=False,
+            corporate_entity__manufacturer__isnull=False,
+        )
+        .order_by(F("year").desc(nulls_last=True), "name")
+        .values_list("corporate_entity__manufacturer_id", "id")
+    ):
+        if mfr_id not in mfr_thumb_model:
+            mfr_thumb_model[mfr_id] = model_id
+    thumb_models = {
+        m.id: m
+        for m in MachineModel.objects.filter(id__in=mfr_thumb_model.values()).only(
+            "id", "extra_data"
+        )
+    }
+
+    # --- Bulk search text + facet data per manufacturer ---
+    mfr_ids = {m.id for m in manufacturers}
+
+    # Entity names per manufacturer
+    mfr_entity_names: dict[int, list[str]] = defaultdict(list)
+    mfr_entity_ids: dict[int, list[int]] = defaultdict(list)
+    for eid, mfr_id, ename in CorporateEntity.objects.active().values_list(
+        "id", "manufacturer_id", "name"
+    ):
+        if mfr_id in mfr_ids:
+            mfr_entity_names[mfr_id].append(ename)
+            mfr_entity_ids[mfr_id].append(eid)
+
+    all_entity_ids = {eid for eids in mfr_entity_ids.values() for eid in eids}
+
+    # Aliases per entity → grouped by manufacturer
+    entity_to_mfr: dict[int, int] = {}
+    for mfr_id, eids in mfr_entity_ids.items():
+        for eid in eids:
+            entity_to_mfr[eid] = mfr_id
+
+    mfr_alias_names: dict[int, list[str]] = defaultdict(list)
+    for eid, aval in CorporateEntityAlias.objects.filter(
+        corporate_entity_id__in=all_entity_ids
+    ).values_list("corporate_entity_id", "value"):
+        mid = entity_to_mfr.get(eid)
+        if mid:
+            mfr_alias_names[mid].append(aval)
+
+    # Locations per manufacturer (with hierarchy)
+    mfr_location_names: dict[int, list[str]] = defaultdict(list)
+    mfr_location_refs: dict[int, dict[str, str]] = defaultdict(dict)
+    for eid, loc_path, loc_name, p1n, p1p, p2n, p2p, p3n, p3p, p4n, p4p in (
+        CorporateEntityLocation.objects.filter(corporate_entity_id__in=all_entity_ids)
+        .select_related("location__parent__parent__parent__parent")
+        .values_list(
+            "corporate_entity_id",
+            "location__location_path",
+            "location__name",
+            "location__parent__name",
+            "location__parent__location_path",
+            "location__parent__parent__name",
+            "location__parent__parent__location_path",
+            "location__parent__parent__parent__name",
+            "location__parent__parent__parent__location_path",
+            "location__parent__parent__parent__parent__name",
+            "location__parent__parent__parent__parent__location_path",
+        )
+    ):
+        mid = entity_to_mfr.get(eid)
+        if not mid:
+            continue
+        for name, path in (
+            (loc_name, loc_path),
+            (p1n, p1p),
+            (p2n, p2p),
+            (p3n, p3p),
+            (p4n, p4p),
+        ):
+            if name:
+                mfr_location_names[mid].append(name)
+            if path and name and path not in mfr_location_refs[mid]:
+                mfr_location_refs[mid][path] = name
+
+    # Tech generations per manufacturer (via models)
+    mfr_tech_gens: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    for mfr_id, tg_slug, tg_name in (
+        MachineModel.objects.active()
+        .filter(
+            variant_of__isnull=True,
+            technology_generation__isnull=False,
+            corporate_entity__manufacturer_id__in=mfr_ids,
+        )
+        .values_list(
+            "corporate_entity__manufacturer_id",
+            "technology_generation__slug",
+            "technology_generation__name",
+        )
+        .distinct()
+    ):
+        mfr_tech_gens[mfr_id].append((tg_slug, tg_name))
+
+    # Persons per manufacturer (via model credits)
+    mfr_persons: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    for mfr_id, p_slug, p_name in (
+        Credit.objects.filter(
+            model__variant_of__isnull=True,
+            model__corporate_entity__manufacturer_id__in=mfr_ids,
+        )
+        .values_list(
+            "model__corporate_entity__manufacturer_id",
+            "person__slug",
+            "person__name",
+        )
+        .distinct()
+    ):
+        mfr_persons[mfr_id].append((p_slug, p_name))
+
+    # --- Assembly ---
     result = []
-    for mfr in qs:
-        thumb = None
+    for mfr in manufacturers:
         search_parts: list[str] = []
-        tech_gen_pairs: list[tuple[str, str]] = []
-        person_pairs: list[tuple[str, str]] = []
+        search_parts.extend(mfr_entity_names.get(mfr.id, []))
+        search_parts.extend(mfr_alias_names.get(mfr.id, []))
+        search_parts.extend(mfr_location_names.get(mfr.id, []))
 
-        model_years: list[int] = []
+        thumb = None
+        tm_id = mfr_thumb_model.get(mfr.id)
+        tm = thumb_models.get(tm_id) if tm_id else None
+        if tm and tm.extra_data:
+            thumb, _ = _extract_image_urls(tm.extra_data, min_rank=min_rank)
 
-        for entity in mfr.entities.all():
-            search_parts.append(entity.name)
-            for alias in entity.aliases.all():
-                search_parts.append(alias.value)
-            for cel in entity.locations.all():
-                loc = cel.location
-                while loc is not None:
-                    if loc.name:
-                        search_parts.append(loc.name)
-                    loc = loc.parent
-            for model in entity.models.all():
-                if thumb is None and model.extra_data:
-                    thumb, _ = _extract_image_urls(model.extra_data)
-                if model.year is not None:
-                    model_years.append(model.year)
-                if model.technology_generation:
-                    tg = model.technology_generation
-                    tech_gen_pairs.append((tg.slug, tg.name))
-                for credit in model.credits.all():
-                    person_pairs.append((credit.person.slug, credit.person.name))
+        loc_refs_map = mfr_location_refs.get(mfr.id, {})
+        locations = [
+            {"slug": path, "name": name} for path, name in loc_refs_map.items()
+        ]
 
         result.append(
             {
@@ -344,12 +449,12 @@ def list_all_manufacturers(request):
                 "slug": mfr.slug,
                 "model_count": mfr.model_count,
                 "thumbnail_url": thumb,
-                "search_text": " | ".join(search_parts) if search_parts else None,
-                "locations": _build_location_refs(mfr.entities.all()),
-                "year_min": min(model_years) if model_years else None,
-                "year_max": max(model_years) if model_years else None,
-                "persons": _dedup_facet_refs(person_pairs),
-                "tech_generations": _dedup_facet_refs(tech_gen_pairs),
+                "search_text": (" | ".join(search_parts) if search_parts else None),
+                "locations": locations,
+                "year_min": mfr.year_min,
+                "year_max": mfr.year_max,
+                "persons": _dedup_facet_refs(mfr_persons.get(mfr.id, [])),
+                "tech_generations": _dedup_facet_refs(mfr_tech_gens.get(mfr.id, [])),
             }
         )
     cache.set(MANUFACTURERS_ALL_KEY, result, timeout=None)

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -262,7 +262,12 @@ def list_manufacturers(request):
 @manufacturers_router.get("/all/", response=list[ManufacturerGridSchema])
 @decorate_view(cache_control(no_cache=True))
 def list_all_manufacturers(request):
-    """Return every manufacturer with model count and thumbnail (no pagination)."""
+    """Return every manufacturer with facet data for client-side filtering.
+
+    Performance-critical: uses bulk queries and lookup maps instead of
+    deep prefetch + Python iteration.  See ``list_all_titles`` for the
+    full explanation of this pattern.
+    """
     from collections import defaultdict
 
     from apps.core.licensing import get_minimum_display_rank

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -175,32 +175,50 @@ def list_people(request):
 @decorate_view(cache_control(no_cache=True))
 def list_all_people(request):
     """Return every person with credit count and thumbnail (no pagination)."""
+    from apps.core.licensing import get_minimum_display_rank
+
     result = cache.get(PEOPLE_ALL_KEY)
     if result is not None:
         return result
 
-    from ..models import Person
+    min_rank = get_minimum_display_rank()
+
+    from ..models import Credit, MachineModel, Person
 
     people = list(
         Person.objects.active()
         .annotate(credit_count=Count("credits"))
-        .prefetch_related("credits__model")
         .order_by("-credit_count")
     )
+
+    # Batch thumbnail: newest credited model with extra_data per person
+    person_thumb_model: dict[int, int] = {}
+    for person_id, model_id in (
+        Credit.objects.filter(
+            model__isnull=False,
+            model__extra_data__isnull=False,
+        )
+        .order_by(F("model__year").desc(nulls_last=True))
+        .values_list("person_id", "model_id")
+    ):
+        if person_id not in person_thumb_model:
+            person_thumb_model[person_id] = model_id
+    thumb_models = {
+        m.id: m
+        for m in MachineModel.objects.filter(
+            id__in=set(person_thumb_model.values())
+        ).only("id", "extra_data")
+    }
+
     result = []
     for p in people:
         thumb = None
-        # Thumbnail from most recent credited machine with image data.
-        for c in sorted(
-            (c for c in p.credits.all() if c.model is not None),
-            key=lambda c: c.model.year or 0,
-            reverse=True,
-        ):
-            if c.model.extra_data:
-                t, _ = _extract_image_urls(c.model.extra_data)
-                if t:
-                    thumb = t
-                    break
+        tm_id = person_thumb_model.get(p.id)
+        tm = thumb_models.get(tm_id) if tm_id else None
+        if tm and tm.extra_data:
+            t, _ = _extract_image_urls(tm.extra_data, min_rank=min_rank)
+            if t:
+                thumb = t
         result.append(
             {
                 "name": p.name,

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -174,7 +174,12 @@ def list_people(request):
 @people_router.get("/all/", response=list[PersonGridSchema])
 @decorate_view(cache_control(no_cache=True))
 def list_all_people(request):
-    """Return every person with credit count and thumbnail (no pagination)."""
+    """Return every person with credit count and thumbnail.
+
+    Uses a bulk query to find the newest credited model per person for
+    thumbnails, instead of prefetching all credits and iterating in Python.
+    See ``list_all_titles`` for the full explanation of this pattern.
+    """
     from apps.core.licensing import get_minimum_display_rank
 
     result = cache.get(PEOPLE_ALL_KEY)

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -134,7 +134,7 @@ def _dedup_facet_refs(items) -> list[dict]:
     return result
 
 
-def _serialize_title_list(title) -> dict:
+def _serialize_title_list(title, *, min_rank: int | None = None) -> dict:
     thumbnail_url = None
     manufacturer = None
     year = None
@@ -177,7 +177,9 @@ def _serialize_title_list(title) -> dict:
             ratings.append(float(m.ipdb_rating))
 
     if machines:
-        thumbnail_url, _ = _extract_image_urls(machines[0].extra_data or {})
+        thumbnail_url, _ = _extract_image_urls(
+            machines[0].extra_data or {}, min_rank=min_rank
+        )
         first = machines[0]
         mfr = (
             first.corporate_entity.manufacturer
@@ -516,15 +518,33 @@ def list_titles(request, display: str = ""):
 @decorate_view(cache_control(no_cache=True))
 def list_all_titles(request):
     """Return every title with minimal fields (no pagination)."""
-    from django.core.cache import cache
+    from collections import defaultdict
 
-    from ..models import Title
+    from django.core.cache import cache
+    from django.db.models import Min, Subquery, OuterRef
+
+    from ..models import Credit, MachineModel, Title, TitleAbbreviation
 
     result = cache.get(TITLES_ALL_KEY)
     if result is not None:
         return result
 
-    qs = (
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
+
+    # --- Scalar fields via subquery annotations + values_list ---
+    first_model = (
+        MachineModel.objects.filter(title=OuterRef("pk"), variant_of__isnull=True)
+        .active()
+        .order_by("year", "name")
+    )
+    # values_list avoids ORM object hydration for 6k+ rows
+    # Indices: 0=id, 1=name, 2=slug, 3=machine_count, 4=latest_year,
+    # 5=primary_mfr_slug, 6=primary_mfr_name, 7=primary_year,
+    # 8=primary_model_id, 9=year_min, 10=ipdb_rating_max,
+    # 11=franchise_slug, 12=franchise_name
+    title_rows = list(
         Title.objects.active()
         .annotate(
             machine_count=Count(
@@ -536,12 +556,191 @@ def list_all_titles(request):
                 "machine_models__year",
                 filter=Q(machine_models__variant_of__isnull=True),
             ),
+            primary_mfr_slug=Subquery(
+                first_model.values("corporate_entity__manufacturer__slug")[:1]
+            ),
+            primary_mfr_name=Subquery(
+                first_model.values("corporate_entity__manufacturer__name")[:1]
+            ),
+            primary_year=Subquery(first_model.values("year")[:1]),
+            primary_model_id=Subquery(first_model.values("pk")[:1]),
+            year_min=Min(
+                "machine_models__year",
+                filter=Q(machine_models__variant_of__isnull=True),
+            ),
+            ipdb_rating_max=Max(
+                "machine_models__ipdb_rating",
+                filter=Q(machine_models__variant_of__isnull=True),
+            ),
         )
-        .select_related("franchise")
-        .prefetch_related(_title_models_prefetch(), "series", "abbreviations")
+        .values_list(
+            "id",
+            "name",
+            "slug",
+            "machine_count",
+            "latest_year",
+            "primary_mfr_slug",
+            "primary_mfr_name",
+            "primary_year",
+            "primary_model_id",
+            "year_min",
+            "ipdb_rating_max",
+            "franchise__slug",
+            "franchise__name",
+        )
         .order_by(F("latest_year").desc(nulls_last=True), "name")
     )
-    result = [_serialize_title_list(t) for t in qs]
+
+    # --- Batch thumbnail fetch ---
+    primary_model_ids = [r[8] for r in title_rows if r[8]]
+    thumb_data: dict[int, str | None] = {}
+    for mid, extra_data in MachineModel.objects.filter(
+        id__in=primary_model_ids
+    ).values_list("id", "extra_data"):
+        if extra_data:
+            thumb, _ = _extract_image_urls(extra_data, min_rank=min_rank)
+            thumb_data[mid] = thumb
+        else:
+            thumb_data[mid] = None
+
+    # --- Bulk abbreviations and series ---
+    title_ids = [r[0] for r in title_rows]
+
+    title_abbrevs: dict[int, list[str]] = defaultdict(list)
+    for tid, value in TitleAbbreviation.objects.filter(
+        title_id__in=title_ids
+    ).values_list("title_id", "value"):
+        title_abbrevs[tid].append(value)
+
+    title_series: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    Series = Title.series.through
+    for tid, slug, name in Series.objects.filter(title_id__in=title_ids).values_list(
+        "title_id", "series__slug", "series__name"
+    ):
+        title_series[tid].append((slug, name))
+
+    # --- Bulk facet queries via through tables ---
+    model_qs = MachineModel.objects.filter(
+        title__isnull=False, variant_of__isnull=True
+    ).active()
+
+    title_model_map: dict[int, list[int]] = defaultdict(list)
+    model_ids: set[int] = set()
+    for title_id, model_id in model_qs.values_list("title_id", "id"):
+        title_model_map[title_id].append(model_id)
+        model_ids.add(model_id)
+
+    model_tech_gen: dict[int, tuple[str, str]] = {}
+    for mid, slug, name in model_qs.filter(
+        technology_generation__isnull=False
+    ).values_list("id", "technology_generation__slug", "technology_generation__name"):
+        model_tech_gen[mid] = (slug, name)
+
+    model_display: dict[int, tuple[str, str]] = {}
+    for mid, slug, name in model_qs.filter(display_type__isnull=False).values_list(
+        "id", "display_type__slug", "display_type__name"
+    ):
+        model_display[mid] = (slug, name)
+
+    model_system: dict[int, tuple[str, str]] = {}
+    for mid, slug, name in model_qs.filter(system__isnull=False).values_list(
+        "id", "system__slug", "system__name"
+    ):
+        model_system[mid] = (slug, name)
+
+    model_player_count: dict[int, int | None] = {}
+    model_year: dict[int, int | None] = {}
+    model_rating: dict[int, Any] = {}
+    for mid, pc, yr, rating in model_qs.values_list(
+        "id", "player_count", "year", "ipdb_rating"
+    ):
+        model_player_count[mid] = pc
+        model_year[mid] = yr
+        model_rating[mid] = rating
+
+    model_themes: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    for mid, slug, name in MachineModel.themes.through.objects.filter(
+        machinemodel_id__in=model_ids
+    ).values_list("machinemodel_id", "theme__slug", "theme__name"):
+        model_themes[mid].append((slug, name))
+
+    model_gf: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    for mid, slug, name in MachineModel.gameplay_features.through.objects.filter(
+        machinemodel_id__in=model_ids
+    ).values_list(
+        "machinemodel_id",
+        "gameplayfeature__slug",
+        "gameplayfeature__name",
+    ):
+        model_gf[mid].append((slug, name))
+
+    model_rt: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    for mid, slug, name in MachineModel.reward_types.through.objects.filter(
+        machinemodel_id__in=model_ids
+    ).values_list("machinemodel_id", "rewardtype__slug", "rewardtype__name"):
+        model_rt[mid].append((slug, name))
+
+    model_persons: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    for mid, slug, name in Credit.objects.filter(model_id__in=model_ids).values_list(
+        "model_id", "person__slug", "person__name"
+    ):
+        model_persons[mid].append((slug, name))
+
+    # --- Assembly ---
+    result = []
+    for r in title_rows:
+        tid = r[0]
+        mids = title_model_map.get(tid, [])
+
+        mfr = {"slug": r[5], "name": r[6]} if r[5] else None
+        franchise = {"slug": r[11], "name": r[12]} if r[11] else None
+
+        result.append(
+            {
+                "name": r[1],
+                "slug": r[2],
+                "abbreviations": title_abbrevs.get(tid, []),
+                "machine_count": r[3],
+                "manufacturer": mfr,
+                "year": r[7],
+                "thumbnail_url": thumb_data.get(r[8]),
+                "tech_generations": _dedup_facet_refs(
+                    model_tech_gen[mid] for mid in mids if mid in model_tech_gen
+                ),
+                "display_types": _dedup_facet_refs(
+                    model_display[mid] for mid in mids if mid in model_display
+                ),
+                "player_counts": sorted(
+                    {
+                        model_player_count[mid]
+                        for mid in mids
+                        if model_player_count.get(mid) is not None
+                    }
+                ),
+                "systems": _dedup_facet_refs(
+                    model_system[mid] for mid in mids if mid in model_system
+                ),
+                "themes": _dedup_facet_refs(
+                    p for mid in mids for p in model_themes.get(mid, [])
+                ),
+                "gameplay_features": _dedup_facet_refs(
+                    p for mid in mids for p in model_gf.get(mid, [])
+                ),
+                "reward_types": _dedup_facet_refs(
+                    p for mid in mids for p in model_rt.get(mid, [])
+                ),
+                "persons": _dedup_facet_refs(
+                    p for mid in mids for p in model_persons.get(mid, [])
+                ),
+                "franchise": franchise,
+                "series": [
+                    {"slug": s, "name": n} for s, n in title_series.get(tid, [])
+                ],
+                "year_min": r[9],
+                "year_max": r[4],
+                "ipdb_rating_max": (float(r[10]) if r[10] else None),
+            }
+        )
     cache.set(TITLES_ALL_KEY, result, timeout=None)
     return result
 

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -517,7 +517,24 @@ def list_titles(request, display: str = ""):
 @titles_router.get("/all/", response=list[TitleListSchema])
 @decorate_view(cache_control(no_cache=True))
 def list_all_titles(request):
-    """Return every title with minimal fields (no pagination)."""
+    """Return every title with facet data for client-side filtering.
+
+    Performance-critical: this serializes ~6k titles with facet arrays
+    aggregated from ~7k machine models.  The result is cached indefinitely
+    and invalidated on data changes, so cold-cache rebuild speed matters.
+
+    Strategy (instead of prefetch + ORM iteration):
+    1. Annotate scalar card fields (manufacturer, year) via correlated
+       subqueries so the DB does the work in one SQL statement.
+    2. Use ``values_list`` instead of full ORM object instantiation to
+       avoid Python-side hydration overhead for thousands of rows.
+    3. Fetch M2M facet data (themes, features, credits, etc.) via bulk
+       queries on through tables into ``dict`` lookup maps.
+    4. Assemble the response dicts from the lookup maps.
+
+    This reduces cold-cache rebuild from ~3.5s to ~0.5s locally
+    (~30s to ~5s on production hardware).
+    """
     from collections import defaultdict
 
     from django.core.cache import cache
@@ -531,19 +548,31 @@ def list_all_titles(request):
 
     from apps.core.licensing import get_minimum_display_rank
 
+    # Cached once for the entire rebuild — avoids ~6k Constance DB lookups.
     min_rank = get_minimum_display_rank()
 
-    # --- Scalar fields via subquery annotations + values_list ---
+    # "First model" = earliest non-variant model by (year, name), used to
+    # derive the title's display manufacturer, year, and thumbnail.
     first_model = (
         MachineModel.objects.filter(title=OuterRef("pk"), variant_of__isnull=True)
         .active()
         .order_by("year", "name")
     )
-    # values_list avoids ORM object hydration for 6k+ rows
-    # Indices: 0=id, 1=name, 2=slug, 3=machine_count, 4=latest_year,
-    # 5=primary_mfr_slug, 6=primary_mfr_name, 7=primary_year,
-    # 8=primary_model_id, 9=year_min, 10=ipdb_rating_max,
-    # 11=franchise_slug, 12=franchise_name
+    # Column indices for the values_list below.
+    T_ID = 0
+    T_NAME = 1
+    T_SLUG = 2
+    T_MACHINE_COUNT = 3
+    T_LATEST_YEAR = 4
+    T_MFR_SLUG = 5
+    T_MFR_NAME = 6
+    T_PRIMARY_YEAR = 7
+    T_PRIMARY_MODEL_ID = 8
+    T_YEAR_MIN = 9
+    T_IPDB_RATING_MAX = 10
+    T_FRANCHISE_SLUG = 11
+    T_FRANCHISE_NAME = 12
+
     title_rows = list(
         Title.objects.active()
         .annotate(
@@ -592,7 +621,9 @@ def list_all_titles(request):
     )
 
     # --- Batch thumbnail fetch ---
-    primary_model_ids = [r[8] for r in title_rows if r[8]]
+    primary_model_ids = [
+        r[T_PRIMARY_MODEL_ID] for r in title_rows if r[T_PRIMARY_MODEL_ID]
+    ]
     thumb_data: dict[int, str | None] = {}
     for mid, extra_data in MachineModel.objects.filter(
         id__in=primary_model_ids
@@ -604,7 +635,7 @@ def list_all_titles(request):
             thumb_data[mid] = None
 
     # --- Bulk abbreviations and series ---
-    title_ids = [r[0] for r in title_rows]
+    title_ids = [r[T_ID] for r in title_rows]
 
     title_abbrevs: dict[int, list[str]] = defaultdict(list)
     for tid, value in TitleAbbreviation.objects.filter(
@@ -649,14 +680,8 @@ def list_all_titles(request):
         model_system[mid] = (slug, name)
 
     model_player_count: dict[int, int | None] = {}
-    model_year: dict[int, int | None] = {}
-    model_rating: dict[int, Any] = {}
-    for mid, pc, yr, rating in model_qs.values_list(
-        "id", "player_count", "year", "ipdb_rating"
-    ):
+    for mid, pc in model_qs.values_list("id", "player_count"):
         model_player_count[mid] = pc
-        model_year[mid] = yr
-        model_rating[mid] = rating
 
     model_themes: dict[int, list[tuple[str, str]]] = defaultdict(list)
     for mid, slug, name in MachineModel.themes.through.objects.filter(
@@ -689,21 +714,25 @@ def list_all_titles(request):
     # --- Assembly ---
     result = []
     for r in title_rows:
-        tid = r[0]
+        tid = r[T_ID]
         mids = title_model_map.get(tid, [])
 
-        mfr = {"slug": r[5], "name": r[6]} if r[5] else None
-        franchise = {"slug": r[11], "name": r[12]} if r[11] else None
+        mfr = {"slug": r[T_MFR_SLUG], "name": r[T_MFR_NAME]} if r[T_MFR_SLUG] else None
+        franchise = (
+            {"slug": r[T_FRANCHISE_SLUG], "name": r[T_FRANCHISE_NAME]}
+            if r[T_FRANCHISE_SLUG]
+            else None
+        )
 
         result.append(
             {
-                "name": r[1],
-                "slug": r[2],
+                "name": r[T_NAME],
+                "slug": r[T_SLUG],
                 "abbreviations": title_abbrevs.get(tid, []),
-                "machine_count": r[3],
+                "machine_count": r[T_MACHINE_COUNT],
                 "manufacturer": mfr,
-                "year": r[7],
-                "thumbnail_url": thumb_data.get(r[8]),
+                "year": r[T_PRIMARY_YEAR],
+                "thumbnail_url": thumb_data.get(r[T_PRIMARY_MODEL_ID]),
                 "tech_generations": _dedup_facet_refs(
                     model_tech_gen[mid] for mid in mids if mid in model_tech_gen
                 ),
@@ -736,9 +765,11 @@ def list_all_titles(request):
                 "series": [
                     {"slug": s, "name": n} for s, n in title_series.get(tid, [])
                 ],
-                "year_min": r[9],
-                "year_max": r[4],
-                "ipdb_rating_max": (float(r[10]) if r[10] else None),
+                "year_min": r[T_YEAR_MIN],
+                "year_max": r[T_LATEST_YEAR],
+                "ipdb_rating_max": (
+                    float(r[T_IPDB_RATING_MAX]) if r[T_IPDB_RATING_MAX] else None
+                ),
             }
         )
     cache.set(TITLES_ALL_KEY, result, timeout=None)

--- a/frontend/src/lib/components/Breadcrumb.svelte
+++ b/frontend/src/lib/components/Breadcrumb.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { resolveHref } from '$lib/utils';
 
-	type Crumb = { label: string; href: string };
+	export type Crumb = { label: string; href: string };
 
 	let { crumbs, current }: { crumbs: Crumb[]; current: string } = $props();
 </script>

--- a/frontend/src/lib/components/DetailPage.svelte
+++ b/frontend/src/lib/components/DetailPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import PageHeader from './PageHeader.svelte';
 	import { pageTitle } from '$lib/constants';
 
 	let {
@@ -18,12 +19,11 @@
 </svelte:head>
 
 <article class="detail">
-	<header>
-		<h1>{title}</h1>
+	<PageHeader {title} --page-header-title-mb="0">
 		{#if subtitle}
 			{@render subtitle()}
 		{/if}
-	</header>
+	</PageHeader>
 
 	{@render children()}
 </article>
@@ -31,16 +31,6 @@
 <style>
 	.detail {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
 	}
 
 	.detail :global(h2) {

--- a/frontend/src/lib/components/EntityDetailLayout.svelte
+++ b/frontend/src/lib/components/EntityDetailLayout.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import type { Crumb } from './Breadcrumb.svelte';
 	import AttributionLine from './AttributionLine.svelte';
-	import Breadcrumb from './Breadcrumb.svelte';
 	import Markdown from './Markdown.svelte';
+	import PageHeader from './PageHeader.svelte';
 	import { pageTitle } from '$lib/constants';
 
 	let {
@@ -13,7 +14,7 @@
 	}: {
 		name: string;
 		description?: { text?: string; html?: string; attribution?: object | null } | null;
-		breadcrumbs?: { label: string; href: string }[] | null;
+		breadcrumbs?: Crumb[] | null;
 		children: Snippet;
 	} = $props();
 </script>
@@ -23,16 +24,12 @@
 </svelte:head>
 
 <article>
-	<header>
-		{#if breadcrumbs}
-			<Breadcrumb crumbs={breadcrumbs} current={name} />
-		{/if}
-		<h1>{name}</h1>
+	<PageHeader title={name} {breadcrumbs}>
 		{#if description?.html}
 			<Markdown html={description.html} />
 			<AttributionLine attribution={description.attribution} />
 		{/if}
-	</header>
+	</PageHeader>
 
 	{@render children()}
 </article>
@@ -40,16 +37,5 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 </style>

--- a/frontend/src/lib/components/LocationDetailPage.svelte
+++ b/frontend/src/lib/components/LocationDetailPage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import type { Crumb } from '$lib/components/Breadcrumb.svelte';
 	import TwoColumnLayout from '$lib/components/TwoColumnLayout.svelte';
 	import CardGrid from '$lib/components/grid/CardGrid.svelte';
 	import SkeletonCard from '$lib/components/cards/SkeletonCard.svelte';
@@ -21,7 +22,7 @@
 		error: boolean;
 		heading: string;
 		subtitle: string;
-		crumbs: { label: string; href: string }[];
+		crumbs: Crumb[];
 		manufacturers: {
 			name: string;
 			slug: string;
@@ -34,27 +35,34 @@
 
 <article>
 	{#if loading}
-		<header>
-			<Breadcrumb {crumbs} current="Loading..." />
-			<h1>Loading...</h1>
-		</header>
+		<PageHeader
+			title="Loading..."
+			breadcrumbs={crumbs}
+			--page-header-mb="var(--size-5)"
+			--page-header-title-mb="var(--size-2)"
+		/>
 		<CardGrid>
 			{#each SKELETON_INDICES as i (i)}
 				<SkeletonCard />
 			{/each}
 		</CardGrid>
 	{:else if error}
-		<header>
-			<Breadcrumb {crumbs} current="Error" />
-			<h1>Not found</h1>
-		</header>
+		<PageHeader
+			title="Not found"
+			breadcrumbs={crumbs}
+			--page-header-mb="var(--size-5)"
+			--page-header-title-mb="var(--size-2)"
+		/>
 		<p class="status error">Failed to load location.</p>
 	{:else}
-		<header>
-			<Breadcrumb {crumbs} current={heading} />
-			<h1>{heading}</h1>
+		<PageHeader
+			title={heading}
+			breadcrumbs={crumbs}
+			--page-header-mb="var(--size-5)"
+			--page-header-title-mb="var(--size-2)"
+		>
 			<p class="subtitle">{subtitle}</p>
-		</header>
+		</PageHeader>
 
 		<TwoColumnLayout>
 			{#snippet main()}
@@ -69,17 +77,6 @@
 </article>
 
 <style>
-	header {
-		margin-bottom: var(--size-5);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
-	}
-
 	.subtitle {
 		font-size: var(--font-size-2);
 		color: var(--color-text-muted);

--- a/frontend/src/lib/components/PageHeader.svelte
+++ b/frontend/src/lib/components/PageHeader.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import Breadcrumb, { type Crumb } from './Breadcrumb.svelte';
+
+	let {
+		title,
+		breadcrumbs = null,
+		children
+	}: {
+		title: string;
+		breadcrumbs?: Crumb[] | null;
+		children?: Snippet;
+	} = $props();
+</script>
+
+<header>
+	{#if breadcrumbs}
+		<Breadcrumb crumbs={breadcrumbs} current={title} />
+	{/if}
+	<h1>{title}</h1>
+	{#if children}
+		{@render children()}
+	{/if}
+</header>
+
+<style>
+	header {
+		margin-bottom: var(--page-header-mb, var(--size-6));
+	}
+
+	h1 {
+		font-size: var(--font-size-7);
+		font-weight: 700;
+		color: var(--color-text-primary);
+		margin-bottom: var(--page-header-title-mb, var(--size-4));
+	}
+</style>

--- a/frontend/src/lib/components/TaxonomyListPage.svelte
+++ b/frontend/src/lib/components/TaxonomyListPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" generics="T extends { slug: string; name: string }">
 	import type { Snippet } from 'svelte';
+	import PageHeader from './PageHeader.svelte';
 	import { resolveHref } from '$lib/utils';
 	import { pageTitle } from '$lib/constants';
 
@@ -37,14 +38,13 @@
 </svelte:head>
 
 <article>
-	<header>
-		<h1>{title}</h1>
+	<PageHeader {title} --page-header-title-mb="0">
 		{#if headerSnippet}
 			{@render headerSnippet()}
 		{:else if subtitle}
 			<p class="subtitle">{subtitle}</p>
 		{/if}
-	</header>
+	</PageHeader>
 
 	{#if loading}
 		<p class="status">Loading...</p>
@@ -72,16 +72,6 @@
 <style>
 	article {
 		max-width: 48rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
 	}
 
 	.subtitle {

--- a/frontend/src/routes/cabinets/[slug]/+layout.svelte
+++ b/frontend/src/routes/cabinets/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -29,10 +29,7 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb crumbs={[{ label: 'Cabinets', href: '/cabinets' }]} current={profile.name} />
-		<h1>{profile.name}</h1>
-	</header>
+	<PageHeader title={profile.name} breadcrumbs={[{ label: 'Cabinets', href: '/cabinets' }]} />
 
 	{#if profile.description?.html}
 		<div class="description">
@@ -55,17 +52,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/corporate-entities/+page.svelte
+++ b/frontend/src/routes/corporate-entities/+page.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import client from '$lib/api/client';
 	import { createAsyncLoader } from '$lib/async-loader.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { pageTitle } from '$lib/constants';
 	import { formatYearRange } from '$lib/utils';
 
@@ -16,9 +17,7 @@
 </svelte:head>
 
 <article>
-	<header>
-		<h1>Corporate Entities</h1>
-	</header>
+	<PageHeader title="Corporate Entities" />
 
 	{#if entities.loading}
 		<p class="status">Loading...</p>
@@ -51,16 +50,6 @@
 <style>
 	article {
 		max-width: 56rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
 	}
 
 	.entity-list {

--- a/frontend/src/routes/corporate-entities/[slug]/+layout.svelte
+++ b/frontend/src/routes/corporate-entities/[slug]/+layout.svelte
@@ -4,7 +4,7 @@
 	import { pageTitle } from '$lib/constants';
 	import { formatYearRange } from '$lib/utils';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import LocationLink from '$lib/components/LocationLink.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
@@ -38,16 +38,15 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb
-			crumbs={[
-				{ label: 'Manufacturers', href: '/manufacturers' },
-				{ label: ce.manufacturer.name, href: `/manufacturers/${ce.manufacturer.slug}` }
-			]}
-			current={ce.name}
-		/>
-		<h1>{ce.name}</h1>
-	</header>
+	<PageHeader
+		title={ce.name}
+		breadcrumbs={[
+			{ label: 'Manufacturers', href: '/manufacturers' },
+			{ label: ce.manufacturer.name, href: `/manufacturers/${ce.manufacturer.slug}` }
+		]}
+		--page-header-mb="var(--size-5)"
+		--page-header-title-mb="var(--size-2)"
+	/>
 
 	<TwoColumnLayout>
 		{#snippet main()}
@@ -103,17 +102,6 @@
 </article>
 
 <style>
-	header {
-		margin-bottom: var(--size-5);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
-	}
-
 	.description {
 		margin-bottom: var(--size-5);
 	}

--- a/frontend/src/routes/credit-roles/[slug]/+page.svelte
+++ b/frontend/src/routes/credit-roles/[slug]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { pageTitle } from '$lib/constants';
 
 	let { data } = $props();
@@ -12,28 +13,16 @@
 </svelte:head>
 
 <article>
-	<header>
-		<h1>{profile.name}</h1>
+	<PageHeader title={profile.name}>
 		{#if profile.description?.html}
 			<Markdown html={profile.description.html} />
 			<AttributionLine attribution={profile.description.attribution} />
 		{/if}
-	</header>
+	</PageHeader>
 </article>
 
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 </style>

--- a/frontend/src/routes/display-subtypes/[slug]/+layout.svelte
+++ b/frontend/src/routes/display-subtypes/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -29,13 +29,10 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb
-			crumbs={[{ label: 'Display Subtypes', href: '/display-subtypes' }]}
-			current={profile.name}
-		/>
-		<h1>{profile.name}</h1>
-	</header>
+	<PageHeader
+		title={profile.name}
+		breadcrumbs={[{ label: 'Display Subtypes', href: '/display-subtypes' }]}
+	/>
 
 	{#if profile.description?.html}
 		<div class="description">
@@ -58,17 +55,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/display-types/[slug]/+layout.svelte
+++ b/frontend/src/routes/display-types/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -29,13 +29,10 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb
-			crumbs={[{ label: 'Display Types', href: '/display-types' }]}
-			current={profile.name}
-		/>
-		<h1>{profile.name}</h1>
-	</header>
+	<PageHeader
+		title={profile.name}
+		breadcrumbs={[{ label: 'Display Types', href: '/display-types' }]}
+	/>
 
 	{#if profile.description?.html}
 		<div class="description">
@@ -58,17 +55,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/franchises/+page.svelte
+++ b/frontend/src/routes/franchises/+page.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import client from '$lib/api/client';
 	import { createAsyncLoader } from '$lib/async-loader.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { pageTitle } from '$lib/constants';
 
 	const allFranchises = createAsyncLoader(async () => {
@@ -16,10 +17,9 @@
 </svelte:head>
 
 <article>
-	<header>
-		<h1>Franchises</h1>
+	<PageHeader title="Franchises" --page-header-title-mb="0">
 		<p class="subtitle">Licensed and original franchises featured in pinball.</p>
-	</header>
+	</PageHeader>
 
 	{#if allFranchises.loading}
 		<p class="status">Loading...</p>
@@ -46,16 +46,6 @@
 <style>
 	article {
 		max-width: 48rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
 	}
 
 	.subtitle {

--- a/frontend/src/routes/franchises/[slug]/+layout.svelte
+++ b/frontend/src/routes/franchises/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -32,10 +32,7 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb crumbs={[{ label: 'Franchises', href: '/franchises' }]} current={franchise.name} />
-		<h1>{franchise.name}</h1>
-	</header>
+	<PageHeader title={franchise.name} breadcrumbs={[{ label: 'Franchises', href: '/franchises' }]} />
 
 	{#if franchise.description?.html}
 		<div class="description">
@@ -60,17 +57,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/game-formats/[slug]/+layout.svelte
+++ b/frontend/src/routes/game-formats/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -29,13 +29,10 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb
-			crumbs={[{ label: 'Game Formats', href: '/game-formats' }]}
-			current={profile.name}
-		/>
-		<h1>{profile.name}</h1>
-	</header>
+	<PageHeader
+		title={profile.name}
+		breadcrumbs={[{ label: 'Game Formats', href: '/game-formats' }]}
+	/>
 
 	{#if profile.description?.html}
 		<div class="description">
@@ -58,17 +55,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/gameplay-features/[slug]/+layout.svelte
+++ b/frontend/src/routes/gameplay-features/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import SidebarList from '$lib/components/SidebarList.svelte';
@@ -52,13 +52,10 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb
-			crumbs={[{ label: 'Gameplay Features', href: '/gameplay-features' }]}
-			current={profile.name}
-		/>
-		<h1>{profile.name}</h1>
-	</header>
+	<PageHeader
+		title={profile.name}
+		breadcrumbs={[{ label: 'Gameplay Features', href: '/gameplay-features' }]}
+	/>
 
 	<TwoColumnLayout>
 		{#snippet main()}
@@ -119,17 +116,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/locations/+page.svelte
+++ b/frontend/src/routes/locations/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import client from '$lib/api/client';
 	import { createAsyncLoader } from '$lib/async-loader.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { resolveHref } from '$lib/utils';
 	import { pageTitle } from '$lib/constants';
 
@@ -19,10 +20,9 @@
 </svelte:head>
 
 <article>
-	<header>
-		<h1>Locations</h1>
+	<PageHeader title="Locations" --page-header-title-mb="0">
 		<p class="subtitle">Browse pinball manufacturers by country, state, and city.</p>
-	</header>
+	</PageHeader>
 
 	{#if locations.loading}
 		<p class="status">Loading...</p>
@@ -62,16 +62,6 @@
 <style>
 	article {
 		max-width: 48rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
 	}
 
 	.subtitle {

--- a/frontend/src/routes/manufacturers/[slug]/+layout.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+layout.svelte
@@ -4,7 +4,7 @@
 	import { pageTitle } from '$lib/constants';
 	import { formatYearRange, resolveHref } from '$lib/utils';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import ExpandableSidebarList from '$lib/components/ExpandableSidebarList.svelte';
 	import LocationLink from '$lib/components/LocationLink.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
@@ -56,10 +56,12 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb crumbs={[{ label: 'Manufacturers', href: '/manufacturers' }]} current={mfr.name} />
-		<h1>{mfr.name}</h1>
-	</header>
+	<PageHeader
+		title={mfr.name}
+		breadcrumbs={[{ label: 'Manufacturers', href: '/manufacturers' }]}
+		--page-header-mb="var(--size-5)"
+		--page-header-title-mb="var(--size-2)"
+	/>
 
 	<TwoColumnLayout>
 		{#snippet main()}
@@ -172,17 +174,6 @@
 </article>
 
 <style>
-	header {
-		margin-bottom: var(--size-5);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
-	}
-
 	.description {
 		margin-bottom: var(--size-5);
 	}

--- a/frontend/src/routes/people/[slug]/+layout.svelte
+++ b/frontend/src/routes/people/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
 	import Tab from '$lib/components/Tab.svelte';
 
@@ -34,10 +34,12 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb crumbs={[{ label: 'People', href: '/people' }]} current={person.name} />
-		<h1>{person.name}</h1>
-	</header>
+	<PageHeader
+		title={person.name}
+		breadcrumbs={[{ label: 'People', href: '/people' }]}
+		--page-header-mb="var(--size-5)"
+		--page-header-title-mb="var(--size-2)"
+	/>
 
 	<TabNav>
 		<Tab active={isDetail} href={resolve(`/people/${slug}`)}>Titles</Tab>
@@ -55,16 +57,5 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-5);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
 	}
 </style>

--- a/frontend/src/routes/review/+page.svelte
+++ b/frontend/src/routes/review/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { pageTitle } from '$lib/constants';
 	import { resolveHref } from '$lib/utils';
 
@@ -12,10 +13,9 @@
 </svelte:head>
 
 <article>
-	<header>
-		<h1>Claims Needing Review</h1>
+	<PageHeader title="Claims Needing Review" --page-header-title-mb="var(--size-2)">
 		<p class="subtitle">{claims.length} claim{claims.length !== 1 ? 's' : ''} flagged for review</p>
-	</header>
+	</PageHeader>
 
 	{#if claims.length === 0}
 		<p class="empty">No claims need review.</p>
@@ -67,17 +67,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
 	}
 
 	.subtitle {

--- a/frontend/src/routes/reward-types/[slug]/+layout.svelte
+++ b/frontend/src/routes/reward-types/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -29,13 +29,10 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb
-			crumbs={[{ label: 'Reward Types', href: '/reward-types' }]}
-			current={profile.name}
-		/>
-		<h1>{profile.name}</h1>
-	</header>
+	<PageHeader
+		title={profile.name}
+		breadcrumbs={[{ label: 'Reward Types', href: '/reward-types' }]}
+	/>
 
 	{#if profile.description?.html}
 		<div class="description">
@@ -58,17 +55,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/series/[slug]/+layout.svelte
+++ b/frontend/src/routes/series/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -32,10 +32,7 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb crumbs={[{ label: 'Series', href: '/series' }]} current={series.name} />
-		<h1>{series.name}</h1>
-	</header>
+	<PageHeader title={series.name} breadcrumbs={[{ label: 'Series', href: '/series' }]} />
 
 	{#if series.description?.html}
 		<div class="description">
@@ -59,17 +56,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/systems/+page.svelte
+++ b/frontend/src/routes/systems/+page.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import client from '$lib/api/client';
 	import { createAsyncLoader } from '$lib/async-loader.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { pageTitle } from '$lib/constants';
 
 	const systems = createAsyncLoader(async () => {
@@ -16,9 +17,7 @@
 </svelte:head>
 
 <article>
-	<header>
-		<h1>Systems</h1>
-	</header>
+	<PageHeader title="Systems" />
 
 	{#if systems.loading}
 		<p class="status">Loading...</p>
@@ -50,16 +49,6 @@
 <style>
 	article {
 		max-width: 48rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
 	}
 
 	.system-list {

--- a/frontend/src/routes/systems/[slug]/+layout.svelte
+++ b/frontend/src/routes/systems/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import SidebarList from '$lib/components/SidebarList.svelte';
@@ -36,10 +36,11 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb crumbs={[{ label: 'Systems', href: '/systems' }]} current={system.name} />
-		<h1>{system.name}</h1>
-	</header>
+	<PageHeader
+		title={system.name}
+		breadcrumbs={[{ label: 'Systems', href: '/systems' }]}
+		--page-header-title-mb="var(--size-2)"
+	/>
 
 	<TwoColumnLayout>
 		{#snippet main()}
@@ -89,17 +90,6 @@
 </article>
 
 <style>
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-2);
-	}
-
 	.description {
 		margin-bottom: var(--size-6);
 	}

--- a/frontend/src/routes/tags/[slug]/+layout.svelte
+++ b/frontend/src/routes/tags/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -29,10 +29,7 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb crumbs={[{ label: 'Tags', href: '/tags' }]} current={profile.name} />
-		<h1>{profile.name}</h1>
-	</header>
+	<PageHeader title={profile.name} breadcrumbs={[{ label: 'Tags', href: '/tags' }]} />
 
 	{#if profile.description?.html}
 		<div class="description">
@@ -55,17 +52,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/technology-generations/[slug]/+layout.svelte
+++ b/frontend/src/routes/technology-generations/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -29,13 +29,10 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb
-			crumbs={[{ label: 'Technology Generations', href: '/technology-generations' }]}
-			current={profile.name}
-		/>
-		<h1>{profile.name}</h1>
-	</header>
+	<PageHeader
+		title={profile.name}
+		breadcrumbs={[{ label: 'Technology Generations', href: '/technology-generations' }]}
+	/>
 
 	{#if profile.description?.html}
 		<div class="description">
@@ -58,17 +55,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/technology-subgenerations/[slug]/+layout.svelte
+++ b/frontend/src/routes/technology-subgenerations/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import TabNav from '$lib/components/TabNav.svelte';
@@ -29,13 +29,10 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb
-			crumbs={[{ label: 'Technology Subgenerations', href: '/technology-subgenerations' }]}
-			current={profile.name}
-		/>
-		<h1>{profile.name}</h1>
-	</header>
+	<PageHeader
+		title={profile.name}
+		breadcrumbs={[{ label: 'Technology Subgenerations', href: '/technology-subgenerations' }]}
+	/>
 
 	{#if profile.description?.html}
 		<div class="description">
@@ -60,17 +57,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {

--- a/frontend/src/routes/themes/[slug]/+layout.svelte
+++ b/frontend/src/routes/themes/[slug]/+layout.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { pageTitle } from '$lib/constants';
 	import { auth } from '$lib/auth.svelte';
-	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import AttributionLine from '$lib/components/AttributionLine.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
 	import SidebarList from '$lib/components/SidebarList.svelte';
@@ -36,10 +36,7 @@
 </svelte:head>
 
 <article>
-	<header>
-		<Breadcrumb crumbs={[{ label: 'Themes', href: '/themes' }]} current={theme.name} />
-		<h1>{theme.name}</h1>
-	</header>
+	<PageHeader title={theme.name} breadcrumbs={[{ label: 'Themes', href: '/themes' }]} />
 
 	<TwoColumnLayout>
 		{#snippet main()}
@@ -98,17 +95,6 @@
 <style>
 	article {
 		max-width: 64rem;
-	}
-
-	header {
-		margin-bottom: var(--size-6);
-	}
-
-	h1 {
-		font-size: var(--font-size-7);
-		font-weight: 700;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-4);
 	}
 
 	.description {


### PR DESCRIPTION
## Summary

Slash cold-cache response times for the four `/all/` endpoints from ~30s aggregate to ~3-5s on production (6-54x faster per endpoint) by replacing deep ORM prefetch with bulk `values_list()` queries, caching `get_minimum_display_rank()` per rebuild, and avoiding full object hydration.

- **titles:** 3.59s → 0.54s (6.6x)
- **models:** 3.17s → 0.26s (12.2x)
- **manufacturers:** 1.37s → 0.09s (15.2x)
- **people:** 1.08s → 0.02s (54x)
- Also extracts a shared `PageHeader` component (adopted in 27 files) and adds docstrings/named constants to the bulk-query code

## Test plan

- [ ] `make test` passes (backend + frontend)
- [ ] Deploy to staging, clear cache, hit each `/all/` endpoint and confirm response shape is unchanged
- [ ] Verify cold-cache load times are significantly faster than before
- [ ] Spot-check a few detail pages to confirm `PageHeader` renders correctly (title, breadcrumbs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)