### PR TITLE
feat(frontend): enable SSR for all detail pages

### DIFF
--- a/frontend/src/routes/cabinets/[slug]/+layout.ts
+++ b/frontend/src/routes/cabinets/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/corporate-entities/[slug]/+layout.ts
+++ b/frontend/src/routes/corporate-entities/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/display-subtypes/[slug]/+layout.ts
+++ b/frontend/src/routes/display-subtypes/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/display-types/[slug]/+layout.ts
+++ b/frontend/src/routes/display-types/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/franchises/[slug]/+layout.ts
+++ b/frontend/src/routes/franchises/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/game-formats/[slug]/+layout.ts
+++ b/frontend/src/routes/game-formats/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/gameplay-features/[slug]/+layout.ts
+++ b/frontend/src/routes/gameplay-features/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/manufacturers/[slug]/+layout.ts
+++ b/frontend/src/routes/manufacturers/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/models/[slug]/+layout.ts
+++ b/frontend/src/routes/models/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/people/[slug]/+layout.ts
+++ b/frontend/src/routes/people/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/reward-types/[slug]/+layout.ts
+++ b/frontend/src/routes/reward-types/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/series/[slug]/+layout.ts
+++ b/frontend/src/routes/series/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/systems/[slug]/+layout.ts
+++ b/frontend/src/routes/systems/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/tags/[slug]/+layout.ts
+++ b/frontend/src/routes/tags/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/technology-generations/[slug]/+layout.ts
+++ b/frontend/src/routes/technology-generations/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/technology-subgenerations/[slug]/+layout.ts
+++ b/frontend/src/routes/technology-subgenerations/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/themes/[slug]/+layout.ts
+++ b/frontend/src/routes/themes/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;

--- a/frontend/src/routes/titles/[slug]/+layout.ts
+++ b/frontend/src/routes/titles/[slug]/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = true;


### PR DESCRIPTION
## Summary
- All 18 `[slug]` detail routes were inheriting `ssr = false` from the `(app)` layout, despite already having `+layout.server.ts` files that fetch data server-side. The browser received an empty shell, downloaded JS, then rendered — defeating the purpose of the server load functions.
- Adds `export const ssr = true` in a new `+layout.ts` for each detail route, so the server returns fully rendered HTML on first load.
- Edit, media, and upload child routes retain their explicit `ssr = false` and are unaffected.

**Routes enabled:** cabinets, corporate-entities, display-subtypes, display-types, franchises, game-formats, gameplay-features, manufacturers, models, people, reward-types, series, systems, tags, technology-generations, technology-subgenerations, themes, titles.

## Test plan
- [ ] Visit several detail pages (`/titles/{slug}`, `/manufacturers/{slug}`, `/people/{slug}`, etc.) and verify content renders immediately (view source should contain page HTML)
- [ ] Verify edit pages (`/titles/{slug}/edit`) still load as CSR (view source should NOT contain edit form HTML)
- [ ] Verify media/upload pages still load as CSR
- [ ] Check browser dev tools — no hydration mismatch warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)