### PR TITLE
perf(api): hoist Constance min_rank lookup out of serialization loops

### DIFF
--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -57,13 +57,15 @@ class FranchiseDetailSchema(Schema):
 # ---------------------------------------------------------------------------
 
 
-def _serialize_title_list(title) -> dict:
+def _serialize_title_list(title, *, min_rank: int | None = None) -> dict:
     thumbnail_url = None
     manufacturer_name = None
     year = None
     machines = list(title.machine_models.all())
     if machines:
-        thumbnail_url, _ = _extract_image_urls(machines[0].extra_data or {})
+        thumbnail_url, _ = _extract_image_urls(
+            machines[0].extra_data or {}, min_rank=min_rank
+        )
         first = machines[0]
         manufacturer_name = (
             first.corporate_entity.manufacturer.name
@@ -144,13 +146,18 @@ def _franchise_detail_qs():
 
 
 def _serialize_franchise_detail(franchise) -> dict:
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     return {
         "name": franchise.name,
         "slug": franchise.slug,
         "description": _build_rich_text(
             franchise, "description", getattr(franchise, "active_claims", [])
         ),
-        "titles": [_serialize_title_list(t) for t in franchise.titles.all()],
+        "titles": [
+            _serialize_title_list(t, min_rank=min_rank) for t in franchise.titles.all()
+        ],
         "sources": build_sources(getattr(franchise, "active_claims", [])),
     }
 

--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -217,13 +217,18 @@ def _build_rich_text(obj, field_name: str, active_claims=None) -> dict:
 
 def _collect_titles(models, *, include_manufacturer: bool = False) -> list[dict]:
     """Group models by title into a deduplicated title list."""
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     titles: dict[str, dict] = {}
     for m in models:
         if m.title is None:
             continue
         key = m.title.slug
         if key not in titles:
-            thumbnail_url = _extract_image_urls(m.extra_data or {})[0]
+            thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[
+                0
+            ]
             entry: dict = {
                 "name": m.title.name,
                 "slug": m.title.slug,
@@ -238,7 +243,9 @@ def _collect_titles(models, *, include_manufacturer: bool = False) -> list[dict]
                 )
             titles[key] = entry
         elif titles[key]["thumbnail_url"] is None:
-            thumbnail_url = _extract_image_urls(m.extra_data or {})[0]
+            thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[
+                0
+            ]
             if thumbnail_url:
                 titles[key]["thumbnail_url"] = thumbnail_url
     return sorted(titles.values(), key=lambda t: (t["year"] is None, -(t["year"] or 0)))
@@ -307,9 +314,14 @@ def _get_feature_descendant_slugs(slug: str) -> set[str]:
     return result
 
 
-def _serialize_title_machine(pm) -> dict:
+def _serialize_title_machine(pm, *, min_rank: int | None = None) -> dict:
     """Serialize a MachineModel for use in title/theme/system machine lists."""
-    thumbnail_url, _ = _extract_image_urls(pm.extra_data or {})
+    if min_rank is None:
+        from apps.core.licensing import get_minimum_display_rank
+
+        min_rank = get_minimum_display_rank()
+
+    thumbnail_url, _ = _extract_image_urls(pm.extra_data or {}, min_rank=min_rank)
 
     # Include variants only when prefetched to avoid N+1 queries.
     variant_qs = (
@@ -322,7 +334,9 @@ def _serialize_title_machine(pm) -> dict:
             "name": v.name,
             "slug": v.slug,
             "year": v.year,
-            "thumbnail_url": _extract_image_urls(v.extra_data or {})[0],
+            "thumbnail_url": _extract_image_urls(v.extra_data or {}, min_rank=min_rank)[
+                0
+            ],
         }
         for v in variant_qs
     ]

--- a/backend/apps/catalog/api/locations.py
+++ b/backend/apps/catalog/api/locations.py
@@ -188,6 +188,9 @@ def _get_manufacturers_for_pks(pks):
         .order_by("-model_count", "name")
     )
 
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     result = []
     for mfr in qs:
         thumb = None
@@ -196,7 +199,7 @@ def _get_manufacturers_for_pks(pks):
                 break
             for model in entity.models.all():
                 if model.extra_data:
-                    thumb, _ = _extract_image_urls(model.extra_data)
+                    thumb, _ = _extract_image_urls(model.extra_data, min_rank=min_rank)
                     if thumb:
                         break
         result.append(

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -247,9 +247,11 @@ def _build_model_list_qs(
     return qs
 
 
-def _serialize_model_list(pm) -> dict:
+def _serialize_model_list(pm, *, min_rank: int | None = None) -> dict:
     primary_media = getattr(pm, "primary_media", None)
-    thumbnail_url, _ = _extract_image_urls(pm.extra_data or {}, primary_media)
+    thumbnail_url, _ = _extract_image_urls(
+        pm.extra_data or {}, primary_media, min_rank=min_rank
+    )
     mfr = (
         pm.corporate_entity.manufacturer
         if pm.corporate_entity and pm.corporate_entity.manufacturer
@@ -292,6 +294,10 @@ def _serialize_model_detail(pm) -> dict:
     """
     from django.db.models import Case, F, IntegerField, Value, When
 
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
+
     credits = [
         {
             "person": {"name": c.person.name, "slug": c.person.slug},
@@ -323,7 +329,7 @@ def _serialize_model_detail(pm) -> dict:
     all_media = getattr(pm, "all_media", None) or []
     primary_media = [em for em in all_media if em.is_primary]
     thumbnail_url, hero_image_url = _extract_image_urls(
-        pm.extra_data or {}, primary_media or None
+        pm.extra_data or {}, primary_media or None, min_rank=min_rank
     )
     image_attribution = _extract_image_attribution(
         pm.extra_data or {}, primary_media or None
@@ -495,7 +501,7 @@ def _serialize_model_detail(pm) -> dict:
             for s in (pm.title.series.all() if pm.title else [])
         ],
         "title_models": [
-            _serialize_title_machine(sibling)
+            _serialize_title_machine(sibling, min_rank=min_rank)
             for sibling in (pm.title.machine_models.all() if pm.title else [])
             if sibling.variant_of_id is None
         ],
@@ -604,7 +610,10 @@ def list_models(
         person=person,
         ordering=ordering,
     )
-    return [_serialize_model_list(pm) for pm in qs]
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
+    return [_serialize_model_list(pm, min_rank=min_rank) for pm in qs]
 
 
 def _build_search_text(pm) -> str:
@@ -670,6 +679,9 @@ def list_recent_models(request):
             "-updated_at",
         )
     )
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     results = []
     seen_titles: set[int | None] = set()
     for m in qs:
@@ -677,7 +689,7 @@ def list_recent_models(request):
         if title_id in seen_titles:
             continue
         seen_titles.add(title_id)
-        thumbnail_url, _ = _extract_image_urls(m.extra_data or {})
+        thumbnail_url, _ = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)
         results.append(
             {
                 "name": m.name,

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -82,6 +82,9 @@ def _serialize_person_detail(person) -> dict:
     (select_related model, model__title, model__manufacturer) and claims
     (to_attr="active_claims").
     """
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     titles: dict[str, dict] = {}
     for c in person.credits.all():
         if c.model is None or c.model.title is None:
@@ -89,7 +92,9 @@ def _serialize_person_detail(person) -> dict:
         title = c.model.title
         key = title.slug
         if key not in titles:
-            thumbnail_url = _extract_image_urls(c.model.extra_data or {})[0]
+            thumbnail_url = _extract_image_urls(
+                c.model.extra_data or {}, min_rank=min_rank
+            )[0]
             titles[key] = {
                 "name": title.name,
                 "slug": title.slug,
@@ -104,7 +109,9 @@ def _serialize_person_detail(person) -> dict:
                 "roles": [],
             }
         elif titles[key]["thumbnail_url"] is None:
-            thumbnail_url = _extract_image_urls(c.model.extra_data or {})[0]
+            thumbnail_url = _extract_image_urls(
+                c.model.extra_data or {}, min_rank=min_rank
+            )[0]
             if thumbnail_url:
                 titles[key]["thumbnail_url"] = thumbnail_url
         role_display = c.role.name

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -60,14 +60,16 @@ class SeriesDetailSchema(Schema):
 # ---------------------------------------------------------------------------
 
 
-def _serialize_title_list(title) -> dict:
+def _serialize_title_list(title, *, min_rank: int | None = None) -> dict:
     """Serialize a Title for use in series listing context."""
     thumbnail_url = None
     manufacturer_name = None
     year = None
     machines = list(title.machine_models.all())
     if machines:
-        thumbnail_url, _ = _extract_image_urls(machines[0].extra_data or {})
+        thumbnail_url, _ = _extract_image_urls(
+            machines[0].extra_data or {}, min_rank=min_rank
+        )
         first = machines[0]
         manufacturer_name = (
             first.corporate_entity.manufacturer.name
@@ -128,13 +130,18 @@ def _series_detail_qs():
 
 
 def _serialize_series_detail(series) -> dict:
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     return {
         "name": series.name,
         "slug": series.slug,
         "description": _build_rich_text(
             series, "description", getattr(series, "active_claims", [])
         ),
-        "titles": [_serialize_title_list(t) for t in series.titles.all()],
+        "titles": [
+            _serialize_title_list(t, min_rank=min_rank) for t in series.titles.all()
+        ],
         "credits": [
             {
                 "person": {"name": c.person.name, "slug": c.person.slug},
@@ -175,12 +182,15 @@ def list_series(request):
             )
         )
     )
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     result = []
     for s in qs:
         thumb = None
         for title in s.titles.all():
             for pm in title.machine_models.all():
-                t, _ = _extract_image_urls(pm.extra_data or {})
+                t, _ = _extract_image_urls(pm.extra_data or {}, min_rank=min_rank)
                 if t:
                     thumb = t
                     break

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -82,13 +82,18 @@ def _system_detail_qs():
 def _serialize_system_detail(system) -> dict:
     from ..models import System
 
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     titles: dict[str, dict] = {}
     for m in system.machine_models.all():
         if m.title is None:
             continue
         key = m.title.slug
         if key not in titles:
-            thumbnail_url = _extract_image_urls(m.extra_data or {})[0]
+            thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[
+                0
+            ]
             titles[key] = {
                 "name": m.title.name,
                 "slug": m.title.slug,
@@ -101,7 +106,9 @@ def _serialize_system_detail(system) -> dict:
                 "thumbnail_url": thumbnail_url,
             }
         elif titles[key]["thumbnail_url"] is None:
-            thumbnail_url = _extract_image_urls(m.extra_data or {})[0]
+            thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[
+                0
+            ]
             if thumbnail_url:
                 titles[key]["thumbnail_url"] = thumbnail_url
 

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -251,11 +251,17 @@ def _reward_type_detail_qs():
 
 
 def _serialize_reward_type_detail(rt) -> dict:
+    from apps.core.licensing import get_minimum_display_rank
+
     from .helpers import _serialize_title_machine
 
+    min_rank = get_minimum_display_rank()
     return {
         **_serialize_taxonomy(rt),
-        "machines": [_serialize_title_machine(pm) for pm in rt.machine_models.all()],
+        "machines": [
+            _serialize_title_machine(pm, min_rank=min_rank)
+            for pm in rt.machine_models.all()
+        ],
     }
 
 

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -76,6 +76,9 @@ def _detail_qs():
 
 
 def _serialize_detail(theme) -> dict:
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     return {
         "name": theme.name,
         "slug": theme.slug,
@@ -87,7 +90,10 @@ def _serialize_detail(theme) -> dict:
         "children": [
             {"name": t.name, "slug": t.slug} for t in theme.children.order_by("name")
         ],
-        "machines": [_serialize_title_machine(pm) for pm in theme.machine_models.all()],
+        "machines": [
+            _serialize_title_machine(pm, min_rank=min_rank)
+            for pm in theme.machine_models.all()
+        ],
         "sources": build_sources(getattr(theme, "active_claims", [])),
     }
 

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -357,8 +357,11 @@ def _compute_agreed_specs(models) -> dict:
 
 
 def _serialize_title_detail(title) -> dict:
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
     model_objs = list(title.machine_models.all())
-    machines = [_serialize_title_machine(pm) for pm in model_objs]
+    machines = [_serialize_title_machine(pm, min_rank=min_rank) for pm in model_objs]
     series = [
         {"name": s.name, "slug": s.slug}
         for s in getattr(title, "series_list", None) or title.series.all()
@@ -368,7 +371,9 @@ def _serialize_title_detail(title) -> dict:
     # Hero image from the earliest model.
     hero_image_url = None
     if model_objs:
-        _, hero_image_url = _extract_image_urls(model_objs[0].extra_data or {})
+        _, hero_image_url = _extract_image_urls(
+            model_objs[0].extra_data or {}, min_rank=min_rank
+        )
 
     # Credits that appear on every model (intersection, not union).
     credit_sets = []
@@ -511,7 +516,10 @@ def list_titles(request, display: str = ""):
         .prefetch_related(_title_models_prefetch(), "series", "abbreviations")
         .order_by("name")
     )
-    return [_serialize_title_list(t) for t in qs]
+    from apps.core.licensing import get_minimum_display_rank
+
+    min_rank = get_minimum_display_rank()
+    return [_serialize_title_list(t, min_rank=min_rank) for t in qs]
 
 
 @titles_router.get("/all/", response=list[TitleListSchema])


### PR DESCRIPTION
## Summary

- Hoists `get_minimum_display_rank()` (a Constance DB lookup) out of serialization loops across all detail and list endpoints
- The fix was already applied to `/all/` endpoints but the same bug existed in 10 other API files — every `_extract_image_urls()` call without `min_rank` triggered a redundant DB hit per loop iteration
- Adds `min_rank` parameter to `_serialize_title_machine`, `_serialize_model_list`, and `_serialize_title_list` (in franchises/series) so callers can hoist once and thread through

## Test plan

- [x] All 1007 catalog tests pass
- [x] All pre-commit hooks pass (ruff, ruff-format, backend tests)
- [x] Final audit confirms zero remaining unprotected `_extract_image_urls()` calls in loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)