### PR TITLE
docs(citations): add source seeding and governance notes

### DIFF
--- a/docs/plans/citations/CitationDomainModel.md
+++ b/docs/plans/citations/CitationDomainModel.md
@@ -283,7 +283,7 @@ Working through concrete fields to discover what's shared, what's type-specific,
 
 | Field     | Value                       |
 | --------- | --------------------------- |
-| title     | The Encyclopedia of Pinball |
+| name      | The Encyclopedia of Pinball |
 | type      | book                        |
 | author    | Richard Bueschel            |
 | publisher | Silverball Amusements       |
@@ -291,29 +291,27 @@ Working through concrete fields to discover what's shared, what's type-specific,
 
 **Child source (an edition):**
 
-| Field    | Value                         |
-| -------- | ----------------------------- |
-| title    | Edition 1                     |
-| type     | book                          |
-| year     | 1996                          |
-| format   | hardcover                     |
-| language | English                       |
-| parent   | → The Encyclopedia of Pinball |
+| Field    | Value                                   |
+| -------- | --------------------------------------- |
+| name     | The Encyclopedia of Pinball - Edition 1 |
+| type     | book                                    |
+| year     | 1996                                    |
+| format   | hardcover                               |
+| language | English                                 |
+| parent   | → The Encyclopedia of Pinball           |
 
 **Deeper child (a translation of an edition):**
 
-| Field    | Value              |
-| -------- | ------------------ |
-| title    | French translation |
-| type     | book               |
-| language | French             |
-| parent   | → Edition 2        |
+| Field    | Value                                                        |
+| -------- | ------------------------------------------------------------ |
+| name     | The Encyclopedia of Pinball - Edition 1 - French translation |
+| type     | book                                                         |
+| language | French                                                       |
+| parent   | → Edition 2                                                  |
 
 Observations:
 
-- **author and publisher live on the root**, not repeated on every child. A child inherits them from its parent chain.
 - **year, format, and language are differentiators** — they're the reason a child exists as a separate source.
-- **title on a child is relative to its parent.** The full display name is assembled by walking the parent chain: "The Encyclopedia of Pinball → Edition 2 → French translation → Kindle version."
 - **ISBN could go on the format-level child** (the specific hardcover or Kindle edition), since each format has its own ISBN.
 
 ### Manual: _The Addams Family_ documentation
@@ -392,7 +390,6 @@ Observations:
 
 - **No new fields needed.** A web article uses title, type, author, date, year, and parent — all fields we already have from books and magazines.
 - **URL is not a source field — it's an access link.** The article _is_ the source; the URL is how you get to it. If the site goes down and an archive.org copy exists, the source is unchanged — only the access links change.
-- **No volume/issue/pages.** Web articles don't have these. The fields are simply unused, which is fine — the model is sparse by design.
 - **The type could be `website` or `magazine`.** Pinball Magazine publishes both print and web. The type on the source distinguishes the form. A print issue and a web article from the same publication are siblings with different types under the same root.
 
 ### Magazine article: Roger C. Sharpe in _Play Meter_
@@ -413,10 +410,6 @@ Three levels: publication → issue → article.
 | ------ | ----------------------------- |
 | title  | 1978 August 15 - Vol 4 Num 15 |
 | type   | magazine                      |
-| date   | 1978-08-15                    |
-| year   | 1978                          |
-| volume | 4                             |
-| issue  | 15                            |
 | parent | → Play Meter                  |
 
 **Child source (the article):**

--- a/docs/plans/citations/CitationSourceSeeding.md
+++ b/docs/plans/citations/CitationSourceSeeding.md
@@ -1,0 +1,75 @@
+# Citation Source Pre-population
+
+We want to pre-populate the system with all the Citation Sources relevant to Pinbase. Pinball books, pinball magazines, pinball websites.
+
+## The Case for Pre-Seeding
+
+We believe that pre-seeding the database with Citation Sources will:
+
+- **Take an enormous burden off citation creation**. It should be MUCH easier to create a citation since you don't have to create the source, and especially much easier with the inline autocomplete UI we're planning. One of the biggest learnings from Wikipedia is that we _must_ make it easier to create citations - it's one of Wikipedia's biggest pains and a major impediment to editor retention.
+- **Reduce one-off creation**. Bias people towards re-use of Citation Sources from day one, so that we don't have one-off Citation Sources entering the system.
+- **Reduce duplicate creation**. If most sources already exist, and most citation entry is selecting an existing source, we train people to not create duplicates. Also, during the ingest/seeding process we can create rich metadata and synonyms/aliases so that it's easy to find the right source.
+- **Avoiding retrofit cost**. If Pinbase wants shared sources, seeding early is much cheaper than trying to normalize thousands of ad hoc sources later. Preventing duplicate creation is cheaper than building workflows to merge and repair them afterward.
+- **Stronger editorial consistency**. Seeding lets Pinbase decide canonical naming, types, and scope centrally instead of leaving those choices to whoever happens to cite something first.
+- **Better hierarchy from day one**. Many source families need structure, not just flat names: publication → issue → article, work → edition, documentation set → manual. That hierarchy is hard to build correctly during casual authoring.
+- **Better access-link enrichment**. Pre-seeded sources can accumulate scans, archive links, and canonical URLs over time, making sources more inspectable for readers and editors.
+
+See [CitationSharing.md](CitationSharing.md) for more of the Wikipedia learnings.
+
+## Feasibilty of Pre-seeding
+
+### Books
+
+Pre-seeding books appears to be very tractable. The likely scale is only several dozen distinct pinball books, and plausibly low hundreds once you include editions, translations, and adjacent technical/reference works.
+
+A quick sample across Google Books, Open Library, and WorldCat surfaced bounded corpus of obvious pinball books, including:
+
+- [_Pinball!_](https://www.amazon.com/dp/0525474811) (Roger C. Sharpe, 1977)
+- _Pinball wizardry_ (Robert Polin, 1979)
+- [_Pinball Machines_](https://www.amazon.com/dp/0764308955) (Heribert Eiden and Jürgen Lukas, 1992)
+- [_The Complete Pinball Book_](https://www.amazon.com/dp/0764337858) (Marco Rossignoli, 1999/2002/2011)
+- [_The Pinball Compendium: Electro-Mechanical Era_](https://www.amazon.com/dp/0764330284) (Michael Shalhoub, 2008)
+- [_Your Pinball Machine_](https://www.amazon.com/dp/0764361805) (B. B. Kamoroff, 2021)
+- [_Pinball: A Graphic History of the Silver Ball_](https://www.amazon.com/dp/125024921X) (Jon Chad, 2024)
+- _Pinball: A Quest for Mastery_ (Tasker Smith, 2026)
+
+### Print Magazines
+
+Pre-seeding paper magazines/newsletters/fanzines appears to be very tractable. It appears to be in the low dozens at most.
+
+A quick AI search surfaced a small, bounded set of obvious pinball-first or pinball-relevant print titles, including:
+
+- _PinGame Journal_ - hobbyist pinball periodical, active since May 1991. <https://en.wikipedia.org/wiki/PinGame_Journal>
+- _Pinball Magazine_ - current print pinball glossy edited by Jonathan Joosten; first issue launched in August 2012. <https://www.pinball-magazine.com/?page_id=583>
+- _Pinhead Classified_ - pinball fanzine; defunct by January 1999, with final issue No. 29 noted in the rec.games.pinball FAQ. <https://gamefaqs.gamespot.com/pinball/916391-pinball-hardware/faqs/1325>
+- _Pinball Trader Newsletter_ - earlier collector publication that predates _PinGame Journal_; active by the late 1980s and still represented in 1991-1992 holdings. <https://library.arcade-museum.com/magazine/pinball-trader>
+- _GameRoom Magazine_ - general gameroom hobbyist magazine with steady pinball coverage; January 1989 to July 2016, with a short relaunch after 2014. <https://en.wikipedia.org/wiki/Gameroom_magazine>
+- _Play Meter_ - major coin-op trade magazine with regular pinball coverage; founded in 1974 and ended in 2018. <https://en.wikipedia.org/wiki/Play_Meter>
+- _RePlay_ - major coin-op trade magazine with regular pinball coverage; founded in October 1975 and still active. <https://www.replaymag.com/about-replay/about-replay-magazine/>
+- _Coin Slot_ - enthusiast coin-op magazine with pinball coverage; published from September 1974 into at least the late 1990s in library holdings. <https://library.arcade-museum.com/magazine/coin-slot>
+- _Canadian Coin Box_ - long-running Canadian coin-op trade magazine with pinball coverage; library holdings run from 1953 into 2000. <https://library.arcade-museum.com/magazine/canadian-coin-box>
+- _Coin-Op Newsletter_ - hobbyist coin-op publication with some pinball relevance; library holdings include issues from 1988-1991 and later. <https://library.arcade-museum.com/magazine/coin-op-newsletter>
+- _Coin Drop International_ - electromechanical coin-op magazine; the 1999 rec.games.pinball FAQ specifically notes its coverage of older and pre-flipper pinball. <https://gamefaqs.gamespot.com/pinball/916391-pinball-hardware/faqs/1325>
+
+If scoped to pinball-dedicated paper publications, the universe appears to be well under twenty roots; if expanded to broader coin-op trade titles with regular pinball coverage, it is still likely only low dozens.
+
+### Major Pinball Websites
+
+Pre-seeding the major pinball websites appears to be highly tractable. We'd pre-seed site/publication/provider roots, not every article, forum post, or product page. The root-site universe appears to be only low dozens overall, with current manufacturer roots in the single digits to low teens.
+
+- **Reference / database / community sites**:
+  - _IPDB_ - the long-running Internet Pinball Database, a comprehensive machine encyclopedia now hosted at ipdb.org. <https://www.ipdb.org/aboutus.html>
+  - _OPDB_ - the Open Pinball Database, a current API-first machine archive. <https://opdb.org/about>
+  - _Pinside_ - the largest general-purpose pinball community/forum/marketplace site. <https://pinside.com/pinball/help/>
+  - _PinWiki_ - community-maintained pinball wiki, launched April 21, 2011. <https://www.pinwiki.com/wiki/index.php/PinWiki%3AAbout>
+  - _Kineticist_ - digital publication and community resource, launched in 2022. <https://www.kineticist.com/about>
+  - _Pinball News_ - independent pinball news and reporting site, started at the end of 1999. <https://www.pinballnews.com/site/2000/01/01/about-pinball-news/>
+  - _This Week in Pinball_ - weekly pinball news site/newsletter, now part of Kineticist. <https://twip.kineticist.com/>
+- **Manufacturer sites**:
+  - _Stern Pinball_ - current major manufacturer; official site includes company history, game pages, and support materials. <https://sternpinball.com/About/>
+  - _Jersey Jack Pinball_ - current major manufacturer founded in 2011. <https://jerseyjackpinball.com/pages/company>
+  - _American Pinball_ - current major manufacturer. <https://www.american-pinball.com/about>
+  - _Spooky Pinball_ - current boutique manufacturer; company founded February 1, 2013. <https://www.spookypinball.com/about-us/>
+  - _Multimorphic_ - current manufacturer/platform company; began as PinballControllers.com in 2009. <https://www.multimorphic.com/about/>
+  - _Pinball Brothers_ - current European manufacturer, formed in 2020. <https://www.pinballbrothers.com/about-us/>
+  - _Chicago Gaming Company_ - current remake/manufacturing company with official product and service resources. <https://www.chicago-gaming.com/>

--- a/docs/plans/citations/Citations.md
+++ b/docs/plans/citations/Citations.md
@@ -20,5 +20,6 @@ However, we're loath to follow the Wikipedia model because the bureaucracy aroun
   - [CitationGranularity.md](CitationGranularity.md): points versus ranges vs sections
   - [CitationDomainModel.md](CitationDomainModel.md): source vs instance vs access link
   - [CitationSourceTypes.md](CitationSourceTypes.md): how to think about different types of Citation Sources
+  - [CitationSourceSeeding.md](CitationSourceSeeding.md): pre-populating the system with relevant Citation Sources
 - Design
   - [CitationsDesign.md](CitationsDesign.md): the current design direction

--- a/docs/plans/citations/CitationsDesign.md
+++ b/docs/plans/citations/CitationsDesign.md
@@ -69,9 +69,15 @@ A single Citation Source can be referenced by many Citation Instances across man
 
 Using shared Citation Sources — rather than having each citation site declare its own source independently — is actually a controversial decision. Wikipedia doesn't do this, though the Wikimedia community wishes it could. See [CitationSharing.md — Recommendation](CitationSharing.md#recommendation) for the full analysis of why Pinbase adopts shared sources and the tradeoffs involved.
 
+##### All Citation Sources are Shared
+
+There's no concept of local-only Citation Sources. If a user creates a one-off Citation Source, it shows up in the autocomplete for everyone.
+
+This will probably get annoying, seeing junk in autocomplete. Post v1, autocomplete could rank and filter in various ways TBD.
+
 #### Citation Source Types
 
-There are different types of Citation Sources. Here's a potential starter list; this has not yet been finalized, and would almost certainly grow as time goes on:
+There are different types of Citation Sources. Here's a potential starter list; we'll build one or two Citation types, see how it goes, and expand from there:
 
 | Type     | Additional fields      | Covers                                                                                     |
 | -------- | ---------------------- | ------------------------------------------------------------------------------------------ |
@@ -105,10 +111,6 @@ Citation Source is a single database table/model with a flat set of mostly-optio
 
 We could have chosen instead to use polymorphic models or a JSONField to capture the differences between types of Citation Sources, but after analysis of the likely Citation Sources, we concluded that they mostly share fields and that it's simpler to have one single table with optional fields.
 
-#### Periodical `volume` and `issue` are structured fields
-
-For periodical sources, `volume` and `issue` are structured fields, not part of the freeform title. The display layer assembles them into a formatted label (e.g., "Vol. 4, No. 15 — August 15, 1978") for autocomplete and read-side rendering.
-
 #### Citation Sources are Hierarchical
 
 Citation Sources are nested:
@@ -133,7 +135,7 @@ See [CitationDomainModel.md](CitationDomainModel.md) for worked examples includi
 
 Each Citation Source stores its own fields independently. Children do not inherit values from their parent chain.
 
-Inheritance adds a level of conceptual complexity that make the system hard to reason about -- both for people editing as well as AIs trying to build the code. We don't, for example, want to deal with the ambiguity of overriding inherited values.
+Inheritance would add a level of conceptual complexity that make the system hard to reason about -- both for people editing as well as AIs trying to build the code. We don't, for example, want to deal with the ambiguity of overriding inherited values.
 
 The create-child UI can pre-fill fields from the parent as a convenience, but the data model treats each record as self-contained.
 
@@ -196,13 +198,17 @@ These are different concepts:
 
 A page that is 90% ingested from IPDB has provenance (we know the data came from IPDB) but no citations (nobody has attached evidence for why the values are correct). Adding a citation would be someone finding the flyer or production record that confirms what IPDB says.
 
+## Citation Seeding
+
+We're going to pre-seed the Citation Source table with a whole bunch of Citation Sources, as described in [CitationSourceSeeding.md](CitationSourceSeeding.md).
+
 ## Contributor UX
 
 ### Citation Source search and creation
 
 The `[[` autocomplete should make finding an existing Citation Source feel as fast as typing inline:
 
-- **Typeahead** searching across title, author, and aliases — "Bueschel" and "Encyclopedia Pinball" should both find the same record.
+- **Typeahead** searching across name, author, and aliases — "Bueschel" and "Encyclopedia Pinball" should both find the same record.
 - **Recently used Citation Sources** surfaced first — if you're working through a book, you shouldn't search for it every paragraph.
 - **Quick-create** that doesn't interrupt the flow — if nothing matches, creating a new Citation Source should be a one-step expansion of the search panel, not a separate page.
 
@@ -252,6 +258,20 @@ Nothing. No references section appears. Uncited pages are normal, not incomplete
 ### Surfacing claim sources to readers
 
 Claim sources (IPDB, OPDB, user, etc.) are already visible to readers via the Sources tab on each entity page. Citations are a separate concept — they are external evidence supporting the data, not provenance for who entered it. Both are reader-facing.
+
+## Governance of Shared Citations
+
+Governance for shared Citation Sources will be lightweight in v1.
+
+- Anyone with at least one edit may edit any Citation Source and create a new one.
+- Editing a shared Citation Source does not require review.
+- Citation Source creates and edits appear in the global changes feed at /changes/. They can be filtered in or out of that view.
+- Editing a shared Citation Source propagates immediately to all Citation Instances that reference it. The Citation Instances themselves are unchanged; only the shared source metadata updates.
+- You cannot re-parent Citation Sources in v1.
+- You cannot merge duplicate Citation Sources in v1.
+- You can delete a Citation Source if there are no active Citation Instances (meaning Citation Instances actually referenced in the catalog data). This allows for deleting incorrect, empty, spammy, or accidentally created shared sources. I believe this is a hard delete. Any reason it shouldn't be?
+
+This is intentionally permissive. More governance will be added post v1. The v1 system will be a progressively wider soft-launch limited to friends of the museum, so we have scope to improve this gradually.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Add [CitationSourceSeeding.md](docs/plans/citations/CitationSourceSeeding.md) documenting the case for pre-populating Citation Sources (books, magazines, websites) with feasibility analysis and concrete examples
- Add governance rules for shared Citation Sources in v1 (permissions, deletion, change feed visibility)
- Clean up domain model examples: rename `title` → `name`, remove redundant field rows, tighten wording

## Test plan

- [ ] Docs-only change — review for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)