### PR TITLE
fix: improve test quality, a11y, and error handling

### DIFF
--- a/frontend/src/lib/components/EntityProvenance.dom.test.ts
+++ b/frontend/src/lib/components/EntityProvenance.dom.test.ts
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/svelte';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import EntityProvenance from './EntityProvenance.svelte';
 
@@ -22,6 +22,10 @@ function deferred<T>() {
 }
 
 describe('EntityProvenance', () => {
+	afterEach(() => {
+		GET.mockReset();
+	});
+
 	it('renders cited edit cards separately from provenance groups', async () => {
 		GET.mockResolvedValue({
 			data: [

--- a/frontend/src/lib/components/ManufacturerFilterSidebar.dom.test.ts
+++ b/frontend/src/lib/components/ManufacturerFilterSidebar.dom.test.ts
@@ -9,7 +9,7 @@ async function selectFirstSearchableOption(
 ) {
 	const input = screen.getByRole('combobox', { name: label });
 	await user.click(input);
-	await user.keyboard('{ArrowDown}{Enter}');
+	await fireEvent.pointerDown(screen.getByRole('option', { name: /usa/i }));
 
 	return input;
 }
@@ -23,6 +23,7 @@ describe('ManufacturerFilterSidebar', () => {
 		const user = userEvent.setup();
 		renderSidebar();
 
+		// Exercise the real pointer-selection path used by SearchableSelect.
 		const locationInput = await selectFirstSearchableOption(user, /location/i);
 		expect(locationInput).toHaveValue('USA');
 

--- a/frontend/src/lib/components/SearchableSelect.dom.test.ts
+++ b/frontend/src/lib/components/SearchableSelect.dom.test.ts
@@ -69,6 +69,19 @@ describe('SearchableSelect', () => {
 		expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument();
 	});
 
+	it('selects an option with pointer down to match the real interaction path', async () => {
+		const user = userEvent.setup();
+		renderSingle();
+
+		await user.click(getCombobox());
+
+		const option = screen.getByRole('option', { name: /stern pinball/i });
+		await fireEvent.pointerDown(option);
+
+		expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+		expect(getCombobox()).toHaveValue('Stern Pinball');
+	});
+
 	it('closes and resets the query on escape', async () => {
 		const user = userEvent.setup();
 		renderSingle();

--- a/frontend/src/lib/components/form/EditCitationField.dom.test.ts
+++ b/frontend/src/lib/components/form/EditCitationField.dom.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -12,6 +12,10 @@ const { GET, POST } = vi.hoisted(() => ({
 vi.mock('$lib/api/client', () => ({
 	default: { GET, POST }
 }));
+
+function getOpenCitationPickerButton() {
+	return screen.getByRole('button', { name: /add citation/i });
+}
 
 describe('EditCitationField', () => {
 	afterEach(() => {
@@ -67,13 +71,13 @@ describe('EditCitationField', () => {
 
 		render(EditCitationField, { showMixedEditWarning: true });
 
-		await user.click(screen.getByRole('button', { name: 'Add citation' }));
+		await user.click(getOpenCitationPickerButton());
 		await user.type(screen.getByRole('combobox', { name: /search sources/i }), 'flyer');
 
-		const sourceResult = await screen.findByText('Williams Flyer \u2014 1993');
-		await user.click(sourceResult);
+		const sourceResult = await screen.findByRole('option', { name: /williams flyer/i });
+		await fireEvent.pointerDown(sourceResult);
 		await user.type(screen.getByRole('textbox', { name: /citation locator/i }), 'p. 2');
-		await user.click(screen.getByRole('button', { name: 'Insert' }));
+		await fireEvent.pointerDown(screen.getByRole('button', { name: 'Insert' }));
 
 		expect(await screen.findByText('Williams Flyer, p. 2')).toBeInTheDocument();
 		expect(
@@ -94,6 +98,49 @@ describe('EditCitationField', () => {
 
 		expect(screen.getByText('Williams Flyer, p. 2')).toBeInTheDocument();
 		await user.click(screen.getByRole('button', { name: 'Remove citation' }));
+		expect(screen.queryByText('Williams Flyer, p. 2')).not.toBeInTheDocument();
+	});
+
+	it('shows an error when the selected citation cannot be loaded', async () => {
+		const user = userEvent.setup();
+		GET.mockImplementation(async (path: string) => {
+			if (path === '/api/citation-sources/search/') {
+				return {
+					data: [
+						{
+							id: 7,
+							name: 'Williams Flyer',
+							source_type: 'web',
+							author: '',
+							publisher: '',
+							year: 1993,
+							isbn: null
+						}
+					]
+				};
+			}
+			throw new Error('network failed');
+		});
+		POST.mockResolvedValue({
+			data: {
+				id: 42,
+				citation_source_id: 7,
+				citation_source_name: 'Williams Flyer',
+				claim_id: null,
+				locator: 'p. 2',
+				created_at: '2026-04-08T00:00:00Z'
+			}
+		});
+
+		render(EditCitationField);
+
+		await user.click(getOpenCitationPickerButton());
+		await user.type(screen.getByRole('combobox', { name: /search sources/i }), 'flyer');
+		await fireEvent.pointerDown(await screen.findByRole('option', { name: /williams flyer/i }));
+		await user.type(screen.getByRole('textbox', { name: /citation locator/i }), 'p. 2');
+		await fireEvent.pointerDown(screen.getByRole('button', { name: 'Insert' }));
+
+		expect(await screen.findByText('Failed to load citation.')).toBeInTheDocument();
 		expect(screen.queryByText('Williams Flyer, p. 2')).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/lib/components/form/EditCitationField.svelte
+++ b/frontend/src/lib/components/form/EditCitationField.svelte
@@ -33,9 +33,15 @@
 			return;
 		}
 
-		const { data } = await client.GET('/api/citation-instances/batch/', {
-			params: { query: { ids: String(citationId) } }
-		});
+		let data;
+		try {
+			({ data } = await client.GET('/api/citation-instances/batch/', {
+				params: { query: { ids: String(citationId) } }
+			}));
+		} catch {
+			citationError = 'Failed to load citation.';
+			return;
+		}
 		const selectedCitation = data?.[0];
 		if (!selectedCitation) {
 			citationError = 'Failed to load citation.';

--- a/frontend/src/lib/components/form/wikilink-autocomplete.dom.test.ts
+++ b/frontend/src/lib/components/form/wikilink-autocomplete.dom.test.ts
@@ -26,6 +26,10 @@ function renderAutocomplete() {
 	return { ...result, oncomplete, oncancel, onfocusreturn };
 }
 
+function resetSearchLinkTargetsMock() {
+	vi.mocked(searchLinkTargets).mockReset().mockResolvedValue({ results: SEARCH_RESULTS });
+}
+
 /** Wait for the fetchLinkTypes promise to resolve and populate the type picker. */
 async function waitForTypes() {
 	await vi.waitFor(() => {
@@ -80,8 +84,8 @@ async function openSearch() {
 
 describe('WikilinkAutocomplete', () => {
 	afterEach(() => {
-		// Reset to default mock — mockResolvedValueOnce overrides persist past mockClear
-		vi.mocked(searchLinkTargets).mockReset().mockResolvedValue({ results: SEARCH_RESULTS });
+		// Reset to default mock — mockResolvedValueOnce overrides persist until implementation reset.
+		resetSearchLinkTargetsMock();
 	});
 
 	// -----------------------------------------------------------------------
@@ -324,8 +328,9 @@ describe('WikilinkAutocomplete', () => {
 				expect(screen.getByRole('combobox', { name: /search title/i })).toBeInTheDocument();
 			});
 
-			// Clear initial call so we can count fresh
-			vi.mocked(searchLinkTargets).mockClear();
+			// Reset the mock fully so the debounce tests start from the default implementation
+			// without inheriting any one-off overrides.
+			resetSearchLinkTargetsMock();
 
 			return screen.getByRole('combobox', { name: /search title/i });
 		}

--- a/frontend/src/lib/components/media/MediaCard.dom.test.ts
+++ b/frontend/src/lib/components/media/MediaCard.dom.test.ts
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import MediaCard from './MediaCard.svelte';
@@ -30,9 +30,9 @@ describe('MediaCard', () => {
 	it('opens the media when clicked or activated by keyboard', async () => {
 		const user = userEvent.setup();
 		const onclick = vi.fn();
-		const { container } = renderCard({ onclick, canEdit: false });
+		renderCard({ onclick, canEdit: false });
 
-		const card = container.querySelector('.media-card') as HTMLElement;
+		const card = screen.getByRole('button', { name: /open backglass image/i });
 		await user.click(card);
 		await user.keyboard('{Enter}');
 		await user.keyboard(' ');
@@ -47,7 +47,7 @@ describe('MediaCard', () => {
 		const onsetprimary = vi.fn();
 		renderCard({ onclick, onsetprimary });
 
-		await user.click(document.querySelector('.action-btn') as HTMLElement);
+		await user.click(screen.getByRole('button', { name: /make primary/i }));
 
 		expect(onsetprimary).toHaveBeenCalledWith('asset-1');
 		expect(onclick).not.toHaveBeenCalled();
@@ -60,7 +60,7 @@ describe('MediaCard', () => {
 		vi.spyOn(window, 'confirm').mockReturnValue(true);
 		renderCard({ onclick, ondelete });
 
-		await user.click(document.querySelector('.action-btn--danger') as HTMLElement);
+		await user.click(screen.getByRole('button', { name: /remove/i }));
 
 		expect(window.confirm).toHaveBeenCalledWith('Remove this image from this machine?');
 		expect(ondelete).toHaveBeenCalledWith('asset-1');

--- a/frontend/src/lib/components/media/MediaCard.svelte
+++ b/frontend/src/lib/components/media/MediaCard.svelte
@@ -41,7 +41,14 @@
 	}
 </script>
 
-<div class="media-card" role="button" tabindex="0" onclick={handleClick} onkeydown={handleKeydown}>
+<div
+	class="media-card"
+	role="button"
+	tabindex="0"
+	aria-label={asset.category ? `Open ${asset.category} image` : 'Open image'}
+	onclick={handleClick}
+	onkeydown={handleKeydown}
+>
 	<div class="thumb-wrapper">
 		<img src={asset.renditions.thumb} alt="" class="thumb" loading="lazy" />
 		{#if asset.category}

--- a/frontend/src/lib/components/media/MediaGrid.dom.test.ts
+++ b/frontend/src/lib/components/media/MediaGrid.dom.test.ts
@@ -46,13 +46,13 @@ describe('MediaGrid', () => {
 
 	it('opens the lightbox from the filtered media set', async () => {
 		const user = userEvent.setup();
-		const { container } = render(MediaGrid, {
+		render(MediaGrid, {
 			media: MEDIA_ITEMS,
 			categories: ['Cabinet', 'Backglass']
 		});
 
 		await user.click(screen.getByRole('button', { name: /backglass \(1\)/i }));
-		await user.click(container.querySelector('.media-card') as HTMLElement);
+		await user.click(screen.getByRole('button', { name: /open backglass image/i }));
 
 		expect(screen.getByText('1 / 1')).toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument();
@@ -60,18 +60,18 @@ describe('MediaGrid', () => {
 
 	it('grows the visible batch when the sentinel intersects', async () => {
 		const media = Array.from({ length: 101 }, (_, index) => makeMedia(index + 1));
-		const { container } = render(MediaGrid, {
+		render(MediaGrid, {
 			media,
 			categories: ['Cabinet']
 		});
 
-		expect(container.querySelectorAll('.media-card')).toHaveLength(100);
+		expect(screen.getAllByRole('button', { name: /^open( .+)? image$/i })).toHaveLength(100);
 		expect(observers).toHaveLength(1);
 
 		observers[0].callback([{ isIntersecting: true }]);
 
 		await vi.waitFor(() => {
-			expect(container.querySelectorAll('.media-card')).toHaveLength(101);
+			expect(screen.getAllByRole('button', { name: /^open( .+)? image$/i })).toHaveLength(101);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Replace CSS-class queries (`.media-card`, `.action-btn`) with role-based queries in MediaCard and MediaGrid tests
- Add `aria-label` to MediaCard's `div[role="button"]` for screen reader accessibility
- Use `fireEvent.pointerDown` for realistic selection paths in SearchableSelect and ManufacturerFilterSidebar tests
- Add try/catch error handling in EditCitationField for network failures, with test coverage
- Fix mock hygiene: add `afterEach` mockReset in EntityProvenance tests, extract `resetSearchLinkTargetsMock` helper in wikilink-autocomplete tests

## Test plan
- [x] All existing frontend tests pass
- [x] New SearchableSelect pointerDown test verifies selection via pointer interaction
- [x] New EditCitationField error test verifies "Failed to load citation." message on network failure
- [x] Pre-commit hooks (lint, typecheck, vitest) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)