### PR TITLE
test: use role queries in citation DOM tests

### DIFF
--- a/frontend/src/lib/components/form/markdown-textarea-citation.dom.test.ts
+++ b/frontend/src/lib/components/form/markdown-textarea-citation.dom.test.ts
@@ -92,14 +92,16 @@ async function searchCitation(
 	await user.keyboard(query);
 
 	await vi.waitFor(() => {
-		expect(screen.getByText(new RegExp(MOCK_SOURCES[0].name))).toBeInTheDocument();
+		expect(
+			screen.getByRole('option', { name: new RegExp(MOCK_SOURCES[0].name) })
+		).toBeInTheDocument();
 	});
 }
 
 async function selectFirstCitationResult() {
 	// DropdownItem uses onpointerdown (not onclick), so fire pointerDown directly
 	// to avoid flaky timing with userEvent.click in jsdom.
-	fireEvent.pointerDown(screen.getByText(new RegExp(MOCK_SOURCES[0].name)));
+	fireEvent.pointerDown(screen.getByRole('option', { name: new RegExp(MOCK_SOURCES[0].name) }));
 
 	return (await screen.findByRole('textbox', {
 		name: /citation locator/i


### PR DESCRIPTION
## Summary
- Replace `getByText` with `getByRole('option')` in citation search result assertions and interactions
- Improves test resilience by querying semantic roles instead of text content
- Better accessibility coverage for the citation autocomplete dropdown

## Test plan
- [x] All existing citation DOM tests pass
- [x] Pre-commit hooks (lint, typecheck, tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)