### PR TITLE
perf(resolve): drop per-object CheckConstraint validation in bulk path

### DIFF
--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -227,11 +227,12 @@ def _resolve_bulk(
     if has_unique_slug:
         resolve_unique_conflicts(all_objs, "slug", model_class, pre_slugs)
 
-    # 4c. Validate check constraints before writing.
-    for obj in all_objs:
-        validate_check_constraints(obj)
-
-    # 5. Bulk write.
+    # 5. Bulk write.  Cross-field CheckConstraints are enforced by the DB
+    # on bulk_update — a violation aborts the whole batch with IntegrityError,
+    # which is the desired ingest behaviour (source data is broken, stop).
+    # Per-object Python-side validation was removed because each call issued
+    # a savepoint + SELECT round trip, producing thousands of round trips per
+    # bulk and triggering Postgres subtransaction SLRU overflow on managed DBs.
     update_fields = list(set(direct_fields.values())) + ["updated_at"]
     if has_extra_data:
         update_fields.append("extra_data")


### PR DESCRIPTION
## Summary

- `_resolve_bulk()` validated every resolved object via `CheckConstraint.validate()`, which issues a SELECT inside a savepoint per constraint per object. A 2318-MachineModel OPDB ingest produced ~9200 savepoints inside one transaction, overflowed Postgres's 64-entry per-backend subxact cache, and hung production ingest for over an hour.
- Remove the per-object loop. DB CHECK constraints enforce the same invariants at `bulk_update` time. Violations now surface as `IntegrityError` with the failing row in Postgres's error detail, which `apply_plan` already records on `IngestRun.errors`.
- Single-object paths (`resolve_entity`, `resolve_machine_model`) are unchanged — at volume=1 the savepoint cost is trivial and the `ValidationError` contract matters for the interactive edit API.

## Measurement

Local Postgres, fresh DB, `ingest_opdb` write path (2318 matched, 19638 claims asserted):

| | Savepoints | Statements | Wall |
|---|---|---|---|
| Before | 9244 | 30140 | ~22s |
| After  | 0    | 2405  | ~8s |

Railway (higher RTT + managed PG) should see a much larger improvement — the previous run accumulated 31k+ savepoints in ~10 min and was still climbing superlinearly when killed.

## Trade-off accepted

A cross-field constraint violation during bulk resolve now aborts the whole `bulk_update` with `IntegrityError` instead of producing a per-row `ValidationError`. That's the right behaviour for ingest (bad source data should fail loudly), and no caller branches on the exception type. A follow-up set-based validator that lists all violators in a single pre-write query is a reasonable next step if you want richer diagnostics, but it isn't required for correctness.

## Test plan

- [x] `pytest apps/catalog/tests/test_db_constraints.py` — 38 passed (single-object validation path unchanged)
- [x] `pytest apps/catalog/tests/ -k "resolve or ingest_opdb"` — 205 passed
- [x] Reproduced the savepoint-storm hang against local Postgres, then verified this change drops savepoint count to 0
- [ ] Run `make ingest` against Railway and confirm `ingest_opdb` completes in seconds, not hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)