### PR TITLE
refactor(editors): declare usesSectionEditorForm on section defs

### DIFF
--- a/frontend/src/lib/components/editors/franchise-edit-sections.ts
+++ b/frontend/src/lib/components/editors/franchise-edit-sections.ts
@@ -2,7 +2,9 @@ import type { EditSectionDef } from './edit-section-def';
 
 export type FranchiseEditSectionKey = 'name' | 'description';
 
-export type FranchiseEditSectionDef = EditSectionDef<FranchiseEditSectionKey>;
+export type FranchiseEditSectionDef = EditSectionDef<FranchiseEditSectionKey> & {
+	usesSectionEditorForm: boolean;
+};
 
 export const FRANCHISE_EDIT_SECTIONS: FranchiseEditSectionDef[] = [
 	{
@@ -10,14 +12,16 @@ export const FRANCHISE_EDIT_SECTIONS: FranchiseEditSectionDef[] = [
 		segment: 'name',
 		label: 'Name',
 		showCitation: true,
-		showMixedEditWarning: false
+		showMixedEditWarning: false,
+		usesSectionEditorForm: true
 	},
 	{
 		key: 'description',
 		segment: 'description',
 		label: 'Description',
 		showCitation: false,
-		showMixedEditWarning: false
+		showMixedEditWarning: false,
+		usesSectionEditorForm: true
 	}
 ];
 

--- a/frontend/src/lib/components/editors/manufacturer-edit-sections.ts
+++ b/frontend/src/lib/components/editors/manufacturer-edit-sections.ts
@@ -2,7 +2,9 @@ import type { EditSectionDef } from './edit-section-def';
 
 export type ManufacturerEditSectionKey = 'name' | 'description' | 'basics';
 
-export type ManufacturerEditSectionDef = EditSectionDef<ManufacturerEditSectionKey>;
+export type ManufacturerEditSectionDef = EditSectionDef<ManufacturerEditSectionKey> & {
+	usesSectionEditorForm: boolean;
+};
 
 export const MANUFACTURER_EDIT_SECTIONS: ManufacturerEditSectionDef[] = [
 	{
@@ -10,21 +12,24 @@ export const MANUFACTURER_EDIT_SECTIONS: ManufacturerEditSectionDef[] = [
 		segment: 'name',
 		label: 'Name',
 		showCitation: true,
-		showMixedEditWarning: false
+		showMixedEditWarning: false,
+		usesSectionEditorForm: true
 	},
 	{
 		key: 'description',
 		segment: 'description',
 		label: 'Description',
 		showCitation: false,
-		showMixedEditWarning: false
+		showMixedEditWarning: false,
+		usesSectionEditorForm: true
 	},
 	{
 		key: 'basics',
 		segment: 'basics',
 		label: 'Basics',
 		showCitation: true,
-		showMixedEditWarning: true
+		showMixedEditWarning: true,
+		usesSectionEditorForm: true
 	}
 ];
 

--- a/frontend/src/lib/components/editors/series-edit-sections.ts
+++ b/frontend/src/lib/components/editors/series-edit-sections.ts
@@ -2,7 +2,9 @@ import type { EditSectionDef } from './edit-section-def';
 
 export type SeriesEditSectionKey = 'name' | 'description';
 
-export type SeriesEditSectionDef = EditSectionDef<SeriesEditSectionKey>;
+export type SeriesEditSectionDef = EditSectionDef<SeriesEditSectionKey> & {
+	usesSectionEditorForm: boolean;
+};
 
 export const SERIES_EDIT_SECTIONS: SeriesEditSectionDef[] = [
 	{
@@ -10,14 +12,16 @@ export const SERIES_EDIT_SECTIONS: SeriesEditSectionDef[] = [
 		segment: 'name',
 		label: 'Name',
 		showCitation: true,
-		showMixedEditWarning: false
+		showMixedEditWarning: false,
+		usesSectionEditorForm: true
 	},
 	{
 		key: 'description',
 		segment: 'description',
 		label: 'Description',
 		showCitation: false,
-		showMixedEditWarning: false
+		showMixedEditWarning: false,
+		usesSectionEditorForm: true
 	}
 ];
 

--- a/frontend/src/routes/franchises/[slug]/+layout.svelte
+++ b/frontend/src/routes/franchises/[slug]/+layout.svelte
@@ -113,10 +113,7 @@
 
 	<SectionEditorHost
 		bind:editingKey={editing}
-		sections={FRANCHISE_EDIT_SECTIONS.map((section) => ({
-			...section,
-			usesSectionEditorForm: true
-		}))}
+		sections={FRANCHISE_EDIT_SECTIONS}
 		switcherItems={editSections}
 	>
 		{#snippet editor(key, { ref, onsaved, onerror, ondirtychange })}

--- a/frontend/src/routes/manufacturers/[slug]/+layout.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+layout.svelte
@@ -222,10 +222,7 @@
 
 	<SectionEditorHost
 		bind:editingKey={editing}
-		sections={MANUFACTURER_EDIT_SECTIONS.map((section) => ({
-			...section,
-			usesSectionEditorForm: true
-		}))}
+		sections={MANUFACTURER_EDIT_SECTIONS}
 		switcherItems={editSections}
 	>
 		{#snippet editor(key, { ref, onsaved, onerror, ondirtychange })}

--- a/frontend/src/routes/series/[slug]/+layout.svelte
+++ b/frontend/src/routes/series/[slug]/+layout.svelte
@@ -113,10 +113,7 @@
 
 	<SectionEditorHost
 		bind:editingKey={editing}
-		sections={SERIES_EDIT_SECTIONS.map((section) => ({
-			...section,
-			usesSectionEditorForm: true
-		}))}
+		sections={SERIES_EDIT_SECTIONS}
 		switcherItems={editSections}
 	>
 		{#snippet editor(key, { ref, onsaved, onerror, ondirtychange })}


### PR DESCRIPTION
## Summary

- Align Manufacturer, Series, and Franchise edit-sections with the pattern already used by Model, Person, CorporateEntity, etc.: set `usesSectionEditorForm: true` on each section def instead of mapping it in at the layout call site.
- Widens the three `*EditSectionDef` types with `usesSectionEditorForm: boolean`.
- Drops the inline `.map()` in each of the three `[slug]/+layout.svelte` files; they now pass the section constants directly.

Purely mechanical — every section was passing `usesSectionEditorForm: true` unconditionally, so no behavior change.

## Test plan

- [ ] Edit a Manufacturer section and confirm the section editor form still opens
- [ ] Edit a Series section and confirm the section editor form still opens
- [ ] Edit a Franchise section and confirm the section editor form still opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)