### PR TITLE
feat(catalog): create/delete/restore for Series + Franchise

### DIFF
--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -14,6 +14,7 @@ from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
 from .edit_claims import execute_claims, plan_scalar_field_claims
+from .entity_crud import register_entity_create, register_entity_delete_restore
 from apps.provenance.helpers import build_sources, claims_prefetch
 
 from .helpers import (
@@ -63,9 +64,9 @@ class FranchiseDetailSchema(Schema):
 franchises_router = Router(tags=["franchises"])
 
 
-@franchises_router.get("/all/", response=list[FranchiseListSchema])
+@franchises_router.get("/", response=list[FranchiseListSchema])
 @decorate_view(cache_control(no_cache=True))
-def list_all_franchises(request):
+def list_franchises(request):
     """Return every franchise with title count (no pagination)."""
     qs = (
         Franchise.objects.active()
@@ -143,3 +144,23 @@ def patch_franchise_claims(request, slug: str, data: ClaimPatchSchema):
 
     franchise = get_object_or_404(_franchise_detail_qs(), slug=franchise.slug)
     return _serialize_franchise_detail(franchise)
+
+
+# ---------------------------------------------------------------------------
+# Create / delete / restore wiring
+# ---------------------------------------------------------------------------
+
+register_entity_create(
+    franchises_router,
+    Franchise,
+    detail_qs=_franchise_detail_qs,
+    serialize_detail=_serialize_franchise_detail,
+    response_schema=FranchiseDetailSchema,
+)
+register_entity_delete_restore(
+    franchises_router,
+    Franchise,
+    detail_qs=_franchise_detail_qs,
+    serialize_detail=_serialize_franchise_detail,
+    response_schema=FranchiseDetailSchema,
+)

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -14,6 +14,7 @@ from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
 from .edit_claims import execute_claims, plan_scalar_field_claims
+from .entity_crud import register_entity_create, register_entity_delete_restore
 from apps.provenance.helpers import build_sources, claims_prefetch
 
 from .helpers import (
@@ -180,3 +181,23 @@ def patch_series_claims(request, slug: str, data: ClaimPatchSchema):
 
     series = get_object_or_404(_series_detail_qs(), slug=series.slug)
     return _serialize_series_detail(series)
+
+
+# ---------------------------------------------------------------------------
+# Create / delete / restore wiring
+# ---------------------------------------------------------------------------
+
+register_entity_create(
+    series_router,
+    Series,
+    detail_qs=_series_detail_qs,
+    serialize_detail=_serialize_series_detail,
+    response_schema=SeriesDetailSchema,
+)
+register_entity_delete_restore(
+    series_router,
+    Series,
+    detail_qs=_series_detail_qs,
+    serialize_detail=_serialize_series_detail,
+    response_schema=SeriesDetailSchema,
+)

--- a/backend/apps/catalog/tests/test_api_taxonomy_crud.py
+++ b/backend/apps/catalog/tests/test_api_taxonomy_crud.py
@@ -17,11 +17,13 @@ from django.core.cache import cache
 from apps.catalog.models import (
     DisplaySubtype,
     DisplayType,
+    Franchise,
     GameplayFeature,
     GameplayFeatureAlias,
     MachineModel,
     RewardType,
     RewardTypeAlias,
+    Series,
     Tag,
     TechnologyGeneration,
     TechnologySubgeneration,
@@ -715,3 +717,252 @@ class TestGameplayFeatureRestore:
         assert resp.status_code == 200, resp.content
         feature.refresh_from_db()
         assert feature.status == "active"
+
+
+# ── Series: create / delete / restore ───────────────────────────────
+
+
+@pytest.mark.django_db
+class TestSeriesCreate:
+    def test_creates_series_with_three_claims(self, client, user):
+        client.force_login(user)
+        resp = _post(
+            client,
+            "/api/series/",
+            {"name": "Eight Ball", "slug": "eight-ball"},
+        )
+        assert resp.status_code == 201, resp.content
+        series = Series.objects.get(slug="eight-ball")
+        assert series.status == "active"
+
+        cs = ChangeSet.objects.get(user=user, action=ChangeSetAction.CREATE)
+        fields = set(
+            Claim.objects.filter(changeset=cs).values_list("field_name", flat=True)
+        )
+        assert fields == {"name", "slug", "status"}
+
+    def test_duplicate_name_rejected(self, client, user):
+        Series.objects.create(name="Eight Ball", slug="eight-ball", status="active")
+        client.force_login(user)
+        resp = _post(
+            client, "/api/series/", {"name": "Eight Ball", "slug": "eight-ball-2"}
+        )
+        assert resp.status_code == 422
+        assert "name" in resp.json()["detail"]["field_errors"]
+
+    def test_duplicate_slug_rejected(self, client, user):
+        Series.objects.create(name="Existing", slug="eight-ball", status="deleted")
+        client.force_login(user)
+        resp = _post(
+            client, "/api/series/", {"name": "Eight Ball", "slug": "eight-ball"}
+        )
+        assert resp.status_code == 422
+        assert "slug" in resp.json()["detail"]["field_errors"]
+
+
+@pytest.mark.django_db
+class TestSeriesDelete:
+    def test_delete_happy_path(self, client, user):
+        series = Series.objects.create(
+            name="Eight Ball", slug="eight-ball", status="active"
+        )
+        client.force_login(user)
+        resp = _post(client, f"/api/series/{series.slug}/delete/", {})
+        assert resp.status_code == 200, resp.content
+        series.refresh_from_db()
+        assert series.status == "deleted"
+
+    def test_delete_blocked_by_active_title(self, client, user):
+        series = Series.objects.create(
+            name="Eight Ball", slug="eight-ball", status="active"
+        )
+        Title.objects.create(
+            name="Eight Ball", slug="eight-ball-title", status="active", series=series
+        )
+
+        client.force_login(user)
+        resp = _post(client, f"/api/series/{series.slug}/delete/", {})
+        assert resp.status_code == 422
+        assert len(resp.json()["blocked_by"]) == 1
+        series.refresh_from_db()
+        assert series.status == "active"
+
+    def test_delete_proceeds_when_referring_title_soft_deleted(self, client, user):
+        series = Series.objects.create(
+            name="Eight Ball", slug="eight-ball", status="active"
+        )
+        Title.objects.create(
+            name="Eight Ball",
+            slug="eight-ball-title",
+            status="deleted",
+            series=series,
+        )
+
+        client.force_login(user)
+        resp = _post(client, f"/api/series/{series.slug}/delete/", {})
+        assert resp.status_code == 200, resp.content
+        series.refresh_from_db()
+        assert series.status == "deleted"
+
+    def test_preview_counts_create_changeset(self, client, user):
+        """A freshly-created Series carries a CREATE ChangeSet, which the
+        preview must surface so the UI's impact summary isn't silently zero."""
+        client.force_login(user)
+        create_resp = _post(
+            client, "/api/series/", {"name": "Eight Ball", "slug": "eight-ball"}
+        )
+        assert create_resp.status_code == 201
+
+        preview = client.get("/api/series/eight-ball/delete-preview/")
+        assert preview.status_code == 200
+        assert preview.json()["changeset_count"] == 1
+
+
+@pytest.mark.django_db
+class TestSeriesRestore:
+    def test_restore_happy_path(self, client, user):
+        series = Series.objects.create(
+            name="Eight Ball", slug="eight-ball", status="deleted"
+        )
+        client.force_login(user)
+        resp = _post(client, f"/api/series/{series.slug}/restore/", {})
+        assert resp.status_code == 200, resp.content
+        series.refresh_from_db()
+        assert series.status == "active"
+
+        # Restore returns the full detail shape, not a minimal status echo.
+        body = resp.json()
+        assert body["slug"] == "eight-ball"
+        assert "titles" in body
+        assert "credits" in body
+        assert "sources" in body
+
+    def test_restore_rejects_active(self, client, user):
+        series = Series.objects.create(
+            name="Eight Ball", slug="eight-ball", status="active"
+        )
+        client.force_login(user)
+        resp = _post(client, f"/api/series/{series.slug}/restore/", {})
+        assert resp.status_code == 422
+
+
+# ── Franchise: create / delete / restore ────────────────────────────
+
+
+@pytest.mark.django_db
+class TestFranchiseCreate:
+    def test_creates_franchise_with_three_claims(self, client, user):
+        client.force_login(user)
+        resp = _post(
+            client,
+            "/api/franchises/",
+            {"name": "Indiana Jones", "slug": "indiana-jones"},
+        )
+        assert resp.status_code == 201, resp.content
+        fr = Franchise.objects.get(slug="indiana-jones")
+        assert fr.status == "active"
+
+        cs = ChangeSet.objects.get(user=user, action=ChangeSetAction.CREATE)
+        fields = set(
+            Claim.objects.filter(changeset=cs).values_list("field_name", flat=True)
+        )
+        assert fields == {"name", "slug", "status"}
+
+    def test_duplicate_name_rejected(self, client, user):
+        Franchise.objects.create(
+            name="Indiana Jones", slug="indiana-jones", status="active"
+        )
+        client.force_login(user)
+        resp = _post(
+            client,
+            "/api/franchises/",
+            {"name": "Indiana Jones", "slug": "indiana-jones-2"},
+        )
+        assert resp.status_code == 422
+        assert "name" in resp.json()["detail"]["field_errors"]
+
+
+@pytest.mark.django_db
+class TestFranchiseDelete:
+    def test_delete_happy_path(self, client, user):
+        fr = Franchise.objects.create(
+            name="Indiana Jones", slug="indiana-jones", status="active"
+        )
+        client.force_login(user)
+        resp = _post(client, f"/api/franchises/{fr.slug}/delete/", {})
+        assert resp.status_code == 200, resp.content
+        fr.refresh_from_db()
+        assert fr.status == "deleted"
+
+    def test_delete_blocked_by_active_title(self, client, user):
+        fr = Franchise.objects.create(
+            name="Indiana Jones", slug="indiana-jones", status="active"
+        )
+        Title.objects.create(
+            name="Indiana Jones",
+            slug="indy-title",
+            status="active",
+            franchise=fr,
+        )
+
+        client.force_login(user)
+        resp = _post(client, f"/api/franchises/{fr.slug}/delete/", {})
+        assert resp.status_code == 422
+        assert len(resp.json()["blocked_by"]) == 1
+        fr.refresh_from_db()
+        assert fr.status == "active"
+
+    def test_preview_surfaces_blocker_slug(self, client, user):
+        fr = Franchise.objects.create(
+            name="Indiana Jones", slug="indiana-jones", status="active"
+        )
+        Title.objects.create(
+            name="Indiana Jones",
+            slug="indy-title",
+            status="active",
+            franchise=fr,
+        )
+
+        client.force_login(user)
+        resp = client.get(f"/api/franchises/{fr.slug}/delete-preview/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert any(b["slug"] == "indy-title" for b in body["blocked_by"])
+
+
+@pytest.mark.django_db
+class TestFranchiseRestore:
+    def test_restore_happy_path(self, client, user):
+        fr = Franchise.objects.create(
+            name="Indiana Jones", slug="indiana-jones", status="deleted"
+        )
+        client.force_login(user)
+        resp = _post(client, f"/api/franchises/{fr.slug}/restore/", {})
+        assert resp.status_code == 200, resp.content
+        fr.refresh_from_db()
+        assert fr.status == "active"
+
+        # Restore returns the full detail shape, not a minimal status echo.
+        body = resp.json()
+        assert body["slug"] == "indiana-jones"
+        assert "titles" in body
+        assert "sources" in body
+
+
+# ── Franchise list endpoint renamed from /all/ to / ─────────────────
+
+
+@pytest.mark.django_db
+class TestFranchiseList:
+    def test_list_endpoint_at_root(self, client):
+        Franchise.objects.create(
+            name="Indiana Jones", slug="indiana-jones", status="active"
+        )
+        resp = client.get("/api/franchises/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert any(f["slug"] == "indiana-jones" for f in body)
+
+    def test_old_all_path_gone(self, client):
+        resp = client.get("/api/franchises/all/")
+        assert resp.status_code == 404

--- a/docs/plans/EntityConversionStatus.md
+++ b/docs/plans/EntityConversionStatus.md
@@ -15,8 +15,8 @@ We've been moving all catalog entities:
 | CorporateEntity         | ✅            | ❌                        |
 | Person                  | ✅            | ✅                        |
 | System                  | ✅            | ❌                        |
-| Series                  | ✅            | ❌                        |
-| Franchise               | ✅            | ❌                        |
+| Series                  | ✅            | ✅                        |
+| Franchise               | ✅            | ✅                        |
 | Theme                   | ✅            | ✅                        |
 | GameplayFeature         | ✅            | ✅                        |
 | TechnologyGeneration    | ✅            | ✅                        |

--- a/frontend/src/lib/components/EditSectionMenu.svelte
+++ b/frontend/src/lib/components/EditSectionMenu.svelte
@@ -24,6 +24,9 @@
 
 <ActionMenu label={label ?? currentLabel} {disabled} {variant}>
 	{#each items as item (item.key)}
+		{#if item.separatorBefore}
+			<hr class="menu-separator" />
+		{/if}
 		<MenuItem
 			href={item.href}
 			onclick={item.onclick}
@@ -34,3 +37,11 @@
 		</MenuItem>
 	{/each}
 </ActionMenu>
+
+<style>
+	.menu-separator {
+		margin: var(--size-1) 0;
+		border: 0;
+		border-top: 1px solid var(--color-border-soft);
+	}
+</style>

--- a/frontend/src/lib/components/edit-section-menu.ts
+++ b/frontend/src/lib/components/edit-section-menu.ts
@@ -3,6 +3,9 @@ export type EditSectionMenuItem = {
 	label: string;
 	href?: string;
 	onclick?: () => void;
+	/** Render a horizontal divider above this item — useful to set off
+	 * destructive actions (e.g. "Delete …") from the section editors. */
+	separatorBefore?: boolean;
 };
 
 /** A labeled dropdown in the page action bar (e.g. "Edit Title", "Edit Model"). */

--- a/frontend/src/lib/components/editors/TitleFranchiseEditor.dom.test.ts
+++ b/frontend/src/lib/components/editors/TitleFranchiseEditor.dom.test.ts
@@ -39,7 +39,7 @@ const INITIAL_TITLE = {
 
 function mockGetResponses() {
 	GET.mockImplementation(async (path: string) => {
-		if (path === '/api/franchises/all/') return FRANCHISES;
+		if (path === '/api/franchises/') return FRANCHISES;
 		if (path === '/api/series/') return SERIES;
 		throw new Error(`Unexpected GET ${path}`);
 	});

--- a/frontend/src/lib/components/editors/title-edit-options.ts
+++ b/frontend/src/lib/components/editors/title-edit-options.ts
@@ -20,7 +20,7 @@ let cachedSeries: Promise<TitleEditOption[]> | null = null;
 export function fetchFranchiseOptions(): Promise<TitleEditOption[]> {
 	if (!cachedFranchises) {
 		cachedFranchises = client
-			.GET('/api/franchises/all/')
+			.GET('/api/franchises/')
 			.then(({ data }) =>
 				(data ?? []).map((f) => ({ slug: f.slug, label: f.name, count: f.title_count }))
 			)

--- a/frontend/src/routes/franchises/+page.svelte
+++ b/frontend/src/routes/franchises/+page.svelte
@@ -1,97 +1,43 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
 	import client from '$lib/api/client';
 	import { createAsyncLoader } from '$lib/async-loader.svelte';
-	import PageHeader from '$lib/components/PageHeader.svelte';
-	import { pageTitle } from '$lib/constants';
+	import TaxonomyListPage from '$lib/components/TaxonomyListPage.svelte';
 
-	const allFranchises = createAsyncLoader(async () => {
-		const { data } = await client.GET('/api/franchises/all/');
+	const loader = createAsyncLoader(async () => {
+		const { data } = await client.GET('/api/franchises/');
 		return data ?? [];
 	}, []);
 </script>
 
-<svelte:head>
-	<title>{pageTitle('Franchises')}</title>
-	<link rel="preload" as="fetch" href="/api/franchises/all/" crossorigin="anonymous" />
-</svelte:head>
-
-<article>
-	<PageHeader title="Franchises" --page-header-title-mb="0">
-		<p class="subtitle">Licensed and original franchises featured in pinball.</p>
-	</PageHeader>
-
-	{#if allFranchises.loading}
-		<p class="status">Loading...</p>
-	{:else if allFranchises.error}
-		<p class="status error">Failed to load franchises.</p>
-	{:else if allFranchises.data.length === 0}
-		<p class="status">No franchises found.</p>
-	{:else}
-		<ul class="feature-list">
-			{#each allFranchises.data as franchise (franchise.slug)}
-				<li>
-					<a href={resolve(`/franchises/${franchise.slug}`)} class="feature-row">
-						<span class="feature-name">{franchise.name}</span>
-						{#if franchise.title_count}
-							<span class="feature-count">{franchise.title_count}</span>
-						{/if}
-					</a>
-				</li>
-			{/each}
-		</ul>
+{#snippet row(f: (typeof loader.data)[number])}
+	<span class="franchise-name">{f.name}</span>
+	{#if f.title_count}
+		<span class="franchise-count">{f.title_count}</span>
 	{/if}
-</article>
+{/snippet}
+
+<TaxonomyListPage
+	title="Franchises"
+	subtitle="Licensed and original franchises featured in pinball."
+	basePath="/franchises"
+	items={loader.data}
+	loading={loader.loading}
+	error={loader.error}
+	rowSnippet={row}
+	rowStyle="justify-content: space-between; gap: var(--size-4)"
+	createHref="/franchises/new"
+/>
 
 <style>
-	article {
-		max-width: 48rem;
-	}
-
-	.subtitle {
+	.franchise-name {
 		font-size: var(--font-size-2);
-		color: var(--color-text-muted);
-		margin-top: var(--size-2);
-	}
-
-	.feature-list {
-		list-style: none;
-		padding: 0;
-	}
-
-	.feature-row {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		padding: var(--size-3) 0;
-		border-bottom: 1px solid var(--color-border-soft);
-		text-decoration: none;
+		font-weight: 500;
 		color: inherit;
 	}
 
-	.feature-row:hover .feature-name {
-		color: var(--color-accent);
-	}
-
-	.feature-name {
-		font-size: var(--font-size-2);
-		color: var(--color-text-primary);
-		font-weight: 500;
-	}
-
-	.feature-count {
+	.franchise-count {
 		font-size: var(--font-size-1);
 		color: var(--color-text-muted);
-	}
-
-	.status {
-		font-size: var(--font-size-2);
-		color: var(--color-text-muted);
-		padding: var(--size-8) 0;
-		text-align: center;
-	}
-
-	.status.error {
-		color: var(--color-error);
+		flex-shrink: 0;
 	}
 </style>

--- a/frontend/src/routes/franchises/[slug]/+layout.svelte
+++ b/frontend/src/routes/franchises/[slug]/+layout.svelte
@@ -69,8 +69,8 @@
 		updateEditQuery(editing);
 	});
 
-	let editSections: EditSectionMenuItem[] = $derived(
-		FRANCHISE_EDIT_SECTIONS.map((section) =>
+	let editSections: EditSectionMenuItem[] = $derived([
+		...FRANCHISE_EDIT_SECTIONS.map((section) =>
 			isMobile
 				? {
 						key: section.key,
@@ -82,8 +82,14 @@
 						label: section.label,
 						onclick: () => (editing = section.key)
 					}
-		)
-	);
+		),
+		{
+			key: 'delete-franchise',
+			label: `Delete ${franchise.name}`,
+			href: resolve(`/franchises/${slug}/delete`),
+			separatorBefore: true
+		}
+	]);
 </script>
 
 <MetaTags title={franchise.name} description={metaDescription} url={page.url.href} />

--- a/frontend/src/routes/franchises/[slug]/delete/+page.ts
+++ b/frontend/src/routes/franchises/[slug]/delete/+page.ts
@@ -1,0 +1,27 @@
+import { redirect } from '@sveltejs/kit';
+import { resolve } from '$app/paths';
+import type { components } from '$lib/api/schema';
+import type { PageLoad } from './$types';
+
+export type DeletePreview = components['schemas']['TaxonomyDeletePreviewSchema'];
+
+export const load: PageLoad = async ({ fetch, params }) => {
+	const authRes = await fetch('/api/auth/me/');
+	if (authRes.ok) {
+		const data = (await authRes.json()) as { is_authenticated?: boolean };
+		if (!data.is_authenticated) {
+			throw redirect(302, resolve('/login'));
+		}
+	}
+
+	const res = await fetch(`/api/franchises/${params.slug}/delete-preview/`);
+	if (res.status === 404) {
+		throw redirect(302, resolve('/franchises'));
+	}
+	if (!res.ok) {
+		throw new Error(`Failed to load delete preview (${res.status})`);
+	}
+
+	const preview = (await res.json()) as DeletePreview;
+	return { preview, slug: params.slug };
+};

--- a/frontend/src/routes/franchises/[slug]/delete/+page@.svelte
+++ b/frontend/src/routes/franchises/[slug]/delete/+page@.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import DeletePage from '$lib/components/DeletePage.svelte';
+	import type { BlockedState } from '$lib/components/delete-page';
+	import type { BlockingReferrer } from '$lib/delete-flow';
+	import { pluralize } from '$lib/utils';
+	import { submitDelete } from './franchise-delete';
+
+	let { data } = $props();
+	let { preview, slug } = $derived(data);
+
+	let blockedReferrers = $derived(preview.blocked_by ?? []);
+
+	let blocked = $derived<BlockedState | null>(
+		blockedReferrers.length > 0
+			? {
+					kind: 'referrers',
+					lead: "This franchise can't be deleted because active titles still point at it:",
+					referrers: blockedReferrers,
+					renderReferrerHref: (r: BlockingReferrer) => (r.slug ? `/titles/${r.slug}` : null),
+					renderReferrerHint: (r: BlockingReferrer) =>
+						`references this franchise via ${r.relation}`,
+					footer: 'Resolve these references, then try again.'
+				}
+			: null
+	);
+
+	let impact = $derived({
+		items: ['this franchise', pluralize(preview.changeset_count, 'change set')],
+		note: 'You can undo this from the toast that appears on the franchises page, or restore the record later from its edit history.'
+	});
+</script>
+
+<DeletePage
+	entityLabel="Franchise"
+	entityName={preview.name}
+	{slug}
+	submit={submitDelete}
+	cancelHref={`/franchises/${slug}`}
+	redirectAfterDelete="/franchises"
+	editHistoryHref={`/franchises/${slug}/edit-history`}
+	{blocked}
+	{impact}
+/>

--- a/frontend/src/routes/franchises/[slug]/delete/franchise-delete.ts
+++ b/frontend/src/routes/franchises/[slug]/delete/franchise-delete.ts
@@ -1,0 +1,6 @@
+import { createDeleteSubmitter } from '$lib/delete-flow';
+import type { components } from '$lib/api/schema';
+
+export type DeleteResponse = components['schemas']['TaxonomyDeleteResponseSchema'];
+
+export const submitDelete = createDeleteSubmitter<DeleteResponse>('/api/franchises/{slug}/delete/');

--- a/frontend/src/routes/franchises/new/+page.svelte
+++ b/frontend/src/routes/franchises/new/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import client from '$lib/api/client';
+	import CreatePage from '$lib/components/CreatePage.svelte';
+
+	let { data } = $props();
+</script>
+
+<CreatePage
+	entityLabel="Franchise"
+	initialName={data.initialName}
+	submit={(body) => client.POST('/api/franchises/', { body })}
+	detailHref={(slug) => `/franchises/${slug}`}
+	cancelHref="/franchises"
+/>

--- a/frontend/src/routes/franchises/new/+page.ts
+++ b/frontend/src/routes/franchises/new/+page.ts
@@ -1,0 +1,17 @@
+import { redirect } from '@sveltejs/kit';
+import { resolve } from '$app/paths';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, url }) => {
+	const res = await fetch('/api/auth/me/');
+	if (res.ok) {
+		const data = (await res.json()) as { is_authenticated?: boolean };
+		if (!data.is_authenticated) {
+			throw redirect(302, resolve('/login'));
+		}
+	}
+
+	return {
+		initialName: url.searchParams.get('name') ?? ''
+	};
+};

--- a/frontend/src/routes/series/+page.svelte
+++ b/frontend/src/routes/series/+page.svelte
@@ -23,6 +23,7 @@
 	error={loader.error}
 	rowSnippet={row}
 	rowStyle="justify-content: space-between; gap: var(--size-4)"
+	createHref="/series/new"
 />
 
 <style>

--- a/frontend/src/routes/series/[slug]/+layout.svelte
+++ b/frontend/src/routes/series/[slug]/+layout.svelte
@@ -69,8 +69,8 @@
 		updateEditQuery(editing);
 	});
 
-	let editSections: EditSectionMenuItem[] = $derived(
-		SERIES_EDIT_SECTIONS.map((section) =>
+	let editSections: EditSectionMenuItem[] = $derived([
+		...SERIES_EDIT_SECTIONS.map((section) =>
 			isMobile
 				? {
 						key: section.key,
@@ -82,8 +82,14 @@
 						label: section.label,
 						onclick: () => (editing = section.key)
 					}
-		)
-	);
+		),
+		{
+			key: 'delete-series',
+			label: `Delete ${series.name}`,
+			href: resolve(`/series/${slug}/delete`),
+			separatorBefore: true
+		}
+	]);
 </script>
 
 <MetaTags title={series.name} description={metaDescription} url={page.url.href} />

--- a/frontend/src/routes/series/[slug]/delete/+page.ts
+++ b/frontend/src/routes/series/[slug]/delete/+page.ts
@@ -1,0 +1,27 @@
+import { redirect } from '@sveltejs/kit';
+import { resolve } from '$app/paths';
+import type { components } from '$lib/api/schema';
+import type { PageLoad } from './$types';
+
+export type DeletePreview = components['schemas']['TaxonomyDeletePreviewSchema'];
+
+export const load: PageLoad = async ({ fetch, params }) => {
+	const authRes = await fetch('/api/auth/me/');
+	if (authRes.ok) {
+		const data = (await authRes.json()) as { is_authenticated?: boolean };
+		if (!data.is_authenticated) {
+			throw redirect(302, resolve('/login'));
+		}
+	}
+
+	const res = await fetch(`/api/series/${params.slug}/delete-preview/`);
+	if (res.status === 404) {
+		throw redirect(302, resolve('/series'));
+	}
+	if (!res.ok) {
+		throw new Error(`Failed to load delete preview (${res.status})`);
+	}
+
+	const preview = (await res.json()) as DeletePreview;
+	return { preview, slug: params.slug };
+};

--- a/frontend/src/routes/series/[slug]/delete/+page@.svelte
+++ b/frontend/src/routes/series/[slug]/delete/+page@.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import DeletePage from '$lib/components/DeletePage.svelte';
+	import type { BlockedState } from '$lib/components/delete-page';
+	import type { BlockingReferrer } from '$lib/delete-flow';
+	import { pluralize } from '$lib/utils';
+	import { submitDelete } from './series-delete';
+
+	let { data } = $props();
+	let { preview, slug } = $derived(data);
+
+	let blockedReferrers = $derived(preview.blocked_by ?? []);
+
+	let blocked = $derived<BlockedState | null>(
+		blockedReferrers.length > 0
+			? {
+					kind: 'referrers',
+					lead: "This series can't be deleted because active titles still point at it:",
+					referrers: blockedReferrers,
+					renderReferrerHref: (r: BlockingReferrer) => (r.slug ? `/titles/${r.slug}` : null),
+					renderReferrerHint: (r: BlockingReferrer) => `references this series via ${r.relation}`,
+					footer: 'Resolve these references, then try again.'
+				}
+			: null
+	);
+
+	let impact = $derived({
+		items: ['this series', pluralize(preview.changeset_count, 'change set')],
+		note: 'You can undo this from the toast that appears on the series page, or restore the record later from its edit history.'
+	});
+</script>
+
+<DeletePage
+	entityLabel="Series"
+	entityName={preview.name}
+	{slug}
+	submit={submitDelete}
+	cancelHref={`/series/${slug}`}
+	redirectAfterDelete="/series"
+	editHistoryHref={`/series/${slug}/edit-history`}
+	{blocked}
+	{impact}
+/>

--- a/frontend/src/routes/series/[slug]/delete/series-delete.ts
+++ b/frontend/src/routes/series/[slug]/delete/series-delete.ts
@@ -1,0 +1,6 @@
+import { createDeleteSubmitter } from '$lib/delete-flow';
+import type { components } from '$lib/api/schema';
+
+export type DeleteResponse = components['schemas']['TaxonomyDeleteResponseSchema'];
+
+export const submitDelete = createDeleteSubmitter<DeleteResponse>('/api/series/{slug}/delete/');

--- a/frontend/src/routes/series/new/+page.svelte
+++ b/frontend/src/routes/series/new/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import client from '$lib/api/client';
+	import CreatePage from '$lib/components/CreatePage.svelte';
+
+	let { data } = $props();
+</script>
+
+<CreatePage
+	entityLabel="Series"
+	initialName={data.initialName}
+	submit={(body) => client.POST('/api/series/', { body })}
+	detailHref={(slug) => `/series/${slug}`}
+	cancelHref="/series"
+/>

--- a/frontend/src/routes/series/new/+page.ts
+++ b/frontend/src/routes/series/new/+page.ts
@@ -1,0 +1,17 @@
+import { redirect } from '@sveltejs/kit';
+import { resolve } from '$app/paths';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, url }) => {
+	const res = await fetch('/api/auth/me/');
+	if (res.ok) {
+		const data = (await res.json()) as { is_authenticated?: boolean };
+		if (!data.is_authenticated) {
+			throw redirect(302, resolve('/login'));
+		}
+	}
+
+	return {
+		initialName: url.searchParams.get('name') ?? ''
+	};
+};


### PR DESCRIPTION
## Summary

- Wires Series and Franchise through the shared `entity_crud` helpers (`register_entity_create` / `register_entity_delete_restore`) from the Theme + GameplayFeature PR. Gains create, soft-delete with Title-PROTECT blocker surfacing, and restore for both entities.
- Normalizes the Franchise list endpoint from `/api/franchises/all/` to `/api/franchises/` — the convention every other catalog list endpoint already follows. Three frontend callsites updated in lockstep (list page, title-edit dropdown, test mock); no alias left behind.
- Frontend adds `/{series,franchises}/new` create pages and `/{series,franchises}/[slug]/delete` confirmation pages (blocking Title referrers link through to `/titles/{slug}`). List pages get "+ New" affordances; Franchises list is ported to `TaxonomyListPage`.
- Detail-page Edit menus gain a destructive "Delete {name}" item separated by a divider; introduces an optional `separatorBefore` flag on `EditSectionMenuItem` to mark destructive actions.
- `EntityConversionStatus.md` ticked for both rows — all but Manufacturer, CorporateEntity, and System now have Create+Delete+Restore shipped.

## Test plan

- [x] `make test` — 2080 passed, 1 skipped (backend) + 918 passed (frontend)
- [x] `make lint` — clean
- [x] `pnpm run check` — 0 errors, 0 warnings
- [x] New backend tests cover: create happy path + all three claim fields; duplicate name / slug rejected; delete happy path; delete blocked by active Title (preview surfaces blocker slug); delete proceeds once referring Title is soft-deleted; preview counts the CREATE ChangeSet; restore happy path returns full detail body; restore rejects when already active; franchise list endpoint at `/` + old `/all/` returns 404.
- [ ] Manual smoke (`make dev`): `/series` + "+ New Series" header link; create round-trip; "Delete {name}" opens confirmation; `/franchises` search + `NoResultsCreatePrompt`; blocker rows link to `/titles/{slug}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)