### PR TITLE
Personalize credit role detail page copy with role name

### DIFF
--- a/frontend/src/lib/components/cards/PersonCard.svelte
+++ b/frontend/src/lib/components/cards/PersonCard.svelte
@@ -6,17 +6,19 @@
 		slug,
 		name,
 		thumbnailUrl = null,
-		creditCount = 0
+		creditCount = 0,
+		creditLabel = 'credit'
 	}: {
 		slug: string;
 		name: string;
 		thumbnailUrl?: string | null;
 		creditCount?: number;
+		creditLabel?: string;
 	} = $props();
 </script>
 
 <Card href={resolve(`/people/${slug}`)} title={name} {thumbnailUrl}>
-	<p class="card-count">{creditCount} credit{creditCount === 1 ? '' : 's'}</p>
+	<p class="card-count">{creditCount} {creditLabel}{creditCount === 1 ? '' : 's'}</p>
 </Card>
 
 <style>

--- a/frontend/src/routes/credit-roles/+page.svelte
+++ b/frontend/src/routes/credit-roles/+page.svelte
@@ -11,7 +11,7 @@
 
 <TaxonomyListPage
 	catalogKey="credit-role"
-	subtitle="Roles credited on pinball machine development."
+	subtitle="Roles credited in game development."
 	items={loader.data}
 	loading={loader.loading}
 	error={loader.error}

--- a/frontend/src/routes/credit-roles/[slug]/+page.svelte
+++ b/frontend/src/routes/credit-roles/[slug]/+page.svelte
@@ -16,14 +16,14 @@
 	</section>
 {/if}
 
-<h2 class="section-heading">People</h2>
+<h2 class="section-heading">People With {profile.name} Credits</h2>
 {#if people.length > 0}
 	<SearchableGrid
 		items={people}
 		filterFields={(item) => [item.name, ...(item.aliases ?? [])]}
-		placeholder="Search people in this role..."
+		placeholder="Search people credited with this role..."
 		entityName="person"
-		entityNamePlural="people"
+		entityNamePlural={`people with ${profile.name} credits`}
 	>
 		{#snippet children(person)}
 			<PersonCard
@@ -31,6 +31,7 @@
 				name={person.name}
 				thumbnailUrl={person.thumbnail_url}
 				creditCount={person.credit_count}
+				creditLabel={`${profile.name} credit`}
 			/>
 		{/snippet}
 	</SearchableGrid>


### PR DESCRIPTION
## Summary
- Credit role detail page heading now reads "People With {Role} Credits"
- Search placeholder updated to "Search people credited with this role..."
- Result count and per-person credit label include the role name (e.g. "3 Design credits")
- Credit roles index subtitle updated to "Roles credited in game development."

## Test plan
- [ ] Visit `/credit-roles/design` and verify heading, placeholder, count, and per-card credit label
- [ ] Verify other uses of `PersonCard` (people index, search results) still render plain "N credits"

🤖 Generated with [Claude Code](https://claude.com/claude-code)