### PR TITLE
refactor(api): move shared DTOs to owning apps + user profile page namespace

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 User = get_user_model()
 
 auth_router = Router(tags=["auth", "private"])
-users_router = Router(tags=["users"])
+user_page_router = Router(tags=["private"])
 
 
 # ── Schemas ──────────────────────────────────────────────────────────
@@ -37,8 +37,33 @@ class AuthStatusSchema(Schema):
     username: Optional[str] = None
 
 
-class ErrorSchema(Schema):
+class _ErrorSchema(Schema):
     detail: str
+
+
+class EntityContributionSchema(Schema):
+    entity_href: str
+    entity_name: str
+    entity_type_label: str
+    edit_count: int
+    last_edited_at: str
+
+
+class UserChangeSetSchema(Schema):
+    id: int
+    note: str
+    created_at: str
+    entity_href: str
+    entity_name: str
+    entity_type_label: str
+
+
+class UserProfileSchema(Schema):
+    username: str
+    member_since: str
+    edit_count: int
+    entities_edited: list[EntityContributionSchema]
+    recent_edits: list[UserChangeSetSchema]
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -182,46 +207,16 @@ def auth_logout(request):
     return {"is_authenticated": False}
 
 
-# ── User profile schemas ───────────────────────────────────────────
-
-
-class EntityContributionSchema(Schema):
-    entity_href: str
-    entity_name: str
-    entity_type_label: str
-    edit_count: int
-    last_edited_at: str
-
-
-class UserChangeSetSchema(Schema):
-    id: int
-    note: str
-    created_at: str
-    entity_href: str
-    entity_name: str
-    entity_type_label: str
-
-
-class UserProfileSchema(Schema):
-    username: str
-    member_since: str
-    edit_count: int
-    entities_edited: list[EntityContributionSchema]
-    recent_edits: list[UserChangeSetSchema]
-
-
-# ── User profile endpoint ──────────────────────────────────────────
-
-
-@users_router.get("/{username}/", response={200: UserProfileSchema, 404: ErrorSchema})
-def user_profile(request, username: str):
-    """Public profile showing a user's contributions."""
+@user_page_router.get(
+    "/{username}/", response={200: UserProfileSchema, 404: _ErrorSchema}
+)
+def user_profile_page(request, username: str):
+    """Page model for the user profile page: contribution history."""
     user = get_object_or_404(User, username=username)
 
     edit_count = ChangeSet.objects.filter(user=user).count()
     member_since = user.profile.created_at.isoformat()
 
-    # Entities edited: distinct (content_type, object_id) from user's claims
     entity_rows = list(
         Claim.objects.filter(user=user, changeset__isnull=False)
         .values("content_type_id", "object_id")
@@ -249,15 +244,12 @@ def user_profile(request, username: str):
             }
         )
 
-    # Recent edits: last 50 changesets with entity context
     recent_changesets = (
         ChangeSet.objects.filter(user=user)
         .prefetch_related("claims")
         .order_by("-created_at")[:50]
     )
 
-    # Collect entity refs from changesets for batch resolution.
-    # Access the prefetch cache via .all() without slicing to avoid N+1.
     cs_entity_refs: list[dict] = []
     cs_first_claim: dict[int, tuple[int, int]] = {}
     for cs in recent_changesets:
@@ -300,5 +292,5 @@ def user_profile(request, username: str):
 
 routers = [
     ("/auth/", auth_router),
-    ("/users/", users_router),
+    ("/pages/user/", user_page_router),
 ]

--- a/backend/apps/accounts/tests/test_user_profile.py
+++ b/backend/apps/accounts/tests/test_user_profile.py
@@ -1,4 +1,4 @@
-"""Tests for GET /api/users/{username}/ endpoint."""
+"""Tests for GET /api/pages/user/{username}/ endpoint."""
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -52,14 +52,14 @@ def model_b(db, bootstrap_source):
 @pytest.mark.django_db
 class TestUserProfileNotFound:
     def test_nonexistent_user_returns_404(self, client):
-        resp = client.get("/api/users/nonexistent/")
+        resp = client.get("/api/pages/user/nonexistent/")
         assert resp.status_code == 404
 
 
 @pytest.mark.django_db
 class TestUserProfileEmpty:
     def test_user_with_no_edits(self, client, user):
-        resp = client.get(f"/api/users/{user.username}/")
+        resp = client.get(f"/api/pages/user/{user.username}/")
         assert resp.status_code == 200
         data = resp.json()
         assert data["username"] == "historian"
@@ -80,7 +80,7 @@ class TestUserProfileWithEdits:
             content_type="application/json",
         )
 
-        resp = client.get(f"/api/users/{user.username}/")
+        resp = client.get(f"/api/pages/user/{user.username}/")
         assert resp.status_code == 200
         data = resp.json()
 
@@ -116,7 +116,7 @@ class TestUserProfileWithEdits:
             content_type="application/json",
         )
 
-        resp = client.get(f"/api/users/{user.username}/")
+        resp = client.get(f"/api/pages/user/{user.username}/")
         data = resp.json()
 
         assert data["edit_count"] == 2
@@ -144,7 +144,7 @@ class TestUserProfileWithEdits:
             content_type="application/json",
         )
 
-        resp = client.get(f"/api/users/{user.username}/")
+        resp = client.get(f"/api/pages/user/{user.username}/")
         data = resp.json()
 
         assert data["edit_count"] == 2
@@ -166,7 +166,7 @@ class TestUserProfileWithEdits:
             content_type="application/json",
         )
 
-        resp = client.get(f"/api/users/{user.username}/")
+        resp = client.get(f"/api/pages/user/{user.username}/")
         data = resp.json()
 
         assert data["edit_count"] == 2
@@ -185,7 +185,7 @@ class TestUserProfileWithEdits:
             content_type="application/json",
         )
 
-        resp = client.get(f"/api/users/{user.username}/")
+        resp = client.get(f"/api/pages/user/{user.username}/")
         data = resp.json()
         assert data["edit_count"] == 0
         assert data["entities_edited"] == []

--- a/backend/apps/catalog/api/corporate_entities.py
+++ b/backend/apps/catalog/api/corporate_entities.py
@@ -6,13 +6,21 @@ from typing import Optional
 
 from django.db.models import Count, F, Prefetch, Q
 from django.shortcuts import get_object_or_404
-
-from apps.core.models import active_status_q
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
+from apps.core.models import active_status_q
+from apps.provenance.helpers import claims_prefetch
+from apps.provenance.schemas import RichTextSchema
+
+from ..models import (
+    CorporateEntity,
+    CorporateEntityLocation,
+    MachineModel,
+    Manufacturer,
+)
 from .edit_claims import (
     execute_claims,
     plan_alias_claims,
@@ -20,8 +28,6 @@ from .edit_claims import (
     validate_scalar_fields,
 )
 from .entity_crud import register_entity_create, register_entity_delete_restore
-from apps.provenance.helpers import claims_prefetch
-
 from .helpers import (
     _build_rich_text,
     _collect_titles,
@@ -32,14 +38,6 @@ from .schemas import (
     CorporateEntityClaimPatchSchema,
     CorporateEntityLocationSchema,
     RelatedTitleSchema,
-    RichTextSchema,
-)
-
-from ..models import (
-    CorporateEntity,
-    CorporateEntityLocation,
-    MachineModel,
-    Manufacturer,
 )
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/catalog/api/edit_claims.py
+++ b/backend/apps/catalog/api/edit_claims.py
@@ -11,16 +11,17 @@ from typing import NoReturn
 
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
-from django.db import IntegrityError, models as db_models, transaction
+from django.db import IntegrityError, transaction
+from django.db import models as db_models
 
 from apps.catalog.claims import build_relationship_claim
 from apps.catalog.models import CreditRole, GameplayFeature, Person
 from apps.core.models import get_claim_fields
 from apps.provenance.models import ChangeSet, ChangeSetAction, CitationInstance, Claim
+from apps.provenance.schemas import EditCitationInput
 from apps.provenance.validation import validate_claim_value
 
 from ..resolve import resolve_after_mutation
-from .schemas import EditCitationInput
 
 
 @dataclass(frozen=True)

--- a/backend/apps/catalog/api/entity_create.py
+++ b/backend/apps/catalog/api/entity_create.py
@@ -29,13 +29,13 @@ from django.db import IntegrityError, transaction
 from django.db.models import Q
 
 from apps.provenance.models import ChangeSetAction
+from apps.provenance.schemas import EditCitationInput
 
 from .edit_claims import (
     ClaimSpec,
     StructuredValidationError,
     execute_claims,
 )
-from .schemas import EditCitationInput
 
 # Slug format is globally consistent across catalog record types: lowercase
 # ASCII letters/digits, single hyphens between segments, no leading/trailing

--- a/backend/apps/catalog/api/entity_crud.py
+++ b/backend/apps/catalog/api/entity_crud.py
@@ -30,6 +30,7 @@ from apps.provenance.rate_limits import (
     DELETE_RATE_LIMIT_SPEC,
     check_and_record,
 )
+from apps.provenance.schemas import EditCitationInput
 
 from .edit_claims import ClaimSpec, execute_claims
 from .entity_create import (
@@ -39,7 +40,7 @@ from .entity_create import (
     validate_name,
     validate_slug_format,
 )
-from .schemas import BlockingReferrerSchema, EditCitationInput
+from .schemas import BlockingReferrerSchema
 from .soft_delete import (
     SoftDeleteBlocked,
     count_entity_changesets,
@@ -47,7 +48,6 @@ from .soft_delete import (
     plan_soft_delete,
     serialize_blocking_referrer,
 )
-
 
 # ---------------------------------------------------------------------------
 # Schemas — names kept stable for OpenAPI consumers.

--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -4,27 +4,24 @@ from __future__ import annotations
 
 from django.db.models import Count, Prefetch, Q
 from django.shortcuts import get_object_or_404
-
-from apps.core.models import active_status_q
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
+from apps.core.licensing import get_minimum_display_rank
+from apps.core.models import active_status_q
+from apps.provenance.helpers import claims_prefetch
+from apps.provenance.schemas import RichTextSchema
+
+from ..models import Franchise, MachineModel, Title
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
-from apps.provenance.helpers import claims_prefetch
-
 from .helpers import (
     _build_rich_text,
     _serialize_title_ref,
 )
-from .schemas import ClaimPatchSchema, RichTextSchema, TitleRefSchema
-
-from apps.core.licensing import get_minimum_display_rank
-
-from ..models import Franchise, MachineModel, Title
-
+from .schemas import ClaimPatchSchema, TitleRefSchema
 
 # ---------------------------------------------------------------------------
 # Schemas

--- a/backend/apps/catalog/api/gameplay_features.py
+++ b/backend/apps/catalog/api/gameplay_features.py
@@ -9,6 +9,11 @@ from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
+from apps.media.schemas import UploadedMediaSchema
+from apps.provenance.helpers import claims_prefetch
+from apps.provenance.schemas import RichTextSchema
+
+from ..models import GameplayFeature
 from ._counts import bulk_title_counts_via_models
 from .edit_claims import (
     execute_claims,
@@ -18,8 +23,6 @@ from .edit_claims import (
     validate_scalar_fields,
 )
 from .entity_crud import register_entity_create, register_entity_delete_restore
-from apps.provenance.helpers import claims_prefetch
-
 from .helpers import (
     _build_rich_text,
     _media_prefetch,
@@ -28,11 +31,7 @@ from .helpers import (
 from .schemas import (
     GameplayFeatureSchema,
     HierarchyClaimPatchSchema,
-    RichTextSchema,
-    UploadedMediaSchema,
 )
-
-from ..models import GameplayFeature
 
 # ---------------------------------------------------------------------------
 # Schemas

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Optional
 
-from django.db.models import F, Prefetch, Q
+from django.db.models import Case, F, IntegerField, Prefetch, Q, Value, When
 from django.shortcuts import get_object_or_404
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
@@ -13,26 +14,9 @@ from ninja.pagination import PageNumberPagination, paginate
 from ninja.responses import Status
 from ninja.security import django_auth
 
-from ..cache import MODELS_ALL_KEY, get_cached_response, set_cached_response
-from .constants import DEFAULT_PAGE_SIZE
-from .edit_claims import (
-    ClaimSpec,
-    StructuredValidationError,
-    execute_claims,
-    plan_abbreviation_claims,
-    plan_credit_claims,
-    plan_gameplay_feature_claims,
-    plan_m2m_claims,
-    plan_scalar_field_claims,
-    raise_form_error,
-)
-from .soft_delete import (
-    SoftDeleteBlocked,
-    count_entity_changesets,
-    execute_soft_delete,
-    plan_soft_delete,
-    serialize_blocking_referrer,
-)
+from apps.core.licensing import get_minimum_display_rank
+from apps.media.models import EntityMedia
+from apps.media.schemas import UploadedMediaSchema
 from apps.provenance.helpers import claims_prefetch
 from apps.provenance.models import ChangeSetAction
 from apps.provenance.rate_limits import (
@@ -40,45 +24,9 @@ from apps.provenance.rate_limits import (
     DELETE_RATE_LIMIT_SPEC,
     check_and_record,
 )
+from apps.provenance.schemas import AttributionSchema, RichTextSchema
 
-from .helpers import (
-    _build_rich_text,
-    _extract_image_attribution,
-    _extract_image_urls,
-    _extract_variant_features,
-    _get_feature_descendant_slugs,
-    _media_prefetch,
-    _serialize_credit,
-    _serialize_title_machine,
-    _serialize_uploaded_media,
-)
-from .schemas import (
-    AttributionSchema,
-    CreditSchema,
-    FranchiseRefSchema,
-    GameplayFeatureSchema,
-    ModelClaimPatchSchema,
-    ModelDeletePreviewSchema,
-    ModelDeleteResponseSchema,
-    ModelDeleteSchema,
-    ModelEditOptionsSchema,
-    ModelRestoreSchema,
-    Ref,
-    RewardTypeSchema,
-    RichTextSchema,
-    SeriesRefSchema,
-    ThemeSchema,
-    TitleMachineSchema,
-    UploadedMediaSchema,
-)
-
-from collections import defaultdict
-
-from django.db.models import Case, IntegerField, Value, When
-
-from apps.core.licensing import get_minimum_display_rank
-from apps.media.models import EntityMedia
-
+from ..cache import MODELS_ALL_KEY, get_cached_response, set_cached_response
 from ..models import (
     Cabinet,
     CorporateEntity,
@@ -101,6 +49,52 @@ from ..models import (
     TechnologySubgeneration,
     Theme,
     Title,
+)
+from .constants import DEFAULT_PAGE_SIZE
+from .edit_claims import (
+    ClaimSpec,
+    StructuredValidationError,
+    execute_claims,
+    plan_abbreviation_claims,
+    plan_credit_claims,
+    plan_gameplay_feature_claims,
+    plan_m2m_claims,
+    plan_scalar_field_claims,
+    raise_form_error,
+)
+from .helpers import (
+    _build_rich_text,
+    _extract_image_attribution,
+    _extract_image_urls,
+    _extract_variant_features,
+    _get_feature_descendant_slugs,
+    _media_prefetch,
+    _serialize_credit,
+    _serialize_title_machine,
+    _serialize_uploaded_media,
+)
+from .schemas import (
+    CreditSchema,
+    FranchiseRefSchema,
+    GameplayFeatureSchema,
+    ModelClaimPatchSchema,
+    ModelDeletePreviewSchema,
+    ModelDeleteResponseSchema,
+    ModelDeleteSchema,
+    ModelEditOptionsSchema,
+    ModelRestoreSchema,
+    Ref,
+    RewardTypeSchema,
+    SeriesRefSchema,
+    ThemeSchema,
+    TitleMachineSchema,
+)
+from .soft_delete import (
+    SoftDeleteBlocked,
+    count_entity_changesets,
+    execute_soft_delete,
+    plan_soft_delete,
+    serialize_blocking_referrer,
 )
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Optional
 
 from django.db.models import Count, F, Max, Min, Prefetch, Q
@@ -12,14 +13,26 @@ from ninja.decorators import decorate_view
 from ninja.pagination import PageNumberPagination, paginate
 from ninja.security import django_auth
 
+from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
-
+from apps.media.schemas import UploadedMediaSchema
+from apps.provenance.helpers import claims_prefetch
+from apps.provenance.schemas import RichTextSchema
 
 from ..cache import MANUFACTURERS_ALL_KEY, get_cached_response, set_cached_response
+from ..models import (
+    CorporateEntity,
+    CorporateEntityAlias,
+    CorporateEntityLocation,
+    Credit,
+    MachineModel,
+    Manufacturer,
+    ManufacturerAlias,
+    System,
+)
 from .constants import DEFAULT_PAGE_SIZE
+from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
-from apps.provenance.helpers import claims_prefetch
-
 from .helpers import (
     _build_rich_text,
     _collect_titles,
@@ -33,26 +46,8 @@ from .schemas import (
     CorporateEntityLocationSchema,
     FacetRef,
     RelatedTitleSchema,
-    RichTextSchema,
-    UploadedMediaSchema,
 )
 from .titles import _dedup_facet_refs
-
-from collections import defaultdict
-
-from apps.core.licensing import get_minimum_display_rank
-
-from ..models import (
-    CorporateEntity,
-    CorporateEntityAlias,
-    CorporateEntityLocation,
-    Credit,
-    MachineModel,
-    Manufacturer,
-    ManufacturerAlias,
-    System,
-)
-from .edit_claims import execute_claims, plan_scalar_field_claims
 
 # ---------------------------------------------------------------------------
 # Schemas

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -13,10 +13,10 @@ from ninja.pagination import PageNumberPagination, paginate
 from ninja.responses import Status
 from ninja.security import django_auth
 
-from ..cache import PEOPLE_ALL_KEY, get_cached_response, set_cached_response
-from .constants import DEFAULT_PAGE_SIZE
-from apps.core.models import active_status_q
 from apps.catalog.naming import normalize_catalog_name
+from apps.core.licensing import get_minimum_display_rank
+from apps.core.models import active_status_q
+from apps.media.schemas import UploadedMediaSchema
 from apps.provenance.helpers import claims_prefetch
 from apps.provenance.models import ChangeSetAction
 from apps.provenance.rate_limits import (
@@ -24,7 +24,12 @@ from apps.provenance.rate_limits import (
     DELETE_RATE_LIMIT_SPEC,
     check_and_record,
 )
+from apps.provenance.schemas import RichTextSchema
 
+from ..cache import PEOPLE_ALL_KEY, get_cached_response, set_cached_response
+from ..models import Credit, MachineModel, Person
+from .constants import DEFAULT_PAGE_SIZE
+from .edit_claims import ClaimSpec, execute_claims, plan_scalar_field_claims
 from .entity_create import (
     assert_name_available,
     assert_slug_available,
@@ -46,8 +51,6 @@ from .schemas import (
     PersonDeleteSchema,
     PersonRestoreSchema,
     RelatedTitleSchema,
-    RichTextSchema,
-    UploadedMediaSchema,
 )
 from .soft_delete import (
     SoftDeleteBlocked,
@@ -56,11 +59,6 @@ from .soft_delete import (
     plan_soft_delete,
     serialize_blocking_referrer,
 )
-
-from apps.core.licensing import get_minimum_display_rank
-
-from ..models import Credit, MachineModel, Person
-from .edit_claims import ClaimSpec, execute_claims, plan_scalar_field_claims
 
 # ---------------------------------------------------------------------------
 # Schemas

--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -6,16 +6,14 @@ from typing import Any, Optional
 
 from ninja import Schema
 
+from apps.provenance.schemas import EditCitationInput
+
 
 class Ref(Schema):
     """A reference to a named entity with a slug."""
 
     name: str
     slug: str
-
-
-class EditCitationInput(Schema):
-    citation_instance_id: int
 
 
 class ClaimPatchSchema(Schema):
@@ -165,48 +163,6 @@ class ModelEditOptionsSchema(Schema):
     models: list[EditOptionItem]
 
 
-class AttributionSchema(Schema):
-    """License and attribution info for a piece of content (image, description, etc.)."""
-
-    license_slug: Optional[str] = None
-    license_name: Optional[str] = None
-    license_url: Optional[str] = None
-    permissiveness_rank: Optional[int] = None
-    requires_attribution: bool = False
-    source_name: Optional[str] = None
-    source_url: Optional[str] = None
-    attribution_text: Optional[str] = None
-
-
-class InlineCitationLinkSchema(Schema):
-    """A link attached to a citation source."""
-
-    url: str
-    label: str
-
-
-class InlineCitationSchema(Schema):
-    """Metadata for an inline citation in rendered markdown."""
-
-    id: int
-    index: int
-    source_name: str
-    source_type: str
-    author: str
-    year: Optional[int] = None
-    locator: str
-    links: list[InlineCitationLinkSchema] = []
-
-
-class RichTextSchema(Schema):
-    """A text field bundled with its rendered HTML, citations, and attribution."""
-
-    text: str = ""
-    html: str = ""
-    citations: list[InlineCitationSchema] = []
-    attribution: Optional[AttributionSchema] = None
-
-
 class ThemeSchema(Schema):
     name: str
     slug: str
@@ -297,16 +253,3 @@ class CorporateEntityLocationSchema(Schema):
     display_name: str
     slug: str
     ancestors: list[CorporateEntityLocationAncestorRef] = []
-
-
-class MediaRenditionsSchema(Schema):
-    thumb: str
-    display: str
-
-
-class UploadedMediaSchema(Schema):
-    asset_uuid: str
-    category: Optional[str] = None
-    is_primary: bool
-    uploaded_by_username: Optional[str] = None
-    renditions: MediaRenditionsSchema

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -6,17 +6,19 @@ from typing import Optional
 
 from django.db.models import Count, F, Prefetch, Q
 from django.shortcuts import get_object_or_404
-
-from apps.core.models import active_status_q
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
+from apps.core.licensing import get_minimum_display_rank
+from apps.core.models import active_status_q
+from apps.provenance.helpers import claims_prefetch
+from apps.provenance.schemas import RichTextSchema
+
+from ..models import Credit, MachineModel, Series, Title
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
-from apps.provenance.helpers import claims_prefetch
-
 from .helpers import (
     _build_rich_text,
     _extract_image_urls,
@@ -26,13 +28,8 @@ from .helpers import (
 from .schemas import (
     ClaimPatchSchema,
     CreditSchema,
-    RichTextSchema,
     TitleRefSchema,
 )
-
-from apps.core.licensing import get_minimum_display_rank
-
-from ..models import Credit, MachineModel, Series, Title
 
 # ---------------------------------------------------------------------------
 # Schemas

--- a/backend/apps/catalog/api/soft_delete.py
+++ b/backend/apps/catalog/api/soft_delete.py
@@ -42,9 +42,9 @@ from django.db import models as db_models
 
 from apps.core.models import CatalogModel, EntityStatusMixin
 from apps.provenance.models import ChangeSet, ChangeSetAction
+from apps.provenance.schemas import EditCitationInput
 
 from .edit_claims import ClaimSpec, execute_multi_entity_claims
-from .schemas import EditCitationInput
 
 
 @dataclass(frozen=True)

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -6,14 +6,20 @@ from typing import Optional
 
 from django.db.models import Count, F, Max, Prefetch, Q
 from django.shortcuts import get_object_or_404
-
-from apps.core.models import active_status_q
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.responses import Status
 from ninja.security import django_auth
 
+from apps.catalog.naming import normalize_catalog_name
+from apps.core.licensing import get_minimum_display_rank
+from apps.core.models import active_status_q
+from apps.provenance.helpers import claims_prefetch
+from apps.provenance.rate_limits import CREATE_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.schemas import EditCitationInput, RichTextSchema
+
+from ..models import MachineModel, Manufacturer, System
 from .edit_claims import (
     ClaimSpec,
     StructuredValidationError,
@@ -28,25 +34,15 @@ from .entity_create import (
     validate_slug_format,
 )
 from .entity_crud import register_entity_delete_restore
-from apps.catalog.naming import normalize_catalog_name
-from apps.provenance.helpers import claims_prefetch
-from apps.provenance.rate_limits import CREATE_RATE_LIMIT_SPEC, check_and_record
-
 from .helpers import (
     _build_rich_text,
     _extract_image_urls,
 )
 from .schemas import (
     ClaimPatchSchema,
-    EditCitationInput,
     Ref,
     RelatedTitleSchema,
-    RichTextSchema,
 )
-
-from apps.core.licensing import get_minimum_display_rank
-
-from ..models import MachineModel, Manufacturer, System
 
 # ---------------------------------------------------------------------------
 # Schemas

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -11,14 +11,10 @@ from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
+from apps.core.licensing import get_minimum_display_rank
+from apps.core.models import active_status_q
 from apps.provenance.helpers import claims_prefetch
-
-from ._counts import bulk_title_counts_via_models
-from .edit_claims import execute_claims, plan_scalar_field_claims
-from .entity_crud import (
-    register_entity_create,
-    register_entity_delete_restore,
-)
+from apps.provenance.schemas import RichTextSchema
 
 from ..models import (
     Cabinet,
@@ -34,17 +30,18 @@ from ..models import (
     TechnologyGeneration,
     TechnologySubgeneration,
 )
-from apps.core.licensing import get_minimum_display_rank
-from apps.core.models import active_status_q
-
+from ._counts import bulk_title_counts_via_models
+from .edit_claims import execute_claims, plan_scalar_field_claims
+from .entity_crud import (
+    register_entity_create,
+    register_entity_delete_restore,
+)
 from .helpers import _build_rich_text, _extract_image_urls, _serialize_title_machine
 from .people import PersonGridSchema
 from .schemas import (
     ClaimPatchSchema,
-    RichTextSchema,
     TitleMachineSchema,
 )
-
 
 # ---------------------------------------------------------------------------
 # Schemas

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -9,6 +9,11 @@ from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
+from apps.core.licensing import get_minimum_display_rank
+from apps.provenance.helpers import claims_prefetch
+from apps.provenance.schemas import RichTextSchema
+
+from ..models import MachineModel, Theme
 from ._counts import bulk_title_counts_via_models
 from .edit_claims import (
     execute_claims,
@@ -18,22 +23,15 @@ from .edit_claims import (
     validate_scalar_fields,
 )
 from .entity_crud import register_entity_create, register_entity_delete_restore
-from apps.provenance.helpers import claims_prefetch
-
 from .helpers import (
     _build_rich_text,
     _serialize_title_machine,
 )
 from .schemas import (
     HierarchyClaimPatchSchema,
-    RichTextSchema,
     ThemeSchema,
     TitleMachineSchema,
 )
-
-from apps.core.licensing import get_minimum_display_rank
-
-from ..models import MachineModel, Theme
 
 # ---------------------------------------------------------------------------
 # Schemas

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import re
+from collections import defaultdict
 from typing import Any, Optional
 
-from django.db.models import Count, F, Max, Prefetch, Q
+from django.db.models import Count, F, Max, Min, OuterRef, Prefetch, Q, Subquery
 from django.shortcuts import get_object_or_404
-
-from apps.core.models import active_status_q
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
 from ninja.decorators import decorate_view
@@ -15,13 +15,35 @@ from ninja.pagination import PageNumberPagination, paginate
 from ninja.responses import Status
 from ninja.security import django_auth
 
+from apps.catalog.naming import MAX_CATALOG_NAME_LENGTH, normalize_catalog_name
+from apps.core.licensing import get_minimum_display_rank
+from apps.core.models import active_status_q
+from apps.media.schemas import MediaRenditionsSchema
+from apps.media.storage import build_public_url, build_storage_key
+from apps.provenance.helpers import claims_prefetch
+from apps.provenance.models import ChangeSetAction
+from apps.provenance.rate_limits import (
+    CREATE_RATE_LIMIT_SPEC,
+    DELETE_RATE_LIMIT_SPEC,
+    check_and_record,
+)
+from apps.provenance.schemas import EditCitationInput, RichTextSchema
+
+from ..cache import TITLES_ALL_KEY, get_cached_response, set_cached_response
+from ..models import (
+    Credit,
+    MachineModel,
+    MachineModelGameplayFeature,
+    Title,
+    TitleAbbreviation,
+)
 from .constants import DEFAULT_PAGE_SIZE
 from .edit_claims import (
     ClaimSpec,
     execute_claims,
     plan_abbreviation_claims,
-    raise_form_error,
     plan_scalar_field_claims,
+    raise_form_error,
 )
 from .entity_create import (
     assert_name_available,
@@ -30,22 +52,6 @@ from .entity_create import (
     validate_name,
     validate_slug_format,
 )
-from .soft_delete import (
-    SoftDeleteBlocked,
-    count_entity_changesets,
-    execute_soft_delete,
-    plan_soft_delete,
-    serialize_blocking_referrer,
-)
-from apps.catalog.naming import MAX_CATALOG_NAME_LENGTH, normalize_catalog_name
-from apps.provenance.helpers import claims_prefetch
-from apps.provenance.models import ChangeSetAction
-from apps.provenance.rate_limits import (
-    CREATE_RATE_LIMIT_SPEC,
-    DELETE_RATE_LIMIT_SPEC,
-    check_and_record,
-)
-
 from .helpers import (
     _build_rich_text,
     _extract_image_urls,
@@ -58,31 +64,19 @@ from .machine_models import MachineModelDetailSchema
 from .schemas import (
     BlockingReferrerSchema,
     CreditSchema,
-    EditCitationInput,
     FacetRef,
     GameplayFeatureSchema,
-    MediaRenditionsSchema,
     ModelCreateSchema,
-    RichTextSchema,
     SeriesRefSchema,
     ThemeSchema,
     TitleMachineSchema,
 )
-import re
-from collections import defaultdict
-
-from django.db.models import Min, OuterRef, Subquery
-
-from apps.core.licensing import get_minimum_display_rank
-from apps.media.storage import build_public_url, build_storage_key
-
-from ..cache import TITLES_ALL_KEY, get_cached_response, set_cached_response
-from ..models import (
-    Credit,
-    MachineModel,
-    MachineModelGameplayFeature,
-    Title,
-    TitleAbbreviation,
+from .soft_delete import (
+    SoftDeleteBlocked,
+    count_entity_changesets,
+    execute_soft_delete,
+    plan_soft_delete,
+    serialize_blocking_referrer,
 )
 
 # ---------------------------------------------------------------------------
@@ -576,7 +570,10 @@ def _serialize_title_detail(title) -> dict:
     # For single-model titles with no variants, include full model detail inline.
     model_detail = None
     if len(machines) == 1 and not machines[0].get("variants"):
-        from .machine_models import _model_detail_qs, _serialize_model_detail  # noqa: E402 — avoid circular at module level
+        from .machine_models import (  # noqa: E402 — avoid circular at module level
+            _model_detail_qs,
+            _serialize_model_detail,
+        )
 
         pm = _model_detail_qs().get(slug=machines[0]["slug"])
         model_detail = _serialize_model_detail(pm)

--- a/backend/apps/catalog/tests/test_api_schema_boundaries.py
+++ b/backend/apps/catalog/tests/test_api_schema_boundaries.py
@@ -1,0 +1,53 @@
+"""Tests for shared API schema ownership boundaries.
+
+Shared wire shapes should be *defined* in the app that owns the domain
+concept, not in `catalog.api.schemas`. Catalog may still import and compose
+them (e.g. `ClaimPatchSchema.citation: EditCitationInput | None`), so we
+check definition site via `__module__` rather than re-export presence.
+"""
+
+from apps.catalog.api import schemas as catalog_schemas
+from apps.media import schemas as media_schemas
+from apps.provenance import schemas as provenance_schemas
+
+
+class TestSharedSchemaOwnership:
+    def test_provenance_owned_shapes_are_defined_in_provenance(self):
+        for name in (
+            "EditCitationInput",
+            "AttributionSchema",
+            "InlineCitationLinkSchema",
+            "InlineCitationSchema",
+            "RichTextSchema",
+        ):
+            cls = getattr(provenance_schemas, name)
+            assert cls.__module__ == "apps.provenance.schemas", (
+                f"{name} should be defined in apps.provenance.schemas, "
+                f"got {cls.__module__}"
+            )
+
+    def test_media_owned_shapes_are_defined_in_media(self):
+        for name in ("MediaRenditionsSchema", "UploadedMediaSchema"):
+            cls = getattr(media_schemas, name)
+            assert cls.__module__ == "apps.media.schemas", (
+                f"{name} should be defined in apps.media.schemas, got {cls.__module__}"
+            )
+
+    def test_catalog_schemas_does_not_redefine_shared_shapes(self):
+        # Catalog may import and compose these, but must not define them.
+        shared_names = (
+            "EditCitationInput",
+            "AttributionSchema",
+            "InlineCitationLinkSchema",
+            "InlineCitationSchema",
+            "RichTextSchema",
+            "MediaRenditionsSchema",
+            "UploadedMediaSchema",
+        )
+        for name in shared_names:
+            cls = getattr(catalog_schemas, name, None)
+            if cls is None:
+                continue
+            assert cls.__module__ != "apps.catalog.api.schemas", (
+                f"{name} is defined in catalog but should live in its owning app"
+            )

--- a/backend/apps/media/schemas.py
+++ b/backend/apps/media/schemas.py
@@ -1,0 +1,24 @@
+"""Shared schemas for media-owned API payloads."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ninja import Schema
+
+
+class MediaRenditionsSchema(Schema):
+    """Public URLs for the renditions exposed in catalog payloads."""
+
+    thumb: str
+    display: str
+
+
+class UploadedMediaSchema(Schema):
+    """A media attachment as surfaced on catalog detail endpoints."""
+
+    asset_uuid: str
+    category: Optional[str] = None
+    is_primary: bool
+    uploaded_by_username: Optional[str] = None
+    renditions: MediaRenditionsSchema

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -44,3 +44,51 @@ class ClaimSchema(Schema):
     created_at: str
     is_winner: bool
     changeset_note: Optional[str] = None
+
+
+class EditCitationInput(Schema):
+    """Reference an existing CitationInstance to clone onto a user edit."""
+
+    citation_instance_id: int
+
+
+class AttributionSchema(Schema):
+    """License and source attribution for rendered content."""
+
+    license_slug: Optional[str] = None
+    license_name: Optional[str] = None
+    license_url: Optional[str] = None
+    permissiveness_rank: Optional[int] = None
+    requires_attribution: bool = False
+    source_name: Optional[str] = None
+    source_url: Optional[str] = None
+    attribution_text: Optional[str] = None
+
+
+class InlineCitationLinkSchema(Schema):
+    """A link attached to a citation source."""
+
+    url: str
+    label: str
+
+
+class InlineCitationSchema(Schema):
+    """Metadata for an inline citation in rendered markdown."""
+
+    id: int
+    index: int
+    source_name: str
+    source_type: str
+    author: str
+    year: Optional[int] = None
+    locator: str
+    links: list[InlineCitationLinkSchema] = []
+
+
+class RichTextSchema(Schema):
+    """A text field bundled with rendered HTML plus provenance metadata."""
+
+    text: str = ""
+    html: str = ""
+    citations: list[InlineCitationSchema] = []
+    attribution: Optional[AttributionSchema] = None

--- a/backend/tests/test_router_registration.py
+++ b/backend/tests/test_router_registration.py
@@ -4,7 +4,7 @@ from config.api import api
 
 EXPECTED_PREFIXES = {
     "/auth/",
-    "/users/",
+    "/pages/user/",
     "/corporate-entities/",
     "/display-types/",
     "/technology-generations/",

--- a/docs/AppBoundaries.md
+++ b/docs/AppBoundaries.md
@@ -14,11 +14,24 @@ This document defines the dependency rules and responsibilities of Pinbase's Dja
 ## Dependencies
 
 ```text
-catalog | provenance | media | citation
+           media.api
+           catalog
 ____________________________
-   core | accounts
+provenance | media.{models,storage,processing,schemas} | citation
+____________________________
+      core | accounts
 ```
 
 - `core` and `accounts` depend on nothing
-- `catalog`, `provenance`, and `media` must not depend on each other (peer isolation)
+- `citation`, `provenance`, and `media.{models,storage,processing,schemas}` are peer-isolated (must not depend on each other)
 - `provenance` depends on `citation` but `citation` does not depend on `provenance`
+- `catalog` uses the full middle tier
+- `media.api` depends on `catalog` and `provenance`: upload handlers write `media_attachment` claims through catalog's relationship-claim registry and persist `Claim` rows directly. This is a structural consequence of `media_attachment` being a catalog-registered relationship type whose target happens to live in media; splitting it out would require extracting the whole relationship-claim machinery into a neutral app
+
+## Exception: Page API endpoints
+
+Page API endpoints (see [WebApiDesign.md § Two API types](WebApiDesign.md#two-api-types)) are expected to cross app layers. A page endpoint's job is to return one route's full rendering payload, which routinely means reading from several apps and returning a composed page model.
+
+A page endpoint lives in the app that owns the _page concept_, not the app that owns the most data it reads. The title detail page is about a title, so `/api/pages/title/{slug}` lives in catalog even though it reads claims from provenance and attachments from media. The user profile page is about a user, so `/api/pages/user/{username}/` lives in accounts even though it reads ChangeSets and Claims from provenance.
+
+The rules above apply to the non-page surface (models, services, helpers). Page endpoints are an intentional carve-out and should not be refactored to obey peer isolation at the cost of the page-composition pattern.

--- a/docs/plans/SourcesFollowUps.md
+++ b/docs/plans/SourcesFollowUps.md
@@ -6,23 +6,6 @@ Ordered by rough ROI.
 
 ---
 
-## Audit `apps/catalog/api/schemas.py` for misplaced schemas
-
-**Problem.** `ClaimSchema` drifted into `apps/catalog/api/schemas.py` because the original consumer was the catalog detail endpoints — but it models a provenance concept, not a catalog concept. Moving it to `apps/provenance/schemas.py` during this refactor was trivial (one consumer left by the end). The same drift pattern probably affected other schemas in that file.
-
-**Why it matters.** `catalog` depends on `provenance`, not the other way around. Schemas placed in the wrong app create backward dependencies that cause circular-import risk and make the layering harder to reason about. Pre-launch is the cheapest time to fix this; every consumer added makes a future move costlier.
-
-**Shape.** Walk each class in [apps/catalog/api/schemas.py](../../backend/apps/catalog/api/schemas.py) and check whether it models a catalog concept (title, machine, person, credit) or a provenance/citation/media/etc. concept. Move anything in the latter group to its owning app.
-
-**Starting points:**
-
-- [backend/apps/catalog/api/schemas.py](../../backend/apps/catalog/api/schemas.py) — contains a mix of genuinely shared catalog shapes (`Ref`, `TitleMachineSchema`) and cross-cutting ones worth examining (`AttributionSchema`, `InlineCitationSchema`, `RichTextSchema`, `UploadedMediaSchema`, `BlockingReferrerSchema`).
-- Search pattern: `grep -rn "from apps.catalog.api.schemas import"` to enumerate consumers per schema and decide the right home.
-
-**Risk.** Low-medium per schema. Each move is mechanical once the right home is chosen. Do them one at a time, regenerate `schema.d.ts`, run tests.
-
----
-
 ## Decide the soft-delete policy for per-entity provenance endpoints
 
 **Problem.** `GET /api/pages/edit-history/{type}/{slug}/` has always returned 200 for soft-deleted entities (no `.active()` filter). `GET /api/pages/sources/{type}/{slug}/` was previously inconsistent — the old `/api/pages/evidence/` predecessor _did_ filter `.active()`. The consolidation refactor made both consistent by dropping `.active()` from sources, but this was a policy call made implicitly, not deliberately.

--- a/frontend/src/routes/users/[username]/+page.ts
+++ b/frontend/src/routes/users/[username]/+page.ts
@@ -6,7 +6,7 @@ export const prerender = false;
 export const ssr = false;
 
 export const load: PageLoad = async ({ params }) => {
-	const { data, response } = await client.GET('/api/users/{username}/', {
+	const { data, response } = await client.GET('/api/pages/user/{username}/', {
 		params: { path: { username: params.username } }
 	});
 


### PR DESCRIPTION
## Summary

Three focused refactors that each clean up a real inconsistency between stated conventions and actual code.

### 1. Shared DTOs move to owning apps

`catalog/api/schemas.py` had accumulated cross-cutting wire shapes that don't model catalog concepts:

- `EditCitationInput`, `RichTextSchema`, `AttributionSchema`, `InlineCitationSchema`, `InlineCitationLinkSchema` → `apps.provenance.schemas` (existing module)
- `UploadedMediaSchema`, `MediaRenditionsSchema` → new `apps.media.schemas` module

Catalog imports and composes them from their new homes. A boundary test (`test_api_schema_boundaries.py`) asserts the invariant by checking `__module__` on each shared class — catalog may still compose these shapes but must not redefine them.

### 2. User profile → Page API namespace

`GET /api/users/{username}/` returns a pure page model (username, member_since, edit_count, entities_edited, recent_edits) for one route's render, not a reusable resource. Moved to `/api/pages/user/{username}/` to match the Page API convention in `docs/WebApiDesign.md`. Router re-tagged `"private"`; endpoint renamed `user_profile` → `user_profile_page`. Frontend caller and router-registration test updated.

### 3. `docs/AppBoundaries.md` aligned with reality

The prior peer-isolation rule didn't match the import graph: `catalog` has always imported from `provenance` and `media`; `media.api` has always imported from `catalog`. Updated the diagram to separate `media.api` (top-of-stack) from media's domain-agnostic submodules (peer-isolated alongside `provenance` and `citation`), documented why the `media.api` → `catalog` + `provenance` coupling is load-bearing (the `media_attachment` relationship registry), and carved out Page API endpoints as an explicit exception that's allowed to cross app layers.

Also removed the now-addressed "audit `apps/catalog/api/schemas.py`" item from `docs/plans/SourcesFollowUps.md`.

## Test plan

- [ ] `make test` passes (2198 backend + 956 frontend at last run)
- [ ] Visit `/users/<your-username>/` — profile renders (hits new URL)
- [ ] `/api/users/<username>/` returns 404 (old URL gone)
- [ ] `/api/pages/user/<username>/` returns the page model
- [ ] OpenAPI regen (`make api-gen`) produces no drift beyond the URL rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)