### PR TITLE
chore(backend): fix B904 exception-chaining violations, re-enable rule

### DIFF
--- a/backend/apps/catalog/api/entity_create.py
+++ b/backend/apps/catalog/api/entity_create.py
@@ -284,11 +284,11 @@ def create_entity_with_claims(
                 note=note,
                 citation=citation,
             )
-    except IntegrityError:
+    except IntegrityError as err:
         raise StructuredValidationError(
             message="Slug collision.",
             field_errors={
                 "slug": f"The slug {slug!r} is already taken. Edit the slug field."
             },
-        )
+        ) from err
     return entity

--- a/backend/apps/catalog/ingestion/ipdb/adapter.py
+++ b/backend/apps/catalog/ingestion/ipdb/adapter.py
@@ -607,10 +607,10 @@ def _process_corporate_entity(
                 year_start = int(parts[0])
                 if len(parts) > 1 and parts[1] != "present":
                     year_end = int(parts[1])
-            except ValueError:
+            except ValueError as err:
                 raise CommandError(
                     f"Cannot parse years_active {ya!r} for IPDB manufacturer {company!r}"
-                )
+                ) from err
 
         ce_slug = generate_unique_slug(company, ce_slugs)
         handle = f"ce:{mfr_id}"

--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -249,14 +249,14 @@ def _clean_and_save(instance, update_fields=None, *, integrity_msg=""):
             detail = "; ".join(parts)
         else:
             detail = str(exc)
-        raise HttpError(422, detail)
+        raise HttpError(422, detail) from exc
     try:
         instance.save(update_fields=update_fields)
     except IntegrityError as exc:
         msg = str(exc).lower()
         if integrity_msg and ("unique" in msg or "duplicate" in msg):
-            raise HttpError(422, integrity_msg)
-        raise HttpError(422, f"Integrity error: {exc}")
+            raise HttpError(422, integrity_msg) from exc
+        raise HttpError(422, f"Integrity error: {exc}") from exc
 
 
 def _detail_qs():

--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -287,8 +287,8 @@ def batch_citation_instances(request, ids: str = ""):
 
     try:
         id_list = [int(x) for x in ids.split(",") if x.strip()]
-    except ValueError:
-        raise HttpError(422, "ids must be comma-separated integers.")
+    except ValueError as err:
+        raise HttpError(422, "ids must be comma-separated integers.") from err
 
     if len(id_list) > 50:
         raise HttpError(422, "Maximum 50 IDs per request.")

--- a/backend/apps/provenance/revert.py
+++ b/backend/apps/provenance/revert.py
@@ -58,7 +58,7 @@ def execute_revert(entity, *, claim_id: int, user, note: str) -> None:
     try:
         target = Claim.objects.get(pk=claim_id, content_type=ct, object_id=entity.pk)
     except Claim.DoesNotExist:
-        raise RevertError("Claim not found for this entity.", status_code=404)
+        raise RevertError("Claim not found for this entity.", status_code=404) from None
 
     if target.source_id is not None:
         raise RevertError("Source-attributed claims cannot be reverted.")

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -120,6 +120,6 @@ def get_field_constraints(request, entity_type: str):
     try:
         model_class = get_linkable_model(entity_type)
     except ValueError:
-        raise HttpError(404, f"Unknown entity type: {entity_type}")
+        raise HttpError(404, f"Unknown entity type: {entity_type}") from None
 
     return _get(model_class)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -67,7 +67,6 @@ ignore = [
     # one rule at a time. Do not add to this list without a follow-up.
     "B007",  # Unused loop variable
     "B017",  # assertRaises(Exception) too broad
-    "B904",  # raise without `from` inside except
     "B905",  # zip() without explicit strict=
     "C401",  # Unnecessary generator in set()
     "C416",  # Unnecessary comprehension


### PR DESCRIPTION
## Summary

- Re-enables B904 in backend/pyproject.toml (removed from the temporary ignore list added in #195).
- Fixes all 8 B904 violations by adding explicit `from err` / `from exc` (chain) or `from None` (suppress) inside the relevant `except` blocks.

## Chaining-vs-suppressing decisions

`from err` / `from exc` — original exception is useful for debugging:
- `apps/catalog/api/entity_create.py` — `IntegrityError` → `StructuredValidationError` (slug collision)
- `apps/catalog/ingestion/ipdb/adapter.py` — `ValueError` → `CommandError` (years_active parse)
- `apps/citation/api.py` — `ValidationError` / `IntegrityError` → `HttpError(422)` (3 sites)
- `apps/provenance/api.py` — `ValueError` → `HttpError(422)` (id parsing)

`from None` — original is an implementation detail the caller shouldn't see:
- `apps/provenance/revert.py` — `Claim.DoesNotExist` → `RevertError(404)`
- `config/api.py` — `ValueError` from `get_linkable_model` → `HttpError(404)`

The per-file-ignore for `apps/*/management/commands/*.py` (which includes B904) stays in place.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run pytest -q` green (2199 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)