### PR TITLE
refactor(frontend): extract SiteShell/FocusSiteShell from root layout

### DIFF
--- a/frontend/src/lib/components/FocusSiteShell.svelte
+++ b/frontend/src/lib/components/FocusSiteShell.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<main class="focus-content">
+	{@render children()}
+</main>
+
+<style>
+	.focus-content {
+		flex: 1;
+		width: 100%;
+	}
+</style>

--- a/frontend/src/lib/components/SiteShell.svelte
+++ b/frontend/src/lib/components/SiteShell.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import Nav from './Nav.svelte';
+	import Footer from './Footer.svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<Nav />
+
+<main class="page-content">
+	{@render children()}
+</main>
+
+<Footer />
+
+<style>
+	.page-content {
+		flex: 1;
+		width: 100%;
+		max-width: 72rem;
+		margin: 0 auto;
+		padding: var(--size-6) var(--size-5);
+	}
+</style>

--- a/frontend/src/lib/focus-mode.test.ts
+++ b/frontend/src/lib/focus-mode.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { isFocusModePath } from './focus-mode';
+
+describe('isFocusModePath', () => {
+	describe('focus-mode routes', () => {
+		it('matches top-level create', () => {
+			expect(isFocusModePath('/titles/new')).toBe(true);
+		});
+
+		it('matches nested create', () => {
+			expect(isFocusModePath('/titles/medieval-madness/models/new')).toBe(true);
+		});
+
+		it('matches edit without section', () => {
+			expect(isFocusModePath('/manufacturers/williams/edit')).toBe(true);
+		});
+
+		it('matches edit with trailing slash', () => {
+			expect(isFocusModePath('/manufacturers/williams/edit/')).toBe(true);
+		});
+
+		it('matches edit with section', () => {
+			expect(isFocusModePath('/models/attack-from-mars/edit/overview')).toBe(true);
+		});
+
+		it('matches delete confirmation', () => {
+			expect(isFocusModePath('/titles/medieval-madness/delete')).toBe(true);
+		});
+	});
+
+	describe('full-chrome routes', () => {
+		it('does not match the home page', () => {
+			expect(isFocusModePath('/')).toBe(false);
+		});
+
+		it('does not match an entity index', () => {
+			expect(isFocusModePath('/titles')).toBe(false);
+		});
+
+		it('does not match a detail page', () => {
+			expect(isFocusModePath('/manufacturers/williams')).toBe(false);
+		});
+
+		it('does not match a detail subroute', () => {
+			expect(isFocusModePath('/manufacturers/williams/media')).toBe(false);
+		});
+
+		it('does not match an entity record whose slug is "delete"', () => {
+			// /:entity/delete is the detail page for a record with slug='delete',
+			// not a delete-confirmation route.
+			expect(isFocusModePath('/titles/delete')).toBe(false);
+		});
+
+		it('does not match an entity record whose slug is "edit"', () => {
+			expect(isFocusModePath('/titles/edit')).toBe(false);
+		});
+
+		it('does not match "new" appearing mid-path', () => {
+			expect(isFocusModePath('/titles/new/something')).toBe(false);
+		});
+
+		it('does not match "delete" appearing mid-path', () => {
+			expect(isFocusModePath('/titles/medieval-madness/delete/extra')).toBe(false);
+		});
+	});
+});

--- a/frontend/src/lib/focus-mode.ts
+++ b/frontend/src/lib/focus-mode.ts
@@ -1,0 +1,19 @@
+/**
+ * Focus-mode routes render their own minimal chrome (no site Nav/Footer or
+ * page-content wrapper). Patterns:
+ *   /:entity/new                         create a top-level record
+ *   /:entity/:slug/:child/new            create a nested record
+ *   /:entity/:slug/edit                  edit (no section)
+ *   /:entity/:slug/edit/:section         edit a section
+ *   /:entity/:slug/delete                destructive confirmation
+ *
+ * `edit` and `delete` require a slug segment before them so a catalog record
+ * with slug='edit' or 'delete' (e.g. /titles/delete) still gets full chrome.
+ * `new` is safe without that guard because SvelteKit's route priority gives
+ * /:entity/new to the create page, not the detail page.
+ */
+const FOCUS_MODE_RE = /\/new$|\/[^/]+\/[^/]+\/edit(\/|$)|\/[^/]+\/[^/]+\/delete$/;
+
+export function isFocusModePath(pathname: string): boolean {
+	return FOCUS_MODE_RE.test(pathname);
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,62 +1,34 @@
 <script>
 	import '../app.css';
 	import { page } from '$app/state';
-	import Nav from '$lib/components/Nav.svelte';
-	import Footer from '$lib/components/Footer.svelte';
+	import SiteShell from '$lib/components/SiteShell.svelte';
+	import FocusSiteShell from '$lib/components/FocusSiteShell.svelte';
 	import ToastHost from '$lib/toast/ToastHost.svelte';
+	import { isFocusModePath } from '$lib/focus-mode';
 
 	let { children } = $props();
 
-	// Focus-mode routes render their own minimal chrome; suppress site
-	// Nav/Footer and the page-content wrapper. Patterns:
-	//   /:entity/new                           create a top-level record
-	//   /:entity/:slug/:child/new              create a nested record
-	//   /:entity/:slug/edit                    edit (no section)
-	//   /:entity/:slug/edit/:section           edit a section
-	//   /:entity/:slug/delete                  destructive confirmation
-	// Note: `edit` and `delete` require a slug segment before them so a
-	// catalog record with slug='edit' or 'delete' (e.g. /titles/delete)
-	// still gets full chrome. `new` is safe without that guard because
-	// SvelteKit's route priority gives /:entity/new to the create page,
-	// not the detail page.
-	let isFocusMode = $derived(
-		/\/new$|\/[^/]+\/[^/]+\/edit(\/|$)|\/[^/]+\/[^/]+\/delete$/.test(page.url.pathname)
-	);
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
 </script>
 
-<div class="site-shell">
-	{#if !isFocusMode}
-		<Nav />
-	{/if}
-
-	<main class:page-content={!isFocusMode} class:focus-content={isFocusMode}>
-		{@render children()}
-	</main>
-
-	{#if !isFocusMode}
-		<Footer />
+<div class="app-root">
+	{#if isFocusMode}
+		<FocusSiteShell>
+			{@render children()}
+		</FocusSiteShell>
+	{:else}
+		<SiteShell>
+			{@render children()}
+		</SiteShell>
 	{/if}
 
 	<ToastHost />
 </div>
 
 <style>
-	.site-shell {
+	.app-root {
 		display: flex;
 		flex-direction: column;
 		min-height: 100dvh;
-	}
-
-	.page-content {
-		flex: 1;
-		width: 100%;
-		max-width: 72rem;
-		margin: 0 auto;
-		padding: var(--size-6) var(--size-5);
-	}
-
-	.focus-content {
-		flex: 1;
-		width: 100%;
 	}
 </style>


### PR DESCRIPTION
## Summary
- Split the chrome branches in `+layout.svelte` into dedicated `SiteShell` and `FocusSiteShell` components
- Moved focus-mode path detection into `$lib/focus-mode` with unit tests
- Root layout now just picks a shell based on the current path

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (vitest incl. new `focus-mode.test.ts`)
- [ ] Smoke: visit a normal route and a focus-mode route (e.g. `/titles/<slug>/edit`) to confirm chrome switches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)