### PR TITLE
feat(frontend): render edit-history and sources as focus views

### DIFF
--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -3,9 +3,11 @@
 	import client from '$lib/api/client';
 	import type { components } from '$lib/api/schema';
 	import { auth } from '$lib/auth.svelte';
+	import FocusContentShell from './FocusContentShell.svelte';
 	import InlineDiff from './InlineDiff.svelte';
 	import UserBadge from './UserBadge.svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+	import { getEntityContext } from '$lib/entity-context';
 	import { isDiffable, formatValue } from './change-display';
 	import SmartDate from './SmartDate.svelte';
 
@@ -13,6 +15,7 @@
 	type FieldChange = components['schemas']['FieldChangeSchema'];
 
 	let { changesets }: { changesets: ChangeSet[] } = $props();
+	const entity = getEntityContext();
 
 	let revertingClaimId = $state<number | null>(null);
 	let revertNote = $state('');
@@ -161,108 +164,106 @@
 	{/if}
 {/snippet}
 
-{#if changesets.length > 0}
-	<section class="edit-history">
-		<h2>Edit History</h2>
-		<ol class="changeset-list">
-			{#each changesets as cs (cs.id)}
-				{#if !isEmptyChangeset(cs)}
-					<li class="changeset">
-						<div class="changeset-header">
-							<UserBadge username={cs.user_display} />
-							<span class="timestamp"><SmartDate iso={cs.created_at} /></span>
-						</div>
-						{#if cs.note}
-							<p class="changeset-note">{cs.note}</p>
-						{/if}
-						<dl class="field-list">
-							{#each cs.changes as change (change.claim_key)}
-								{#if change.is_retracted}
-									{@const info =
-										change.claim_id != null ? retractionLookup.get(change.claim_id) : undefined}
-									<div
-										class="field-row field-row-retraction"
-										class:field-row-diff={isDiffable(change)}
-									>
-										<dt>{change.field_name}</dt>
-										<dd>
-											<span class="reverted-badge">reverted</span>
-											{#if info}
-												by {#if info.user_display}<a href="/users/{info.user_display}"
-														>{info.user_display}</a
-													>{:else}system{/if}
-												on
-												<span class="timestamp"><SmartDate iso={info.created_at} /></span
-												>{#if info.note}:
-													{info.note}{/if}
+<FocusContentShell backHref={entity.detailHref} maxWidth="64rem">
+	{#snippet heading()}
+		<h1>Edit History</h1>
+	{/snippet}
+
+	{#if changesets.length > 0}
+		<section class="edit-history">
+			<ol class="changeset-list">
+				{#each changesets as cs (cs.id)}
+					{#if !isEmptyChangeset(cs)}
+						<li class="changeset">
+							<div class="changeset-header">
+								<UserBadge username={cs.user_display} />
+								<span class="timestamp"><SmartDate iso={cs.created_at} /></span>
+							</div>
+							{#if cs.note}
+								<p class="changeset-note">{cs.note}</p>
+							{/if}
+							<dl class="field-list">
+								{#each cs.changes as change (change.claim_key)}
+									{#if change.is_retracted}
+										{@const info =
+											change.claim_id != null ? retractionLookup.get(change.claim_id) : undefined}
+										<div
+											class="field-row field-row-retraction"
+											class:field-row-diff={isDiffable(change)}
+										>
+											<dt>{change.field_name}</dt>
+											<dd>
+												<span class="reverted-badge">reverted</span>
+												{#if info}
+													by {#if info.user_display}<a href="/users/{info.user_display}"
+															>{info.user_display}</a
+														>{:else}system{/if}
+													on
+													<span class="timestamp"><SmartDate iso={info.created_at} /></span
+													>{#if info.note}:
+														{info.note}{/if}
+												{/if}
+											</dd>
+											{#if isDiffable(change)}
+												<dd>
+													<InlineDiff oldValue={change.old_value} newValue={change.new_value} />
+												</dd>
+											{:else}
+												<dd>
+													{#if change.old_value !== null && change.old_value !== undefined}
+														<span class="old-value">{formatValue(change.old_value)}</span>
+														<span class="arrow">&rarr;</span>
+													{/if}
+													<span class="old-value">{formatValue(change.new_value)}</span>
+												</dd>
 											{/if}
-										</dd>
-										{#if isDiffable(change)}
+										</div>
+									{:else if isDiffable(change)}
+										<div class="field-row field-row-diff">
+											<dt>{change.field_name}</dt>
 											<dd>
 												<InlineDiff oldValue={change.old_value} newValue={change.new_value} />
 											</dd>
-										{:else}
+											{@render revertControls(change)}
+										</div>
+									{:else}
+										<div class="field-row">
+											<dt>{change.field_name}</dt>
 											<dd>
 												{#if change.old_value !== null && change.old_value !== undefined}
 													<span class="old-value">{formatValue(change.old_value)}</span>
 													<span class="arrow">&rarr;</span>
 												{/if}
-												<span class="old-value">{formatValue(change.new_value)}</span>
+												<span class="new-value">{formatValue(change.new_value)}</span>
 											</dd>
-										{/if}
-									</div>
-								{:else if isDiffable(change)}
-									<div class="field-row field-row-diff">
-										<dt>{change.field_name}</dt>
-										<dd>
-											<InlineDiff oldValue={change.old_value} newValue={change.new_value} />
-										</dd>
-										{@render revertControls(change)}
-									</div>
-								{:else}
-									<div class="field-row">
-										<dt>{change.field_name}</dt>
-										<dd>
-											{#if change.old_value !== null && change.old_value !== undefined}
-												<span class="old-value">{formatValue(change.old_value)}</span>
-												<span class="arrow">&rarr;</span>
-											{/if}
-											<span class="new-value">{formatValue(change.new_value)}</span>
-										</dd>
-										{@render revertControls(change)}
-									</div>
-								{/if}
-							{/each}
-							<!-- Show retractions that couldn't be matched to an original change -->
-							{#each cs.retractions ?? [] as retraction (retraction.claim_key)}
-								{#if !matchedRetractionIds.has(retraction.claim_id)}
-									<div class="field-row field-row-retraction">
-										<dt>{retraction.field_name}</dt>
-										<dd>
-											<span class="reverted-badge">reverted</span>
-											<span class="old-value">{formatValue(retraction.old_value)}</span>
-										</dd>
-									</div>
-								{/if}
-							{/each}
-						</dl>
-					</li>
-				{/if}
-			{/each}
-		</ol>
-	</section>
-{:else}
-	<p class="no-history">No edit history yet.</p>
-{/if}
+											{@render revertControls(change)}
+										</div>
+									{/if}
+								{/each}
+								<!-- Show retractions that couldn't be matched to an original change -->
+								{#each cs.retractions ?? [] as retraction (retraction.claim_key)}
+									{#if !matchedRetractionIds.has(retraction.claim_id)}
+										<div class="field-row field-row-retraction">
+											<dt>{retraction.field_name}</dt>
+											<dd>
+												<span class="reverted-badge">reverted</span>
+												<span class="old-value">{formatValue(retraction.old_value)}</span>
+											</dd>
+										</div>
+									{/if}
+								{/each}
+							</dl>
+						</li>
+					{/if}
+				{/each}
+			</ol>
+		</section>
+	{:else}
+		<p class="no-history">No edit history yet.</p>
+	{/if}
+</FocusContentShell>
 
 <style>
-	h2 {
-		font-size: var(--font-size-3);
-		font-weight: 600;
-		color: var(--color-text-primary);
-		margin-bottom: var(--size-3);
-	}
-
 	.changeset-list {
 		list-style: none;
 		padding: 0;

--- a/frontend/src/lib/components/EditSectionShell.svelte
+++ b/frontend/src/lib/components/EditSectionShell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import EditSectionMenu from '$lib/components/EditSectionMenu.svelte';
+	import FocusContentShell from '$lib/components/FocusContentShell.svelte';
 	import type { EditSectionMenuItem } from '$lib/components/edit-section-menu';
 
 	let {
@@ -20,54 +21,24 @@
 	} = $props();
 </script>
 
-<div class="edit-shell">
-	<header class="edit-header">
-		<a href={detailHref} class="back-link">&larr; Back</a>
-		<div class="heading-slot" aria-label={currentSectionKey ? undefined : fallbackHeading}>
-			{#if currentSectionKey}
-				<EditSectionMenu
-					items={switcherItems}
-					currentKey={currentSectionKey}
-					disabled={editorDirty}
-					variant="heading"
-				/>
-			{:else}
-				<h1 class="fallback-heading">{fallbackHeading}</h1>
-			{/if}
-		</div>
-	</header>
+<FocusContentShell backHref={detailHref}>
+	{#snippet heading()}
+		{#if currentSectionKey}
+			<EditSectionMenu
+				items={switcherItems}
+				currentKey={currentSectionKey}
+				disabled={editorDirty}
+				variant="heading"
+			/>
+		{:else}
+			<h1 class="fallback-heading">{fallbackHeading}</h1>
+		{/if}
+	{/snippet}
 
 	{@render children()}
-</div>
+</FocusContentShell>
 
 <style>
-	.edit-shell {
-		max-width: 48rem;
-		margin: 0 auto;
-		padding: var(--size-4);
-	}
-
-	.edit-header {
-		position: relative;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		margin-bottom: var(--size-4);
-		min-height: 2.5rem;
-	}
-
-	.back-link {
-		position: absolute;
-		left: 0;
-		font-size: var(--font-size-1);
-		color: var(--color-text-muted);
-		text-decoration: none;
-	}
-
-	.back-link:hover {
-		color: var(--color-text-primary);
-	}
-
 	.fallback-heading {
 		font-size: var(--font-size-3);
 		font-weight: 600;

--- a/frontend/src/lib/components/EntitySources.dom.test.ts
+++ b/frontend/src/lib/components/EntitySources.dom.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
 
-import EntitySources from './EntitySources.svelte';
+import EntitySources from './EntitySources.test-harness.svelte';
 
 const sampleClaim = {
 	source_name: 'IPDB',
@@ -45,7 +45,7 @@ describe('EntitySources', () => {
 		expect(screen.getByText('Documented the flyer')).toBeInTheDocument();
 		expect(screen.getByText(/Applies to: year, description/i)).toBeInTheDocument();
 		expect(screen.getByText('Williams Flyer')).toBeInTheDocument();
-		expect(screen.getByText('Sources')).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Sources', level: 1 })).toBeInTheDocument();
 		expect(screen.getByText('Single source (1 field)')).toBeInTheDocument();
 	});
 
@@ -57,7 +57,7 @@ describe('EntitySources', () => {
 			}
 		});
 
-		expect(screen.getByText('Sources')).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Sources', level: 1 })).toBeInTheDocument();
 		expect(screen.queryByText('Evidence')).not.toBeInTheDocument();
 	});
 
@@ -66,7 +66,7 @@ describe('EntitySources', () => {
 			props: { sources: [sampleClaim] }
 		});
 
-		expect(screen.getByText('Sources')).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Sources', level: 1 })).toBeInTheDocument();
 		expect(screen.queryByText('Evidence')).not.toBeInTheDocument();
 	});
 

--- a/frontend/src/lib/components/EntitySources.svelte
+++ b/frontend/src/lib/components/EntitySources.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import type { components } from '$lib/api/schema';
+	import FocusContentShell from './FocusContentShell.svelte';
 	import UserBadge from './UserBadge.svelte';
 	import SmartDate from './SmartDate.svelte';
+	import { getEntityContext } from '$lib/entity-context';
 	import { groupSourcesByField } from './entity-provenance';
 
 	type Claim = components['schemas']['ClaimSchema'];
@@ -16,6 +18,7 @@
 	} = $props();
 
 	let sourceGroups = $derived(groupSourcesByField(sources));
+	const entity = getEntityContext();
 
 	function claimAttribution(claim: Claim): string {
 		return claim.source_name ?? (claim.user_display ? `@${claim.user_display}` : 'Unknown');
@@ -42,135 +45,140 @@
 	{/if}
 {/snippet}
 
-{#if sources.length > 0}
-	{@const { conflicts, agreed, single } = sourceGroups}
-	{@const contributorNames = [
-		...new Set(
-			sources
-				.map((c) => c.source_name ?? (c.user_display ? `@${c.user_display}` : null))
-				.filter(Boolean)
-		)
-	]}
-	<section class="sources">
-		{#if evidence.length > 0}
-			<section class="evidence">
-				<h2>Evidence</h2>
-				<ol class="changeset-list">
-					{#each evidence as changeset (changeset.id)}
-						<li class="changeset-card">
-							<div class="changeset-header">
-								{#if changeset.user_display}
-									<UserBadge username={changeset.user_display} />
-								{:else}
-									<span class="source-badge">Unknown</span>
-								{/if}
-								<span class="timestamp"><SmartDate iso={changeset.created_at} /></span>
-							</div>
-							{#if changeset.note}
-								<p class="evidence-note">{changeset.note}</p>
-							{/if}
-							<p class="changeset-fields">Applies to: {changeset.fields.join(', ')}</p>
-							{#each changeset.citations as citation, i (i)}
-								<div class="evidence-citation">
-									<div class="source-name">{citation.source_name}</div>
-									{#if citation.author || citation.year}
-										<div class="meta">
-											{[citation.author, citation.year].filter(Boolean).join(', ')}
-										</div>
+<FocusContentShell backHref={entity.detailHref} maxWidth="64rem">
+	{#snippet heading()}
+		<h1>Sources</h1>
+	{/snippet}
+
+	{#if sources.length > 0}
+		{@const { conflicts, agreed, single } = sourceGroups}
+		{@const contributorNames = [
+			...new Set(
+				sources
+					.map((c) => c.source_name ?? (c.user_display ? `@${c.user_display}` : null))
+					.filter(Boolean)
+			)
+		]}
+		<section class="sources">
+			{#if evidence.length > 0}
+				<section class="evidence">
+					<h2>Evidence</h2>
+					<ol class="changeset-list">
+						{#each evidence as changeset (changeset.id)}
+							<li class="changeset-card">
+								<div class="changeset-header">
+									{#if changeset.user_display}
+										<UserBadge username={changeset.user_display} />
+									{:else}
+										<span class="source-badge">Unknown</span>
 									{/if}
-									{#if citation.locator}
-										<div class="locator">{citation.locator}</div>
-									{/if}
-									{#if citation.links.length > 0}
-										<div class="links">
-											{#each citation.links as link (link.url)}
-												<a href={link.url} target="_blank" rel="noopener">{link.label}</a>
-											{/each}
-										</div>
-									{/if}
+									<span class="timestamp"><SmartDate iso={changeset.created_at} /></span>
 								</div>
-							{/each}
-						</li>
-					{/each}
-				</ol>
-			</section>
-		{/if}
-
-		<h2>Sources</h2>
-		<p class="sources-summary">
-			{contributorNames.join(' and ')} contributed to this record.
-		</p>
-
-		{#if conflicts.length > 0}
-			<details class="sources-group" open>
-				<summary>
-					<h3>
-						Conflicts resolved ({conflicts.length} field{conflicts.length === 1 ? '' : 's'})
-					</h3>
-				</summary>
-				<dl class="field-list">
-					{#each conflicts as { field, claims } (field)}
-						<div class="field-row conflict">
-							<dt>{field}</dt>
-							<dd>
-								{#each claims as claim, i (i)}
-									<span class="claim" class:used={claim.is_winner}>
-										{@render claimDetail(claim)}
-									</span>
+								{#if changeset.note}
+									<p class="evidence-note">{changeset.note}</p>
+								{/if}
+								<p class="changeset-fields">Applies to: {changeset.fields.join(', ')}</p>
+								{#each changeset.citations as citation, i (i)}
+									<div class="evidence-citation">
+										<div class="source-name">{citation.source_name}</div>
+										{#if citation.author || citation.year}
+											<div class="meta">
+												{[citation.author, citation.year].filter(Boolean).join(', ')}
+											</div>
+										{/if}
+										{#if citation.locator}
+											<div class="locator">{citation.locator}</div>
+										{/if}
+										{#if citation.links.length > 0}
+											<div class="links">
+												{#each citation.links as link (link.url)}
+													<a href={link.url} target="_blank" rel="noopener">{link.label}</a>
+												{/each}
+											</div>
+										{/if}
+									</div>
 								{/each}
-							</dd>
-						</div>
-					{/each}
-				</dl>
-			</details>
-		{/if}
+							</li>
+						{/each}
+					</ol>
+				</section>
+			{/if}
 
-		{#if agreed.length > 0}
-			<details class="sources-group">
-				<summary>
-					<h3>Sources agree ({agreed.length} field{agreed.length === 1 ? '' : 's'})</h3>
-				</summary>
-				<dl class="field-list">
-					{#each agreed as { field, claims } (field)}
-						<div class="field-row">
-							<dt>{field}</dt>
-							<dd>
-								<span class="claim used">
-									{formatValue(claims[0].value)}
-									<span class="source-list">
-										{claims.map(claimAttribution).join(', ')}
+			<p class="sources-summary">
+				{contributorNames.join(' and ')} contributed to this record.
+			</p>
+
+			{#if conflicts.length > 0}
+				<details class="sources-group" open>
+					<summary>
+						<h3>
+							Conflicts resolved ({conflicts.length} field{conflicts.length === 1 ? '' : 's'})
+						</h3>
+					</summary>
+					<dl class="field-list">
+						{#each conflicts as { field, claims } (field)}
+							<div class="field-row conflict">
+								<dt>{field}</dt>
+								<dd>
+									{#each claims as claim, i (i)}
+										<span class="claim" class:used={claim.is_winner}>
+											{@render claimDetail(claim)}
+										</span>
+									{/each}
+								</dd>
+							</div>
+						{/each}
+					</dl>
+				</details>
+			{/if}
+
+			{#if agreed.length > 0}
+				<details class="sources-group">
+					<summary>
+						<h3>Sources agree ({agreed.length} field{agreed.length === 1 ? '' : 's'})</h3>
+					</summary>
+					<dl class="field-list">
+						{#each agreed as { field, claims } (field)}
+							<div class="field-row">
+								<dt>{field}</dt>
+								<dd>
+									<span class="claim used">
+										{formatValue(claims[0].value)}
+										<span class="source-list">
+											{claims.map(claimAttribution).join(', ')}
+										</span>
 									</span>
-								</span>
-							</dd>
-						</div>
-					{/each}
-				</dl>
-			</details>
-		{/if}
+								</dd>
+							</div>
+						{/each}
+					</dl>
+				</details>
+			{/if}
 
-		{#if single.length > 0}
-			<details class="sources-group">
-				<summary>
-					<h3>Single source ({single.length} field{single.length === 1 ? '' : 's'})</h3>
-				</summary>
-				<dl class="field-list">
-					{#each single as { field, claims } (field)}
-						<div class="field-row">
-							<dt>{field}</dt>
-							<dd>
-								<span class="claim used">
-									{@render claimDetail(claims[0])}
-								</span>
-							</dd>
-						</div>
-					{/each}
-				</dl>
-			</details>
-		{/if}
-	</section>
-{:else}
-	<p class="no-sources">No source data recorded yet.</p>
-{/if}
+			{#if single.length > 0}
+				<details class="sources-group">
+					<summary>
+						<h3>Single source ({single.length} field{single.length === 1 ? '' : 's'})</h3>
+					</summary>
+					<dl class="field-list">
+						{#each single as { field, claims } (field)}
+							<div class="field-row">
+								<dt>{field}</dt>
+								<dd>
+									<span class="claim used">
+										{@render claimDetail(claims[0])}
+									</span>
+								</dd>
+							</div>
+						{/each}
+					</dl>
+				</details>
+			{/if}
+		</section>
+	{:else}
+		<p class="no-sources">No source data recorded yet.</p>
+	{/if}
+</FocusContentShell>
 
 <style>
 	h2 {

--- a/frontend/src/lib/components/EntitySources.test-harness.svelte
+++ b/frontend/src/lib/components/EntitySources.test-harness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import EntitySources from './EntitySources.svelte';
+	import { setEntityContext } from '$lib/entity-context';
+
+	let { sources, evidence = undefined } = $props();
+
+	setEntityContext({
+		name: 'Test Entity',
+		detailHref: '/test-entity/test-slug'
+	});
+</script>
+
+<EntitySources {sources} {evidence} />

--- a/frontend/src/lib/components/FocusContentShell.svelte
+++ b/frontend/src/lib/components/FocusContentShell.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		backHref,
+		maxWidth = '48rem',
+		heading,
+		children
+	}: {
+		backHref: string;
+		maxWidth?: string;
+		heading: Snippet;
+		children: Snippet;
+	} = $props();
+</script>
+
+<div class="focus-shell" style:max-width={maxWidth}>
+	<header class="focus-header">
+		<a href={backHref} class="back-link">&larr; Back</a>
+		<div class="heading-slot">
+			{@render heading()}
+		</div>
+	</header>
+
+	{@render children()}
+</div>
+
+<style>
+	.focus-shell {
+		margin: 0 auto;
+		padding: var(--size-4);
+	}
+
+	.focus-header {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		margin-bottom: var(--size-4);
+		min-height: 2.5rem;
+	}
+
+	.back-link {
+		position: absolute;
+		left: 0;
+		font-size: var(--font-size-1);
+		color: var(--color-text-muted);
+		text-decoration: none;
+	}
+
+	.back-link:hover {
+		color: var(--color-text-primary);
+	}
+</style>

--- a/frontend/src/lib/components/FocusContentShell.test-harness.svelte
+++ b/frontend/src/lib/components/FocusContentShell.test-harness.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import FocusContentShell from './FocusContentShell.svelte';
+
+	let {
+		backHref = '/titles/medieval-madness',
+		maxWidth = undefined
+	}: {
+		backHref?: string;
+		maxWidth?: string;
+	} = $props();
+</script>
+
+{#snippet headingSnippet()}
+	<h1>Edit History</h1>
+{/snippet}
+
+<FocusContentShell {backHref} {maxWidth} heading={headingSnippet}>
+	<div>Audit content</div>
+</FocusContentShell>

--- a/frontend/src/lib/components/FocusContentShell.test.ts
+++ b/frontend/src/lib/components/FocusContentShell.test.ts
@@ -1,0 +1,31 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import Harness from './FocusContentShell.test-harness.svelte';
+
+describe('FocusContentShell', () => {
+	it('renders the back link, heading slot, and children', () => {
+		const { body } = render(Harness, {
+			props: { backHref: '/titles/medieval-madness' }
+		});
+
+		expect(body).toContain('href="/titles/medieval-madness"');
+		expect(body).toContain('Back');
+		expect(body).toContain('<h1>Edit History</h1>');
+		expect(body).toContain('Audit content');
+	});
+
+	it('applies a custom max-width when provided', () => {
+		const { body } = render(Harness, {
+			props: { maxWidth: '64rem' }
+		});
+
+		expect(body).toContain('max-width: 64rem');
+	});
+
+	it('uses the default max-width when none is provided', () => {
+		const { body } = render(Harness, {});
+
+		expect(body).toContain('max-width: 48rem');
+	});
+});

--- a/frontend/src/lib/components/TaxonomyDetailBaseLayout.svelte
+++ b/frontend/src/lib/components/TaxonomyDetailBaseLayout.svelte
@@ -17,6 +17,8 @@
 	} from '$lib/components/editors/edit-action-context';
 	import type { SectionEditorHandle } from '$lib/components/editors/editor-contract';
 	import { resolveDetailSubrouteMode } from '$lib/detail-subroute-mode';
+	import { isFocusModePath } from '$lib/focus-mode';
+	import { setEntityContext } from '$lib/entity-context';
 	import { createIsMobileFlag } from '$lib/use-is-mobile.svelte';
 
 	type SectionDef = EditSectionDef<TKey> & { usesSectionEditorForm: boolean };
@@ -80,12 +82,21 @@
 	let metaDescription = $derived(profile.description.text || `${profile.name} — ${SITE_NAME}`);
 	let mode = $derived(resolveDetailSubrouteMode(page.url.pathname));
 	let isDetail = $derived(mode === 'detail');
-	let isEdit = $derived(mode === 'edit');
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
 	const isMobileFlag = createIsMobileFlag(LAYOUT_BREAKPOINT);
 	let isMobile = $derived(isMobileFlag.current);
 	let editing = $state<TKey | null>(null);
-	let syncEnabled = $derived(!isMobile && !isEdit);
+	let syncEnabled = $derived(!isMobile && !isFocusMode);
 	let lastUrlEditing = $state<TKey | null>(null);
+
+	setEntityContext({
+		get name() {
+			return profile.name;
+		},
+		get detailHref() {
+			return resolveHref(`${basePath}/${slug}`);
+		}
+	});
 
 	$effect(() => {
 		auth.load();
@@ -180,7 +191,7 @@
 
 <MetaTags title={profile.name} description={metaDescription} url={page.url.href} />
 
-{#if isEdit}
+{#if isFocusMode}
 	{@render children()}
 {:else}
 	{#snippet actionBar()}

--- a/frontend/src/lib/detail-subroute-match.test.ts
+++ b/frontend/src/lib/detail-subroute-match.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchDetailSubroute } from './detail-subroute-match';
+
+describe('matchDetailSubroute', () => {
+	it('returns the subroute segment of /:entity/:slug/:subroute', () => {
+		expect(matchDetailSubroute('/titles/medieval-madness/edit-history')).toBe('edit-history');
+		expect(matchDetailSubroute('/titles/medieval-madness/sources')).toBe('sources');
+		expect(matchDetailSubroute('/manufacturers/williams/edit')).toBe('edit');
+		expect(matchDetailSubroute('/models/attack-from-mars/media')).toBe('media');
+	});
+
+	it('returns the subroute when extra segments follow', () => {
+		expect(matchDetailSubroute('/models/attack-from-mars/edit/overview')).toBe('edit');
+		expect(matchDetailSubroute('/manufacturers/williams/media/upload')).toBe('media');
+	});
+
+	it('returns null when there is no slug', () => {
+		expect(matchDetailSubroute('/titles')).toBeNull();
+		expect(matchDetailSubroute('/')).toBeNull();
+		expect(matchDetailSubroute('')).toBeNull();
+	});
+
+	it('returns null when only entity + slug are present (no subroute)', () => {
+		expect(matchDetailSubroute('/titles/medieval-madness')).toBeNull();
+		expect(matchDetailSubroute('/titles/sources')).toBeNull();
+		expect(matchDetailSubroute('/titles/edit-history')).toBeNull();
+		expect(matchDetailSubroute('/titles/edit')).toBeNull();
+	});
+
+	it('ignores trailing slash', () => {
+		expect(matchDetailSubroute('/titles/medieval-madness/edit/')).toBe('edit');
+	});
+});

--- a/frontend/src/lib/detail-subroute-match.ts
+++ b/frontend/src/lib/detail-subroute-match.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns the subroute segment of `/:entity/:slug/:subroute(/...)`,
+ * or `null` when the pathname has fewer than three segments.
+ *
+ * Both `isFocusModePath` and `resolveDetailSubrouteMode` use this helper
+ * so they cannot drift on the slug-guard rule: a detail page for a record
+ * whose slug happens to be `sources`, `edit-history`, `edit`, etc. (e.g.
+ * `/titles/sources`) must NOT classify as that subroute.
+ */
+export function matchDetailSubroute(pathname: string): string | null {
+	const segments = pathname.split('/').filter(Boolean);
+	if (segments.length < 3) return null;
+	return segments[2];
+}

--- a/frontend/src/lib/detail-subroute-mode.test.ts
+++ b/frontend/src/lib/detail-subroute-mode.test.ts
@@ -30,4 +30,23 @@ describe('resolveDetailSubrouteMode', () => {
 	it('returns edit-history for the edit history route', () => {
 		expect(resolveDetailSubrouteMode('/titles/medieval-madness/edit-history')).toBe('edit-history');
 	});
+
+	it('returns detail when slug happens to be "sources"', () => {
+		// /titles/sources is a detail page for a title with slug='sources',
+		// not the sources audit route — guards against the includes()-based
+		// classifier bug.
+		expect(resolveDetailSubrouteMode('/titles/sources')).toBe('detail');
+	});
+
+	it('returns detail when slug happens to be "edit-history"', () => {
+		expect(resolveDetailSubrouteMode('/titles/edit-history')).toBe('detail');
+	});
+
+	it('returns detail when slug happens to be "edit"', () => {
+		expect(resolveDetailSubrouteMode('/titles/edit')).toBe('detail');
+	});
+
+	it('returns detail when slug happens to be "media"', () => {
+		expect(resolveDetailSubrouteMode('/titles/media')).toBe('detail');
+	});
 });

--- a/frontend/src/lib/detail-subroute-mode.ts
+++ b/frontend/src/lib/detail-subroute-mode.ts
@@ -1,15 +1,19 @@
+import { matchDetailSubroute } from './detail-subroute-match';
+
 export type DetailSubrouteMode = 'detail' | 'edit' | 'media' | 'sources' | 'edit-history';
 
-function pathSegments(pathname: string): string[] {
-	return pathname.split('/').filter(Boolean);
-}
-
 export function resolveDetailSubrouteMode(pathname: string): DetailSubrouteMode {
-	const segments = pathSegments(pathname);
-
-	if (segments.includes('edit-history')) return 'edit-history';
-	if (segments.includes('sources')) return 'sources';
-	if (segments.includes('media')) return 'media';
-	if (segments.includes('edit')) return 'edit';
-	return 'detail';
+	const subroute = matchDetailSubroute(pathname);
+	switch (subroute) {
+		case 'edit-history':
+			return 'edit-history';
+		case 'sources':
+			return 'sources';
+		case 'media':
+			return 'media';
+		case 'edit':
+			return 'edit';
+		default:
+			return 'detail';
+	}
 }

--- a/frontend/src/lib/entity-context.ts
+++ b/frontend/src/lib/entity-context.ts
@@ -1,0 +1,30 @@
+import { getContext, setContext } from 'svelte';
+
+/**
+ * Context exposed by every entity `[slug]/+layout.svelte` so descendant
+ * routes (audit pages, focus shells, etc.) can read the entity's display
+ * name and detail URL without coupling to the loader's data-key (which
+ * varies across entities: `data.title`, `data.profile`, `data.model`, …).
+ *
+ * Callers should pass an object whose properties are getters so values
+ * stay reactive across navigation (e.g. `/titles/A/sources` → `/titles/B/sources`
+ * must re-read `title.name`).
+ */
+export type EntityContext = {
+	readonly name: string;
+	readonly detailHref: string;
+};
+
+const ENTITY_CONTEXT_KEY = Symbol('entity');
+
+export function setEntityContext(context: EntityContext): void {
+	setContext(ENTITY_CONTEXT_KEY, context);
+}
+
+export function getEntityContext(): EntityContext {
+	const context = getContext<EntityContext | undefined>(ENTITY_CONTEXT_KEY);
+	if (!context) {
+		throw new Error('entity context missing — must be rendered inside an entity [slug] layout');
+	}
+	return context;
+}

--- a/frontend/src/lib/focus-mode.test.ts
+++ b/frontend/src/lib/focus-mode.test.ts
@@ -27,6 +27,14 @@ describe('isFocusModePath', () => {
 		it('matches delete confirmation', () => {
 			expect(isFocusModePath('/titles/medieval-madness/delete')).toBe(true);
 		});
+
+		it('matches edit-history', () => {
+			expect(isFocusModePath('/titles/medieval-madness/edit-history')).toBe(true);
+		});
+
+		it('matches sources', () => {
+			expect(isFocusModePath('/titles/medieval-madness/sources')).toBe(true);
+		});
 	});
 
 	describe('full-chrome routes', () => {
@@ -62,6 +70,22 @@ describe('isFocusModePath', () => {
 
 		it('does not match "delete" appearing mid-path', () => {
 			expect(isFocusModePath('/titles/medieval-madness/delete/extra')).toBe(false);
+		});
+
+		it('does not match an entity record whose slug is "sources"', () => {
+			expect(isFocusModePath('/titles/sources')).toBe(false);
+		});
+
+		it('does not match an entity record whose slug is "edit-history"', () => {
+			expect(isFocusModePath('/titles/edit-history')).toBe(false);
+		});
+
+		it('does not match "sources" with trailing extra segments', () => {
+			expect(isFocusModePath('/titles/medieval-madness/sources/something')).toBe(false);
+		});
+
+		it('does not match "edit-history" with trailing extra segments', () => {
+			expect(isFocusModePath('/titles/medieval-madness/edit-history/something')).toBe(false);
 		});
 	});
 });

--- a/frontend/src/lib/focus-mode.ts
+++ b/frontend/src/lib/focus-mode.ts
@@ -1,3 +1,5 @@
+import { matchDetailSubroute } from './detail-subroute-match';
+
 /**
  * Focus-mode routes render their own minimal chrome (no site Nav/Footer or
  * page-content wrapper). Patterns:
@@ -6,14 +8,31 @@
  *   /:entity/:slug/edit                  edit (no section)
  *   /:entity/:slug/edit/:section         edit a section
  *   /:entity/:slug/delete                destructive confirmation
+ *   /:entity/:slug/edit-history          audit: changeset history
+ *   /:entity/:slug/sources               audit: source claims
  *
- * `edit` and `delete` require a slug segment before them so a catalog record
- * with slug='edit' or 'delete' (e.g. /titles/delete) still gets full chrome.
+ * `edit`, `delete`, `edit-history`, and `sources` require a slug segment
+ * before them so a catalog record with slug='edit' / 'sources' / etc. (e.g.
+ * /titles/sources) still gets full chrome. Slug-guard matching is delegated
+ * to `matchDetailSubroute` so this stays in sync with `resolveDetailSubrouteMode`.
+ *
  * `new` is safe without that guard because SvelteKit's route priority gives
  * /:entity/new to the create page, not the detail page.
  */
-const FOCUS_MODE_RE = /\/new$|\/[^/]+\/[^/]+\/edit(\/|$)|\/[^/]+\/[^/]+\/delete$/;
+const FOCUS_SUBROUTES_NESTED = new Set(['edit']);
+const FOCUS_SUBROUTES_TERMINAL = new Set(['delete', 'edit-history', 'sources']);
 
 export function isFocusModePath(pathname: string): boolean {
-	return FOCUS_MODE_RE.test(pathname);
+	const segments = pathname.split('/').filter(Boolean);
+	if (segments.length === 0) return false;
+
+	if (segments[segments.length - 1] === 'new') return true;
+
+	const subroute = matchDetailSubroute(pathname);
+	if (!subroute) return false;
+
+	if (FOCUS_SUBROUTES_NESTED.has(subroute)) return true;
+	if (FOCUS_SUBROUTES_TERMINAL.has(subroute) && segments.length === 3) return true;
+
+	return false;
 }

--- a/frontend/src/routes/cabinets/[slug]/edit-history/edit-history-page.test-harness.svelte
+++ b/frontend/src/routes/cabinets/[slug]/edit-history/edit-history-page.test-harness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Page from './+page.svelte';
+	import { setEntityContext } from '$lib/entity-context';
+
+	let { data } = $props();
+
+	setEntityContext({
+		name: 'Standard Body',
+		detailHref: '/cabinets/standard-body'
+	});
+</script>
+
+<Page {data} />

--- a/frontend/src/routes/cabinets/[slug]/edit-history/edit-history-page.test.ts
+++ b/frontend/src/routes/cabinets/[slug]/edit-history/edit-history-page.test.ts
@@ -1,0 +1,17 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import Harness from './edit-history-page.test-harness.svelte';
+
+describe('cabinet edit-history page (taxonomy representative)', () => {
+	it('wraps EditHistory in FocusContentShell with back link to detail and an Edit History heading', () => {
+		const { body } = render(Harness, {
+			props: { data: { changesets: [] } }
+		});
+
+		expect(body).toContain('href="/cabinets/standard-body"');
+		expect(body).toContain('Back');
+		expect(body).toContain('<h1>Edit History</h1>');
+		expect(body.toLowerCase()).toContain('no edit history yet');
+	});
+});

--- a/frontend/src/routes/cabinets/[slug]/sources/sources-page.test-harness.svelte
+++ b/frontend/src/routes/cabinets/[slug]/sources/sources-page.test-harness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Page from './+page.svelte';
+	import { setEntityContext } from '$lib/entity-context';
+
+	let { data } = $props();
+
+	setEntityContext({
+		name: 'Standard Body',
+		detailHref: '/cabinets/standard-body'
+	});
+</script>
+
+<Page {data} />

--- a/frontend/src/routes/cabinets/[slug]/sources/sources-page.test.ts
+++ b/frontend/src/routes/cabinets/[slug]/sources/sources-page.test.ts
@@ -1,0 +1,17 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import Harness from './sources-page.test-harness.svelte';
+
+describe('cabinet sources page (taxonomy representative)', () => {
+	it('wraps EntitySources in FocusContentShell with back link to detail and a Sources heading', () => {
+		const { body } = render(Harness, {
+			props: { data: { sources: [], evidence: [] } }
+		});
+
+		expect(body).toContain('href="/cabinets/standard-body"');
+		expect(body).toContain('Back');
+		expect(body).toContain('<h1>Sources</h1>');
+		expect(body.toLowerCase()).toContain('no source data recorded yet');
+	});
+});

--- a/frontend/src/routes/corporate-entities/[slug]/+layout.svelte
+++ b/frontend/src/routes/corporate-entities/[slug]/+layout.svelte
@@ -21,6 +21,8 @@
 	} from '$lib/components/editors/corporate-entity-edit-sections';
 	import { LAYOUT_BREAKPOINT } from '$lib/constants';
 	import { resolveDetailSubrouteMode } from '$lib/detail-subroute-mode';
+	import { isFocusModePath } from '$lib/focus-mode';
+	import { setEntityContext } from '$lib/entity-context';
 	import { createIsMobileFlag } from '$lib/use-is-mobile.svelte';
 	import CorporateEntityEditorSwitch from './edit/CorporateEntityEditorSwitch.svelte';
 
@@ -32,11 +34,20 @@
 	let metaDescription = $derived(ce.description?.text || `${ce.name} — ${SITE_NAME}`);
 	let mode = $derived(resolveDetailSubrouteMode(page.url.pathname));
 	let isDetail = $derived(mode === 'detail');
-	let isEdit = $derived(mode === 'edit');
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
+
+	setEntityContext({
+		get name() {
+			return ce.name;
+		},
+		get detailHref() {
+			return resolve(`/corporate-entities/${slug}`);
+		}
+	});
 	const isMobileFlag = createIsMobileFlag(LAYOUT_BREAKPOINT);
 	let isMobile = $derived(isMobileFlag.current);
 	let editing = $state<CorporateEntityEditSectionKey | null>(null);
-	let syncEnabled = $derived(!isMobile && !isEdit);
+	let syncEnabled = $derived(!isMobile && !isFocusMode);
 	// Tracks the last URL-derived edit section so local modal state doesn't immediately write it back.
 	let lastUrlEditing = $state<CorporateEntityEditSectionKey | null>(null);
 
@@ -117,7 +128,7 @@
 
 <MetaTags title={ce.name} description={metaDescription} url={page.url.href} />
 
-{#if isEdit}
+{#if isFocusMode}
 	{@render children()}
 {:else}
 	{#snippet actionBar()}

--- a/frontend/src/routes/franchises/[slug]/+layout.svelte
+++ b/frontend/src/routes/franchises/[slug]/+layout.svelte
@@ -17,6 +17,8 @@
 	} from '$lib/components/editors/franchise-edit-sections';
 	import { LAYOUT_BREAKPOINT } from '$lib/constants';
 	import { resolveDetailSubrouteMode } from '$lib/detail-subroute-mode';
+	import { isFocusModePath } from '$lib/focus-mode';
+	import { setEntityContext } from '$lib/entity-context';
 	import { createIsMobileFlag } from '$lib/use-is-mobile.svelte';
 	import FranchiseEditorSwitch from './edit/FranchiseEditorSwitch.svelte';
 
@@ -27,11 +29,20 @@
 	let metaDescription = $derived(franchise.description?.text || `${franchise.name} — ${SITE_NAME}`);
 	let mode = $derived(resolveDetailSubrouteMode(page.url.pathname));
 	let isDetail = $derived(mode === 'detail');
-	let isEdit = $derived(mode === 'edit');
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
+
+	setEntityContext({
+		get name() {
+			return franchise.name;
+		},
+		get detailHref() {
+			return resolve(`/franchises/${slug}`);
+		}
+	});
 	const isMobileFlag = createIsMobileFlag(LAYOUT_BREAKPOINT);
 	let isMobile = $derived(isMobileFlag.current);
 	let editing = $state<FranchiseEditSectionKey | null>(null);
-	let syncEnabled = $derived(!isMobile && !isEdit);
+	let syncEnabled = $derived(!isMobile && !isFocusMode);
 	// Tracks the last URL-derived edit section so local modal state doesn't immediately write it back.
 	let lastUrlEditing = $state<FranchiseEditSectionKey | null>(null);
 
@@ -94,7 +105,7 @@
 
 <MetaTags title={franchise.name} description={metaDescription} url={page.url.href} />
 
-{#if isEdit}
+{#if isFocusMode}
 	{@render children()}
 {:else}
 	{#snippet actionBar()}

--- a/frontend/src/routes/manufacturers/[slug]/+layout.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+layout.svelte
@@ -23,6 +23,8 @@
 	} from '$lib/components/editors/manufacturer-edit-sections';
 	import { LAYOUT_BREAKPOINT } from '$lib/constants';
 	import { resolveDetailSubrouteMode } from '$lib/detail-subroute-mode';
+	import { isFocusModePath } from '$lib/focus-mode';
+	import { setEntityContext } from '$lib/entity-context';
 	import { createIsMobileFlag } from '$lib/use-is-mobile.svelte';
 	import ManufacturerEditorSwitch from './edit/ManufacturerEditorSwitch.svelte';
 
@@ -34,11 +36,20 @@
 	let metaDescription = $derived(mfr.description?.text || `${mfr.name} — pinball manufacturer`);
 	let mode = $derived(resolveDetailSubrouteMode(page.url.pathname));
 	let isDetail = $derived(mode === 'detail');
-	let isEdit = $derived(mode === 'edit');
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
+
+	setEntityContext({
+		get name() {
+			return mfr.name;
+		},
+		get detailHref() {
+			return resolve(`/manufacturers/${slug}`);
+		}
+	});
 	const isMobileFlag = createIsMobileFlag(LAYOUT_BREAKPOINT);
 	let isMobile = $derived(isMobileFlag.current);
 	let editing = $state<ManufacturerEditSectionKey | null>(null);
-	let syncEnabled = $derived(!isMobile && !isEdit);
+	let syncEnabled = $derived(!isMobile && !isFocusMode);
 	// Tracks the last URL-derived edit section so local modal state doesn't immediately write it back.
 	let lastUrlEditing = $state<ManufacturerEditSectionKey | null>(null);
 
@@ -123,7 +134,7 @@
 	imageAlt={mfr.logo_url ? `${mfr.name} logo` : undefined}
 />
 
-{#if isEdit}
+{#if isFocusMode}
 	{@render children()}
 {:else}
 	{#snippet actionBar()}

--- a/frontend/src/routes/manufacturers/[slug]/edit-history/edit-history-page.test-harness.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/edit-history/edit-history-page.test-harness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Page from './+page.svelte';
+	import { setEntityContext } from '$lib/entity-context';
+
+	let { data } = $props();
+
+	setEntityContext({
+		name: 'Williams',
+		detailHref: '/manufacturers/williams'
+	});
+</script>
+
+<Page {data} />

--- a/frontend/src/routes/manufacturers/[slug]/edit-history/edit-history-page.test.ts
+++ b/frontend/src/routes/manufacturers/[slug]/edit-history/edit-history-page.test.ts
@@ -1,0 +1,17 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import Harness from './edit-history-page.test-harness.svelte';
+
+describe('manufacturer edit-history page', () => {
+	it('wraps EditHistory in FocusContentShell with back link to detail and an Edit History heading', () => {
+		const { body } = render(Harness, {
+			props: { data: { changesets: [] } }
+		});
+
+		expect(body).toContain('href="/manufacturers/williams"');
+		expect(body).toContain('Back');
+		expect(body).toContain('<h1>Edit History</h1>');
+		expect(body.toLowerCase()).toContain('no edit history yet');
+	});
+});

--- a/frontend/src/routes/manufacturers/[slug]/manufacturer-layout.test.ts
+++ b/frontend/src/routes/manufacturers/[slug]/manufacturer-layout.test.ts
@@ -83,6 +83,29 @@ describe('manufacturer layout', () => {
 		expect(body).toContain('/manufacturers/williams');
 	});
 
+	it('strips the detail shell on sources subroutes (focus mode)', () => {
+		pageState.url = new URL('http://localhost:5173/manufacturers/williams/sources');
+
+		const { body } = render(Harness, {
+			props: { data: { manufacturer: MOCK_MANUFACTURER } }
+		});
+
+		expect(body).toContain('Child content');
+		expect(body).not.toContain('History');
+		expect(body).not.toContain('Page sections');
+	});
+
+	it('strips the detail shell on edit-history subroutes (focus mode)', () => {
+		pageState.url = new URL('http://localhost:5173/manufacturers/williams/edit-history');
+
+		const { body } = render(Harness, {
+			props: { data: { manufacturer: MOCK_MANUFACTURER } }
+		});
+
+		expect(body).toContain('Child content');
+		expect(body).not.toContain('History');
+	});
+
 	it('renders a direct edit link on the Links sidebar section when authenticated', () => {
 		authState.isAuthenticated = true;
 

--- a/frontend/src/routes/manufacturers/[slug]/sources/sources-page.test-harness.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/sources/sources-page.test-harness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Page from './+page.svelte';
+	import { setEntityContext } from '$lib/entity-context';
+
+	let { data } = $props();
+
+	setEntityContext({
+		name: 'Williams',
+		detailHref: '/manufacturers/williams'
+	});
+</script>
+
+<Page {data} />

--- a/frontend/src/routes/manufacturers/[slug]/sources/sources-page.test.ts
+++ b/frontend/src/routes/manufacturers/[slug]/sources/sources-page.test.ts
@@ -1,0 +1,17 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import Harness from './sources-page.test-harness.svelte';
+
+describe('manufacturer sources page', () => {
+	it('wraps EntitySources in FocusContentShell with back link to detail and a Sources heading', () => {
+		const { body } = render(Harness, {
+			props: { data: { sources: [], evidence: [] } }
+		});
+
+		expect(body).toContain('href="/manufacturers/williams"');
+		expect(body).toContain('Back');
+		expect(body).toContain('<h1>Sources</h1>');
+		expect(body.toLowerCase()).toContain('no source data recorded yet');
+	});
+});

--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -19,6 +19,8 @@
 	import { LAYOUT_BREAKPOINT } from '$lib/constants';
 	import { modelHasTitleOwnedIdentity } from '$lib/catalog-rules';
 	import { resolveDetailSubrouteMode } from '$lib/detail-subroute-mode';
+	import { isFocusModePath } from '$lib/focus-mode';
+	import { setEntityContext } from '$lib/entity-context';
 	import { modelEditActionContext } from '$lib/components/editors/edit-action-context';
 	import { createIsMobileFlag } from '$lib/use-is-mobile.svelte';
 	import MediaEditor from '$lib/components/editors/MediaEditor.svelte';
@@ -33,11 +35,20 @@
 	});
 
 	let mode = $derived(resolveDetailSubrouteMode(page.url.pathname));
-	let isEdit = $derived(mode === 'edit');
 	// isDetail still drives (a) the "Reader" back-link in PageActionBar,
 	// and (b) whether the sidebar is desktop-only — on sub-routes the sidebar
 	// is shown on mobile too because the main column no longer duplicates it.
 	let isDetail = $derived(mode === 'detail');
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
+
+	setEntityContext({
+		get name() {
+			return model.name;
+		},
+		get detailHref() {
+			return resolve(`/models/${slug}`);
+		}
+	});
 
 	// Mobile detection — matches TwoColumnLayout breakpoint (LAYOUT_BREAKPOINT)
 	const isMobileFlag = createIsMobileFlag(LAYOUT_BREAKPOINT);
@@ -89,7 +100,7 @@
 	let availableSections = $derived(modelSectionsFor(modelHasTitleOwnedIdentity(model)));
 
 	let editing = $state<ModelEditSectionKey | null>(null);
-	let syncEnabled = $derived(!isMobile && !isEdit);
+	let syncEnabled = $derived(!isMobile && !isFocusMode);
 	// Tracks the last URL-derived edit section so local modal state doesn't immediately write it back.
 	let lastUrlEditing = $state<ModelEditSectionKey | null>(null);
 
@@ -192,18 +203,16 @@
 	imageAlt={model.hero_image_url ? `${model.name} pinball machine` : undefined}
 />
 
-{#if isEdit}
+{#if isFocusMode}
 	{@render children()}
 {:else}
 	{#snippet actionBar()}
-		{#if !isEdit}
-			<PageActionBar
-				detailHref={isDetail ? undefined : resolve(`/models/${slug}`)}
-				editSections={auth.isAuthenticated ? editSections : undefined}
-				historyHref={resolve(`/models/${slug}/edit-history`)}
-				sourcesHref={resolve(`/models/${slug}/sources`)}
-			/>
-		{/if}
+		<PageActionBar
+			detailHref={isDetail ? undefined : resolve(`/models/${slug}`)}
+			editSections={auth.isAuthenticated ? editSections : undefined}
+			historyHref={resolve(`/models/${slug}/edit-history`)}
+			sourcesHref={resolve(`/models/${slug}/sources`)}
+		/>
 	{/snippet}
 
 	{#snippet main()}
@@ -367,7 +376,7 @@
 		sidebarDesktopOnly={isDetail}
 		{actionBar}
 		{main}
-		sidebar={isEdit ? undefined : sidebar}
+		{sidebar}
 	/>
 
 	<SectionEditorHost

--- a/frontend/src/routes/people/[slug]/+layout.svelte
+++ b/frontend/src/routes/people/[slug]/+layout.svelte
@@ -18,6 +18,8 @@
 	} from '$lib/components/editors/person-edit-sections';
 	import { LAYOUT_BREAKPOINT } from '$lib/constants';
 	import { resolveDetailSubrouteMode } from '$lib/detail-subroute-mode';
+	import { isFocusModePath } from '$lib/focus-mode';
+	import { setEntityContext } from '$lib/entity-context';
 	import { createIsMobileFlag } from '$lib/use-is-mobile.svelte';
 	import PersonEditorSwitch from './edit/PersonEditorSwitch.svelte';
 
@@ -30,11 +32,20 @@
 	);
 	let mode = $derived(resolveDetailSubrouteMode(page.url.pathname));
 	let isDetail = $derived(mode === 'detail');
-	let isEdit = $derived(mode === 'edit');
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
+
+	setEntityContext({
+		get name() {
+			return person.name;
+		},
+		get detailHref() {
+			return resolve(`/people/${slug}`);
+		}
+	});
 	const isMobileFlag = createIsMobileFlag(LAYOUT_BREAKPOINT);
 	let isMobile = $derived(isMobileFlag.current);
 	let editing = $state<PersonEditSectionKey | null>(null);
-	let syncEnabled = $derived(!isMobile && !isEdit);
+	let syncEnabled = $derived(!isMobile && !isFocusMode);
 	// Tracks the last URL-derived edit section so local modal state doesn't immediately write it back.
 	let lastUrlEditing = $state<PersonEditSectionKey | null>(null);
 
@@ -115,7 +126,7 @@
 	imageAlt={person.photo_url ? `Photo of ${person.name}` : undefined}
 />
 
-{#if isEdit}
+{#if isFocusMode}
 	{@render children()}
 {:else}
 	{#snippet actionBar()}

--- a/frontend/src/routes/series/[slug]/+layout.svelte
+++ b/frontend/src/routes/series/[slug]/+layout.svelte
@@ -17,6 +17,8 @@
 	} from '$lib/components/editors/series-edit-sections';
 	import { LAYOUT_BREAKPOINT } from '$lib/constants';
 	import { resolveDetailSubrouteMode } from '$lib/detail-subroute-mode';
+	import { isFocusModePath } from '$lib/focus-mode';
+	import { setEntityContext } from '$lib/entity-context';
 	import { createIsMobileFlag } from '$lib/use-is-mobile.svelte';
 	import SeriesEditorSwitch from './edit/SeriesEditorSwitch.svelte';
 
@@ -27,11 +29,20 @@
 	let metaDescription = $derived(series.description?.text || `${series.name} — ${SITE_NAME}`);
 	let mode = $derived(resolveDetailSubrouteMode(page.url.pathname));
 	let isDetail = $derived(mode === 'detail');
-	let isEdit = $derived(mode === 'edit');
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
+
+	setEntityContext({
+		get name() {
+			return series.name;
+		},
+		get detailHref() {
+			return resolve(`/series/${slug}`);
+		}
+	});
 	const isMobileFlag = createIsMobileFlag(LAYOUT_BREAKPOINT);
 	let isMobile = $derived(isMobileFlag.current);
 	let editing = $state<SeriesEditSectionKey | null>(null);
-	let syncEnabled = $derived(!isMobile && !isEdit);
+	let syncEnabled = $derived(!isMobile && !isFocusMode);
 	// Tracks the last URL-derived edit section so local modal state doesn't immediately write it back.
 	let lastUrlEditing = $state<SeriesEditSectionKey | null>(null);
 
@@ -94,7 +105,7 @@
 
 <MetaTags title={series.name} description={metaDescription} url={page.url.href} />
 
-{#if isEdit}
+{#if isFocusMode}
 	{@render children()}
 {:else}
 	{#snippet actionBar()}

--- a/frontend/src/routes/systems/[slug]/+layout.svelte
+++ b/frontend/src/routes/systems/[slug]/+layout.svelte
@@ -20,6 +20,8 @@
 	} from '$lib/components/editors/system-edit-sections';
 	import { LAYOUT_BREAKPOINT } from '$lib/constants';
 	import { resolveDetailSubrouteMode } from '$lib/detail-subroute-mode';
+	import { isFocusModePath } from '$lib/focus-mode';
+	import { setEntityContext } from '$lib/entity-context';
 	import { createIsMobileFlag } from '$lib/use-is-mobile.svelte';
 	import SystemEditorSwitch from './edit/SystemEditorSwitch.svelte';
 
@@ -30,11 +32,20 @@
 	let metaDescription = $derived(system.description?.text || `${system.name} — ${SITE_NAME}`);
 	let mode = $derived(resolveDetailSubrouteMode(page.url.pathname));
 	let isDetail = $derived(mode === 'detail');
-	let isEdit = $derived(mode === 'edit');
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
+
+	setEntityContext({
+		get name() {
+			return system.name;
+		},
+		get detailHref() {
+			return resolve(`/systems/${slug}`);
+		}
+	});
 	const isMobileFlag = createIsMobileFlag(LAYOUT_BREAKPOINT);
 	let isMobile = $derived(isMobileFlag.current);
 	let editing = $state<SystemEditSectionKey | null>(null);
-	let syncEnabled = $derived(!isMobile && !isEdit);
+	let syncEnabled = $derived(!isMobile && !isFocusMode);
 	let lastUrlEditing = $state<SystemEditSectionKey | null>(null);
 
 	$effect(() => {
@@ -100,7 +111,7 @@
 
 <MetaTags title={system.name} description={metaDescription} url={page.url.href} />
 
-{#if isEdit}
+{#if isFocusMode}
 	{@render children()}
 {:else}
 	{#snippet actionBar()}

--- a/frontend/src/routes/titles/[slug]/+layout.svelte
+++ b/frontend/src/routes/titles/[slug]/+layout.svelte
@@ -19,6 +19,8 @@
 	import { getMenuItemAction, type EditSectionMenuItem } from '$lib/components/edit-section-menu';
 	import { LAYOUT_BREAKPOINT } from '$lib/constants';
 	import { resolveDetailSubrouteMode } from '$lib/detail-subroute-mode';
+	import { isFocusModePath } from '$lib/focus-mode';
+	import { setEntityContext } from '$lib/entity-context';
 	import {
 		combinedSectionsFor,
 		type CombinedSectionKey
@@ -43,8 +45,17 @@
 	});
 
 	let mode = $derived(resolveDetailSubrouteMode(page.url.pathname));
-	let isEdit = $derived(mode === 'edit');
 	let isDetail = $derived(mode === 'detail');
+	let isFocusMode = $derived(isFocusModePath(page.url.pathname));
+
+	setEntityContext({
+		get name() {
+			return title.name;
+		},
+		get detailHref() {
+			return resolve(`/titles/${slug}`);
+		}
+	});
 
 	// Mobile detection — matches TwoColumnLayout breakpoint (LAYOUT_BREAKPOINT)
 	const isMobileFlag = createIsMobileFlag(LAYOUT_BREAKPOINT);
@@ -82,7 +93,7 @@
 
 	let sections = $derived(combinedSectionsFor(!!md));
 	let editing = $state<CombinedSectionKey | null>(null);
-	let syncEnabled = $derived(!isMobile && !isEdit);
+	let syncEnabled = $derived(!isMobile && !isFocusMode);
 	// Tracks the last URL-derived edit section so local modal state doesn't immediately write it back.
 	let lastUrlEditing = $state<CombinedSectionKey | null>(null);
 
@@ -178,7 +189,7 @@
 	imageAlt={heroImage ? `${title.name} pinball machine` : undefined}
 />
 
-{#if isEdit}
+{#if isFocusMode}
 	{@render children()}
 {:else}
 	{#if title.needs_review}
@@ -186,14 +197,12 @@
 	{/if}
 
 	{#snippet actionBar()}
-		{#if !isEdit}
-			<PageActionBar
-				detailHref={isDetail ? undefined : resolve(`/titles/${slug}`)}
-				editSections={editSectionsForBar}
-				historyHref={resolve(`/titles/${slug}/edit-history`)}
-				sourcesHref={resolve(`/titles/${slug}/sources`)}
-			/>
-		{/if}
+		<PageActionBar
+			detailHref={isDetail ? undefined : resolve(`/titles/${slug}`)}
+			editSections={editSectionsForBar}
+			historyHref={resolve(`/titles/${slug}/edit-history`)}
+			sourcesHref={resolve(`/titles/${slug}/sources`)}
+		/>
 	{/snippet}
 
 	{#snippet main()}
@@ -353,7 +362,7 @@
 		sidebarDesktopOnly={isDetail}
 		{actionBar}
 		{main}
-		sidebar={isEdit ? undefined : sidebar}
+		{sidebar}
 	/>
 
 	<SectionEditorHost bind:editingKey={editing} {sections} {switcherItems}>

--- a/frontend/src/routes/titles/[slug]/edit-history/edit-history-page.test-harness.svelte
+++ b/frontend/src/routes/titles/[slug]/edit-history/edit-history-page.test-harness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Page from './+page.svelte';
+	import { setEntityContext } from '$lib/entity-context';
+
+	let { data } = $props();
+
+	setEntityContext({
+		name: 'Medieval Madness',
+		detailHref: '/titles/medieval-madness'
+	});
+</script>
+
+<Page {data} />

--- a/frontend/src/routes/titles/[slug]/edit-history/edit-history-page.test.ts
+++ b/frontend/src/routes/titles/[slug]/edit-history/edit-history-page.test.ts
@@ -1,0 +1,18 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import Harness from './edit-history-page.test-harness.svelte';
+
+describe('title edit-history page', () => {
+	it('wraps EditHistory in FocusContentShell with back link to detail and an Edit History heading', () => {
+		const { body } = render(Harness, {
+			props: { data: { changesets: [] } }
+		});
+
+		expect(body).toContain('href="/titles/medieval-madness"');
+		expect(body).toContain('Back');
+		expect(body).toContain('<h1>Edit History</h1>');
+		// EditHistory empty-state passes through.
+		expect(body.toLowerCase()).toContain('no edit history yet');
+	});
+});

--- a/frontend/src/routes/titles/[slug]/sources/sources-page.test-harness.svelte
+++ b/frontend/src/routes/titles/[slug]/sources/sources-page.test-harness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Page from './+page.svelte';
+	import { setEntityContext } from '$lib/entity-context';
+
+	let { data } = $props();
+
+	setEntityContext({
+		name: 'Medieval Madness',
+		detailHref: '/titles/medieval-madness'
+	});
+</script>
+
+<Page {data} />

--- a/frontend/src/routes/titles/[slug]/sources/sources-page.test.ts
+++ b/frontend/src/routes/titles/[slug]/sources/sources-page.test.ts
@@ -1,0 +1,18 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import Harness from './sources-page.test-harness.svelte';
+
+describe('title sources page', () => {
+	it('wraps EntitySources in FocusContentShell with back link to detail and a Sources heading', () => {
+		const { body } = render(Harness, {
+			props: { data: { sources: [], evidence: [] } }
+		});
+
+		expect(body).toContain('href="/titles/medieval-madness"');
+		expect(body).toContain('Back');
+		expect(body).toContain('<h1>Sources</h1>');
+		// EntitySources empty-state passes through.
+		expect(body.toLowerCase()).toContain('no source data recorded yet');
+	});
+});

--- a/frontend/src/routes/titles/[slug]/title-layout.test.ts
+++ b/frontend/src/routes/titles/[slug]/title-layout.test.ts
@@ -72,15 +72,29 @@ describe('title layout', () => {
 		expect(body).not.toContain('>Back<');
 	});
 
-	it('renders a Back link on sources subroutes', () => {
+	it('strips the detail shell on sources subroutes (focus mode)', () => {
 		pageState.url = new URL('http://localhost:5173/titles/medieval-madness/sources');
 
 		const { body } = render(Harness, {
 			props: { data: { title: MOCK_TITLE } }
 		});
 
-		expect(body).toContain('>Back<');
-		expect(body).toContain('/titles/medieval-madness');
+		// Layout renders only the child in focus mode; chrome is gone.
+		expect(body).toContain('Child content');
+		expect(body).not.toContain('History');
+		expect(body).not.toContain('Sources');
+		expect(body).not.toContain('Edit');
+	});
+
+	it('strips the detail shell on edit-history subroutes (focus mode)', () => {
+		pageState.url = new URL('http://localhost:5173/titles/medieval-madness/edit-history');
+
+		const { body } = render(Harness, {
+			props: { data: { title: MOCK_TITLE } }
+		});
+
+		expect(body).toContain('Child content');
+		expect(body).not.toContain('History');
 	});
 
 	it('renders direct edit links on editable title sidebar sections when authenticated', () => {


### PR DESCRIPTION
## Summary

The audit routes `/:entity/[slug]/edit-history` and `/:entity/[slug]/sources` now render with minimal chrome — back link + heading + content — instead of the full detail shell, per [docs/plans/HistorySourcesUX.md](docs/plans/HistorySourcesUX.md).

- Extract `FocusContentShell` from `EditSectionShell`; `EditSectionShell` now delegates to it. `EntitySources` and `EditHistory` self-frame in the shell.
- Expose entity name + detail href via a Svelte context (`entity-context.ts`) so audit page templates don't couple to per-entity data-key variations.
- Unify the entity-layout shell gate from `isEdit` to `isFocusMode`. Extend `isFocusModePath` to cover `edit-history` and `sources` with proper slug-guards.
- Factor the slug-guard into a shared `matchDetailSubroute` helper used by both `isFocusModePath` and `resolveDetailSubrouteMode` so they can't drift. Fixes a pre-existing bug where `/titles/sources` (slug='sources') misclassified as `mode='sources'`.
- Gate URL-sync effect with `!isFocusMode` so audit routes skip it entirely.

## Test plan

- [ ] `/titles/medieval-madness/edit-history`: no hero, no sidebar, no site nav. Back link + "Edit History" heading + changeset list.
- [ ] `/titles/medieval-madness/sources`: same shape, "Sources" heading.
- [ ] `/manufacturers/williams/edit-history` and `/manufacturers/williams/sources`: same pattern.
- [ ] `/cabinets/standard-body/edit-history` (taxonomy representative): same pattern.
- [ ] Back link returns to the detail route with full chrome restored.
- [ ] `/titles/medieval-madness/edit` still focus-mode (no regression from gate unification).
- [ ] `/titles/medieval-madness` still renders `RecordDetailShell` with sidebar and action bar.
- [ ] Deep-link `/titles/medieval-madness/sources` directly — SSR returns focus view from first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)