### PR TITLE
refactor(backend): NamedTuples and tighter types in typed modules

### DIFF
--- a/backend/apps/catalog/_alias_registry.py
+++ b/backend/apps/catalog/_alias_registry.py
@@ -7,20 +7,28 @@ creating circular dependencies — it only touches ``core.models.AliasBase``.
 from __future__ import annotations
 
 import functools
+from typing import NamedTuple
 
 from django.db import models
 
 
+class AliasType(NamedTuple):
+    """A discovered ``AliasBase`` subclass and the claim field that holds its aliases."""
+
+    parent_model: type[models.Model]
+    claim_field: str
+
+
 @functools.lru_cache(maxsize=1)
-def discover_alias_types() -> tuple[tuple[type[models.Model], str], ...]:
-    """Return ``((parent_model, claim_field_name), ...)`` for every AliasBase subclass.
+def discover_alias_types() -> tuple[AliasType, ...]:
+    """Return an ``AliasType`` per ``AliasBase`` subclass.
 
     Must be called after Django's app registry is ready (i.e. not at import
     time).  Results are cached after the first call.
     """
     from apps.core.models import AliasBase
 
-    result: list[tuple[type[models.Model], str]] = []
+    result: list[AliasType] = []
     for alias_cls in AliasBase.__subclasses__():
         # Each AliasBase subclass has exactly one FK to its parent model.
         fks = [
@@ -39,6 +47,6 @@ def discover_alias_types() -> tuple[tuple[type[models.Model], str], ...]:
         if verbose_name is None:
             raise RuntimeError(f"{alias_cls.__name__} parent model has no verbose_name")
         claim_field = f"{verbose_name.replace(' ', '_')}_alias"
-        result.append((parent_model, claim_field))
+        result.append(AliasType(parent_model, claim_field))
 
-    return tuple(sorted(result, key=lambda pair: pair[1]))
+    return tuple(sorted(result, key=lambda at: at.claim_field))

--- a/backend/apps/catalog/claims.py
+++ b/backend/apps/catalog/claims.py
@@ -93,8 +93,8 @@ def _get_literal_schemas() -> dict[str, LiteralKey]:
         from ._alias_registry import discover_alias_types
 
         _literal_schemas = {"abbreviation": LiteralKey("value", "value")}
-        for _model, claim_field in discover_alias_types():
-            _literal_schemas[claim_field] = LiteralKey("alias_value", "alias")
+        for at in discover_alias_types():
+            _literal_schemas[at.claim_field] = LiteralKey("alias_value", "alias")
     return _literal_schemas
 
 

--- a/backend/apps/catalog/ingestion/parsers.py
+++ b/backend/apps/catalog/ingestion/parsers.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from apps.catalog.models import Location
 
 
 def parse_ipdb_date(s: str | None) -> tuple[int | None, int | None]:
@@ -263,7 +266,7 @@ def parse_ipdb_location(location: str) -> dict[str, str]:
     return _normalize_location({"city": "", "state": "", "country": parts[0]})
 
 
-def _get_location_root(loc: Any) -> Any:
+def _get_location_root(loc: Location) -> Location:
     """Walk the parent chain to find the root (country) Location."""
     while loc.parent is not None:
         loc = loc.parent

--- a/backend/apps/catalog/management/commands/export_catalog_meta.py
+++ b/backend/apps/catalog/management/commands/export_catalog_meta.py
@@ -14,8 +14,9 @@ Run via ``make api-gen`` or directly::
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -23,18 +24,27 @@ from django.core.management.base import BaseCommand
 from apps.core.models import LinkableModel
 
 
+class CatalogEntry(NamedTuple):
+    entity_type: str
+    entity_type_plural: str
+    label: str
+    label_plural: str
+
+
 class Command(BaseCommand):
     help = "Generate frontend/src/lib/api/catalog-meta.ts from linkable models."
 
     def handle(self, **options: Any) -> None:
-        catalog_meta: list[tuple[str, str, str, str]] = []
+        catalog_meta: list[CatalogEntry] = []
         media_categories: dict[str, list[str]] = {}
 
-        for cls in _iter_concrete_subclasses(LinkableModel):
+        for cls in _iter_concrete_subclasses(LinkableModel):  # type: ignore[type-abstract]
             key = cls.entity_type
             label = str(cls._meta.verbose_name).title()
             label_plural = str(cls._meta.verbose_name_plural).title()
-            catalog_meta.append((key, cls.entity_type_plural, label, label_plural))
+            catalog_meta.append(
+                CatalogEntry(key, cls.entity_type_plural, label, label_plural)
+            )
             cats = getattr(cls, "MEDIA_CATEGORIES", [])
             if cats:
                 media_categories[key] = list(cats)
@@ -47,12 +57,12 @@ class Command(BaseCommand):
             "",
             "export const CATALOG_META = {",
         ]
-        for key, plural, label, label_plural in catalog_meta:
-            lines.append(f"\t'{key}': {{")
-            lines.append(f"\t\tentity_type: '{key}',")
-            lines.append(f"\t\tentity_type_plural: '{plural}',")
-            lines.append(f"\t\tlabel: '{label}',")
-            lines.append(f"\t\tlabel_plural: '{label_plural}',")
+        for entry in catalog_meta:
+            lines.append(f"\t'{entry.entity_type}': {{")
+            lines.append(f"\t\tentity_type: '{entry.entity_type}',")
+            lines.append(f"\t\tentity_type_plural: '{entry.entity_type_plural}',")
+            lines.append(f"\t\tlabel: '{entry.label}',")
+            lines.append(f"\t\tlabel_plural: '{entry.label_plural}',")
             lines.append("\t},")
         lines.append("} as const;")
         lines.append("")
@@ -72,10 +82,11 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(f"Wrote {output_path}"))
 
 
-def _iter_concrete_subclasses(root: type[Any]) -> Any:
+def _iter_concrete_subclasses(
+    root: type[LinkableModel],
+) -> Iterator[type[LinkableModel]]:
     for cls in root.__subclasses__():
         yield from _iter_concrete_subclasses(cls)
-        meta = getattr(cls, "_meta", None)
-        if meta is None or meta.abstract:
+        if cls._meta.abstract:
             continue
         yield cls

--- a/backend/apps/catalog/management/commands/pull_ingest_sources.py
+++ b/backend/apps/catalog/management/commands/pull_ingest_sources.py
@@ -20,11 +20,12 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import http.client
 import json
 import os
 import tempfile
 import urllib.request
-from typing import Any
+from typing import Any, cast
 from urllib.error import HTTPError
 
 from django.core.management.base import BaseCommand
@@ -50,8 +51,10 @@ _MANIFESTS = [
 ]
 
 
-def _urlopen(url: str) -> Any:
-    return _OPENER.open(url)
+def _urlopen(url: str) -> http.client.HTTPResponse:
+    # OpenerDirector.open() is typed as Any in typeshed; the concrete return for
+    # http/https URLs is an HTTPResponse.
+    return cast(http.client.HTTPResponse, _OPENER.open(url))
 
 
 def _sha256(path: str) -> str:

--- a/backend/apps/catalog/resolve/_dispatch.py
+++ b/backend/apps/catalog/resolve/_dispatch.py
@@ -34,7 +34,7 @@ def _get_alias_dispatch() -> dict[str, type]:
     global _alias_dispatch
     if _alias_dispatch is None:
         _alias_dispatch = {
-            field_name: model for model, field_name in discover_alias_types()
+            at.claim_field: at.parent_model for at in discover_alias_types()
         }
     return _alias_dispatch
 

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 from apps.provenance.models import Claim
 
-from .._alias_registry import discover_alias_types
+from .._alias_registry import AliasType, discover_alias_types
 from ..models import (
     CorporateEntity,
     CorporateEntityLocation,
@@ -672,7 +672,7 @@ def _resolve_aliases(
 # registry is guaranteed to be ready.  ``ALIAS_TYPES`` is kept as a public
 # binding (same shape as before) so that existing callers — including the
 # test suite — continue to work.
-ALIAS_TYPES: list[tuple[type, str]] = list(discover_alias_types())
+ALIAS_TYPES: list[AliasType] = list(discover_alias_types())
 
 
 def resolve_theme_aliases() -> None:

--- a/backend/apps/provenance/admin.py
+++ b/backend/apps/provenance/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Model
 from django.http import HttpRequest
 
 from .models import (
@@ -9,6 +10,23 @@ from .models import (
     Source,
     SourceFieldLicense,
 )
+
+
+class ReadOnlyAdminMixin:
+    """Disallow add / change / delete so the admin is view-only."""
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        return False
+
+    def has_change_permission(
+        self, request: HttpRequest, obj: Model | None = None
+    ) -> bool:
+        return False
+
+    def has_delete_permission(
+        self, request: HttpRequest, obj: Model | None = None
+    ) -> bool:
+        return False
 
 
 class SourceFieldLicenseInline(admin.TabularInline[SourceFieldLicense, Source]):
@@ -34,7 +52,7 @@ class SourceAdmin(admin.ModelAdmin[Source]):
 
 
 @admin.register(IngestRun)
-class IngestRunAdmin(admin.ModelAdmin[IngestRun]):
+class IngestRunAdmin(ReadOnlyAdminMixin, admin.ModelAdmin[IngestRun]):
     """Read-only inspection view. IngestRun records are created by the apply layer."""
 
     list_display = ("pk", "source", "status", "started_at", "finished_at")
@@ -55,23 +73,6 @@ class IngestRunAdmin(admin.ModelAdmin[IngestRun]):
         "errors",
     )
 
-    def has_add_permission(self, request: HttpRequest) -> bool:
-        return False
-
-    def has_change_permission(
-        self,
-        request: HttpRequest,
-        obj: IngestRun | None = None,
-    ) -> bool:
-        return False
-
-    def has_delete_permission(
-        self,
-        request: HttpRequest,
-        obj: IngestRun | None = None,
-    ) -> bool:
-        return False
-
 
 @admin.register(ChangeSet)
 class ChangeSetAdmin(admin.ModelAdmin[ChangeSet]):
@@ -87,7 +88,7 @@ class ChangeSetAdmin(admin.ModelAdmin[ChangeSet]):
 
 
 @admin.register(Claim)
-class ClaimAdmin(admin.ModelAdmin[Claim]):
+class ClaimAdmin(ReadOnlyAdminMixin, admin.ModelAdmin[Claim]):
     """Read-only inspection view. Claims must not be created or edited in admin."""
 
     list_display = (
@@ -109,26 +110,9 @@ class ClaimAdmin(admin.ModelAdmin[Claim]):
             return s[:80] + "..."
         return s
 
-    def has_add_permission(self, request: HttpRequest) -> bool:
-        return False
-
-    def has_change_permission(
-        self,
-        request: HttpRequest,
-        obj: Claim | None = None,
-    ) -> bool:
-        return False
-
-    def has_delete_permission(
-        self,
-        request: HttpRequest,
-        obj: Claim | None = None,
-    ) -> bool:
-        return False
-
 
 @admin.register(CitationInstance)
-class CitationInstanceAdmin(admin.ModelAdmin[CitationInstance]):
+class CitationInstanceAdmin(ReadOnlyAdminMixin, admin.ModelAdmin[CitationInstance]):
     """Read-only inspection view. CitationInstances are immutable."""
 
     list_display = ("citation_source", "claim", "locator_truncated", "created_at")
@@ -140,20 +124,3 @@ class CitationInstanceAdmin(admin.ModelAdmin[CitationInstance]):
         if len(obj.locator) > 60:
             return obj.locator[:60] + "..."
         return obj.locator
-
-    def has_add_permission(self, request: HttpRequest) -> bool:
-        return False
-
-    def has_change_permission(
-        self,
-        request: HttpRequest,
-        obj: CitationInstance | None = None,
-    ) -> bool:
-        return False
-
-    def has_delete_permission(
-        self,
-        request: HttpRequest,
-        obj: CitationInstance | None = None,
-    ) -> bool:
-        return False

--- a/backend/apps/provenance/rate_limits.py
+++ b/backend/apps/provenance/rate_limits.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 import math
 import time
 from dataclasses import dataclass
-from typing import Any
 
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.core.cache import cache
 
 from .constants import (
@@ -77,14 +77,16 @@ def _cache_key(user_id: int, bucket: str) -> str:
     return f"ratelimit:{bucket}:user:{user_id}"
 
 
-def check_and_record(user: Any, spec: RateLimitSpec) -> None:
+def check_and_record(
+    user: AbstractBaseUser | AnonymousUser | None, spec: RateLimitSpec
+) -> None:
     """Consume one slot in the user's bucket, or raise if the bucket is full.
 
     Staff users bypass the check entirely and nothing is recorded for them.
     """
     if user is None or not user.is_authenticated:
         raise RateLimitExceededError(bucket=spec.bucket, retry_after=1)
-    if user.is_staff:
+    if getattr(user, "is_staff", False):
         return
 
     now = time.time()
@@ -104,6 +106,6 @@ def check_and_record(user: Any, spec: RateLimitSpec) -> None:
     cache.set(key, pruned, timeout=spec.window_seconds + _CACHE_TTL_FUDGE_SECONDS)
 
 
-def reset_for_user(user: Any, bucket: str) -> None:
+def reset_for_user(user: AbstractBaseUser, bucket: str) -> None:
     """Test helper: clear a user's bucket."""
     cache.delete(_cache_key(user.pk, bucket))

--- a/backend/apps/provenance/tests/test_rate_limits.py
+++ b/backend/apps/provenance/tests/test_rate_limits.py
@@ -127,12 +127,10 @@ class TestRateLimits:
             reset_for_user(other, SPEC.bucket)
 
     def test_anonymous_raises(self):
-        class Anon:
-            is_authenticated = False
-            is_staff = False
+        from django.contrib.auth.models import AnonymousUser
 
         with pytest.raises(RateLimitExceededError):
-            check_and_record(Anon(), SPEC)
+            check_and_record(AnonymousUser(), SPEC)
 
 
 class TestBucketConfig:


### PR DESCRIPTION
## Summary

Follow-ups from review of the recent type-annotation commits (3bdf073f, c39d755d, a2902577):

- **NamedTuples** replace opaque positional tuples where the review flagged readability concerns:
  - `AliasType(parent_model, claim_field)` in `catalog/_alias_registry.py` — replaces `tuple[tuple[type, str], ...]` used by four call sites (`claims.py`, `resolve/_dispatch.py`, `resolve/_relationships.py`).
  - `CatalogEntry` in `export_catalog_meta.py` — replaces `list[tuple[str, str, str, str]]` where four positional strings were being packed and unpacked across 20 lines.
- **Real types in place of `Any`:**
  - `_iter_concrete_subclasses` now returns `Iterator[type[LinkableModel]]`.
  - `_urlopen` returns `http.client.HTTPResponse` (via `cast`, since `OpenerDirector.open()` is typed as `Any` in typeshed).
  - `_get_location_root` takes and returns `Location`.
  - Rate-limit helpers accept `AbstractBaseUser | AnonymousUser | None` / `AbstractBaseUser` instead of `Any`; the one duck-typed test was updated to use `AnonymousUser`.
- **`ReadOnlyAdminMixin`** in `provenance/admin.py` — consolidates the `has_add/change/delete_permission` trio that was duplicated across three admin classes (~18 lines removed).

## Test plan

- [x] `ruff check` clean
- [x] `mypy` via `mypy-baseline filter` — no new errors introduced
- [x] Full backend pytest: 2200 passed, 1 skipped
- [x] `python manage.py export_catalog_meta` produces identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)