### PR TITLE
Promote EntityKey to NamedTuple in apps/core/types

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import secrets
 from datetime import datetime
-from typing import Protocol
+from typing import Protocol, TypedDict
 
 from django.conf import settings
 from django.contrib.auth import get_user_model, login, logout
@@ -22,11 +22,8 @@ from django.shortcuts import get_object_or_404
 from django.utils.http import url_has_allowed_host_and_scheme
 from ninja import Router, Schema
 
-from apps.provenance.entity_resolution import (
-    EntityKey,
-    EntityRef,
-    batch_resolve_entities,
-)
+from apps.core.types import EntityKey
+from apps.provenance.entity_resolution import batch_resolve_entities
 from apps.provenance.models import ChangeSet, Claim
 
 from .models import UserProfile
@@ -86,7 +83,9 @@ class WorkOSUser(Protocol):
     last_name: str | None
 
 
-class EntityContributionRow(EntityRef):
+class EntityContributionRow(TypedDict):
+    content_type_id: int
+    object_id: int
     edit_count: int
     last_edited_at: datetime
 
@@ -265,8 +264,7 @@ def user_profile_page(request: HttpRequest, username: str) -> UserProfileSchema:
     entity_rows: list[EntityContributionRow] = []
     for row in raw_entity_rows:
         last_edited_at = row["last_edited_at"]
-        if not isinstance(last_edited_at, datetime):
-            continue
+        assert isinstance(last_edited_at, datetime)
         entity_rows.append(
             {
                 "content_type_id": int(row["content_type_id"]),
@@ -276,11 +274,13 @@ def user_profile_page(request: HttpRequest, username: str) -> UserProfileSchema:
             }
         )
 
-    resolved = batch_resolve_entities(entity_rows)
+    resolved = batch_resolve_entities(
+        [EntityKey(row["content_type_id"], row["object_id"]) for row in entity_rows]
+    )
 
     entities_edited: list[EntityContributionSchema] = []
     for row in entity_rows:
-        meta = resolved.get((row["content_type_id"], row["object_id"]))
+        meta = resolved.get(EntityKey(row["content_type_id"], row["object_id"]))
         if not meta:
             continue
         entities_edited.append(
@@ -299,18 +299,18 @@ def user_profile_page(request: HttpRequest, username: str) -> UserProfileSchema:
         .order_by("-created_at")[:50]
     )
 
-    cs_entity_refs: list[EntityRef] = []
+    cs_entity_keys: list[EntityKey] = []
     cs_first_claim: dict[int, EntityKey] = {}
     for cs in recent_changesets:
         prefetched_claims = cs.claims.all()
         if prefetched_claims:
             c = prefetched_claims[0]
             assert cs.pk is not None
-            key = (c.content_type_id, c.object_id)
+            key = EntityKey(c.content_type_id, c.object_id)
             cs_first_claim[cs.pk] = key
-            cs_entity_refs.append({"content_type_id": key[0], "object_id": key[1]})
+            cs_entity_keys.append(key)
 
-    cs_resolved = batch_resolve_entities(cs_entity_refs)
+    cs_resolved = batch_resolve_entities(cs_entity_keys)
 
     recent_edits: list[UserChangeSetSchema] = []
     for cs in recent_changesets:

--- a/backend/apps/core/types.py
+++ b/backend/apps/core/types.py
@@ -1,0 +1,16 @@
+"""Cross-app shared types."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class EntityKey(NamedTuple):
+    """Hashable reference to a catalog entity via content-type + object id.
+
+    Used both as a dict key and as the input shape for helpers that fan out
+    across content types (e.g. ``batch_resolve_entities``).
+    """
+
+    content_type_id: int
+    object_id: int

--- a/backend/apps/provenance/entity_resolution.py
+++ b/backend/apps/provenance/entity_resolution.py
@@ -12,19 +12,13 @@ from typing import TypedDict
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
-
-class EntityRef(TypedDict):
-    content_type_id: int
-    object_id: int
+from apps.core.types import EntityKey
 
 
 class ResolvedEntityMeta(TypedDict):
     href: str
     name: str
     type_label: str
-
-
-type EntityKey = tuple[int, int]
 
 
 def resolve_entity_href(
@@ -39,18 +33,17 @@ def resolve_entity_href(
 
 
 def batch_resolve_entities(
-    entity_rows: Sequence[EntityRef],
+    entity_keys: Sequence[EntityKey],
 ) -> dict[EntityKey, ResolvedEntityMeta]:
-    """Resolve entity metadata from (content_type_id, object_id) pairs.
+    """Resolve entity metadata from a sequence of ``EntityKey`` refs.
 
-    Returns a dict mapping (content_type_id, object_id) to
-    {"href": str, "name": str, "type_label": str}, skipping unresolvable
-    entities.
+    Returns a dict mapping each ``EntityKey`` to its resolved metadata,
+    skipping entries whose content type or object cannot be resolved.
     """
     # Group by content_type_id, deduplicating object_ids
     by_ct: dict[int, set[int]] = defaultdict(set)
-    for row in entity_rows:
-        by_ct[row["content_type_id"]].add(row["object_id"])
+    for key in entity_keys:
+        by_ct[key.content_type_id].add(key.object_id)
 
     resolved: dict[EntityKey, ResolvedEntityMeta] = {}
     for ct_id, obj_ids in by_ct.items():
@@ -65,7 +58,7 @@ def batch_resolve_entities(
             if href is None:
                 continue
             name = getattr(entity, "name", None)
-            resolved[(ct_id, obj_id)] = {
+            resolved[EntityKey(ct_id, obj_id)] = {
                 "href": href,
                 "name": name if isinstance(name, str) else str(entity),
                 "type_label": type_label,

--- a/backend/apps/provenance/page_endpoints.py
+++ b/backend/apps/provenance/page_endpoints.py
@@ -23,8 +23,9 @@ from ninja.decorators import decorate_view
 from ninja.responses import Status
 
 from apps.core.entity_types import get_linkable_model
+from apps.core.types import EntityKey
 
-from .entity_resolution import EntityKey, EntityRef, batch_resolve_entities
+from .entity_resolution import batch_resolve_entities
 from .evidence import build_cited_changesets
 from .helpers import active_claims, build_sources, claims_prefetch
 from .history import build_edit_history
@@ -254,7 +255,7 @@ def list_changes(
     changesets, next_cursor = cursor_paginate(qs, cursor, limit)
 
     # Batch-resolve entity metadata.
-    entity_refs: list[EntityRef] = []
+    entity_keys: list[EntityKey] = []
     cs_entity_map: dict[int, EntityKey] = {}
     for cs in changesets:
         claims = cs.claims.all()
@@ -262,11 +263,11 @@ def list_changes(
         first = next(iter(claims), None) or next(iter(retracted), None)
         if first:
             assert cs.pk is not None
-            key = (first.content_type_id, first.object_id)
+            key = EntityKey(first.content_type_id, first.object_id)
             cs_entity_map[cs.pk] = key
-            entity_refs.append({"content_type_id": key[0], "object_id": key[1]})
+            entity_keys.append(key)
 
-    resolved = batch_resolve_entities(entity_refs)
+    resolved = batch_resolve_entities(entity_keys)
 
     items: list[ChangeSetSummarySchema] = []
     for cs in changesets:
@@ -330,9 +331,9 @@ def change_detail(
     obj_id = first.object_id
 
     # Resolve entity metadata.
-    entity_refs: list[EntityRef] = [{"content_type_id": ct_id, "object_id": obj_id}]
-    meta_map = batch_resolve_entities(entity_refs)
-    meta = meta_map.get((ct_id, obj_id))
+    entity_key = EntityKey(ct_id, obj_id)
+    meta_map = batch_resolve_entities([entity_key])
+    meta = meta_map.get(entity_key)
     if not meta:
         return Status(404, {"detail": "Entity no longer exists."})
 


### PR DESCRIPTION
## Summary

Follow-up to 9cb68e0e (accounts type-coverage PR). Per [TypeFixing.md](docs/plans/TypeFixing.md) smell #5, the `tuple[int, int]` shape used for `(content_type_id, object_id)` across apps is the plan's canonical repeated-shape case that warrants a NamedTuple in `apps/core/types.py`. The previous PR used a bare `type EntityKey = tuple[int, int]` alias, which cured the signature but left callers doing positional `key[0]` / `key[1]` access — exactly the label-less-tuple smell the plan targets.

- Introduce `apps/core/types.EntityKey` as the shared NamedTuple (fields: `content_type_id`, `object_id`). This is the home the plan prescribes for cross-app shapes; future chunks import from here rather than redefining.
- Drop the `EntityRef` TypedDict from `apps/provenance/entity_resolution.py`. `EntityKey` doubles as hashable dict key *and* input shape, so `batch_resolve_entities` takes `Sequence[EntityKey]` and returns `dict[EntityKey, ResolvedEntityMeta]` — one type, not two.
- Migrate the two existing callers (`apps/accounts/api.py`, `apps/provenance/page_endpoints.py`) to construct `EntityKey(...)` and do attribute access.
- Tighten a silent `continue` in `user_profile_page`: the aggregate `Max("changeset__created_at")` can't produce a non-`datetime` given the query's filters, so an `assert` documents the invariant instead of swallowing hypothetical rows.

Other `tuple[int, int]` occurrences in catalog/provenance (in `revert.py`, `models/claim.py`, `ingestion/apply.py`, `resolve/`) are left for their own chunk sessions per the plan's spillover rule — they don't flow through `batch_resolve_entities`.

## Test plan

- [x] `uv run ruff check apps/` clean
- [x] `uv run pytest` — 2208 passed, 1 skipped
- [x] No new mypy errors in touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)