### PR TITLE
refactor(citation): tighten types per TypeFixing plan

### DIFF
--- a/backend/apps/citation/admin.py
+++ b/backend/apps/citation/admin.py
@@ -1,6 +1,5 @@
-from typing import Any, cast
-
 from django.contrib import admin
+from django.forms import BaseInlineFormSet, ModelForm
 from django.http import HttpRequest
 
 from .models import CitationSource, CitationSourceLink
@@ -41,11 +40,11 @@ class CitationSourceAdmin(admin.ModelAdmin[CitationSource]):
         self,
         request: HttpRequest,
         obj: CitationSource,
-        form: Any,
+        form: ModelForm[CitationSource],
         change: bool,
     ) -> None:
         assert request.user.is_authenticated
-        user = cast(Any, request.user)
+        user = request.user
         if not change:
             obj.created_by = user
         obj.updated_by = user
@@ -54,12 +53,14 @@ class CitationSourceAdmin(admin.ModelAdmin[CitationSource]):
     def save_formset(
         self,
         request: HttpRequest,
-        form: Any,
-        formset: Any,
+        form: ModelForm[CitationSource],
+        formset: BaseInlineFormSet[
+            CitationSourceLink, CitationSource, ModelForm[CitationSourceLink]
+        ],
         change: bool,
     ) -> None:
         assert request.user.is_authenticated
-        user = cast(Any, request.user)
+        user = request.user
         instances = formset.save(commit=False)
         for instance in instances:
             if isinstance(instance, CitationSourceLink):

--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -7,6 +7,7 @@ Auto-discovered via the ``routers`` list convention in config/api.py.
 from __future__ import annotations
 
 from dataclasses import asdict
+from typing import TypedDict, cast
 
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
@@ -19,7 +20,7 @@ from ninja.security import django_auth
 from ninja.throttling import AuthRateThrottle
 from pydantic import field_validator
 
-from .extraction import classify_input, extract_isbn, normalize_isbn
+from .extraction import ExtractionMatch, classify_input, extract_isbn, normalize_isbn
 from .extractors import EXTRACTORS, recognize_url
 from .models import CitationSource, CitationSourceLink
 from .url_extraction import extract_url
@@ -216,6 +217,24 @@ class ExtractResponseSchema(Schema):
     error: str | None = None
     confidence: str = ""
     source_api: str = ""
+
+
+class _ExtractDraftDict(TypedDict):
+    name: str
+    source_type: str
+    author: str
+    publisher: str
+    year: int | None
+    isbn: str | None
+    url: str | None
+
+
+class _ExtractResponseDict(TypedDict, total=False):
+    match: ExtractionMatch
+    draft: _ExtractDraftDict
+    error: str
+    confidence: str
+    source_api: str
 
 
 # ---------------------------------------------------------------------------
@@ -491,11 +510,11 @@ def extract_citation_source(request, data: ExtractRequestSchema):
     else:
         raise HttpError(422, "Unsupported input")
 
-    resp: dict[str, object] = {}
+    resp: _ExtractResponseDict = {}
     if result.match:
         resp["match"] = result.match
     if result.draft:
-        resp["draft"] = asdict(result.draft)
+        resp["draft"] = cast(_ExtractDraftDict, asdict(result.draft))
     if result.error:
         resp["error"] = result.error
     resp["confidence"] = result.confidence

--- a/backend/apps/citation/management/commands/seed_citation_sources.py
+++ b/backend/apps/citation/management/commands/seed_citation_sources.py
@@ -10,7 +10,12 @@ from apps.citation.seeding import ensure_citation_sources
 class Command(BaseCommand):
     help = "Seed citation sources with known pinball reference works."
 
-    def handle(self, *args: Any, **options: Any) -> None:
+    # argparse-driven Django management command surface — framework owns kwargs
+    def handle(
+        self,
+        *args: Any,  # noqa: ANN401
+        **options: Any,  # noqa: ANN401
+    ) -> None:
         counts = ensure_citation_sources()
         self.stdout.write(
             f"Citation sources: {counts['created']} created, "

--- a/backend/apps/citation/safe_fetch.py
+++ b/backend/apps/citation/safe_fetch.py
@@ -15,6 +15,7 @@ import socket
 import ssl
 import time
 from dataclasses import dataclass
+from typing import NamedTuple
 from urllib.parse import urljoin, urlparse
 
 # ---------------------------------------------------------------------------
@@ -36,6 +37,13 @@ class FetchResponse:
     status: int
     headers: dict[str, str]  # lowercased header names
     body: bytes  # already read, capped at max_bytes
+
+
+class _FetchOneResult(NamedTuple):
+    status: int
+    headers: dict[str, str]
+    body: bytes
+    redirect_location: str | None
 
 
 # ---------------------------------------------------------------------------
@@ -92,8 +100,8 @@ def _fetch_one(
     use_tls: bool,
     timeout: float,
     max_bytes: int,
-) -> tuple[int, dict[str, str], bytes, str | None]:
-    """Single HTTP request to *ip*.  Returns (status, headers, body, redirect_location)."""
+) -> _FetchOneResult:
+    """Single HTTP request to *ip*."""
     # Always create a plain HTTPConnection to the resolved IP.
     # For TLS we wrap the socket after connect() — this lets us use
     # server_hostname for SNI/cert validation against the real hostname.
@@ -121,7 +129,7 @@ def _fetch_one(
             if status in (301, 302, 303, 307, 308)
             else None
         )
-        return status, resp_headers, body, redirect
+        return _FetchOneResult(status, resp_headers, body, redirect)
     finally:
         conn.close()
 
@@ -148,7 +156,7 @@ def safe_fetch(url: str, *, timeout: float, max_bytes: int = 65536) -> FetchResp
     deadline = time.monotonic() + timeout
 
     current_url = url
-    last_response: tuple[int, dict[str, str], bytes] | None = None
+    last_response: FetchResponse | None = None
     for _ in range(_MAX_REDIRECTS + 1):
         parsed = urlparse(current_url)
         scheme = parsed.scheme.lower()
@@ -174,7 +182,7 @@ def safe_fetch(url: str, *, timeout: float, max_bytes: int = 65536) -> FetchResp
             raise TimeoutError("wall-clock deadline exceeded")
         hop_timeout = max(remaining, 0.5)
 
-        status, headers, body, redirect_location = _fetch_one(
+        result = _fetch_one(
             ip,
             port,
             hostname,
@@ -183,15 +191,16 @@ def safe_fetch(url: str, *, timeout: float, max_bytes: int = 65536) -> FetchResp
             timeout=hop_timeout,
             max_bytes=max_bytes,
         )
-        last_response = (status, headers, body)
+        last_response = FetchResponse(
+            status=result.status, headers=result.headers, body=result.body
+        )
 
-        if redirect_location is None:
-            return FetchResponse(status=status, headers=headers, body=body)
+        if result.redirect_location is None:
+            return last_response
 
         # Follow redirect — resolve the new URL
-        current_url = urljoin(current_url, redirect_location)
+        current_url = urljoin(current_url, result.redirect_location)
 
     # Exhausted redirect budget — return last response as-is
     assert last_response is not None
-    status, headers, body = last_response
-    return FetchResponse(status=status, headers=headers, body=body)
+    return last_response

--- a/backend/apps/citation/seeding.py
+++ b/backend/apps/citation/seeding.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from django.core.management.base import CommandError
 from django.db import transaction
 
 from apps.citation.seed_data import SEED_SOURCES as _SEED_SOURCES
 from apps.citation.seed_data.types import SeedSource
+
+if TYPE_CHECKING:
+    from apps.citation.models import CitationSource
 
 
 def ensure_citation_sources(
@@ -50,7 +53,7 @@ _SOURCE_FIELDS = frozenset(
 
 def _seed_nodes(
     nodes: list[SeedSource],
-    parent: Any,
+    parent: CitationSource | None,
     counts: dict[str, int],
 ) -> None:
     from apps.citation.models import CitationSource, CitationSourceLink

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -88,7 +88,6 @@ ignore = [
 "**/__init__.py" = ["F401"]  # re-exports from barrel modules are the whole point of __init__.py
 # ANN401 grandfathering
 "apps/catalog/**" = ["ANN401"]
-"apps/citation/**" = ["ANN401"]
 "apps/core/**" = ["ANN401"]
 "apps/provenance/**" = ["ANN401"]
 "config/**" = ["ANN401"]


### PR DESCRIPTION
## Summary

Clears all six type-smell categories from [docs/plans/TypeFixing.md](../blob/main/docs/plans/TypeFixing.md) in `apps/citation/` and ratchets ANN401 so regressions fail CI.

**Structural rewrite (commit 1):** `safe_fetch._fetch_one` now returns a `_FetchOneResult` NamedTuple instead of a 4-positional tuple; the `last_response` local collapses into a `FetchResponse | None`.

**Annotation tightenings + ratchet (commit 2):**
- `admin.py`: `save_model`/`save_formset` now take concrete `ModelForm[...]` and `BaseInlineFormSet[...]` params; dropped `cast(Any, request.user)` since `assert request.user.is_authenticated` already narrows to `User`.
- `seeding.py`: `_seed_nodes(parent=...)` is `CitationSource | None`.
- `seed_citation_sources` command: `**kwargs: Any` / `**args: Any` kept with `# noqa: ANN401` (argparse-driven — framework-owned callback surface, one of the plan's legitimate exceptions).
- `api.py`: `extract` endpoint's response dict is now `_ExtractResponseDict` (TypedDict) instead of `dict[str, object]`.
- `pyproject.toml`: `apps/citation/**` removed from ANN401 grandfathering.

Re-running the Phase 1 smell greps against `backend/apps/citation/` returns the expected floor (only the two explicitly-triaged `noqa: ANN401` kwargs lines).

## Test plan

- [x] `./scripts/lint` (ruff + ruff format + mypy-baseline + frontend lint) passes
- [x] `./scripts/test` — 285 backend tests, 997 frontend tests pass
- [x] Phase 1 greps scoped to `apps/citation/` return only triaged exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)