### PR TITLE
refactor(catalog/api): tighten types per TypeFixing plan

### DIFF
--- a/backend/apps/catalog/api/_typing.py
+++ b/backend/apps/catalog/api/_typing.py
@@ -1,8 +1,8 @@
-"""Typing protocols for dynamic catalog API query shapes."""
+"""Typing protocols and named-tuple shapes for catalog API query plumbing."""
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import NamedTuple, Protocol
 
 
 class HasModelCount(Protocol):
@@ -20,3 +20,29 @@ class HasTitleCount(Protocol):
 
 class HasCreditCount(Protocol):
     credit_count: int
+
+
+class SlugName(NamedTuple):
+    """A (slug, name) pair for a facet ref pulled in bulk from ``values_list``.
+
+    Used throughout list-endpoint assembly where we collect slug+display-name
+    pairs per row (tech generations, themes, gameplay features, etc.) without
+    the overhead of a full Schema instance.
+    """
+
+    slug: str
+    name: str
+
+
+class CreditKey(NamedTuple):
+    """A credit identified by (person_slug, role_slug) — the input-side key."""
+
+    person_slug: str
+    role_slug: str
+
+
+class CreditPkKey(NamedTuple):
+    """A credit identified by (person_pk, role_pk) — the DB-side key."""
+
+    person_pk: int
+    role_pk: int

--- a/backend/apps/catalog/api/edit_claims.py
+++ b/backend/apps/catalog/api/edit_claims.py
@@ -23,6 +23,7 @@ from apps.provenance.schemas import EditCitationInput
 from apps.provenance.validation import validate_claim_value
 
 from ..resolve import resolve_after_mutation
+from ._typing import CreditKey, CreditPkKey
 
 
 @dataclass(frozen=True)
@@ -30,6 +31,9 @@ class ClaimSpec:
     """A planned claim to be written — separates diffing from execution."""
 
     field_name: str
+    # Claim values are intentionally polymorphic (str | int | bool | dict for
+    # relationship claims | None); ``object`` is the accurate type, and
+    # consumers narrow per field_name before persisting.
     value: object
     claim_key: str = ""
 
@@ -575,7 +579,9 @@ def plan_credit_claims(
 
     Raises HttpError 422 on invalid input.
     """
-    raw_desired = [(credit.person_slug, credit.role) for credit in desired_credits]
+    raw_desired = [
+        CreditKey(credit.person_slug, credit.role) for credit in desired_credits
+    ]
 
     if raw_desired:
         desired_person_slugs = {p for p, _ in raw_desired}
@@ -610,26 +616,26 @@ def plan_credit_claims(
                 "slug", "pk"
             )
         )
-        desired_pks: set[tuple[int, int]] = {
-            (person_slug_to_pk[p], role_slug_to_pk[r]) for p, r in desired
+        desired_pks: set[CreditPkKey] = {
+            CreditPkKey(person_slug_to_pk[p], role_slug_to_pk[r]) for p, r in desired
         }
     else:
         desired_pks = set()
 
     # Current state from prefetched credits (by PK).
-    current_pks: set[tuple[int, int]] = set()
+    current_pks: set[CreditPkKey] = set()
     for credit in entity.credits.all():
-        current_pks.add((credit.person_id, credit.role_id))
+        current_pks.add(CreditPkKey(credit.person_id, credit.role_id))
 
     return build_credit_claim_specs(current_pks, desired_pks)
 
 
 def normalize_credit_inputs(
-    desired_credits: list[tuple[str, str]],
+    desired_credits: list[CreditKey],
     *,
     available_people: set[str] | None = None,
     available_roles: set[str] | None = None,
-) -> set[tuple[str, str]]:
+) -> set[CreditKey]:
     """Normalize credits into unique (person_slug, role_slug) pairs.
 
     When available slug sets are provided, unknown people or roles are rejected
@@ -639,9 +645,9 @@ def normalize_credit_inputs(
     can display them inline on the corresponding row.
     """
     errors = ValidationErrors()
-    desired: set[tuple[str, str]] = set()
+    desired: set[CreditKey] = set()
     for person_slug, role in desired_credits:
-        pair = (person_slug, role)
+        pair = CreditKey(person_slug, role)
         if pair in desired:
             errors.add_field(f"credits.{person_slug}:{role}", "Duplicate credit.")
             continue
@@ -672,8 +678,8 @@ def normalize_credit_inputs(
 
 
 def build_credit_claim_specs(
-    current: set[tuple[int, int]],
-    desired: set[tuple[int, int]],
+    current: set[CreditPkKey],
+    desired: set[CreditPkKey],
 ) -> list[ClaimSpec]:
     """Build diff-based ClaimSpecs for credit relationship changes."""
     specs: list[ClaimSpec] = []

--- a/backend/apps/catalog/api/entity_crud.py
+++ b/backend/apps/catalog/api/entity_crud.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from django.db.models import Q
+from django.db.models import Model, Q
 from django.shortcuts import get_object_or_404
 from ninja import Router, Schema
 from ninja.responses import Status
@@ -278,7 +278,7 @@ def register_entity_create(
     serialize_detail: SerializeFn,
     response_schema: type[Schema],
     parent_field: str | None = None,
-    parent_model: Any = None,
+    parent_model: type[Model] | None = None,
     route_suffix: str = "",
     scope_filter_builder: Callable[[Any], Q] | None = None,
     include_deleted_name_check: bool = False,
@@ -369,7 +369,9 @@ def register_entity_create(
         assert parent_model is not None
 
         def _create_parented(request, parent_slug: str, data: TaxonomyCreateSchema):
-            parent = get_object_or_404(parent_model.objects.active(), slug=parent_slug)
+            # django-stubs doesn't expose .objects on abstract type[Model], and
+            # the concrete manager here adds a custom .active() filter.
+            parent = get_object_or_404(parent_model.objects.active(), slug=parent_slug)  # type: ignore[attr-defined]
             return _do_create(request, data, parent=parent)
 
         path = f"/{{parent_slug}}/{route_suffix}/"

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -31,7 +31,7 @@ from ..models import (
     ManufacturerAlias,
     System,
 )
-from ._typing import HasModelCount, HasYearRange
+from ._typing import HasModelCount, HasYearRange, SlugName
 from .constants import DEFAULT_PAGE_SIZE
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
@@ -378,7 +378,7 @@ def list_all_manufacturers(request):
                 mfr_location_refs[mid][path] = name
 
     # Tech generations per manufacturer (via models)
-    mfr_tech_gens: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    mfr_tech_gens: dict[int, list[SlugName]] = defaultdict(list)
     for mfr_id, tg_slug, tg_name in (
         MachineModel.objects.active()
         .filter(
@@ -393,10 +393,10 @@ def list_all_manufacturers(request):
         )
         .distinct()
     ):
-        mfr_tech_gens[mfr_id].append((tg_slug, tg_name))
+        mfr_tech_gens[mfr_id].append(SlugName(tg_slug, tg_name))
 
     # Persons per manufacturer (via model credits)
-    mfr_persons: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    mfr_persons: dict[int, list[SlugName]] = defaultdict(list)
     for mfr_id, p_slug, p_name in (
         Credit.objects.filter(
             model__variant_of__isnull=True,
@@ -409,7 +409,7 @@ def list_all_manufacturers(request):
         )
         .distinct()
     ):
-        mfr_persons[mfr_id].append((p_slug, p_name))
+        mfr_persons[mfr_id].append(SlugName(p_slug, p_name))
 
     # --- Assembly ---
     result = []

--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -17,12 +17,16 @@ class Ref(Schema):
 
 
 class ClaimPatchSchema(Schema):
+    # ``fields`` maps claim-field name → new value. Values are polymorphic per
+    # field (str, int, bool, slug string for FK-backed claims, None) and are
+    # validated downstream by ``validate_claim_value``; no fixed TypedDict.
     fields: dict[str, Any]
     note: str = ""
     citation: EditCitationInput | None = None
 
 
 class HierarchyClaimPatchSchema(Schema):
+    # See ClaimPatchSchema.fields — polymorphic per claim field, validated downstream.
     fields: dict[str, Any] = {}
     parents: list[str] | None = None
     aliases: list[str] | None = None
@@ -31,6 +35,7 @@ class HierarchyClaimPatchSchema(Schema):
 
 
 class CorporateEntityClaimPatchSchema(Schema):
+    # See ClaimPatchSchema.fields — polymorphic per claim field, validated downstream.
     fields: dict[str, Any] = {}
     aliases: list[str] | None = None
     note: str = ""
@@ -48,6 +53,7 @@ class CreditInput(Schema):
 
 
 class ModelClaimPatchSchema(Schema):
+    # See ClaimPatchSchema.fields — polymorphic per claim field, validated downstream.
     fields: dict[str, Any] = {}
     themes: list[str] | None = None
     tags: list[str] | None = None

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -38,6 +38,7 @@ from ..models import (
     Title,
     TitleAbbreviation,
 )
+from ._typing import CreditKey, SlugName
 from .constants import DEFAULT_PAGE_SIZE
 from .edit_claims import (
     ClaimSpec,
@@ -179,6 +180,8 @@ class TitleDetailSchema(Schema):
 
 
 class TitleClaimPatchSchema(Schema):
+    # See schemas.ClaimPatchSchema.fields — polymorphic per claim field,
+    # validated downstream by ``validate_claim_value``.
     fields: dict[str, Any] = {}
     abbreviations: list[str] | None = None
     note: str = ""
@@ -546,11 +549,11 @@ def _serialize_title_detail(title) -> dict:
 
     # Credits that appear on every model (intersection, not union).
     credit_sets = []
-    credit_data: dict[tuple[str, str], dict] = {}
+    credit_data: dict[CreditKey, dict] = {}
     for pm in model_objs:
-        model_keys: set[tuple[str, str]] = set()
+        model_keys: set[CreditKey] = set()
         for c in pm.credits.all():
-            key = (c.person.slug, c.role.slug)
+            key = CreditKey(c.person.slug, c.role.slug)
             model_keys.add(key)
             credit_data.setdefault(key, _serialize_credit(c))
         credit_sets.append(model_keys)
@@ -802,35 +805,35 @@ def list_all_titles(request):
         title_model_map[title_id].append(model_id)
         model_ids.add(model_id)
 
-    model_tech_gen: dict[int, tuple[str, str]] = {}
+    model_tech_gen: dict[int, SlugName] = {}
     for mid, slug, name in model_qs.filter(
         technology_generation__isnull=False
     ).values_list("id", "technology_generation__slug", "technology_generation__name"):
-        model_tech_gen[mid] = (slug, name)
+        model_tech_gen[mid] = SlugName(slug, name)
 
-    model_display: dict[int, tuple[str, str]] = {}
+    model_display: dict[int, SlugName] = {}
     for mid, slug, name in model_qs.filter(display_type__isnull=False).values_list(
         "id", "display_type__slug", "display_type__name"
     ):
-        model_display[mid] = (slug, name)
+        model_display[mid] = SlugName(slug, name)
 
-    model_system: dict[int, tuple[str, str]] = {}
+    model_system: dict[int, SlugName] = {}
     for mid, slug, name in model_qs.filter(system__isnull=False).values_list(
         "id", "system__slug", "system__name"
     ):
-        model_system[mid] = (slug, name)
+        model_system[mid] = SlugName(slug, name)
 
     model_player_count: dict[int, int | None] = {}
     for mid, pc in model_qs.values_list("id", "player_count"):
         model_player_count[mid] = pc
 
-    model_themes: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    model_themes: dict[int, list[SlugName]] = defaultdict(list)
     for mid, slug, name in MachineModel.themes.through.objects.filter(
         machinemodel_id__in=model_ids
     ).values_list("machinemodel_id", "theme__slug", "theme__name"):
-        model_themes[mid].append((slug, name))
+        model_themes[mid].append(SlugName(slug, name))
 
-    model_gf: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    model_gf: dict[int, list[SlugName]] = defaultdict(list)
     for mid, slug, name in MachineModel.gameplay_features.through.objects.filter(
         machinemodel_id__in=model_ids
     ).values_list(
@@ -838,19 +841,19 @@ def list_all_titles(request):
         "gameplayfeature__slug",
         "gameplayfeature__name",
     ):
-        model_gf[mid].append((slug, name))
+        model_gf[mid].append(SlugName(slug, name))
 
-    model_rt: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    model_rt: dict[int, list[SlugName]] = defaultdict(list)
     for mid, slug, name in MachineModel.reward_types.through.objects.filter(
         machinemodel_id__in=model_ids
     ).values_list("machinemodel_id", "rewardtype__slug", "rewardtype__name"):
-        model_rt[mid].append((slug, name))
+        model_rt[mid].append(SlugName(slug, name))
 
-    model_persons: dict[int, list[tuple[str, str]]] = defaultdict(list)
+    model_persons: dict[int, list[SlugName]] = defaultdict(list)
     for mid, slug, name in Credit.objects.filter(model_id__in=model_ids).values_list(
         "model_id", "person__slug", "person__name"
     ):
-        model_persons[mid].append((slug, name))
+        model_persons[mid].append(SlugName(slug, name))
 
     # --- Assembly ---
     result = []

--- a/backend/apps/catalog/tests/test_edit_claims.py
+++ b/backend/apps/catalog/tests/test_edit_claims.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from apps.catalog.api._typing import CreditKey, CreditPkKey
 from apps.catalog.api.edit_claims import (
     FieldConstraint,
     StructuredValidationError,
@@ -219,7 +220,10 @@ class TestNormalizeCreditInputs:
     def test_rejects_duplicate_pair(self):
         with pytest.raises(StructuredValidationError) as exc_info:
             normalize_credit_inputs(
-                [("pat-lawlor", "design"), ("pat-lawlor", "design")]
+                [
+                    CreditKey("pat-lawlor", "design"),
+                    CreditKey("pat-lawlor", "design"),
+                ]
             )
         assert exc_info.value.field_errors == {
             "credits.pat-lawlor:design": "Duplicate credit.",
@@ -228,7 +232,7 @@ class TestNormalizeCreditInputs:
     def test_rejects_unknown_person(self):
         with pytest.raises(StructuredValidationError) as exc_info:
             normalize_credit_inputs(
-                [("pat-lawlor", "design")],
+                [CreditKey("pat-lawlor", "design")],
                 available_people={"john-youssi"},
                 available_roles={"design"},
             )
@@ -239,7 +243,7 @@ class TestNormalizeCreditInputs:
     def test_rejects_unknown_role(self):
         with pytest.raises(StructuredValidationError) as exc_info:
             normalize_credit_inputs(
-                [("pat-lawlor", "design")],
+                [CreditKey("pat-lawlor", "design")],
                 available_people={"pat-lawlor"},
                 available_roles={"software"},
             )
@@ -250,7 +254,10 @@ class TestNormalizeCreditInputs:
     def test_duplicate_error_not_clobbered_by_unknown_person(self):
         with pytest.raises(StructuredValidationError) as exc_info:
             normalize_credit_inputs(
-                [("pat-lawlor", "design"), ("pat-lawlor", "design")],
+                [
+                    CreditKey("pat-lawlor", "design"),
+                    CreditKey("pat-lawlor", "design"),
+                ],
                 available_people={"john-youssi"},
                 available_roles={"design"},
             )
@@ -260,21 +267,24 @@ class TestNormalizeCreditInputs:
 
     def test_allows_same_person_with_different_roles(self):
         desired = normalize_credit_inputs(
-            [("pat-lawlor", "design"), ("pat-lawlor", "software")],
+            [
+                CreditKey("pat-lawlor", "design"),
+                CreditKey("pat-lawlor", "software"),
+            ],
             available_people={"pat-lawlor"},
             available_roles={"design", "software"},
         )
         assert desired == {
-            ("pat-lawlor", "design"),
-            ("pat-lawlor", "software"),
+            CreditKey("pat-lawlor", "design"),
+            CreditKey("pat-lawlor", "software"),
         }
 
 
 class TestBuildCreditClaimSpecs:
     def test_builds_add_and_remove_specs(self):
         specs = build_credit_claim_specs(
-            current={(100, 200)},
-            desired={(101, 201)},
+            current={CreditPkKey(100, 200)},
+            desired={CreditPkKey(101, 201)},
         )
         by_key = {spec.claim_key: spec for spec in specs}
         assert set(by_key) == {
@@ -286,8 +296,8 @@ class TestBuildCreditClaimSpecs:
 
     def test_skips_unchanged_specs(self):
         specs = build_credit_claim_specs(
-            current={(101, 201)},
-            desired={(101, 201)},
+            current={CreditPkKey(101, 201)},
+            desired={CreditPkKey(101, 201)},
         )
         assert specs == []
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -87,7 +87,12 @@ ignore = [
 "scripts/*.py" = ["T201"]
 "**/__init__.py" = ["F401"]  # re-exports from barrel modules are the whole point of __init__.py
 # ANN401 grandfathering
-"apps/catalog/**" = ["ANN401"]
+"apps/catalog/apps.py" = ["ANN401"]
+"apps/catalog/signals.py" = ["ANN401"]
+"apps/catalog/ingestion/**" = ["ANN401"]
+"apps/catalog/management/**" = ["ANN401"]
+"apps/catalog/resolve/**" = ["ANN401"]
+"apps/catalog/tests/**" = ["ANN401"]  # tests stay grandfathered; source is clean
 "apps/provenance/**" = ["ANN401"]
 "config/**" = ["ANN401"]
 


### PR DESCRIPTION
## Summary

First chunk of the catalog app for the [TypeFixing](docs/plans/TypeFixing.md) process — pilot on `apps/catalog/api/` since the full app exceeded the ~60-item size threshold.

- **Smell #4/#5 (structural):** introduced `SlugName`, `CreditKey`, `CreditPkKey` in [apps/catalog/api/_typing.py](backend/apps/catalog/api/_typing.py) and migrated 20 call sites across `manufacturers.py`, `titles.py`, `edit_claims.py`, plus test callers in `tests/test_edit_claims.py`. Replaces `tuple[str, str]` / `tuple[int, int]` positional access with named-field access.
- **Smell #1/#6 (tightenings):** narrowed `register_entity_create.parent_model: Any` → `type[Model] | None` with a scoped `# type: ignore[attr-defined]` on the single `.objects.active()` call (django-stubs limitation). Left `ClaimSpec.value: object` and the four `fields: dict[str, Any]` claim-patch payloads annotated with plain comments — they are intentionally polymorphic and validated per-field downstream.
- **Ratchet:** replaced `apps/catalog/** = ["ANN401"]` with explicit globs for still-dirty subdirs (`ingestion`, `management`, `resolve`, tests, two top-level modules). `apps/catalog/api/` now fails CI on any new `Any` parameter or return.

Skipped (documented in grep pass): `tuple[str, int | None]` ×3 — occurrences split across two semantically distinct meanings (gameplay-feature `(name, count)` vs `(slug, count)`), neither group alone ≥3.

## Test plan

- [x] `make lint` — ruff clean, mypy baseline unchanged (2 preexisting env-only notes)
- [x] `uv run pytest apps/catalog/tests/` — 1367 passed
- [x] `uv run pytest` — 2208 passed
- [x] Scoped smell greps against `apps/catalog/api/` return zero unexplained hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)