### PR TITLE
Tighten catalog/resolve types per TypeFixing plan

### DIFF
--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -334,6 +334,8 @@ def _apply_resolution(
     pm: MachineModel,
     winners: dict[str, Claim],
     claim_fields: dict[str, str],
+    # field_defaults values are Django field defaults — scalars, None, or
+    # callable output; see ``_helpers.get_field_defaults``.
     field_defaults: dict[str, Any],
     fk_info: FKInfo,
     sfl_map: dict | None = None,
@@ -387,3 +389,4 @@ def _apply_resolution(
                 )
 
     pm.extra_data = extra_data
+

--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -389,4 +389,3 @@ def _apply_resolution(
                 )
 
     pm.extra_data = extra_data
-

--- a/backend/apps/catalog/resolve/_dispatch.py
+++ b/backend/apps/catalog/resolve/_dispatch.py
@@ -9,7 +9,7 @@ the claim field names that changed, then invalidates cached endpoint data.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 from django.db import transaction
 
@@ -26,6 +26,27 @@ logger = logging.getLogger(__name__)
 # Dispatch tables — built lazily to avoid import-time model access
 # ---------------------------------------------------------------------------
 
+
+class ParentDispatchSpec(NamedTuple):
+    """Entry in the parent-hierarchy dispatch table."""
+
+    model: type
+    claim_field_prefix: str | None
+
+
+class CustomDispatchSpec(NamedTuple):
+    """Entry in the custom-resolver dispatch table.
+
+    Each entry specifies which model type it applies to, which
+    ``resolve_all_*`` function to call, and which keyword argument
+    receives the scoped ID set.
+    """
+
+    entity_model: type
+    resolver_function_name: str
+    id_kwarg_name: str
+
+
 _alias_dispatch: dict[str, type] | None = None
 
 
@@ -39,39 +60,38 @@ def _get_alias_dispatch() -> dict[str, type]:
     return _alias_dispatch
 
 
-_parent_dispatch: dict[str, tuple[type, str | None]] | None = None
+_parent_dispatch: dict[str, ParentDispatchSpec] | None = None
 
 
-def _get_parent_dispatch() -> dict[str, tuple[type, str | None]]:
-    """field_name → (model, claim_field_prefix) for _resolve_parents()."""
+def _get_parent_dispatch() -> dict[str, ParentDispatchSpec]:
+    """field_name → ParentDispatchSpec for _resolve_parents()."""
     global _parent_dispatch
     if _parent_dispatch is None:
         from ..models import GameplayFeature, Theme
 
         _parent_dispatch = {
-            "theme_parent": (Theme, None),
-            "gameplay_feature_parent": (GameplayFeature, "gameplay_feature"),
+            "theme_parent": ParentDispatchSpec(Theme, None),
+            "gameplay_feature_parent": ParentDispatchSpec(
+                GameplayFeature, "gameplay_feature"
+            ),
         }
     return _parent_dispatch
 
 
-_custom_dispatch: dict[str, tuple[type, str, str]] | None = None
+_custom_dispatch: dict[str, CustomDispatchSpec] | None = None
 
 
-def _get_custom_dispatch() -> dict[str, tuple[type, str, str]]:
-    """field_name → (entity_model, resolver_function_name, id_kwarg_name).
-
-    Each entry specifies which model type it applies to, which
-    ``resolve_all_*`` function to call, and which keyword argument
-    receives the scoped ID set.
-    """
+def _get_custom_dispatch() -> dict[str, CustomDispatchSpec]:
+    """field_name → CustomDispatchSpec for entity-specific resolvers."""
     global _custom_dispatch
     if _custom_dispatch is None:
         from ..models import CorporateEntity, Title
 
         _custom_dispatch = {
-            "abbreviation": (Title, "resolve_all_title_abbreviations", "model_ids"),
-            "location": (
+            "abbreviation": CustomDispatchSpec(
+                Title, "resolve_all_title_abbreviations", "model_ids"
+            ),
+            "location": CustomDispatchSpec(
                 CorporateEntity,
                 "resolve_all_corporate_entity_locations",
                 "entity_ids",
@@ -161,24 +181,29 @@ def _resolve_non_machine_model(
     if rel_fields is not None:
         for fn in rel_fields:
             if fn in parent_dispatch:
-                model, prefix = parent_dispatch[fn]
-                if model is entity_type:
-                    _resolve_parents(model, claim_field_prefix=prefix)
+                spec = parent_dispatch[fn]
+                if spec.model is entity_type:
+                    _resolve_parents(
+                        spec.model, claim_field_prefix=spec.claim_field_prefix
+                    )
     else:
-        for _fn, (model, prefix) in parent_dispatch.items():
-            if model is entity_type:
-                _resolve_parents(model, claim_field_prefix=prefix)
+        for spec in parent_dispatch.values():
+            if spec.model is entity_type:
+                _resolve_parents(spec.model, claim_field_prefix=spec.claim_field_prefix)
 
     # --- Custom resolvers (abbreviation, location) ---
     custom_dispatch = _get_custom_dispatch()
     if rel_fields is not None:
         for fn in rel_fields:
-            if fn in custom_dispatch and custom_dispatch[fn][0] is entity_type:
+            if (
+                fn in custom_dispatch
+                and custom_dispatch[fn].entity_model is entity_type
+            ):
                 _call_custom_resolver(custom_dispatch[fn], entity.pk)
     else:
-        for _fn, spec in custom_dispatch.items():
-            if spec[0] is entity_type:
-                _call_custom_resolver(spec, entity.pk)
+        for custom_spec in custom_dispatch.values():
+            if custom_spec.entity_model is entity_type:
+                _call_custom_resolver(custom_spec, entity.pk)
 
     # --- Media attachments ---
     from apps.core.models import MediaSupported
@@ -195,10 +220,10 @@ def _resolve_non_machine_model(
     resolve_entity(entity)
 
 
-def _call_custom_resolver(spec: tuple[type, str, str], entity_pk: int) -> None:
+def _call_custom_resolver(spec: CustomDispatchSpec, entity_pk: int) -> None:
     """Call a custom resolver by name with scoped IDs."""
     from . import _relationships
 
-    _model, func_name, id_kwarg = spec
-    func = getattr(_relationships, func_name)
-    func(**{id_kwarg: {entity_pk}})
+    func = getattr(_relationships, spec.resolver_function_name)
+    func(**{spec.id_kwarg_name: {entity_pk}})
+

--- a/backend/apps/catalog/resolve/_dispatch.py
+++ b/backend/apps/catalog/resolve/_dispatch.py
@@ -226,4 +226,3 @@ def _call_custom_resolver(spec: CustomDispatchSpec, entity_pk: int) -> None:
 
     func = getattr(_relationships, spec.resolver_function_name)
     func(**{spec.id_kwarg_name: {entity_pk}})
-

--- a/backend/apps/catalog/resolve/_helpers.py
+++ b/backend/apps/catalog/resolve/_helpers.py
@@ -44,7 +44,9 @@ class FKInfo:
     """FK field metadata and pre-fetched lookups for bulk resolution."""
 
     fk_fields: set[str] = field(default_factory=set)
-    lookups: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # {attr: {lookup_value: related_instance}} — inner dict maps the claim's
+    # string payload (typically slug) to the fully-fetched target model row.
+    lookups: dict[str, dict[str, models.Model]] = field(default_factory=dict)
 
 
 # ------------------------------------------------------------------
@@ -56,8 +58,8 @@ def _resolve_fk_generic(
     model_class: type[models.Model],
     field_name: str,
     value,
-    lookup: dict[str, Any] | None = None,
-) -> Any | None:
+    lookup: dict[str, models.Model] | None = None,
+) -> models.Model | None:
     """Resolve a claim value to an FK instance by introspecting the Django field.
 
     Uses ``slug`` as the default lookup key on the target model.  Models can
@@ -198,7 +200,14 @@ def get_field_defaults(
     model_class: type[models.Model],
     direct_fields: dict[str, str],
 ) -> dict[str, Any]:
-    """Compute reset values for direct fields by inspecting Django model metadata."""
+    """Compute reset values for direct fields by inspecting Django model metadata.
+
+    The returned values are ``dict[str, Any]`` because Django field defaults
+    are genuinely heterogeneous — any Python scalar, ``None``, or the return
+    of an arbitrary callable.  Narrowing further would require per-field
+    type variance that callers don't need.
+    """
+    # Values are Django field defaults — scalars, None, or callable output.
     defaults: dict[str, Any] = {}
     for attr in direct_fields.values():
         field = model_class._meta.get_field(attr)
@@ -316,3 +325,4 @@ def resolve_unique_conflicts(
             )
             setattr(loser, field_name, pre_values[cast(int, loser.pk)])
             seen[getattr(winner, field_name)] = winner
+

--- a/backend/apps/catalog/resolve/_helpers.py
+++ b/backend/apps/catalog/resolve/_helpers.py
@@ -325,4 +325,3 @@ def resolve_unique_conflicts(
             )
             setattr(loser, field_name, pre_values[cast(int, loser.pk)])
             seen[getattr(winner, field_name)] = winner
-

--- a/backend/apps/catalog/resolve/_media.py
+++ b/backend/apps/catalog/resolve/_media.py
@@ -304,4 +304,3 @@ def resolve_media_attachments(
         EntityMedia.objects.bulk_update(
             list(rows.values()), ["category", "is_primary"], batch_size=2000
         )
-

--- a/backend/apps/catalog/resolve/_media.py
+++ b/backend/apps/catalog/resolve/_media.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import datetime
-from typing import cast
+from typing import NamedTuple, cast
 
 from django.contrib.contenttypes.models import ContentType
 
 from apps.core.models import MediaSupported
+from apps.core.types import EntityKey
 from apps.media.models import EntityMedia, MediaAsset
 from apps.provenance.models import Claim
 from apps.provenance.typing import HasEffectivePriority
@@ -17,6 +18,53 @@ from apps.provenance.typing import HasEffectivePriority
 from ._helpers import _annotate_priority
 
 logger = logging.getLogger(__name__)
+
+
+class ClaimWinnerKey(NamedTuple):
+    """Dedup key for the first-winner-per-(entity, claim_key) pass."""
+
+    content_type_id: int
+    object_id: int
+    claim_key: str
+
+
+class CtInfo(NamedTuple):
+    """Cached per-content-type metadata used during media resolution."""
+
+    model_class: type | None
+    is_media_supported: bool
+    categories: list[str]
+
+
+class EntityCategoryKey(NamedTuple):
+    """Group key for per-category primary enforcement and auto-promotion."""
+
+    content_type_id: int
+    object_id: int
+    category: str | None
+
+
+class PrimaryCandidate(NamedTuple):
+    """An asset competing for primary within an (entity, category) group."""
+
+    asset_pk: int
+    priority: int
+    created_at: datetime
+
+
+class AttachmentTimestamp(NamedTuple):
+    """Asset + claim timestamp, used for auto-promotion ordering."""
+
+    asset_pk: int
+    created_at: datetime
+
+
+class MediaRowState(NamedTuple):
+    """Existing (or target) EntityMedia row state."""
+
+    row_pk: int
+    category: str | None
+    is_primary: bool
 
 
 def resolve_media_attachments(
@@ -46,23 +94,22 @@ def resolve_media_attachments(
 
     # Winner per (content_type_id, object_id, claim_key).
     # Keep priority + created_at for primary enforcement.
-    winners_by_entity: dict[tuple[int, int], list[Claim]] = {}
-    seen: set[tuple[int, int, str]] = set()
+    winners_by_entity: dict[EntityKey, list[Claim]] = {}
+    seen: set[ClaimWinnerKey] = set()
     for claim in claims:
-        key = (claim.content_type_id, claim.object_id, claim.claim_key)
+        key = ClaimWinnerKey(claim.content_type_id, claim.object_id, claim.claim_key)
         if key not in seen:
             seen.add(key)
-            entity_key = (claim.content_type_id, claim.object_id)
+            entity_key = EntityKey(claim.content_type_id, claim.object_id)
             winners_by_entity.setdefault(entity_key, []).append(claim)
 
     # -- Validate winners & build desired state -----------------------------
 
     valid_asset_pks = set(MediaAsset.objects.values_list("pk", flat=True))
 
-    # Cache content_type → (model_class, is_media_supported, categories)
-    _ct_cache: dict[int, tuple[type | None, bool, list[str]]] = {}
+    _ct_cache: dict[int, CtInfo] = {}
 
-    def _ct_info(ct_id: int) -> tuple[type | None, bool, list[str]]:
+    def _ct_info(ct_id: int) -> CtInfo:
         if ct_id not in _ct_cache:
             ct = ContentType.objects.get_for_id(ct_id)
             model_class = ct.model_class()
@@ -74,31 +121,28 @@ def resolve_media_attachments(
                 if is_supported
                 else []
             )
-            _ct_cache[ct_id] = (model_class, is_supported, categories)
+            _ct_cache[ct_id] = CtInfo(model_class, is_supported, categories)
         return _ct_cache[ct_id]
 
-    # Desired: {(ct_id, obj_id): {asset_pk: (category, is_primary)}}
+    # Desired: {EntityKey: {asset_pk: (category, is_primary)}}
     # Also track claim priority/created_at for primary enforcement.
-    desired_by_entity: dict[tuple[int, int], dict[int, tuple[str | None, bool]]] = {}
-    # For primary enforcement: {(ct_id, obj_id, category): [(asset_pk, priority, created_at)]}
-    primary_candidates: dict[
-        tuple[int, int, str | None], list[tuple[int, int, datetime]]
-    ] = defaultdict(list)
-    # For auto-promotion: all attachments per (entity, category) with timestamps
-    all_attachments: dict[tuple[int, int, str | None], list[tuple[int, datetime]]] = (
-        defaultdict(list)
+    desired_by_entity: dict[EntityKey, dict[int, tuple[str | None, bool]]] = {}
+    primary_candidates: dict[EntityCategoryKey, list[PrimaryCandidate]] = defaultdict(
+        list
+    )
+    all_attachments: dict[EntityCategoryKey, list[AttachmentTimestamp]] = defaultdict(
+        list
     )
 
     for entity_key, claims_list in winners_by_entity.items():
-        ct_id, obj_id = entity_key
-        _model_class, is_supported, allowed_cats = _ct_info(ct_id)
+        ct_info = _ct_info(entity_key.content_type_id)
 
-        if not is_supported:
+        if not ct_info.is_media_supported:
             logger.warning(
                 "media_attachment claim on non-MediaSupported entity "
                 "(content_type_id=%s, object_id=%s) — skipping",
-                ct_id,
-                obj_id,
+                entity_key.content_type_id,
+                entity_key.object_id,
             )
             continue
 
@@ -114,34 +158,41 @@ def resolve_media_attachments(
                     "Unresolved media_asset pk %r in claim "
                     "(content_type_id=%s, object_id=%s)",
                     asset_pk,
-                    ct_id,
-                    obj_id,
+                    entity_key.content_type_id,
+                    entity_key.object_id,
                 )
                 continue
 
             category = val.get("category")
             if category is not None and (
-                not allowed_cats or category not in allowed_cats
+                not ct_info.categories or category not in ct_info.categories
             ):
                 logger.warning(
                     "Invalid category %r in media_attachment claim "
                     "(content_type_id=%s, object_id=%s) — skipping",
                     category,
-                    ct_id,
-                    obj_id,
+                    entity_key.content_type_id,
+                    entity_key.object_id,
                 )
                 continue
 
             is_primary = bool(val.get("is_primary", False))
             desired[asset_pk] = (category, is_primary)
 
-            all_attachments[(ct_id, obj_id, category)].append(
-                (asset_pk, claim.created_at)
+            group_key = EntityCategoryKey(
+                entity_key.content_type_id, entity_key.object_id, category
+            )
+            all_attachments[group_key].append(
+                AttachmentTimestamp(asset_pk, claim.created_at)
             )
             if is_primary:
                 effective_priority = cast(HasEffectivePriority, claim)
-                primary_candidates[(ct_id, obj_id, category)].append(
-                    (asset_pk, effective_priority.effective_priority, claim.created_at)
+                primary_candidates[group_key].append(
+                    PrimaryCandidate(
+                        asset_pk,
+                        effective_priority.effective_priority,
+                        claim.created_at,
+                    )
                 )
 
         desired_by_entity[entity_key] = desired
@@ -153,41 +204,39 @@ def resolve_media_attachments(
     for group_key, candidates in primary_candidates.items():
         if len(candidates) <= 1:
             continue
-        ct_id, obj_id, category = group_key
-        entity_key = (ct_id, obj_id)
+        entity_key = EntityKey(group_key.content_type_id, group_key.object_id)
         if entity_key not in desired_by_entity:
             continue
         desired = desired_by_entity[entity_key]
 
-        # Sort: highest priority first, then most recent
-        candidates.sort(key=lambda c: (c[1], c[2]), reverse=True)
-        winner_asset_pk = candidates[0][0]
+        candidates.sort(key=lambda c: (c.priority, c.created_at), reverse=True)
+        winner_asset_pk = candidates[0].asset_pk
 
-        for asset_pk, _prio, _ts in candidates:
-            if asset_pk != winner_asset_pk:
-                old_cat, _old_primary = desired[asset_pk]
-                desired[asset_pk] = (old_cat, False)
+        for candidate in candidates:
+            if candidate.asset_pk != winner_asset_pk:
+                old_cat, _old_primary = desired[candidate.asset_pk]
+                desired[candidate.asset_pk] = (old_cat, False)
 
     # -- Auto-promotion ----------------------------------------------------
     # If no attachment in a (entity, category) group is primary, promote the
     # oldest (first uploaded) so there's always a primary per category.
 
     for group_key, attachments in all_attachments.items():
-        ct_id, obj_id, category = group_key
-        entity_key = (ct_id, obj_id)
+        entity_key = EntityKey(group_key.content_type_id, group_key.object_id)
         if entity_key not in desired_by_entity:
             continue
         desired = desired_by_entity[entity_key]
 
         has_primary = any(
-            primary for asset_pk, (cat, primary) in desired.items() if cat == category
+            primary
+            for _asset_pk, (cat, primary) in desired.items()
+            if cat == group_key.category
         )
         if has_primary:
             continue
 
-        # Oldest first
-        attachments.sort(key=lambda a: a[1])
-        winner_asset_pk = attachments[0][0]
+        attachments.sort(key=lambda a: a.created_at)
+        winner_asset_pk = attachments[0].asset_pk
         old_cat, _ = desired[winner_asset_pk]
         desired[winner_asset_pk] = (old_cat, True)
 
@@ -199,53 +248,46 @@ def resolve_media_attachments(
     if entity_ids is not None:
         existing_qs = existing_qs.filter(object_id__in=entity_ids)
 
-    # {(ct_id, obj_id): {asset_pk: (row_pk, category, is_primary)}}
-    existing_by_entity: dict[
-        tuple[int, int], dict[int, tuple[int, str | None, bool]]
-    ] = {}
+    existing_by_entity: dict[EntityKey, dict[int, MediaRowState]] = {}
     for row in existing_qs.values_list(
         "pk", "content_type_id", "object_id", "asset_id", "category", "is_primary"
     ):
         pk, ct_id, obj_id, asset_id, category, is_primary = row
-        existing_by_entity.setdefault((ct_id, obj_id), {})[asset_id] = (
-            pk,
-            category,
-            is_primary,
+        existing_by_entity.setdefault(EntityKey(ct_id, obj_id), {})[asset_id] = (
+            MediaRowState(pk, category, is_primary)
         )
 
     # -- Three-way diff -----------------------------------------------------
 
     to_create: list[EntityMedia] = []
     to_delete_pks: list[int] = []
-    to_update: list[tuple[int, str | None, bool]] = []  # (pk, category, is_primary)
+    to_update: list[MediaRowState] = []
 
-    # Process entities that have desired state (from claims).
     all_entity_keys = set(desired_by_entity) | set(existing_by_entity)
 
     for entity_key in all_entity_keys:
         desired = desired_by_entity.get(entity_key, {})
         existing = existing_by_entity.get(entity_key, {})
-        ct_id, obj_id = entity_key
 
         for asset_pk, (cat, primary) in desired.items():
             if asset_pk not in existing:
                 to_create.append(
                     EntityMedia(
-                        content_type_id=ct_id,
-                        object_id=obj_id,
+                        content_type_id=entity_key.content_type_id,
+                        object_id=entity_key.object_id,
                         asset_id=asset_pk,
                         category=cat,
                         is_primary=primary,
                     )
                 )
             else:
-                row_pk, existing_cat, existing_primary = existing[asset_pk]
-                if existing_cat != cat or existing_primary != primary:
-                    to_update.append((row_pk, cat, primary))
+                existing_row = existing[asset_pk]
+                if existing_row.category != cat or existing_row.is_primary != primary:
+                    to_update.append(MediaRowState(existing_row.row_pk, cat, primary))
 
-        for asset_pk, (row_pk, _cat, _primary) in existing.items():
+        for asset_pk, existing_row in existing.items():
             if asset_pk not in desired:
-                to_delete_pks.append(row_pk)
+                to_delete_pks.append(existing_row.row_pk)
 
     # -- Apply --------------------------------------------------------------
 
@@ -254,11 +296,12 @@ def resolve_media_attachments(
     if to_create:
         EntityMedia.objects.bulk_create(to_create, batch_size=2000)
     if to_update:
-        rows = EntityMedia.objects.in_bulk([pk for pk, _, _ in to_update])
-        for pk, cat, primary in to_update:
-            row = rows[pk]
-            row.category = cat
-            row.is_primary = primary
+        rows = EntityMedia.objects.in_bulk([update.row_pk for update in to_update])
+        for update in to_update:
+            row = rows[update.row_pk]
+            row.category = update.category
+            row.is_primary = update.is_primary
         EntityMedia.objects.bulk_update(
             list(rows.values()), ["category", "is_primary"], batch_size=2000
         )
+

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import NamedTuple
 
 from apps.provenance.models import Claim
 
@@ -33,6 +34,25 @@ from ..models import (
 from ._helpers import _annotate_priority
 
 logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------
+# Shared tuple shapes
+# ------------------------------------------------------------------
+
+
+class ClaimDedupKey(NamedTuple):
+    """Dedup key when picking first-winner-per-claim_key for an entity."""
+
+    object_id: int
+    claim_key: str
+
+
+class CreditAssignment(NamedTuple):
+    """A (person, role) pair materialised into a Credit row."""
+
+    person_id: int
+    role_id: int
 
 
 # ------------------------------------------------------------------
@@ -83,9 +103,9 @@ def _resolve_machine_model_m2m(
 
     # Pick winner per (object_id, claim_key).
     winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
+    seen: set[ClaimDedupKey] = set()
     for claim in claims:
-        key = (claim.object_id, claim.claim_key)
+        key = ClaimDedupKey(claim.object_id, claim.claim_key)
         if key not in seen:
             seen.add(key)
             winners_by_model.setdefault(claim.object_id, []).append(claim)
@@ -192,9 +212,9 @@ def resolve_all_gameplay_features(
 
     # Pick winner per (object_id, claim_key).
     winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
+    seen: set[ClaimDedupKey] = set()
     for claim in claims:
-        key = (claim.object_id, claim.claim_key)
+        key = ClaimDedupKey(claim.object_id, claim.claim_key)
         if key not in seen:
             seen.add(key)
             winners_by_model.setdefault(claim.object_id, []).append(claim)
@@ -321,16 +341,16 @@ def resolve_all_credits(
     )
 
     winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
+    seen: set[ClaimDedupKey] = set()
     for claim in credit_claims:
-        key = (claim.object_id, claim.claim_key)
+        key = ClaimDedupKey(claim.object_id, claim.claim_key)
         if key not in seen:
             seen.add(key)
             winners_by_model.setdefault(claim.object_id, []).append(claim)
 
-    desired_by_model: dict[int, set[tuple[int, int]]] = {}
+    desired_by_model: dict[int, set[CreditAssignment]] = {}
     for model_id, claims_list in winners_by_model.items():
-        desired: set[tuple[int, int]] = set()
+        desired: set[CreditAssignment] = set()
         for claim in claims_list:
             val = claim.value
             if not val.get("exists", True):
@@ -351,17 +371,17 @@ def resolve_all_credits(
                     model_id,
                 )
                 continue
-            desired.add((person_pk, role_pk))
+            desired.add(CreditAssignment(person_pk, role_pk))
         desired_by_model[model_id] = desired
 
     if model_ids is not None:
         all_model_ids = model_ids
     else:
         all_model_ids = set(MachineModel.objects.values_list("pk", flat=True))
-    existing_by_model: dict[int, set[tuple[int, int]]] = {}
+    existing_by_model: dict[int, set[CreditAssignment]] = {}
     dc_qs = Credit.objects.filter(model_id__in=all_model_ids)
     for dc in dc_qs.values_list("model_id", "person_id", "role_id"):
-        existing_by_model.setdefault(dc[0], set()).add((dc[1], dc[2]))
+        existing_by_model.setdefault(dc[0], set()).add(CreditAssignment(dc[1], dc[2]))
 
     to_create: list[Credit] = []
     to_delete_pks: list[int] = []
@@ -370,9 +390,13 @@ def resolve_all_credits(
         desired = desired_by_model.get(model_id, set())
         existing = existing_by_model.get(model_id, set())
 
-        for person_id, role_id in desired - existing:
+        for assignment in desired - existing:
             to_create.append(
-                Credit(model_id=model_id, person_id=person_id, role_id=role_id)
+                Credit(
+                    model_id=model_id,
+                    person_id=assignment.person_id,
+                    role_id=assignment.role_id,
+                )
             )
 
     for dc in Credit.objects.filter(model_id__in=all_model_ids).values_list(
@@ -380,7 +404,7 @@ def resolve_all_credits(
     ):
         pk, model_id, person_id, role_id = dc
         desired = desired_by_model.get(model_id, set())
-        if (person_id, role_id) not in desired:
+        if CreditAssignment(person_id, role_id) not in desired:
             to_delete_pks.append(pk)
 
     if to_delete_pks:
@@ -413,9 +437,9 @@ def resolve_all_title_abbreviations(
     )
 
     winners_by_title: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
+    seen: set[ClaimDedupKey] = set()
     for claim in abbr_claims:
-        key = (claim.object_id, claim.claim_key)
+        key = ClaimDedupKey(claim.object_id, claim.claim_key)
         if key not in seen:
             seen.add(key)
             winners_by_title.setdefault(claim.object_id, []).append(claim)
@@ -511,9 +535,9 @@ def resolve_all_model_abbreviations(
     )
 
     winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
+    seen: set[ClaimDedupKey] = set()
     for claim in abbr_claims:
-        key = (claim.object_id, claim.claim_key)
+        key = ClaimDedupKey(claim.object_id, claim.claim_key)
         if key not in seen:
             seen.add(key)
             winners_by_model.setdefault(claim.object_id, []).append(claim)
@@ -603,9 +627,9 @@ def _resolve_aliases(
 
     # Pick winners per (object_id, claim_key).
     winners_by_parent: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
+    seen: set[ClaimDedupKey] = set()
     for claim in claims_qs:
-        key = (claim.object_id, claim.claim_key)
+        key = ClaimDedupKey(claim.object_id, claim.claim_key)
         if key not in seen:
             seen.add(key)
             winners_by_parent.setdefault(claim.object_id, []).append(claim)
@@ -734,9 +758,9 @@ def _resolve_parents(parent_model, *, claim_field_prefix: str | None = None) -> 
 
     # Pick winners per (object_id, claim_key).
     winners_by_child: dict[int, list[Claim]] = {}
-    seen: set[tuple[int, str]] = set()
+    seen: set[ClaimDedupKey] = set()
     for claim in claims_qs:
-        key = (claim.object_id, claim.claim_key)
+        key = ClaimDedupKey(claim.object_id, claim.claim_key)
         if key not in seen:
             seen.add(key)
             winners_by_child.setdefault(claim.object_id, []).append(claim)
@@ -885,3 +909,4 @@ def resolve_all_corporate_entity_locations(
         deleted = CorporateEntityLocation.objects.filter(pk__in=stale_pks).delete()[0]
 
     return {"created": created, "deleted": deleted}
+

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -909,4 +909,3 @@ def resolve_all_corporate_entity_locations(
         deleted = CorporateEntityLocation.objects.filter(pk__in=stale_pks).delete()[0]
 
     return {"created": created, "deleted": deleted}
-

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -91,7 +91,6 @@ ignore = [
 "apps/catalog/signals.py" = ["ANN401"]
 "apps/catalog/ingestion/**" = ["ANN401"]
 "apps/catalog/management/**" = ["ANN401"]
-"apps/catalog/resolve/**" = ["ANN401"]
 "apps/catalog/tests/**" = ["ANN401"]  # tests stay grandfathered; source is clean
 "apps/provenance/**" = ["ANN401"]
 "config/**" = ["ANN401"]


### PR DESCRIPTION
## Summary

Next chunk of the [TypeFixing](../blob/main/docs/plans/TypeFixing.md) plan: clears the six annotation smells in `apps/catalog/resolve/` and ratchets ruff's `ANN401` grandfathering to lock the chunk in.

- **Structural (smells #4, #5)** — introduce NamedTuples for the tuple shapes that were being unpacked positionally:
  - `_dispatch.py`: `ParentDispatchSpec`, `CustomDispatchSpec` for the two lazy dispatch tables.
  - `_media.py`: `ClaimWinnerKey`, `CtInfo`, `EntityCategoryKey`, `PrimaryCandidate`, `AttachmentTimestamp`, `MediaRowState`. Adopts the existing `apps.core.types.EntityKey` for `(content_type_id, object_id)` dict keys.
  - `_relationships.py`: `ClaimDedupKey` for the 7 per-entity/per-claim_key dedup passes and `CreditAssignment` for the `(person_id, role_id)` credit pairs.
- **Tightening (smells #3, #6)** — `_resolve_fk_generic` now returns `models.Model | None`; `FKInfo.lookups` / `lookup` param typed to `dict[str, models.Model]`. `get_field_defaults` keeps `dict[str, Any]` with a plain comment — Django field defaults are genuinely heterogeneous (scalars, `None`, callable output).
- **Ratchet** — drops `"apps/catalog/resolve/**"` from ruff `per-file-ignores`, so future `Any`/`object` annotations in that subtree will fail CI.

No behaviour change; the resolver test suite (150/150) still passes and mypy reports **0 new errors** against the baseline.

## Test plan

- [ ] `make lint` passes (ruff includes the now-enforced `ANN401` for `apps/catalog/resolve/**`).
- [ ] `uv run pytest apps/catalog/tests/test_resolve*.py apps/catalog/tests/test_manufacturer_resolver.py` — 150 tests pass locally.
- [ ] Re-running the TypeFixing greps against `apps/catalog/resolve/` shows zero hits for smells #1–#4 and the remaining #6 hits carry an explanatory comment.
- [ ] `git grep 'apps/catalog/resolve/\*\*' backend/pyproject.toml` returns nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LbwH3hpqsGc7kMWKRbCz8)_