### PR TITLE
Install pre-commit hooks on Claude SessionStart

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,10 @@
           {
             "type": "command",
             "command": "cd frontend && pnpm install"
+          },
+          {
+            "type": "command",
+            "command": "uvx pre-commit install"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Claude Code on the web gets a fresh container + clone every session, and git clones don't copy `.git/hooks/`. Without `pre-commit install`, web sessions commit without `end-of-file-fixer`, `trailing-whitespace`, `ruff-format`, etc. — formatting drift only gets caught by CI (as just happened on #242).

Adds `uvx pre-commit install` as a fourth command in the existing `SessionStart` hook list in `.claude/settings.json`. `uvx` is already on PATH in the web container, `pre-commit install` is idempotent (overwrites the hook script), and `Bash(pre-commit install:*)` is already in the `permissions.allow` list. The download/cache cost is paid once per container.

## Test plan

- [ ] Run `uvx pre-commit install` manually in a fresh clone — confirms `.git/hooks/pre-commit` appears.
- [ ] Make a change that violates `end-of-file-fixer` and `git commit`; hook should auto-fix or reject.
- [ ] Next Claude Code web session starts with the hook present (visible via `ls .git/hooks/pre-commit` in the session).

---
_Generated by [Claude Code](https://claude.ai/code/session_011LbwH3hpqsGc7kMWKRbCz8)_