### PR TITLE
Filter all three install-hint notes from mypy output

### DIFF
--- a/backend/mypy-baseline.txt
+++ b/backend/mypy-baseline.txt
@@ -12,8 +12,6 @@ apps/catalog/ingestion/wikidata_sparql.py:0: error: Missing type arguments for g
 apps/catalog/ingestion/wikidata_sparql.py:0: error: Missing type arguments for generic type "dict"  [type-arg]
 apps/catalog/ingestion/wikidata_sparql.py:0: error: Missing type arguments for generic type "dict"  [type-arg]
 apps/catalog/ingestion/fandom_wiki.py:0: error: Library stubs not installed for "requests"  [import-untyped]
-apps/catalog/ingestion/fandom_wiki.py:0: note: Hint: "python3 -m pip install types-requests"
-apps/catalog/ingestion/fandom_wiki.py:0: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 apps/catalog/ingestion/fandom_wiki.py:0: error: Missing type arguments for generic type "dict"  [type-arg]
 apps/catalog/ingestion/fandom_wiki.py:0: error: Missing type arguments for generic type "dict"  [type-arg]
 apps/catalog/ingestion/fandom_wiki.py:0: error: Missing type arguments for generic type "dict"  [type-arg]

--- a/docs/plans/TypeFixing.md
+++ b/docs/plans/TypeFixing.md
@@ -191,7 +191,15 @@ A one-shot audit converges on "this chunk is done" only until the next PR re-int
 
 **If you do opt into mypy cleanup, sanity-check the baseline sync output.** After running the sync command, open [`backend/mypy-baseline.txt`](../../backend/mypy-baseline.txt) and confirm it is still one mypy error per line, with no summary/footer text like `Found 738 errors...` and no truncated lines. The sync tool only sees stdout; if mypy's output format changes or summary text leaks into the stream, you can end up with a malformed baseline file that fails the next lint run.
 
-**Sync via `mypy`, not `dmypy`.** CI runs [`scripts/mypy`](../../scripts/mypy) (plain mypy), while the pre-commit hook runs [`scripts/dmypy`](../../scripts/dmypy) (the daemon). The two tools emit subtly different output — notably, `mypy` emits `See https://.../missing-imports` notes for every `import-untyped` error, while `dmypy` sometimes omits them (e.g. for function-scoped imports). If you pipe `dmypy`'s output into `mypy-baseline sync`, the resulting baseline will drop notes that `mypy` still emits, and CI will fail with `+1` new note even though the pre-commit hook was green locally. Always sync with `uv run --directory backend mypy --config-file pyproject.toml . | uv run --directory backend mypy-baseline sync --ignore '.*--install-types.*'`.
+**Sync via `mypy`, not `dmypy`, and match the wrapper's `--ignore` set.** CI runs [`scripts/mypy`](../../scripts/mypy) (plain mypy), while the pre-commit hook runs [`scripts/dmypy`](../../scripts/dmypy) (the daemon). The two tools emit subtly different output — notably, `mypy` emits `See https://.../missing-imports` notes for every `import-untyped` error, while `dmypy` sometimes omits them (e.g. for function-scoped imports). The three install-hint notes that float around (`(or run "mypy --install-types" ...)`, `Hint: "python3 -m pip install types-*"`, `See https://.../missing-imports`) also flip on/off per-environment depending on which stub packages are already installed. `scripts/mypy` and `scripts/dmypy` filter all three via `--ignore`, so if you sync the baseline without the same ignores, dead install-hint entries will sit in `mypy-baseline.txt` and CI's filter will report them as `fixed` (non-zero exit). Always sync with:
+
+```sh
+uv run --directory backend mypy --config-file pyproject.toml . \
+  | uv run --directory backend mypy-baseline sync \
+      --ignore '.*--install-types.*' '.*pip install types-.*' '.*missing-imports.*'
+```
+
+Note: `mypy-baseline` accepts multiple patterns after a single `--ignore` flag, but silently keeps only the last when you repeat the flag. Pass all three patterns to one flag.
 
 **What the ratchet actually locks in.** Honest accounting:
 

--- a/scripts/dmypy
+++ b/scripts/dmypy
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Daemon variant of scripts/mypy. See scripts/mypy for the full explanation
-# of exit-code logic, PIPESTATUS handling, and why --ignore is used for the
-# install-types note. Same rules apply here; this script just swaps `mypy`
-# for `dmypy check` against a pre-warmed daemon.
+# of exit-code logic, PIPESTATUS handling, and which install-hint notes the
+# --ignore flags are filtering. Same rules apply here; this script just swaps
+# `mypy` for `dmypy check` against a pre-warmed daemon.
 #
 # dmypy holds the project type graph in memory between runs; first invocation
 # spins up the daemon (slow, ~5s on dev, longer on CI), subsequent runs reuse
@@ -24,7 +24,8 @@ fi
 # treated as positional FILE arguments. Always run the full backend tree (see
 # scripts/mypy for rationale on why we ignore caller-supplied paths).
 uv run --directory backend dmypy check -- . \
-    | uv run --directory backend mypy-baseline filter --ignore '.*--install-types.*'
+    | uv run --directory backend mypy-baseline filter \
+        --ignore '.*--install-types.*' '.*pip install types-.*' '.*missing-imports.*'
 statuses=("${PIPESTATUS[@]}")
 dmypy_status=${statuses[0]}
 filter_status=${statuses[1]}

--- a/scripts/mypy
+++ b/scripts/mypy
@@ -37,14 +37,25 @@ set -eu
 # mypy-baseline.txt, and baselined errors appear as "new". Ignoring passed
 # paths keeps the output format consistent across every entry point.
 #
-# `--ignore 'mypy --install-types'` drops one specific note that mypy emits
-# but dmypy doesn't (the "or run mypy --install-types" suggestion chained
-# after any import-untyped error). Targeting this one line keeps mypy and
-# dmypy output matching the baseline, without suppressing the genuinely
-# useful diagnostic notes mypy attaches to errors (type-suggestion hints,
-# "-> None" recommendations, variance explanations, etc.).
+# `--ignore` drops the three environment-dependent notes that mypy attaches
+# to `import-untyped` errors:
+#
+#   * `(or run "mypy --install-types" ...)` — emitted by mypy, omitted by
+#     dmypy for function-scoped imports.
+#   * `Hint: "python3 -m pip install types-*"` — emitted only when the
+#     missing stub package is on PyPI, so it flips on/off with the installed
+#     stubs on each machine.
+#   * `See https://...missing-imports` — emitted by mypy (and sometimes
+#     dmypy) per import-untyped error, but which sites get the note varies
+#     across mypy versions and whether the stubs are already installed.
+#
+# The underlying `import-untyped` errors stay baselined; only these three
+# accompanying hint notes are filtered, so mypy/dmypy/local/CI all agree on
+# what the baseline should contain. Other notes (type suggestions, "-> None"
+# recommendations, variance explanations, etc.) still pass through.
 uv run --directory backend mypy --config-file pyproject.toml . \
-    | uv run --directory backend mypy-baseline filter --ignore '.*--install-types.*'
+    | uv run --directory backend mypy-baseline filter \
+        --ignore '.*--install-types.*' '.*pip install types-.*' '.*missing-imports.*'
 statuses=("${PIPESTATUS[@]}")
 mypy_status=${statuses[0]}
 filter_status=${statuses[1]}


### PR DESCRIPTION
## Summary
Expand the mypy/dmypy output filtering to remove all three environment-dependent install-hint notes that mypy attaches to `import-untyped` errors, not just the `--install-types` suggestion. This ensures consistent baseline output across different machines and mypy versions.

## Key Changes
- **scripts/mypy & scripts/dmypy**: Updated `--ignore` patterns to filter three notes:
  - `(or run "mypy --install-types" ...)` — emitted by mypy, omitted by dmypy for function-scoped imports
  - `Hint: "python3 -m pip install types-*"` — only emitted when stub packages are on PyPI
  - `See https://.../missing-imports` — varies across mypy versions and stub installation state

- **docs/plans/TypeFixing.md**: Updated baseline sync instructions to:
  - Clarify that all three install-hint notes are environment-dependent
  - Provide the correct `--ignore` command with all three patterns for manual syncs
  - Warn that `mypy-baseline` silently keeps only the last pattern when `--ignore` is repeated; pass all patterns to a single flag

- **backend/mypy-baseline.txt**: Removed two install-hint note entries that are now filtered, keeping only the underlying `import-untyped` error

## Implementation Details
The underlying `import-untyped` errors remain baselined; only the three accompanying hint notes are filtered. This allows mypy, dmypy, local development, and CI to all agree on what the baseline should contain, while other diagnostic notes (type suggestions, variance explanations, etc.) still pass through.

https://claude.ai/code/session_017WrghTPK2EAUXMUeZTbfsH