### PR TITLE
fix(ingest/ipdb): match whole theme string before splitting

### DIFF
--- a/backend/apps/catalog/ingestion/ipdb/adapter.py
+++ b/backend/apps/catalog/ingestion/ipdb/adapter.py
@@ -38,6 +38,7 @@ from apps.catalog.ingestion.ipdb.features import (
     extract_ipdb_gameplay_features,
     extract_ipdb_reward_types,
     load_mpu_to_system_slug,
+    normalize_theme_key,
     parse_ipdb_themes,
     validate_narrative_slugs,
 )
@@ -190,7 +191,13 @@ def build_ipdb_plan(
     person_slugs: set[str] = set(Person.objects.values_list("slug", flat=True))
 
     # Theme lookup.
-    theme_by_slug: dict[str, Theme] = {t.slug: t for t in Theme.objects.all()}
+    themes_qs = list(Theme.objects.prefetch_related("aliases").all())
+    theme_by_slug: dict[str, Theme] = {t.slug: t for t in themes_qs}
+    theme_name_lookup: dict[str, str] = {}
+    for _t in themes_qs:
+        theme_name_lookup[normalize_theme_key(_t.name)] = _t.slug
+        for _alias in _t.aliases.all():
+            theme_name_lookup.setdefault(normalize_theme_key(_alias.value), _t.slug)
 
     # Build the plan.
     plan = IngestPlan(
@@ -301,7 +308,9 @@ def build_ipdb_plan(
 
         # Queue themes.
         if mr.record.theme:
-            theme_slugs = parse_ipdb_themes(unescape(mr.record.theme))
+            theme_slugs = parse_ipdb_themes(
+                unescape(mr.record.theme), theme_name_lookup
+            )
             if theme_slugs:
                 theme_queue.append((target, theme_slugs))
 

--- a/backend/apps/catalog/ingestion/ipdb/features.py
+++ b/backend/apps/catalog/ingestion/ipdb/features.py
@@ -28,14 +28,32 @@ IPDB_TAG_MAP: dict[str, list[str]] = {
 }
 
 
-def parse_ipdb_themes(raw_theme: str) -> list[str]:
+_THEME_WS_RE = re.compile(r"\s+")
+
+
+def normalize_theme_key(s: str) -> str:
+    """Normalize a theme name/alias for case- and whitespace-insensitive lookup."""
+    return _THEME_WS_RE.sub(" ", s.strip()).lower()
+
+
+def parse_ipdb_themes(raw_theme: str, name_lookup: dict[str, str]) -> list[str]:
     """Split an IPDB theme string and return canonical theme slugs.
 
-    Splits on `` - `` (and ``, `` for comma-delimited entries), looks up
-    each token in IPDB_TAG_MAP (or slugifies if unmapped), and returns
-    deduplicated slugs.
+    First checks whether the whole raw string matches a known pindata theme
+    name or alias verbatim (case- and whitespace-insensitive via
+    ``normalize_theme_key``); if so, emits that slug and skips splitting.
+    This handles canonical names that legitimately contain ``, `` or `` - ``
+    (e.g. "Land, Air, and Space Exploration").
+
+    Otherwise splits on `` - `` (and ``, `` for comma-delimited entries),
+    looks up each token in IPDB_TAG_MAP (or slugifies if unmapped), and
+    returns deduplicated slugs.
     """
     from django.utils.text import slugify
+
+    whole = name_lookup.get(normalize_theme_key(raw_theme))
+    if whole:
+        return [whole]
 
     tags: list[str] = []
     for part in raw_theme.split(" - "):

--- a/backend/apps/catalog/tests/test_ingest_ipdb.py
+++ b/backend/apps/catalog/tests/test_ingest_ipdb.py
@@ -6,7 +6,10 @@ import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from apps.catalog.ingestion.ipdb.features import extract_ipdb_gameplay_features
+from apps.catalog.ingestion.ipdb.features import (
+    extract_ipdb_gameplay_features,
+    parse_ipdb_themes,
+)
 from apps.catalog.models import (
     Credit,
     MachineModel,
@@ -653,3 +656,48 @@ class TestExtractIpdbGameplayFeatures:
         assert counts["pop-bumpers"] == 3
         assert counts["spinning-targets"] == 1
         assert counts["3-ball-multiball"] is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for parse_ipdb_themes
+# ---------------------------------------------------------------------------
+
+
+class TestParseIpdbThemes:
+    """Whole-string match before splitting.
+
+    Catalog theme names or aliases may legitimately contain ``, `` or `` - ``.
+    The parser must consult the name_lookup for a whole-string match before
+    falling through to IPDB's `` - ``/``, `` split convention.
+    """
+
+    def test_ipdb_4117_comma_in_theme_name(self):
+        # IpdbId 4117 (Explorer, Nordamatic, 1976): pindata theme name
+        # contains commas — must not split.
+        raw = "Land, Air, and Space Exploration"
+        lookup = {
+            "land, air, and space exploration": "land-air-and-space-exploration",
+        }
+        assert parse_ipdb_themes(raw, lookup) == ["land-air-and-space-exploration"]
+
+    def test_whole_string_match_is_case_and_whitespace_insensitive(self):
+        raw = "land,  AIR, and space  exploration"
+        lookup = {
+            "land, air, and space exploration": "land-air-and-space-exploration",
+        }
+        assert parse_ipdb_themes(raw, lookup) == ["land-air-and-space-exploration"]
+
+    def test_alias_match(self):
+        raw = "LASE"
+        lookup = {"lase": "land-air-and-space-exploration"}
+        assert parse_ipdb_themes(raw, lookup) == ["land-air-and-space-exploration"]
+
+    def test_fall_through_splits_on_hyphen_and_comma(self):
+        assert parse_ipdb_themes("Fantasy - Adventure", {}) == [
+            "fantasy",
+            "adventure",
+        ]
+        assert parse_ipdb_themes("Sports, Baseball", {}) == ["sports", "baseball"]
+
+    def test_fall_through_applies_ipdb_tag_map(self):
+        assert parse_ipdb_themes("Basebal", {}) == ["baseball"]


### PR DESCRIPTION
## Summary
- `parse_ipdb_themes` now takes a normalized name/alias lookup and short-circuits on a whole-string match before falling through to the existing `" - "` / `", "` split convention.
- Fixes IPDB machine 4117 (Explorer, Nordamatic, 1976), whose theme `"Land, Air, and Space Exploration"` was being tokenized into `land` / `air` / `and-space-exploration` — none of which are real pindata themes. The pindata theme with that exact comma-bearing name has shipped; this change lets the next ingest pick up the correct `land-air-and-space-exploration` slug.
- Adapter builds the lookup from `Theme.objects.prefetch_related("aliases")` so names and aliases both match, without N+1.

Whole-string-only (not per-` - `-part) is deliberate: IPDB uses ` - ` as a separator, so per-part lookup would silently pick one interpretation in ambiguous cases. Mirrors the pinexplore SQL fix in deanmoses/pinexplore#1.

## Test plan
- [x] `pytest apps/catalog/tests/test_ingest_ipdb.py` — new `TestParseIpdbThemes` cases (IPDB 4117, case/whitespace insensitivity, alias match, fall-through split, IPDB_TAG_MAP still applies)
- [x] `pytest apps/catalog/tests/test_ipdb_adapter.py`
- [x] `pytest apps/catalog/tests/` — full catalog suite (1372 passed)
- [x] ruff + mypy clean on changed files
- [ ] Run `make ingest` against the real DB and verify machine 4117 has theme `land-air-and-space-exploration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)