### PR TITLE
Improve type safety for django-constance configuration

### DIFF
--- a/backend/config/management/commands/export_openapi_schema.py
+++ b/backend/config/management/commands/export_openapi_schema.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
             help="Output file path (default: backend/openapi.json)",
         )
 
-    def handle(self, *args: object, **options: Any) -> None:
+    def handle(self, *args: object, **options: Any) -> None:  # noqa: ANN401 — argparse-driven options schema owned by Django
         schema = api.get_openapi_schema()
         output_path = Path(options["output"])
         output_path.write_text(json.dumps(schema, indent=2))

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import NamedTuple
 
 import dj_database_url
 import django_stubs_ext
@@ -230,11 +230,21 @@ DISPLAY_POLICY_CHOICES = (
     ("licensed-only", "✅ Show Only Licensed Content — no OPDB or IPDB images"),
 )
 
-CONSTANCE_CONFIG: dict[str, Any] = {
-    "CONTENT_DISPLAY_POLICY": (
-        "licensed-only",
-        "Controls which content is shown based on license status",
-        str,
+
+# django-constance expects each CONSTANCE_CONFIG value to be a tuple of
+# (default, help_text, field_type_or_name). It unpacks positionally, which is
+# why this is a NamedTuple rather than a TypedDict.
+class ConstanceSpec(NamedTuple):
+    default: object
+    help_text: str
+    field: type | str
+
+
+CONSTANCE_CONFIG: dict[str, ConstanceSpec] = {
+    "CONTENT_DISPLAY_POLICY": ConstanceSpec(
+        default="licensed-only",
+        help_text="Controls which content is shown based on license status",
+        field=str,
     ),
 }
 
@@ -245,10 +255,10 @@ CONSTANCE_ADDITIONAL_FIELDS = {
     ],
 }
 
-CONSTANCE_CONFIG["CONTENT_DISPLAY_POLICY"] = (
-    "licensed-only",
-    "Controls which content is shown based on license status",
-    "display_policy_select",
+CONSTANCE_CONFIG["CONTENT_DISPLAY_POLICY"] = ConstanceSpec(
+    default="licensed-only",
+    help_text="Controls which content is shown based on license status",
+    field="display_policy_select",
 )
 
 CONSTANCE_CONFIG_FIELDSETS = (("Content Display", ("CONTENT_DISPLAY_POLICY",)),)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -92,7 +92,6 @@ ignore = [
 "apps/catalog/ingestion/**" = ["ANN401"]
 "apps/catalog/management/**" = ["ANN401"]
 "apps/catalog/tests/**" = ["ANN401"]  # tests stay grandfathered; source is clean
-"config/**" = ["ANN401"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["apps", "config"]


### PR DESCRIPTION
## Summary
Refactored the `CONSTANCE_CONFIG` dictionary to use a `NamedTuple` for better type safety and clarity, replacing untyped tuples with explicitly named fields. This improves code maintainability and enables stricter linting.

## Key Changes
- Created `ConstanceSpec` NamedTuple with named fields (`default`, `help_text`, `field`) to replace positional tuple unpacking
- Updated all `CONSTANCE_CONFIG` entries to use `ConstanceSpec` constructor with named arguments for improved readability
- Updated type annotation from `dict[str, Any]` to `dict[str, ConstanceSpec]` for better type checking
- Removed overly broad `ANN401` ignore rule from `config/**` in ruff configuration, replacing it with a targeted noqa comment on the specific Django-driven function that requires it
- Added clarifying comment explaining why NamedTuple is used instead of TypedDict (due to positional unpacking requirement)

## Implementation Details
The change maintains full backward compatibility with django-constance while improving code clarity. The `NamedTuple` approach was chosen over `TypedDict` because django-constance unpacks the configuration values positionally, requiring a tuple-like structure. Named fields make the intent of each tuple element explicit without sacrificing the positional unpacking behavior.

https://claude.ai/code/session_01RVWwitvD5jLv5PyBwJJtAj