### PR TITLE
feat(frontend): show record name in edit/history/sources header

### DIFF
--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -164,9 +164,14 @@
   {/if}
 {/snippet}
 
-<FocusContentShell backHref={entity.detailHref} maxWidth="64rem">
+<FocusContentShell
+  backHref={entity.detailHref}
+  recordName={entity.name}
+  recordHref={entity.detailHref}
+  maxWidth="64rem"
+>
   {#snippet heading()}
-    <h1>Edit History</h1>
+    <h1 class="page-label">Edit History</h1>
   {/snippet}
 
   {#if changesets.length > 0}
@@ -264,6 +269,13 @@
 </FocusContentShell>
 
 <style>
+  .page-label {
+    margin: 0;
+    font-size: inherit;
+    font-weight: inherit;
+    color: inherit;
+  }
+
   .changeset-list {
     list-style: none;
     padding: 0;

--- a/frontend/src/lib/components/EditSectionShell.svelte
+++ b/frontend/src/lib/components/EditSectionShell.svelte
@@ -3,6 +3,7 @@
   import EditSectionMenu from '$lib/components/EditSectionMenu.svelte';
   import FocusContentShell from '$lib/components/FocusContentShell.svelte';
   import type { EditSectionMenuItem } from '$lib/components/edit-section-menu';
+  import { getEntityContext } from '$lib/entity-context';
 
   let {
     detailHref,
@@ -19,9 +20,11 @@
     fallbackHeading?: string;
     children: Snippet;
   } = $props();
+
+  const entity = getEntityContext();
 </script>
 
-<FocusContentShell backHref={detailHref}>
+<FocusContentShell backHref={detailHref} recordName={entity.name} recordHref={entity.detailHref}>
   {#snippet heading()}
     {#if currentSectionKey}
       <EditSectionMenu

--- a/frontend/src/lib/components/EntitySources.svelte
+++ b/frontend/src/lib/components/EntitySources.svelte
@@ -45,9 +45,14 @@
   {/if}
 {/snippet}
 
-<FocusContentShell backHref={entity.detailHref} maxWidth="64rem">
+<FocusContentShell
+  backHref={entity.detailHref}
+  recordName={entity.name}
+  recordHref={entity.detailHref}
+  maxWidth="64rem"
+>
   {#snippet heading()}
-    <h1>Sources</h1>
+    <h1 class="page-label">Sources</h1>
   {/snippet}
 
   {#if sources.length > 0}
@@ -181,6 +186,13 @@
 </FocusContentShell>
 
 <style>
+  .page-label {
+    margin: 0;
+    font-size: inherit;
+    font-weight: inherit;
+    color: inherit;
+  }
+
   h2 {
     font-size: var(--font-size-3);
     font-weight: 600;

--- a/frontend/src/lib/components/FocusContentShell.svelte
+++ b/frontend/src/lib/components/FocusContentShell.svelte
@@ -3,11 +3,15 @@
 
   let {
     backHref,
+    recordName,
+    recordHref,
     maxWidth = '48rem',
     heading,
     children,
   }: {
     backHref: string;
+    recordName?: string;
+    recordHref?: string;
     maxWidth?: string;
     heading: Snippet;
     children: Snippet;
@@ -16,7 +20,13 @@
 
 <div class="focus-shell" style:max-width={maxWidth}>
   <header class="focus-header">
-    <a href={backHref} class="back-link">&larr; Back</a>
+    <a href={backHref} class="back-link">
+      <span class="back-arrow" aria-hidden="true">&larr;</span>
+      <span class="back-text">Back</span>
+    </a>
+    {#if recordName && recordHref}
+      <a href={recordHref} class="record-name" title={recordName}>{recordName}</a>
+    {/if}
     <div class="heading-slot">
       {@render heading()}
     </div>
@@ -32,17 +42,20 @@
   }
 
   .focus-header {
-    position: relative;
     display: flex;
     align-items: center;
-    justify-content: center;
+    gap: var(--size-3);
+    padding-bottom: var(--size-3);
     margin-bottom: var(--size-4);
     min-height: 2.5rem;
+    border-bottom: 1px solid var(--color-border-soft);
   }
 
   .back-link {
-    position: absolute;
-    left: 0;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.25em;
+    flex-shrink: 0;
     font-size: var(--font-size-1);
     color: var(--color-text-muted);
     text-decoration: none;
@@ -50,5 +63,33 @@
 
   .back-link:hover {
     color: var(--color-text-primary);
+  }
+
+  .record-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--font-size-3);
+    font-weight: 600;
+    color: var(--color-text-primary);
+    text-decoration: none;
+  }
+
+  .record-name:hover {
+    text-decoration: underline;
+  }
+
+  .heading-slot {
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+
+  /* Keep in sync with LAYOUT_BREAKPOINT (52rem). */
+  @media (max-width: 52rem) {
+    .back-text {
+      display: none;
+    }
   }
 </style>

--- a/frontend/src/lib/components/FocusContentShell.test-harness.svelte
+++ b/frontend/src/lib/components/FocusContentShell.test-harness.svelte
@@ -3,9 +3,13 @@
 
   let {
     backHref = '/titles/medieval-madness',
+    recordName = undefined,
+    recordHref = undefined,
     maxWidth = undefined,
   }: {
     backHref?: string;
+    recordName?: string;
+    recordHref?: string;
     maxWidth?: string;
   } = $props();
 </script>
@@ -14,6 +18,6 @@
   <h1>Edit History</h1>
 {/snippet}
 
-<FocusContentShell {backHref} {maxWidth} heading={headingSnippet}>
+<FocusContentShell {backHref} {recordName} {recordHref} {maxWidth} heading={headingSnippet}>
   <div>Audit content</div>
 </FocusContentShell>

--- a/frontend/src/lib/components/FocusContentShell.test.ts
+++ b/frontend/src/lib/components/FocusContentShell.test.ts
@@ -15,6 +15,27 @@ describe('FocusContentShell', () => {
     expect(body).toContain('Audit content');
   });
 
+  it('renders the record name as a link when provided', () => {
+    const { body } = render(Harness, {
+      props: {
+        backHref: '/titles/medieval-madness',
+        recordName: 'Medieval Madness',
+        recordHref: '/titles/medieval-madness',
+      },
+    });
+
+    expect(body).toContain('Medieval Madness');
+    expect(body).toContain('title="Medieval Madness"');
+  });
+
+  it('omits the record name when not provided', () => {
+    const { body } = render(Harness, {
+      props: { backHref: '/titles/medieval-madness' },
+    });
+
+    expect(body).not.toContain('class="record-name"');
+  });
+
   it('applies a custom max-width when provided', () => {
     const { body } = render(Harness, {
       props: { maxWidth: '64rem' },

--- a/frontend/src/routes/cabinets/[slug]/edit-history/edit-history-page.test.ts
+++ b/frontend/src/routes/cabinets/[slug]/edit-history/edit-history-page.test.ts
@@ -11,7 +11,7 @@ describe('cabinet edit-history page (taxonomy representative)', () => {
 
     expect(body).toContain('href="/cabinets/standard-body"');
     expect(body).toContain('Back');
-    expect(body).toContain('<h1>Edit History</h1>');
+    expect(body).toContain('>Edit History</h1>');
     expect(body.toLowerCase()).toContain('no edit history yet');
   });
 });

--- a/frontend/src/routes/cabinets/[slug]/sources/sources-page.test.ts
+++ b/frontend/src/routes/cabinets/[slug]/sources/sources-page.test.ts
@@ -11,7 +11,7 @@ describe('cabinet sources page (taxonomy representative)', () => {
 
     expect(body).toContain('href="/cabinets/standard-body"');
     expect(body).toContain('Back');
-    expect(body).toContain('<h1>Sources</h1>');
+    expect(body).toContain('>Sources</h1>');
     expect(body.toLowerCase()).toContain('no source data recorded yet');
   });
 });

--- a/frontend/src/routes/manufacturers/[slug]/edit-history/edit-history-page.test.ts
+++ b/frontend/src/routes/manufacturers/[slug]/edit-history/edit-history-page.test.ts
@@ -11,7 +11,7 @@ describe('manufacturer edit-history page', () => {
 
     expect(body).toContain('href="/manufacturers/williams"');
     expect(body).toContain('Back');
-    expect(body).toContain('<h1>Edit History</h1>');
+    expect(body).toContain('>Edit History</h1>');
     expect(body.toLowerCase()).toContain('no edit history yet');
   });
 });

--- a/frontend/src/routes/manufacturers/[slug]/sources/sources-page.test.ts
+++ b/frontend/src/routes/manufacturers/[slug]/sources/sources-page.test.ts
@@ -11,7 +11,7 @@ describe('manufacturer sources page', () => {
 
     expect(body).toContain('href="/manufacturers/williams"');
     expect(body).toContain('Back');
-    expect(body).toContain('<h1>Sources</h1>');
+    expect(body).toContain('>Sources</h1>');
     expect(body.toLowerCase()).toContain('no source data recorded yet');
   });
 });

--- a/frontend/src/routes/titles/[slug]/edit-history/edit-history-page.test.ts
+++ b/frontend/src/routes/titles/[slug]/edit-history/edit-history-page.test.ts
@@ -11,7 +11,7 @@ describe('title edit-history page', () => {
 
     expect(body).toContain('href="/titles/medieval-madness"');
     expect(body).toContain('Back');
-    expect(body).toContain('<h1>Edit History</h1>');
+    expect(body).toContain('>Edit History</h1>');
     // EditHistory empty-state passes through.
     expect(body.toLowerCase()).toContain('no edit history yet');
   });

--- a/frontend/src/routes/titles/[slug]/sources/sources-page.test.ts
+++ b/frontend/src/routes/titles/[slug]/sources/sources-page.test.ts
@@ -11,7 +11,7 @@ describe('title sources page', () => {
 
     expect(body).toContain('href="/titles/medieval-madness"');
     expect(body).toContain('Back');
-    expect(body).toContain('<h1>Sources</h1>');
+    expect(body).toContain('>Sources</h1>');
     // EntitySources empty-state passes through.
     expect(body.toLowerCase()).toContain('no source data recorded yet');
   });


### PR DESCRIPTION
## Summary

- Edit, Edit History, and Sources pages now show what's being viewed: `FocusContentShell` renders `← Back` + the record name (linked to the detail page, truncates with ellipsis) + the view label / section picker.
- Record name and detail href are pulled from the existing entity context, so route layouts didn't need changes.
- `← Back` text collapses to an icon-only arrow below `LAYOUT_BREAKPOINT` (52rem).
- A hairline bottom border separates the header from page content.
- "Edit History" / "Sources" h1s get `font-size/weight/color: inherit` so they render at body size, matching the `EditSectionMenu`'s heading-variant treatment on the Edit page.

## Test plan

- [ ] Load an Edit page on a real record — confirm `← Back [Record] [Section ▾]` reads correctly and the section picker still works
- [ ] Load Edit History and Sources for records with short names, long names, and very long names — confirm truncation + tooltip
- [ ] Resize below 52rem — confirm "Back" text collapses to an icon-only arrow
- [ ] Click the record name — should navigate to the detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)