### PR TITLE
Extract JsonBody type alias for test client helpers

### DIFF
--- a/backend/apps/catalog/tests/test_api_claims_additional_entities.py
+++ b/backend/apps/catalog/tests/test_api_claims_additional_entities.py
@@ -28,6 +28,7 @@ from apps.catalog.models import (
 )
 from apps.catalog.tests.conftest import make_machine_model
 from apps.citation.models import CitationSource
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, CitationInstance, Claim, Source
 from apps.provenance.test_factories import user_changeset
 
@@ -49,7 +50,7 @@ def citation_source(db):
     )
 
 
-def _patch(client, path: str, body: dict[str, object]):
+def _patch(client, path: str, body: JsonBody):
     return client.patch(
         path,
         data=json.dumps(body),

--- a/backend/apps/catalog/tests/test_api_claims_title.py
+++ b/backend/apps/catalog/tests/test_api_claims_title.py
@@ -12,6 +12,7 @@ from apps.catalog.models import Franchise, Title
 from apps.catalog.resolve import resolve_all_entities
 from apps.catalog.resolve._relationships import resolve_all_title_abbreviations
 from apps.citation.models import CitationSource
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, Claim, Source
 from apps.provenance.test_factories import user_changeset
 
@@ -54,7 +55,7 @@ def citation_source(db):
     return CitationSource.objects.create(name="Williams Flyer", source_type="web")
 
 
-def _patch(client, slug: str, body: dict[str, object]):
+def _patch(client, slug: str, body: JsonBody):
     return client.patch(
         f"/api/titles/{slug}/claims/",
         data=json.dumps(body),

--- a/backend/apps/catalog/tests/test_api_corporate_entity_create.py
+++ b/backend/apps/catalog/tests/test_api_corporate_entity_create.py
@@ -15,6 +15,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import CorporateEntity, Manufacturer
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 User = get_user_model()
@@ -44,7 +45,7 @@ def _clear_cache():
     cache.clear()
 
 
-def _post(client, parent_slug: str, body: dict[str, object]):
+def _post(client, parent_slug: str, body: JsonBody):
     return client.post(
         f"/api/manufacturers/{parent_slug}/corporate-entities/",
         data=json.dumps(body),

--- a/backend/apps/catalog/tests/test_api_corporate_entity_delete.py
+++ b/backend/apps/catalog/tests/test_api_corporate_entity_delete.py
@@ -22,6 +22,7 @@ from apps.catalog.models import (
     Manufacturer,
     Title,
 )
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
 
 User = get_user_model()
@@ -79,7 +80,7 @@ def _make_model(
     return m
 
 
-def _post_delete(client, slug: str, body: dict[str, object] | None = None):
+def _post_delete(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/corporate-entities/{slug}/delete/",
         data=json.dumps(body or {}),
@@ -87,7 +88,7 @@ def _post_delete(client, slug: str, body: dict[str, object] | None = None):
     )
 
 
-def _post_restore(client, slug: str, body: dict[str, object] | None = None):
+def _post_restore(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/corporate-entities/{slug}/restore/",
         data=json.dumps(body or {}),

--- a/backend/apps/catalog/tests/test_api_credit_roles.py
+++ b/backend/apps/catalog/tests/test_api_credit_roles.py
@@ -17,6 +17,7 @@ from apps.catalog.models import (
     Title,
 )
 from apps.catalog.tests.conftest import make_machine_model
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 User = get_user_model()
@@ -34,7 +35,7 @@ def _clear_cache():
     cache.clear()
 
 
-def _post(client, path: str, body: dict[str, object]):
+def _post(client, path: str, body: JsonBody):
     return client.post(path, data=json.dumps(body), content_type="application/json")
 
 

--- a/backend/apps/catalog/tests/test_api_manufacturer_create.py
+++ b/backend/apps/catalog/tests/test_api_manufacturer_create.py
@@ -15,6 +15,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import Manufacturer
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 User = get_user_model()
@@ -37,7 +38,7 @@ def _clear_cache():
     cache.clear()
 
 
-def _post(client, body: dict[str, object]):
+def _post(client, body: JsonBody):
     return client.post(
         "/api/manufacturers/",
         data=json.dumps(body),

--- a/backend/apps/catalog/tests/test_api_manufacturer_delete.py
+++ b/backend/apps/catalog/tests/test_api_manufacturer_delete.py
@@ -14,6 +14,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import CorporateEntity, Manufacturer, System
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
 
 User = get_user_model()
@@ -63,7 +64,7 @@ def _make_system(bootstrap_source, mfr, slug: str, *, status: str = "active") ->
     return s
 
 
-def _post_delete(client, slug: str, body: dict[str, object] | None = None):
+def _post_delete(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/manufacturers/{slug}/delete/",
         data=json.dumps(body or {}),
@@ -71,7 +72,7 @@ def _post_delete(client, slug: str, body: dict[str, object] | None = None):
     )
 
 
-def _post_restore(client, slug: str, body: dict[str, object] | None = None):
+def _post_restore(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/manufacturers/{slug}/restore/",
         data=json.dumps(body or {}),

--- a/backend/apps/catalog/tests/test_api_model_create.py
+++ b/backend/apps/catalog/tests/test_api_model_create.py
@@ -16,6 +16,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import MachineModel, Title
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 User = get_user_model()
@@ -43,7 +44,7 @@ def _clear_cache():
     cache.clear()
 
 
-def _post(client, title_slug: str, body: dict[str, object]):
+def _post(client, title_slug: str, body: JsonBody):
     return client.post(
         f"/api/titles/{title_slug}/models/",
         data=json.dumps(body),
@@ -51,7 +52,7 @@ def _post(client, title_slug: str, body: dict[str, object]):
     )
 
 
-def _post_title(client, body: dict[str, object]):
+def _post_title(client, body: JsonBody):
     return client.post(
         "/api/titles/",
         data=json.dumps(body),

--- a/backend/apps/catalog/tests/test_api_model_delete.py
+++ b/backend/apps/catalog/tests/test_api_model_delete.py
@@ -14,6 +14,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import MachineModel, Title
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
 
 User = get_user_model()
@@ -77,7 +78,7 @@ def _make_model(
     return m
 
 
-def _post_delete(client, slug: str, body: dict[str, object] | None = None):
+def _post_delete(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/models/{slug}/delete/",
         data=json.dumps(body or {}),
@@ -85,7 +86,7 @@ def _post_delete(client, slug: str, body: dict[str, object] | None = None):
     )
 
 
-def _post_restore(client, slug: str, body: dict[str, object] | None = None):
+def _post_restore(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/models/{slug}/restore/",
         data=json.dumps(body or {}),

--- a/backend/apps/catalog/tests/test_api_person_create.py
+++ b/backend/apps/catalog/tests/test_api_person_create.py
@@ -15,6 +15,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import Person, PersonAlias
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 User = get_user_model()
@@ -37,7 +38,7 @@ def _clear_cache():
     cache.clear()
 
 
-def _post(client, body: dict[str, object]):
+def _post(client, body: JsonBody):
     return client.post(
         "/api/people/",
         data=json.dumps(body),

--- a/backend/apps/catalog/tests/test_api_person_delete.py
+++ b/backend/apps/catalog/tests/test_api_person_delete.py
@@ -15,6 +15,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import Credit, CreditRole, MachineModel, Person, Series, Title
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
 
 User = get_user_model()
@@ -73,7 +74,7 @@ def _make_model(
     return m
 
 
-def _post_delete(client, slug: str, body: dict[str, object] | None = None):
+def _post_delete(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/people/{slug}/delete/",
         data=json.dumps(body or {}),
@@ -81,7 +82,7 @@ def _post_delete(client, slug: str, body: dict[str, object] | None = None):
     )
 
 
-def _post_restore(client, slug: str, body: dict[str, object] | None = None):
+def _post_restore(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/people/{slug}/restore/",
         data=json.dumps(body or {}),

--- a/backend/apps/catalog/tests/test_api_system_create.py
+++ b/backend/apps/catalog/tests/test_api_system_create.py
@@ -14,6 +14,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import Manufacturer, System
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 User = get_user_model()
@@ -41,7 +42,7 @@ def _clear_cache():
     cache.clear()
 
 
-def _post(client, body: dict[str, object]):
+def _post(client, body: JsonBody):
     return client.post(
         "/api/systems/",
         data=json.dumps(body),

--- a/backend/apps/catalog/tests/test_api_system_delete.py
+++ b/backend/apps/catalog/tests/test_api_system_delete.py
@@ -14,6 +14,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import MachineModel, Manufacturer, System, Title
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
 
 User = get_user_model()
@@ -69,7 +70,7 @@ def _make_model(
     return m
 
 
-def _post_delete(client, slug: str, body: dict[str, object] | None = None):
+def _post_delete(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/systems/{slug}/delete/",
         data=json.dumps(body or {}),
@@ -77,7 +78,7 @@ def _post_delete(client, slug: str, body: dict[str, object] | None = None):
     )
 
 
-def _post_restore(client, slug: str, body: dict[str, object] | None = None):
+def _post_restore(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/systems/{slug}/restore/",
         data=json.dumps(body or {}),

--- a/backend/apps/catalog/tests/test_api_taxonomy_crud.py
+++ b/backend/apps/catalog/tests/test_api_taxonomy_crud.py
@@ -31,6 +31,7 @@ from apps.catalog.models import (
     ThemeAlias,
     Title,
 )
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 User = get_user_model()
@@ -53,7 +54,7 @@ def _clear_cache():
     cache.clear()
 
 
-def _post(client, path: str, body: dict[str, object]):
+def _post(client, path: str, body: JsonBody):
     return client.post(path, data=json.dumps(body), content_type="application/json")
 
 

--- a/backend/apps/catalog/tests/test_api_title_create.py
+++ b/backend/apps/catalog/tests/test_api_title_create.py
@@ -18,6 +18,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import Title
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 User = get_user_model()
@@ -40,7 +41,7 @@ def _clear_cache():
     cache.clear()
 
 
-def _post(client, body: dict[str, object]):
+def _post(client, body: JsonBody):
     return client.post(
         "/api/titles/",
         data=json.dumps(body),
@@ -48,7 +49,7 @@ def _post(client, body: dict[str, object]):
     )
 
 
-def _patch(client, slug: str, body: dict[str, object]):
+def _patch(client, slug: str, body: JsonBody):
     return client.patch(
         f"/api/titles/{slug}/claims/",
         data=json.dumps(body),

--- a/backend/apps/catalog/tests/test_api_title_delete.py
+++ b/backend/apps/catalog/tests/test_api_title_delete.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 
 from apps.catalog.models import MachineModel, Title
+from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
 
 User = get_user_model()
@@ -64,7 +65,7 @@ def _make_model(bootstrap_source, title: Title, slug: str) -> MachineModel:
     return m
 
 
-def _post_delete(client, slug: str, body: dict[str, object] | None = None):
+def _post_delete(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/titles/{slug}/delete/",
         data=json.dumps(body or {}),
@@ -72,7 +73,7 @@ def _post_delete(client, slug: str, body: dict[str, object] | None = None):
     )
 
 
-def _post_restore(client, slug: str, body: dict[str, object] | None = None):
+def _post_restore(client, slug: str, body: JsonBody | None = None):
     return client.post(
         f"/api/titles/{slug}/restore/",
         data=json.dumps(body or {}),

--- a/backend/apps/catalog/tests/test_ingest_wikidata.py
+++ b/backend/apps/catalog/tests/test_ingest_wikidata.py
@@ -6,6 +6,7 @@ from django.core.management import call_command
 from apps.catalog.ingestion.wikidata_sparql import parse_wikidata_date
 from apps.catalog.models import Credit, CreditRole, MachineModel, Person
 from apps.catalog.tests.conftest import make_machine_model
+from apps.core.types import JsonBody
 from apps.provenance.models import Claim, Source
 
 FIXTURES = "apps/catalog/tests/fixtures"
@@ -197,7 +198,7 @@ class TestFromDumpEmpty:
         import json
         import tempfile
 
-        empty: dict[str, object] = {"results": {"bindings": []}}
+        empty: JsonBody = {"results": {"bindings": []}}
         data = {"persons": empty, "bio": empty, "credits": empty}
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(data, f)

--- a/backend/apps/catalog/tests/test_ingest_wikidata_manufacturers.py
+++ b/backend/apps/catalog/tests/test_ingest_wikidata_manufacturers.py
@@ -7,6 +7,7 @@ import pytest
 from django.core.management import call_command
 
 from apps.catalog.models import Manufacturer
+from apps.core.types import JsonBody
 from apps.provenance.models import Claim, Source
 
 FIXTURES = "apps/catalog/tests/fixtures"
@@ -106,7 +107,7 @@ class TestFromDumpEmpty:
     """Empty dump should not crash and should still create the source."""
 
     def test_empty_bindings(self, db):
-        empty: dict[str, object] = {"results": {"bindings": []}}
+        empty: JsonBody = {"results": {"bindings": []}}
         data = {"manufacturers": empty, "bio": empty}
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(data, f)

--- a/backend/apps/core/types.py
+++ b/backend/apps/core/types.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
+# JSON request/response body for test-client helpers. Endpoint-specific
+# shapes are validated at the API boundary by Django-Ninja schemas; the
+# value type stays ``object`` so callers can pass arbitrary dict literals
+# without per-endpoint TypedDicts.
+type JsonBody = dict[str, object]
+
 
 class EntityKey(NamedTuple):
     """Hashable reference to a catalog entity via content-type + object id.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -86,8 +86,6 @@ ignore = [
 "apps/*/management/commands/*.py" = ["T20", "S603", "S607", "B904"]  # print, subprocess, raise-from in commands
 "scripts/*.py" = ["T201"]
 "**/__init__.py" = ["F401"]  # re-exports from barrel modules are the whole point of __init__.py
-# ANN401 grandfathering
-"apps/catalog/tests/**" = ["ANN401"]  # tests stay grandfathered; source is clean
 
 [tool.ruff.lint.isort]
 known-first-party = ["apps", "config"]


### PR DESCRIPTION
## Summary
Introduces a reusable `JsonBody` type alias in the core types module to standardize type annotations for JSON request/response bodies in test client helper functions across the codebase.

## Key Changes
- Added `JsonBody = dict[str, object]` type alias to `backend/apps/core/types.py` with documentation explaining its purpose for test-client helpers
- Updated 17 test modules to import and use `JsonBody` instead of inline `dict[str, object]` type annotations:
  - API endpoint tests (corporate entities, manufacturers, models, people, systems, titles)
  - Claims and taxonomy tests
  - Wikidata ingestion tests
- Removed the `ANN401` grandfathering rule from `pyproject.toml` for test files, as the type annotations are now properly typed with the `JsonBody` alias

## Implementation Details
The `JsonBody` type is intentionally kept as `dict[str, object]` (rather than more specific TypedDicts) to allow test callers to pass arbitrary dict literals without per-endpoint type definitions. Endpoint-specific validation happens at the API boundary via Django-Ninja schemas. This change improves code consistency and maintainability while keeping test code flexible.

https://claude.ai/code/session_015K9LVLskwmvmSHnskdAHJN