### PR TITLE
refactor: consolidate duplicate structural types

### DIFF
--- a/backend/apps/catalog/ingestion/apply.py
+++ b/backend/apps/catalog/ingestion/apply.py
@@ -28,7 +28,13 @@ from django.db import models, transaction
 from django.utils import timezone
 
 from apps.core.types import ClaimIdentity, EntityKey
-from apps.provenance.models import ChangeSet, Claim, IngestRun, Source
+from apps.provenance.models import (
+    ChangeSet,
+    Claim,
+    ExistingClaimRow,
+    IngestRun,
+    Source,
+)
 from apps.provenance.validation import validate_claims_batch
 
 logger = logging.getLogger(__name__)
@@ -51,22 +57,6 @@ class RetractEntry(NamedTuple):
     pk: int
     content_type_id: int
     object_id: int
-
-
-class _ExistingClaimRow(NamedTuple):
-    """Partial Claim row cached during ``_diff_claims`` diffing.
-
-    Fetched via ``values_list`` to avoid JSONField deserialization cost on
-    large sources. Field order matches the ``values_list`` column order.
-    """
-
-    # ``value`` is the raw JSONField payload — scalar, dict, list, or null.
-    value: object
-    citation: str
-    needs_review: bool
-    needs_review_notes: str
-    license_id: int | None
-    pk: int
 
 
 # ---------------------------------------------------------------------------
@@ -654,7 +644,7 @@ def _diff_claims(
     for c in valid_claims:
         by_ct[c.content_type_id].add(c.object_id)
 
-    existing: dict[ClaimIdentity, _ExistingClaimRow] = {}
+    existing: dict[ClaimIdentity, ExistingClaimRow] = {}
     for ct_id, obj_ids in by_ct.items():
         for row in Claim.objects.filter(
             source=source,
@@ -673,7 +663,7 @@ def _diff_claims(
             "license_id",
         ):
             pk, ct, oid, ck, val, cit, nr, nrn, lic_id = row
-            existing[ClaimIdentity(ct, oid, ck)] = _ExistingClaimRow(
+            existing[ClaimIdentity(ct, oid, ck)] = ExistingClaimRow(
                 value=val,
                 citation=cit,
                 needs_review=nr,

--- a/backend/apps/catalog/resolve/_media.py
+++ b/backend/apps/catalog/resolve/_media.py
@@ -10,7 +10,7 @@ from typing import NamedTuple, cast
 from django.contrib.contenttypes.models import ContentType
 
 from apps.core.models import MediaSupported
-from apps.core.types import EntityKey
+from apps.core.types import ClaimIdentity, EntityKey
 from apps.media.models import EntityMedia, MediaAsset
 from apps.provenance.models import Claim
 from apps.provenance.typing import HasEffectivePriority
@@ -18,14 +18,6 @@ from apps.provenance.typing import HasEffectivePriority
 from ._helpers import _annotate_priority
 
 logger = logging.getLogger(__name__)
-
-
-class ClaimWinnerKey(NamedTuple):
-    """Dedup key for the first-winner-per-(entity, claim_key) pass."""
-
-    content_type_id: int
-    object_id: int
-    claim_key: str
 
 
 class CtInfo(NamedTuple):
@@ -95,9 +87,9 @@ def resolve_media_attachments(
     # Winner per (content_type_id, object_id, claim_key).
     # Keep priority + created_at for primary enforcement.
     winners_by_entity: dict[EntityKey, list[Claim]] = {}
-    seen: set[ClaimWinnerKey] = set()
+    seen: set[ClaimIdentity] = set()
     for claim in claims:
-        key = ClaimWinnerKey(claim.content_type_id, claim.object_id, claim.claim_key)
+        key = ClaimIdentity(claim.content_type_id, claim.object_id, claim.claim_key)
         if key not in seen:
             seen.add(key)
             entity_key = EntityKey(claim.content_type_id, claim.object_id)

--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -7,7 +7,6 @@ Auto-discovered via the ``routers`` list convention in config/api.py.
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import TypedDict, cast
 
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
@@ -20,7 +19,7 @@ from ninja.security import django_auth
 from ninja.throttling import AuthRateThrottle
 from pydantic import field_validator
 
-from .extraction import ExtractionMatch, classify_input, extract_isbn, normalize_isbn
+from .extraction import classify_input, extract_isbn, normalize_isbn
 from .extractors import EXTRACTORS, recognize_url
 from .models import CitationSource, CitationSourceLink
 from .url_extraction import extract_url
@@ -217,24 +216,6 @@ class ExtractResponseSchema(Schema):
     error: str | None = None
     confidence: str = ""
     source_api: str = ""
-
-
-class _ExtractDraftDict(TypedDict):
-    name: str
-    source_type: str
-    author: str
-    publisher: str
-    year: int | None
-    isbn: str | None
-    url: str | None
-
-
-class _ExtractResponseDict(TypedDict, total=False):
-    match: ExtractionMatch
-    draft: _ExtractDraftDict
-    error: str
-    confidence: str
-    source_api: str
 
 
 # ---------------------------------------------------------------------------
@@ -510,17 +491,13 @@ def extract_citation_source(request, data: ExtractRequestSchema):
     else:
         raise HttpError(422, "Unsupported input")
 
-    resp: _ExtractResponseDict = {}
-    if result.match:
-        resp["match"] = result.match
-    if result.draft:
-        resp["draft"] = cast(_ExtractDraftDict, asdict(result.draft))
-    if result.error:
-        resp["error"] = result.error
-    resp["confidence"] = result.confidence
-    resp["source_api"] = result.source_api
-
-    return resp
+    return ExtractResponseSchema(
+        match=ExtractMatchSchema(**result.match) if result.match else None,
+        draft=ExtractDraftSchema(**asdict(result.draft)) if result.draft else None,
+        error=result.error,
+        confidence=result.confidence,
+        source_api=result.source_api,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/provenance/models/__init__.py
+++ b/backend/apps/provenance/models/__init__.py
@@ -6,6 +6,6 @@ continues to work unchanged.
 
 from .changeset import ChangeSet, ChangeSetAction
 from .citation_instance import CitationInstance
-from .claim import Claim, ClaimManager, make_claim_key
+from .claim import Claim, ClaimManager, ExistingClaimRow, make_claim_key
 from .ingest_run import IngestRun
 from .source import Source, SourceFieldLicense

--- a/backend/apps/provenance/models/claim.py
+++ b/backend/apps/provenance/models/claim.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
     from .citation_instance import CitationInstance
 
 
-class _ExistingClaimRow(NamedTuple):
-    """Partial Claim row cached during ``bulk_assert_claims`` diffing.
+class ExistingClaimRow(NamedTuple):
+    """Partial Claim row cached during claim diffing.
 
     Fetched via ``values_list`` to avoid JSONField deserialization cost on
     large sources. Field order matches the ``values_list`` column order.
@@ -198,7 +198,7 @@ class ClaimManager(models.Manager):
         # Use values_list to avoid full ORM object instantiation — on large
         # sources (40-50k+ claims) the overhead of JSONField deserialization
         # on full Claim objects causes multi-minute stalls on SQLite.
-        existing: dict[ClaimIdentity, _ExistingClaimRow] = {}
+        existing: dict[ClaimIdentity, ExistingClaimRow] = {}
         for row in self.filter(source=source, is_active=True).values_list(
             "pk",
             "content_type_id",
@@ -211,7 +211,7 @@ class ClaimManager(models.Manager):
             "license_id",
         ):
             pk, ct_id, obj_id, ck, val, cit, nr, nrn, lic_id = row
-            existing[ClaimIdentity(ct_id, obj_id, ck)] = _ExistingClaimRow(
+            existing[ClaimIdentity(ct_id, obj_id, ck)] = ExistingClaimRow(
                 value=val,
                 citation=cit,
                 needs_review=nr,


### PR DESCRIPTION
## Summary

Three structural-type duplications found by a type-inventory analyzer and collapsed to their canonical definitions:

- **`ClaimWinnerKey`** in `catalog/resolve/_media.py` — identical to `ClaimIdentity` in `apps.core.types`. Replaced with an import.
- **`_ExistingClaimRow`** in `catalog/ingestion/apply.py` — byte-for-byte copy of the one in `provenance/models/claim.py`. Promoted the provenance version to public `ExistingClaimRow`, exported it, deleted the duplicate.
- **`_ExtractDraftDict` / `_ExtractResponseDict`** in `citation/api.py` — shadow TypedDicts that mirrored `ExtractDraftSchema` / `ExtractResponseSchema`. Deleted them; handler now returns `ExtractResponseSchema` directly.

Five files, net -41 lines.

## Wire format

Unchanged. The citation-extract handler used to build a sparse dict; Ninja was already coercing it into `ExtractResponseSchema` and serializing via Pydantic, so declared fields with defaults always appeared in the JSON output anyway. Verified:

```
from sparse dict: {"draft":null,"match":null,"error":null,"confidence":"","source_api":""}
from full schema: {"draft":null,"match":null,"error":null,"confidence":"","source_api":""}
```

## Test plan

- [x] `pytest apps/provenance apps/catalog apps/citation apps/core` — 1,974 passing
- [x] `ruff check` + `ruff format --check` clean on all five files
- [x] `mypy` clean on refactored `extract_citation_source` handler
- [x] Grep for lingering references to removed names — none
- [x] Pre-commit hooks passed (including backend tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)