### PR TITLE
refactor: dedupe provenance/catalog schema types

### DIFF
--- a/backend/apps/catalog/api/corporate_entities.py
+++ b/backend/apps/catalog/api/corporate_entities.py
@@ -38,6 +38,7 @@ from .manufacturers import manufacturers_router
 from .schemas import (
     CorporateEntityClaimPatchSchema,
     CorporateEntityLocationSchema,
+    Ref,
     RelatedTitleSchema,
 )
 
@@ -46,15 +47,10 @@ from .schemas import (
 # ---------------------------------------------------------------------------
 
 
-class ManufacturerRef(Schema):
-    name: str
-    slug: str
-
-
 class CorporateEntityListSchema(Schema):
     name: str
     slug: str
-    manufacturer: ManufacturerRef
+    manufacturer: Ref
     year_start: int | None = None
     year_end: int | None = None
     model_count: int = 0
@@ -65,7 +61,7 @@ class CorporateEntityDetailSchema(Schema):
     name: str
     slug: str
     description: RichTextSchema = RichTextSchema()
-    manufacturer: ManufacturerRef
+    manufacturer: Ref
     year_start: int | None = None
     year_end: int | None = None
     aliases: list[str] = []

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -46,7 +46,7 @@ from .helpers import (
 from .schemas import (
     ClaimPatchSchema,
     CorporateEntityLocationSchema,
-    FacetRef,
+    Ref,
     RelatedTitleSchema,
 )
 from .titles import _dedup_facet_refs
@@ -58,11 +58,11 @@ class ManufacturerGridSchema(Schema):
     model_count: int = 0
     thumbnail_url: str | None = None
     search_text: str | None = None
-    locations: list[FacetRef] = []
+    locations: list[Ref] = []
     year_min: int | None = None
     year_max: int | None = None
-    persons: list[FacetRef] = []
-    tech_generations: list[FacetRef] = []
+    persons: list[Ref] = []
+    tech_generations: list[Ref] = []
 
 
 class ManufacturerSchema(Schema):
@@ -206,7 +206,7 @@ def _manufacturer_qs():
 
 
 def _build_location_refs(entities) -> list[dict]:
-    """Build location FacetRefs for each location and all its ancestors.
+    """Build location Refs for each location and all its ancestors.
 
     Uses location_path as the slug so refs are globally unique and stable.
     """

--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -236,11 +236,6 @@ class FranchiseRefSchema(Schema):
     slug: str
 
 
-class FacetRef(Schema):
-    slug: str
-    name: str
-
-
 class CreditSchema(Schema):
     person: Ref
     role: str

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -28,7 +28,7 @@ from apps.provenance.rate_limits import (
     DELETE_RATE_LIMIT_SPEC,
     check_and_record,
 )
-from apps.provenance.schemas import EditCitationInput, RichTextSchema
+from apps.provenance.schemas import EditCitationInput, ReviewLinkSchema, RichTextSchema
 
 from ..cache import TITLES_ALL_KEY, get_cached_response, set_cached_response
 from ..models import (
@@ -70,9 +70,9 @@ from .machine_models import (
 from .schemas import (
     BlockingReferrerSchema,
     CreditSchema,
-    FacetRef,
     GameplayFeatureSchema,
     ModelCreateSchema,
+    Ref,
     SeriesRefSchema,
     ThemeSchema,
     TitleMachineSchema,
@@ -95,46 +95,41 @@ class TitleListSchema(Schema):
     slug: str
     abbreviations: list[str] = []
     model_count: int = 0
-    manufacturer: FacetRef | None = None
+    manufacturer: Ref | None = None
     year: int | None = None
     thumbnail_url: str | None = None
     # Facet data — aggregated from non-variant models
-    tech_generations: list[FacetRef] = []
-    display_types: list[FacetRef] = []
+    tech_generations: list[Ref] = []
+    display_types: list[Ref] = []
     player_counts: list[int] = []
-    systems: list[FacetRef] = []
-    themes: list[FacetRef] = []
-    gameplay_features: list[FacetRef] = []
-    reward_types: list[FacetRef] = []
-    persons: list[FacetRef] = []
-    franchise: FacetRef | None = None
-    series: FacetRef | None = None
+    systems: list[Ref] = []
+    themes: list[Ref] = []
+    gameplay_features: list[Ref] = []
+    reward_types: list[Ref] = []
+    persons: list[Ref] = []
+    franchise: Ref | None = None
+    series: Ref | None = None
     year_min: int | None = None
     year_max: int | None = None
     ipdb_rating_max: float | None = None
 
 
-class ReviewLinkSchema(Schema):
-    label: str
-    url: str
-
-
 class AgreedSpecsSchema(Schema):
     """Spec fields where all child models of a title agree on the value."""
 
-    technology_generation: FacetRef | None = None
-    technology_subgeneration: FacetRef | None = None
-    display_type: FacetRef | None = None
+    technology_generation: Ref | None = None
+    technology_subgeneration: Ref | None = None
+    display_type: Ref | None = None
     player_count: int | None = None
     flipper_count: int | None = None
-    system: FacetRef | None = None
-    cabinet: FacetRef | None = None
-    game_format: FacetRef | None = None
-    display_subtype: FacetRef | None = None
+    system: Ref | None = None
+    cabinet: Ref | None = None
+    game_format: Ref | None = None
+    display_subtype: Ref | None = None
     themes: list[ThemeSchema] = []
     gameplay_features: list[GameplayFeatureSchema] = []
-    reward_types: list[FacetRef] = []
-    tags: list[FacetRef] = []
+    reward_types: list[Ref] = []
+    tags: list[Ref] = []
     production_quantity: str | None = None
 
 
@@ -143,8 +138,8 @@ class CrossTitleLinkSchema(Schema):
     a specific model under the current title."""
 
     relation: str
-    other_title: FacetRef
-    source_model: FacetRef
+    other_title: Ref
+    source_model: Ref
 
 
 class AggregatedMediaSchema(Schema):
@@ -155,7 +150,7 @@ class AggregatedMediaSchema(Schema):
     is_primary: bool
     uploaded_by_username: str | None = None
     renditions: MediaRenditionsSchema
-    source_model: FacetRef
+    source_model: Ref
 
 
 class TitleDetailSchema(Schema):
@@ -169,7 +164,7 @@ class TitleDetailSchema(Schema):
     needs_review_notes: str = ""
     review_links: list[ReviewLinkSchema] = []
     hero_image_url: str | None = None
-    franchise: FacetRef | None = None
+    franchise: Ref | None = None
     machines: list[TitleMachineSchema]
     series: SeriesRefSchema | None = None
     credits: list[CreditSchema] = []

--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -23,6 +23,7 @@ from apps.citation.models import CitationSource
 
 from .models import CitationInstance
 from .page_endpoints import pages_router
+from .schemas import ReviewLinkSchema
 
 
 class SourceSchema(Schema):
@@ -32,11 +33,6 @@ class SourceSchema(Schema):
     priority: int
     url: str
     description: str
-
-
-class ReviewLinkSchema(Schema):
-    label: str
-    url: str
 
 
 class ReviewClaimSchema(Schema):

--- a/backend/apps/provenance/helpers.py
+++ b/backend/apps/provenance/helpers.py
@@ -3,28 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, TypedDict, cast
+from typing import cast
 
 from django.db import models
 from django.db.models import Case, F, IntegerField, Prefetch, QuerySet, Value, When
 
 from .models import CitationInstance, Claim
-
-
-class SourceRow(TypedDict):
-    """Serialized per-claim entry matching ``ClaimSchema`` in schemas.py."""
-
-    source_name: str | None
-    source_slug: str | None
-    user_display: str | None
-    field_name: str
-    # Claim values are arbitrary JSON (scalar, dict, list, null) by design;
-    # the schema serializes them as ``object`` for the same reason.
-    value: Any
-    citation: str
-    created_at: str
-    is_winner: bool
-    changeset_note: str | None
+from .schemas import ClaimSchema
 
 
 def claims_prefetch(
@@ -86,30 +71,30 @@ def citation_instances(claim: Claim) -> list[CitationInstance]:
     return cast(list[CitationInstance], instances)
 
 
-def build_sources(claims: Iterable[Claim]) -> list[SourceRow]:
+def build_sources(claims: Iterable[Claim]) -> list[ClaimSchema]:
     """Serialize pre-fetched active claims into the sources list format.
 
     Claims should be ordered by claim_key, -priority, -created_at. The first
     claim seen per claim_key is marked as the winner.
     """
     winners: set[str] = set()
-    sources: list[SourceRow] = []
+    sources: list[ClaimSchema] = []
     for claim in claims:
         is_winner = claim.claim_key not in winners
         if is_winner:
             winners.add(claim.claim_key)
         sources.append(
-            {
-                "source_name": claim.source.name if claim.source else None,
-                "source_slug": claim.source.slug if claim.source else None,
-                "user_display": claim.user.username if claim.user else None,
-                "field_name": claim.field_name,
-                "value": claim.value,
-                "citation": claim.citation,
-                "created_at": claim.created_at.isoformat(),
-                "is_winner": is_winner,
-                "changeset_note": claim.changeset.note if claim.changeset else None,
-            }
+            ClaimSchema(
+                source_name=claim.source.name if claim.source else None,
+                source_slug=claim.source.slug if claim.source else None,
+                user_display=claim.user.username if claim.user else None,
+                field_name=claim.field_name,
+                value=claim.value,
+                citation=claim.citation,
+                created_at=claim.created_at.isoformat(),
+                is_winner=is_winner,
+                changeset_note=claim.changeset.note if claim.changeset else None,
+            )
         )
-    sources.sort(key=lambda c: c["created_at"], reverse=True)
+    sources.sort(key=lambda c: c.created_at, reverse=True)
     return sources

--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -3,48 +3,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, TypedDict
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Case, F, IntegerField, Model, Prefetch, Q, Value, When
 
 from .models import ChangeSet, Claim
-
-
-class FieldChange(TypedDict):
-    """One field change within a ChangeSet; mirrors ``FieldChangeSchema``."""
-
-    field_name: str
-    claim_key: str
-    # old/new values are claim payloads (arbitrary JSON: scalar, dict, list, null).
-    old_value: Any
-    new_value: Any
-    claim_id: int
-    claim_user_id: int | None
-    is_active: bool
-    is_winning: bool
-    is_retracted: bool
-
-
-class Retraction(TypedDict):
-    """One retracted claim recorded on a ChangeSet; mirrors ``RetractionSchema``."""
-
-    claim_id: int
-    field_name: str
-    claim_key: str
-    # old_value is the retracted claim's stored payload (arbitrary JSON).
-    old_value: Any
-
-
-class ChangeSetHistory(TypedDict):
-    """One changeset with its changes and retractions for the edit-history page."""
-
-    id: int
-    user_display: str | None
-    note: str
-    created_at: str
-    changes: list[FieldChange]
-    retractions: list[Retraction]
+from .schemas import ChangeSetSchema, FieldChangeSchema, RetractionSchema
 
 
 def _compute_winning_claim_ids(ct: ContentType, entity_pk: int) -> set[int]:
@@ -81,12 +45,12 @@ def _compute_winning_claim_ids(ct: ContentType, entity_pk: int) -> set[int]:
     return winners
 
 
-def build_edit_history(entity: Model) -> list[ChangeSetHistory]:
+def build_edit_history(entity: Model) -> list[ChangeSetSchema]:
     """Build changeset-grouped edit history with old→new diffs for an entity.
 
-    Returns a list of dicts matching ChangeSetSchema, newest first.
-    Uses two queries to avoid N+1: one for changesets with their claims,
-    one for all inactive user claims (to look up previous values).
+    Returns ChangeSetSchema rows newest first. Uses two queries to avoid N+1:
+    one for changesets with their claims, one for all inactive user claims
+    (to look up previous values).
     """
     ct = ContentType.objects.get_for_model(entity)
 
@@ -139,9 +103,9 @@ def build_edit_history(entity: Model) -> list[ChangeSetHistory]:
     winning_ids = _compute_winning_claim_ids(ct, entity.pk)
 
     # 4. Build response.
-    result: list[ChangeSetHistory] = []
+    result: list[ChangeSetSchema] = []
     for cs in changesets:
-        changes: list[FieldChange] = []
+        changes: list[FieldChangeSchema] = []
         for claim in cs.claims.all():
             chain = (
                 history.get((claim.claim_key, claim.user_id), [])
@@ -154,37 +118,38 @@ def build_edit_history(entity: Model) -> list[ChangeSetHistory]:
                     old_value = chain[i + 1].value
                     break
             changes.append(
-                {
-                    "field_name": claim.field_name,
-                    "claim_key": claim.claim_key,
-                    "old_value": old_value,
-                    "new_value": claim.value,
-                    "claim_id": claim.pk,
-                    "claim_user_id": claim.user_id,
-                    "is_active": claim.is_active,
-                    "is_winning": claim.pk in winning_ids,
-                    "is_retracted": claim.retracted_by_changeset_id is not None,
-                }
+                FieldChangeSchema(
+                    field_name=claim.field_name,
+                    claim_key=claim.claim_key,
+                    old_value=old_value,
+                    new_value=claim.value,
+                    claim_id=claim.pk,
+                    claim_user_id=claim.user_id,
+                    is_active=claim.is_active,
+                    is_winning=claim.pk in winning_ids,
+                    is_retracted=claim.retracted_by_changeset_id is not None,
+                )
             )
 
-        retractions: list[Retraction] = [
-            {
-                "claim_id": c.pk,
-                "field_name": c.field_name,
-                "claim_key": c.claim_key,
-                "old_value": c.value,
-            }
+        retractions: list[RetractionSchema] = [
+            RetractionSchema(
+                claim_id=c.pk,
+                field_name=c.field_name,
+                claim_key=c.claim_key,
+                old_value=c.value,
+            )
             for c in cs.retracted_claims.all()
         ]
 
+        assert cs.pk is not None
         result.append(
-            {
-                "id": cs.pk,
-                "user_display": cs.user.username if cs.user else None,
-                "note": cs.note,
-                "created_at": cs.created_at.isoformat(),
-                "changes": changes,
-                "retractions": retractions,
-            }
+            ChangeSetSchema(
+                id=cs.pk,
+                user_display=cs.user.username if cs.user else None,
+                note=cs.note,
+                created_at=cs.created_at.isoformat(),
+                changes=changes,
+                retractions=retractions,
+            )
         )
     return result

--- a/backend/apps/provenance/page_endpoints.py
+++ b/backend/apps/provenance/page_endpoints.py
@@ -29,7 +29,12 @@ from .entity_resolution import batch_resolve_entities
 from .evidence import build_cited_changesets
 from .helpers import active_claims, build_sources, claims_prefetch
 from .history import build_edit_history
-from .schemas import ClaimSchema, FieldChangeSchema, RetractionSchema
+from .schemas import (
+    ChangeSetSchema,
+    ClaimSchema,
+    FieldChangeSchema,
+    RetractionSchema,
+)
 
 
 class ChangeSetSummarySchema(Schema):
@@ -99,17 +104,6 @@ class SourcesPageSchema(Schema):
     evidence: list[CitedChangeSetSchema]
 
 
-class ChangeSetSchema(Schema):
-    """A grouped edit session with per-field diffs."""
-
-    id: int
-    user_display: str | None = None
-    note: str
-    created_at: str
-    changes: list[FieldChangeSchema]
-    retractions: list[RetractionSchema] = []
-
-
 type ErrorPayload = dict[str, str]
 
 
@@ -150,17 +144,7 @@ def edit_history_page(
     except ValueError:
         return Status(404, {"detail": f"Unknown entity type: {entity_type}"})
     entity = get_object_or_404(model_class, slug=slug)
-    return [
-        ChangeSetSchema(
-            id=row["id"],
-            user_display=row["user_display"],
-            note=row["note"],
-            created_at=row["created_at"],
-            changes=[FieldChangeSchema(**c) for c in row["changes"]],
-            retractions=[RetractionSchema(**r) for r in row["retractions"]],
-        )
-        for row in build_edit_history(entity)
-    ]
+    return build_edit_history(entity)
 
 
 @pages_router.get(
@@ -188,7 +172,7 @@ def sources_page(
         model_class._default_manager.prefetch_related(claims_prefetch()), slug=slug
     )
     claims = active_claims(entity)
-    sources = [ClaimSchema(**source) for source in build_sources(claims)]
+    sources = build_sources(claims)
     evidence = [
         CitedChangeSetSchema(
             id=row["id"],

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -35,6 +35,17 @@ class RetractionSchema(Schema):
     old_value: object
 
 
+class ChangeSetSchema(Schema):
+    """A grouped edit session with per-field diffs."""
+
+    id: int
+    user_display: str | None = None
+    note: str
+    created_at: str
+    changes: list[FieldChangeSchema]
+    retractions: list[RetractionSchema] = []
+
+
 class ClaimSchema(Schema):
     """A single per-field claim as surfaced to the Sources UI."""
 

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -79,6 +79,13 @@ class AttributionSchema(Schema):
     attribution_text: str | None = None
 
 
+class ReviewLinkSchema(Schema):
+    """A link out to an external page relevant to a needs-review item."""
+
+    label: str
+    url: str
+
+
 class InlineCitationLinkSchema(Schema):
     """A link attached to a citation source."""
 


### PR DESCRIPTION
## Summary

Follow-up to the structural-type dedupe work. Two small, independent cleanups in one PR:

- **Provenance helpers stop mirroring their own Schemas.** `FieldChange`, `Retraction`, `ChangeSetHistory`, and `SourceRow` were TypedDicts whose docstrings literally said "mirrors FieldChangeSchema" etc. Drop them; have `build_edit_history` / `build_sources` return `ChangeSetSchema` / `ClaimSchema` directly. `ChangeSetSchema` moves from `page_endpoints.py` into `schemas.py` next to its siblings.
- **Catalog `Ref` schemas unified.** `Ref`, `FacetRef`, and `ManufacturerRef` were three names for the same two-field `{name, slug}` shape. Keep `Ref`; drop the other two. Also promote `ReviewLinkSchema` (duplicated verbatim in `provenance/api.py` and `catalog/api/titles.py`) to `apps.provenance.schemas` as the shared home.

Types that look similar but are intentionally separate — `Create`/`Delete`/`Restore` schema families (endpoint-local names drive generated-client ergonomics) and `ExtractionDraft`/`ExtractionMatch` (real dataclass lifecycle before API serialization) — are left alone.

Net: −6 types, −4 `Schema(**row)` adapter loops, generated OpenAPI loses `FacetRef` and `ManufacturerRef` (both subsumed by `Ref`).

## Test plan

- [x] `make lint` — ruff clean, mypy baseline unchanged (`new: 0`)
- [x] `uv run pytest` — 2213 passed, 1 skipped
- [ ] Confirm generated `schema.d.ts` regenerates cleanly after merge (`make api-gen`)
- [ ] Spot-check frontend render of a Title detail page (uses `Ref`/ex-`FacetRef`) and a Corporate Entity page (uses `Ref`/ex-`ManufacturerRef`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)