### PR TITLE
refactor(api): consolidate duplicate Ninja schemas

### DIFF
--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -135,12 +135,6 @@ class VariantSchema(Schema):
     variant_features: list[str] = []
 
 
-class ConversionSchema(Schema):
-    name: str
-    slug: str
-    year: int | None = None
-
-
 class ModelRefSchema(Schema):
     """A reference to a machine model with name, slug, and optional year."""
 
@@ -191,9 +185,9 @@ class MachineModelDetailSchema(Schema):
     variant_of: ModelRefSchema | None = None
     variant_siblings: list[VariantSchema] = []
     converted_from: ModelRefSchema | None = None
-    conversions: list[ConversionSchema] = []
+    conversions: list[ModelRefSchema] = []
     remake_of: ModelRefSchema | None = None
-    remakes: list[ConversionSchema] = []
+    remakes: list[ModelRefSchema] = []
     title_models: list[TitleMachineSchema] = []
 
 

--- a/backend/apps/catalog/tests/test_api_schema_boundaries.py
+++ b/backend/apps/catalog/tests/test_api_schema_boundaries.py
@@ -16,7 +16,7 @@ class TestSharedSchemaOwnership:
         for name in (
             "EditCitationInput",
             "AttributionSchema",
-            "InlineCitationLinkSchema",
+            "CitationLinkSchema",
             "InlineCitationSchema",
             "RichTextSchema",
         ):
@@ -38,7 +38,7 @@ class TestSharedSchemaOwnership:
         shared_names = (
             "EditCitationInput",
             "AttributionSchema",
-            "InlineCitationLinkSchema",
+            "CitationLinkSchema",
             "InlineCitationSchema",
             "RichTextSchema",
             "MediaRenditionsSchema",

--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -63,7 +63,7 @@ class CitationSourceSearchSchema(Schema):
     identifier_key: str = ""
 
 
-class RecognitionChildSchema(Schema):
+class CitationSourceMatchSchema(Schema):
     id: int
     name: str
     skip_locator: bool = False
@@ -71,7 +71,7 @@ class RecognitionChildSchema(Schema):
 
 class RecognitionSchema(Schema):
     parent: CitationSourceParentSchema
-    child: RecognitionChildSchema | None = None
+    child: CitationSourceMatchSchema | None = None
     identifier: str | None = None
 
 
@@ -204,15 +204,9 @@ class ExtractDraftSchema(Schema):
     url: str | None = None
 
 
-class ExtractMatchSchema(Schema):
-    id: int
-    name: str
-    skip_locator: bool = False
-
-
 class ExtractResponseSchema(Schema):
     draft: ExtractDraftSchema | None = None
-    match: ExtractMatchSchema | None = None
+    match: CitationSourceMatchSchema | None = None
     error: str | None = None
     confidence: str = ""
     source_api: str = ""
@@ -492,7 +486,7 @@ def extract_citation_source(request, data: ExtractRequestSchema):
         raise HttpError(422, "Unsupported input")
 
     return ExtractResponseSchema(
-        match=ExtractMatchSchema(**result.match) if result.match else None,
+        match=CitationSourceMatchSchema(**result.match) if result.match else None,
         draft=ExtractDraftSchema(**asdict(result.draft)) if result.draft else None,
         error=result.error,
         confidence=result.confidence,

--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -23,7 +23,7 @@ from apps.citation.models import CitationSource
 
 from .models import CitationInstance
 from .page_endpoints import pages_router
-from .schemas import ReviewLinkSchema
+from .schemas import CitationLinkSchema, ReviewLinkSchema
 
 
 class SourceSchema(Schema):
@@ -260,11 +260,6 @@ def list_citation_instances(
     ]
 
 
-class BatchCitationLinkOut(Schema):
-    url: str
-    label: str
-
-
 class BatchCitationInstanceOut(Schema):
     id: int
     source_name: str
@@ -272,7 +267,7 @@ class BatchCitationInstanceOut(Schema):
     author: str
     year: int | None = None
     locator: str
-    links: list[BatchCitationLinkOut] = []
+    links: list[CitationLinkSchema] = []
 
 
 @citation_instances_router.get(

--- a/backend/apps/provenance/page_endpoints.py
+++ b/backend/apps/provenance/page_endpoints.py
@@ -31,6 +31,7 @@ from .helpers import active_claims, build_sources, claims_prefetch
 from .history import build_edit_history
 from .schemas import (
     ChangeSetSchema,
+    CitationLinkSchema,
     ClaimSchema,
     FieldChangeSchema,
     RetractionSchema,
@@ -70,18 +71,13 @@ class ChangeSetDetailSchema(Schema):
     retractions: list[RetractionSchema]
 
 
-class EvidenceLinkSchema(Schema):
-    url: str
-    label: str
-
-
 class CitedChangeSetCitationSchema(Schema):
     source_name: str
     source_type: str
     author: str
     year: int | None = None
     locator: str
-    links: list[EvidenceLinkSchema] = []
+    links: list[CitationLinkSchema] = []
 
 
 class CitedChangeSetSchema(Schema):
@@ -187,7 +183,7 @@ def sources_page(
                     author=c["author"],
                     year=c["year"],
                     locator=c["locator"],
-                    links=[EvidenceLinkSchema(**link) for link in c["links"]],
+                    links=[CitationLinkSchema(**link) for link in c["links"]],
                 )
                 for c in row["citations"]
             ],

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -86,7 +86,7 @@ class ReviewLinkSchema(Schema):
     url: str
 
 
-class InlineCitationLinkSchema(Schema):
+class CitationLinkSchema(Schema):
     """A link attached to a citation source."""
 
     url: str
@@ -103,7 +103,7 @@ class InlineCitationSchema(Schema):
     author: str
     year: int | None = None
     locator: str
-    links: list[InlineCitationLinkSchema] = []
+    links: list[CitationLinkSchema] = []
 
 
 class RichTextSchema(Schema):


### PR DESCRIPTION
## Summary

Three sets of structurally identical Ninja API schemas collapsed into shared names, continuing the recent dedupe pattern from #255.

- **citation** — `RecognitionChildSchema` + `ExtractMatchSchema` → `CitationSourceMatchSchema`. Both were `(id, name, skip_locator)` references to a matched `CitationSource`.
- **catalog** — `ConversionSchema` dropped; `conversions`/`remakes` now reuse `ModelRefSchema`. Both were `(name, slug, year)` machine-model references.
- **provenance** — `InlineCitationLinkSchema` renamed to `CitationLinkSchema` and reused in place of `EvidenceLinkSchema` (page_endpoints.py) and `BatchCitationLinkOut` (api.py). All three were `(url, label)` on a citation source.

`ReviewLinkSchema` is kept distinct — same shape, different semantic domain (needs-review target, not a citation source), matching the precedent set in #255.

## Test plan

- [x] `pytest apps/catalog apps/citation apps/provenance` passes (1871 tests)
- [x] Schema-boundary test updated to reference `CitationLinkSchema`
- [ ] CI green
- [ ] `make api-gen` on consumer side picks up renamed schema names without frontend breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)