### PR TITLE
chore(claude): raise backend SessionStart timeout + instrument script

### DIFF
--- a/.claude/hooks/session-start-backend.sh
+++ b/.claude/hooks/session-start-backend.sh
@@ -13,12 +13,41 @@
 #
 # Localhost Claude Code sessions skip the ``uv self update`` + Python
 # install — those mutate global tooling we don't own.
-set -euo pipefail
+#
+# Emits one ``[step] elapsed=Ns`` line per stage plus a final total so
+# SessionStart banner output makes failures (timeout, nonzero exit) visible
+# instead of silent.  An ERR trap reports which step failed on the way out.
+# The per-hook timeout in .claude/settings.json (600s) has to stay
+# comfortably above the worst cold-start total — bump both together if
+# cold-start totals creep toward it.
+set -eEuo pipefail
+
+script_start=$SECONDS
+current_step="startup"
+trap 'echo "[session-start-backend] FAILED step=${current_step} elapsed=$((SECONDS - script_start))s exit=$?"' ERR
+
+run_step() {
+  local name=$1
+  shift
+  current_step=$name
+  local t0=$SECONDS
+  "$@"
+  echo "[session-start-backend] ${name} elapsed=$((SECONDS - t0))s"
+}
 
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
-  uv self update
-  uv python install 3.14
+  run_step "uv-self-update" uv self update
+  run_step "uv-python-install" uv python install 3.14
 fi
 
-( cd backend && uv sync )
-( cd backend && uv run python manage.py migrate --no-input ) || true
+run_step "uv-sync" bash -c 'cd backend && uv sync'
+
+# Migrations aren't a hard dependency for session startup — a migration
+# error shouldn't wedge the whole hook — so run without the ERR trap.
+current_step="migrate"
+migrate_start=$SECONDS
+( cd backend && uv run python manage.py migrate --no-input ) || \
+  echo "[session-start-backend] migrate FAILED (non-fatal) elapsed=$((SECONDS - migrate_start))s"
+echo "[session-start-backend] migrate elapsed=$((SECONDS - migrate_start))s"
+
+echo "[session-start-backend] done total=$((SECONDS - script_start))s"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,7 +47,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/session-start-backend.sh"
+            "command": "bash .claude/hooks/session-start-backend.sh",
+            "timeout": 600
           },
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- Add `"timeout": 600` to the backend `SessionStart` hook entry. Claude Code's default hook timeout is 60s; a cold container needs `uv self update` + `uv python install 3.14` (which downloads ~100 MB) + `uv sync` to complete before the sandbox is usable, and that can run 2–3 minutes. When it times out silently, the venv is left on uv 0.8.17 / Python 3.14.0rc2, which blows up django-ninja imports via pydantic's `prefer_fwd_module` assertion. Only the backend hook gets the longer timeout; pnpm and pre-commit stay on the default.
- Instrument `session-start-backend.sh` with per-step timing and an ERR trap. Each stage now prints `[session-start-backend] <step> elapsed=Ns`, with a final `total=Ns`. Failures (including the migrate step, which stays non-fatal) print which step failed on the way out instead of being invisible. Requires `set -eE` — `set -e` alone doesn't propagate ERR traps into shell functions.

Future cold-start regressions (bigger Python builds, new slow steps, uv updates) will now show up in the SessionStart banner. If `total=` ever creeps toward 600s, bump both the script and the settings timeout together.

## Test plan

- [ ] Cold container SessionStart completes and prints per-step + total timings
- [ ] Warm resume prints per-step + total (typically 1–2s)
- [ ] Intentionally break a step (e.g. `uv sync` with a bad lockfile) and confirm the `FAILED step=...` line appears
- [ ] Confirm `uvx pre-commit install` and `cd frontend && pnpm install` hooks are unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_015K9LVLskwmvmSHnskdAHJN)_