### PR TITLE
fix(catalog): honor exists=False on CE location claims

### DIFF
--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -877,7 +877,10 @@ def resolve_all_corporate_entity_locations(
 
     desired: dict[int, set[int]] = defaultdict(set)
     for row in active_claims:
-        loc_pk = (row["value"] or {}).get("location")
+        val = row["value"] or {}
+        if not val.get("exists", True):
+            continue
+        loc_pk = val.get("location")
         if loc_pk and loc_pk in valid_loc_pks:
             desired[row["object_id"]].add(loc_pk)
 

--- a/backend/apps/catalog/tests/test_resolve.py
+++ b/backend/apps/catalog/tests/test_resolve.py
@@ -478,6 +478,42 @@ class TestResolveCorporateEntityLocations:
         assert result["deleted"] == 1
         assert not CorporateEntityLocation.objects.filter(corporate_entity=ce).exists()
 
+    def test_retraction_claim_does_not_create_cel(self, db):
+        source = Source.objects.create(name="PB", source_type="editorial", priority=300)
+        ce = self._make_ce("williams")
+        loc = self._make_location("usa/il/chicago")
+        claim_key, value = build_relationship_claim(
+            "location", {"location": loc.pk}, exists=False
+        )
+        Claim.objects.assert_claim(
+            ce, "location", value, source=source, claim_key=claim_key
+        )
+
+        resolve_all_corporate_entity_locations()
+
+        assert not CorporateEntityLocation.objects.filter(
+            corporate_entity=ce, location=loc
+        ).exists()
+
+    def test_retraction_claim_removes_existing_cel(self, db):
+        source = Source.objects.create(name="PB", source_type="editorial", priority=300)
+        ce = self._make_ce("williams")
+        loc = self._make_location("usa/il/chicago")
+        self._assert_location(source, ce, loc)
+        resolve_all_corporate_entity_locations()
+        assert CorporateEntityLocation.objects.filter(corporate_entity=ce).count() == 1
+
+        claim_key, value = build_relationship_claim(
+            "location", {"location": loc.pk}, exists=False
+        )
+        Claim.objects.assert_claim(
+            ce, "location", value, source=source, claim_key=claim_key
+        )
+        result = resolve_all_corporate_entity_locations()
+
+        assert result["deleted"] == 1
+        assert not CorporateEntityLocation.objects.filter(corporate_entity=ce).exists()
+
     def test_handles_multiple_ces(self, db):
         source = Source.objects.create(name="PB", source_type="editorial", priority=300)
         ce1 = self._make_ce("williams")


### PR DESCRIPTION
## Summary
- `resolve_all_corporate_entity_locations` ignored `exists=False` on `location` claims, so retractions silently no-opped instead of removing the `CorporateEntityLocation` row.
- Added the `exists` guard to match every sibling resolver in the same file.
- TDD: two failing tests added first (retraction doesn't create a CEL; retraction removes an existing CEL), then the one-line fix.

Implements [docs/plans/types/LocationRetractionFix.md](docs/plans/types/LocationRetractionFix.md) (Step 10.1 of MypyFixing.md).

## Test plan
- [x] `uv run pytest apps/catalog/tests/test_resolve.py apps/catalog/tests/test_resolve_bulk.py` — 59 passed
- [x] New tests fail before the fix for the expected reason, pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)