### PR TITLE
refactor(typing): ClassVar on Shape 2 catalog model attrs

### DIFF
--- a/backend/apps/catalog/models/gameplay_feature.py
+++ b/backend/apps/catalog/models/gameplay_feature.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.validators import MinValueValidator
 from django.db import models
@@ -39,7 +41,10 @@ class GameplayFeature(
 
     entity_type = "gameplay-feature"
     entity_type_plural = "gameplay-features"
-    soft_delete_usage_blockers = ("machine_models", "children")
+    soft_delete_usage_blockers: ClassVar[tuple[str, ...]] = (
+        "machine_models",
+        "children",
+    )
     MEDIA_CATEGORIES = ["other"]
     aliases: models.Manager[GameplayFeatureAlias]
     children: models.Manager[GameplayFeature]

--- a/backend/apps/catalog/models/location.py
+++ b/backend/apps/catalog/models/location.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.db.models.functions import Lower, Now
@@ -28,8 +30,8 @@ class Location(EntityStatusMixin, models.Model):
     are claim-controlled — pindata is the authoritative source.
     """
 
-    claims_exempt = frozenset({"location_path"})
-    claim_fk_lookups = {"parent": "location_path"}
+    claims_exempt: ClassVar[frozenset[str]] = frozenset({"location_path"})
+    claim_fk_lookups: ClassVar[dict[str, str]] = {"parent": "location_path"}
 
     created_at = models.DateTimeField(auto_now_add=True, db_default=Now())
     updated_at = models.DateTimeField(auto_now=True)

--- a/backend/apps/catalog/models/taxonomy.py
+++ b/backend/apps/catalog/models/taxonomy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
@@ -211,7 +211,7 @@ class RewardType(CatalogModel, EntityStatusMixin, SluggedModel, TimeStampedModel
 
     entity_type = "reward-type"
     entity_type_plural = "reward-types"
-    soft_delete_usage_blockers = ("machine_models",)
+    soft_delete_usage_blockers: ClassVar[tuple[str, ...]] = ("machine_models",)
 
     name = models.CharField(
         max_length=200, unique=True, validators=[validate_no_mojibake]
@@ -273,7 +273,7 @@ class Tag(CatalogModel, EntityStatusMixin, SluggedModel, TimeStampedModel):
 
     entity_type = "tag"
     entity_type_plural = "tags"
-    soft_delete_usage_blockers = ("machine_models",)
+    soft_delete_usage_blockers: ClassVar[tuple[str, ...]] = ("machine_models",)
 
     name = models.CharField(
         max_length=200, unique=True, validators=[validate_no_mojibake]
@@ -319,7 +319,10 @@ class CreditRole(CatalogModel, EntityStatusMixin, SluggedModel, TimeStampedModel
     # role. Credit itself has no EntityStatusMixin, so we expose two M2M
     # accessors through Credit and let the generic usage-blocker walker
     # (soft_delete._iter_usage_blockers) filter each via .active().
-    soft_delete_usage_blockers = ("machine_models", "series_credited")
+    soft_delete_usage_blockers: ClassVar[tuple[str, ...]] = (
+        "machine_models",
+        "series_credited",
+    )
 
     name = models.CharField(
         max_length=200, unique=True, validators=[validate_no_mojibake]

--- a/backend/apps/catalog/models/theme.py
+++ b/backend/apps/catalog/models/theme.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.db.models.functions import Lower
@@ -32,7 +34,10 @@ class Theme(CatalogModel, EntityStatusMixin, SluggedModel, TimeStampedModel):
 
     entity_type = "theme"
     entity_type_plural = "themes"
-    soft_delete_usage_blockers = ("machine_models", "children")
+    soft_delete_usage_blockers: ClassVar[tuple[str, ...]] = (
+        "machine_models",
+        "children",
+    )
     aliases: models.Manager[ThemeAlias]
     children: models.Manager[Theme]
 

--- a/backend/apps/catalog/models/title.py
+++ b/backend/apps/catalog/models/title.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.validators import MinValueValidator
@@ -50,7 +50,7 @@ class Title(CatalogModel, EntityStatusMixin, SluggedModel, TimeStampedModel):
     # (each gets a ``status=deleted`` claim in the same ChangeSet). The DB FK
     # from MachineModel.title is PROTECT, which blocks hard deletion; the
     # cascade here is an application-layer rule over resolved ``status``.
-    soft_delete_cascade_relations = ("machine_models",)
+    soft_delete_cascade_relations: ClassVar[tuple[str, ...]] = ("machine_models",)
 
     opdb_id = models.CharField(
         max_length=50,


### PR DESCRIPTION
## Summary

- Add `ClassVar[...]` annotations to Shape 2 opt-in class attrs on catalog models: `claim_fk_lookups`, `claims_exempt`, `soft_delete_cascade_relations`, `soft_delete_usage_blockers`.
- Declarations only — consumer-side `getattr(model, "attr", default)` reads stay unchanged per the canonical Shape 2 access pattern.
- Implements the first cleanup item from [docs/plans/model_driven_metadata/ModelDrivenMetadataCleanup.md](docs/plans/model_driven_metadata/ModelDrivenMetadataCleanup.md).

## Scope

7 declaration sites across 5 files:

- [backend/apps/catalog/models/location.py](backend/apps/catalog/models/location.py) — `claims_exempt`, `claim_fk_lookups`
- [backend/apps/catalog/models/title.py](backend/apps/catalog/models/title.py) — `soft_delete_cascade_relations`
- [backend/apps/catalog/models/theme.py](backend/apps/catalog/models/theme.py), [taxonomy.py](backend/apps/catalog/models/taxonomy.py) (RewardType, Tag, CreditRole), [gameplay_feature.py](backend/apps/catalog/models/gameplay_feature.py) — `soft_delete_usage_blockers`

Explicitly out of scope: `entity_type` typing, `MEDIA_CATEGORIES` readiness validator, and all other cleanup items from the doc — to be handled separately.

Note: `api_type_key` listed in the cleanup doc does not exist in the codebase. Removed from the doc in a parallel change on `docs/typing-planning`.

## Test plan

- [x] Pre-commit hooks pass (ruff, mypy/dmypy, backend tests, secret scan)
- [x] Attrs load at runtime with expected values under Django setup
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)