### PR TITLE
docs(plans): extract ResolveHardening sequence for claim-value shape work

### DIFF
--- a/docs/plans/types/CatalogResolveBaselineCleanup.md
+++ b/docs/plans/types/CatalogResolveBaselineCleanup.md
@@ -1,0 +1,93 @@
+# Catalog Resolve Baseline Cleanup
+
+Step 4 of [ResolveHardening.md](ResolveHardening.md). Mypy baseline burn-down on `backend/apps/catalog/resolve/*.py`: helper function signatures and tuple-variable-reuse cleanup. Bundled with the hardening sequence because it touches the same files as Steps 2–3, not because baseline reduction is load-bearing for the hardening story.
+
+## Context
+
+After Step 3 ([CatalogResolveTyping.md](CatalogResolveTyping.md)) lands, the claim-value shape work is done but two other classes of mypy entries remain in `catalog/resolve/*`:
+
+- **Untyped keystone helpers.** `validate_check_constraints`, `_coerce`, `_resolve_fk_generic`, `_sync_markdown_references`, `_resolve_aliases`, `_resolve_parents`, `resolve_entity`, `resolve_all_entities`, `_annotate_priority` — missing signatures. `_annotate_priority(qs)` is the keystone: it contributes ~9 `no-untyped-call` entries across every resolver.
+- **Tuple-shape variable reuse** in `_relationships.py` and `_media.py`: loop variables get assigned from `values_list(...)` tuples of different arities (or a tuple and a model instance) in the same scope, tripping `Incompatible types in assignment` + `Need more than N values to unpack`.
+
+## Scope — behavior-preserving
+
+Pure typing cleanup. No resolver logic changes. Baseline only moves downward.
+
+## Prerequisites
+
+[CatalogResolveTyping.md](CatalogResolveTyping.md) (Step 3) lands first. Rationale: Step 3's Phase B rewrites most resolver loops to add `cast` calls; rebasing this cleanup over that diff is more friction than doing it after.
+
+## Approach
+
+### Phase 1 — Type keystone helpers
+
+Annotate in callee-before-caller order:
+
+- [\_helpers.py](../../../backend/apps/catalog/resolve/_helpers.py): `validate_check_constraints(obj: models.Model) -> None`; `_coerce(model_class: type[models.Model], attr: str, value: object) -> object`; `_resolve_fk_generic(..., value: object, ...)`; **`_annotate_priority(qs: QuerySet[Claim]) -> QuerySet[Claim]`** (kills ~9 `no-untyped-call` errors). Only [\_media.py:181](../../../backend/apps/catalog/resolve/_media.py#L181) reads `effective_priority`, and it already uses `cast(HasEffectivePriority, claim)` — keep it.
+- [\_entities.py](../../../backend/apps/catalog/resolve/_entities.py): `_sync_markdown_references(obj: models.Model)`; `_resolve_single(obj: models.Model, ...)`; `_resolve_bulk(model_class: type[models.Model], ...)`; `resolve_entity(obj: models.Model) -> models.Model`; `resolve_all_entities(model_class: type[models.Model], *, object_ids: set[int] | None = None)`. Flip `extra_data: dict | None = {} if has_extra_data else None` to `JsonBody | None` — both locals mutate the dict, so the covariant `JsonData = Mapping[str, object]` is wrong; invariant `JsonBody = dict[str, object]` is correct per [core/types.py:19-20](../../../backend/apps/core/types.py#L19).
+- [\_relationships.py](../../../backend/apps/catalog/resolve/_relationships.py): `_resolve_aliases(parent_model: type[models.Model], claim_field_name: str)`; `_resolve_parents(parent_model: type[models.Model], *, claim_field_prefix: str | None = None)`. Reverse-relation accessors (`parent_model.aliases.rel`, `parent_model.parents.through`) are category-#3 `Any` per the idiom — Django's descriptor API genuinely discards the info. Confine the ignores to two small helpers:
+  - `_get_alias_rel_info(parent: type[models.Model]) -> tuple[type[models.Model], str]` — returns `(alias_model, fk_col)` from `parent.aliases.rel` with a single `# type: ignore[attr-defined]` + comment naming the GenericRelation reverse-accessor constraint.
+  - `_get_parents_through(parent: type[models.Model]) -> type[models.Model]` — returns `parent.parents.through`, same pattern.
+
+  A Protocol can't express `parents.through` (or the `.rel.field.name` path), so helper-with-ignore is the minimum-touch option; scattering the ignores across `_resolve_aliases` / `_resolve_parents` loop bodies would be easier to accidentally normalize.
+
+- [\_\_init\_\_.py](../../../backend/apps/catalog/resolve/__init__.py): the `dict | None` / `dict` generics on `sfl_map`, `extra_data`, `_apply_resolution` signatures.
+
+**Done when:** every function in `resolve/` has a full signature; `no-untyped-call` entries on `_annotate_priority` are gone across all five files.
+
+### Phase 2 — Clean up tuple-reuse in `_relationships.py` and `_media.py`
+
+Two files, same pattern: a loop variable gets assigned from `values_list(...)` with one tuple arity and then reassigned in a later scope (either a different values_list, or a model instance from `in_bulk`). Mypy locks in the first-seen type and flags every divergence.
+
+- `_relationships.py` — baseline lines 81–92 and siblings. ~6 loops across `_resolve_machine_model_m2m`, `resolve_all_gameplay_features`, `resolve_all_credits`, both abbreviation resolvers, `_resolve_aliases`, `_resolve_parents`. `resolve_all_gameplay_features` in particular has the same tuple-vs-instance collision as `_media.py`: [line 253-258](../../../backend/apps/catalog/resolve/_relationships.py#L253) uses `row` for a `values_list` tuple, then [line 294](../../../backend/apps/catalog/resolve/_relationships.py#L294) reassigns `row = rows[pk]` to a `MachineModelGameplayFeature` instance and writes `row.count = count` — this triggers three baseline entries (`[assignment]`, `[method-assign]`, second `[assignment]`) that all collapse when the inner-loop local is renamed (`mgf_row` or similar).
+- `_media.py` — baseline entries at [\_media.py:244-250](../../../backend/apps/catalog/resolve/_media.py#L244) (values_list row) colliding with [\_media.py:293](../../../backend/apps/catalog/resolve/_media.py#L293) (`row = rows[update.row_pk]` — the `EntityMedia` instance). Rename the inner-loop local (`media_row` or similar).
+
+Fix by inline-unpacking the tuple at the loop header and renaming any colliding inner-scope reuse:
+
+```python
+# before
+for row in MachineModelGameplayFeature.objects.filter(...).values_list(
+    "pk", "machinemodel_id", "gameplayfeature_id", "count"
+):
+    pk, mid, fk_id, count = row
+    ...
+
+# after
+for pk, mid, fk_id, count in MachineModelGameplayFeature.objects.filter(...).values_list(
+    "pk", "machinemodel_id", "gameplayfeature_id", "count"
+):
+    ...
+```
+
+Sequenced after Phase 1 so collateral `no-untyped-call` errors are already gone and don't clutter the diff.
+
+**Done when:** baseline for `resolve/_relationships.py` and `resolve/_media.py` is zero.
+
+## Ordering
+
+1 → 2. Phase 1's helper annotations remove `no-untyped-call` noise that would otherwise clutter Phase 2's diff.
+
+## Critical files
+
+- `backend/apps/catalog/resolve/_helpers.py` — `_annotate_priority` annotation is the keystone.
+- `backend/apps/catalog/resolve/_relationships.py` — bulk of the signatures + tuple cleanup.
+- `backend/apps/catalog/resolve/_entities.py`, `_media.py`, `__init__.py` — smaller passes.
+
+## Reuse
+
+- `JsonBody` from [apps/core/types.py](../../../backend/apps/core/types.py) — invariant `dict[str, object]` alias for mutable JSON-shaped dicts. Use for `extra_data` locals and signatures that build up the dict. `JsonData` (covariant `Mapping[str, object]`) is for read-only params; don't use it where the code assigns into the dict.
+- NamedTuple shapes in `_media.py` (`CtInfo`, `PrimaryCandidate`, `AttachmentTimestamp`, `MediaRowState`, `EntityCategoryKey`) — the template for any incidental tuple-shape cleanup that falls out of Phase 2.
+
+## Non-goals
+
+- No architectural refactoring of `_resolve_single` / `_resolve_bulk` / `_apply_resolution`.
+- No new abstractions — signatures only.
+- No subscript flip on resolver reads — that's Step 5 ([ResolverReadsTightening.md](ResolverReadsTightening.md)).
+
+## Verification
+
+- `./scripts/mypy` — expect baseline `new: 0` at every phase, `fixed: >0` at each.
+  - After Phase 1: the ~9 `no-untyped-call` entries on `_annotate_priority` gone; `no-untyped-def` entries on `_helpers.py` / `_entities.py` gone.
+  - After Phase 2: `_relationships.py` and `_media.py` baselines at zero.
+- `uv run --directory backend pytest apps/catalog/tests/test_resolve*.py apps/catalog/tests/test_bulk_resolve*.py` — behavior-preserving; all resolver tests pass.
+- After each phase, sync baseline with `uv run --directory backend mypy --config-file pyproject.toml . 2>&1 | uv run --directory backend mypy-baseline sync` once `./scripts/mypy` reports `new: 0`.

--- a/docs/plans/types/CatalogResolveTyping.md
+++ b/docs/plans/types/CatalogResolveTyping.md
@@ -1,29 +1,24 @@
-# Step 10.3: `catalog/resolve/*` typing pass
+# Catalog Resolve Claim-Value Typing
 
-Detailed plan for [Step 10.3 of MypyFixing.md](MypyFixing.md). Step 10.1 is done (commit `e1d8886e`); Step 10.2 lands before this one. Both are tracked in MypyFixing.md, not here.
+Step 3 of [ResolveHardening.md](ResolveHardening.md). Defines the read-side TypedDict vocabulary for claim values in `backend/apps/catalog/resolve/*.py` and wires each resolver to `cast` to its shape. Pure claim-value shape work — helper-signature and tuple-reuse cleanup are moved to Step 4 ([CatalogResolveBaselineCleanup.md](CatalogResolveBaselineCleanup.md)).
 
 ## Context
 
-45 baseline mypy entries in `backend/apps/catalog/resolve/*.py`. The user's stated goal is **not** just burning down entries — it's defining the types _up front_ before wiring, to avoid the reverse-engineering pattern from the catalog-app refactor.
+The user's stated goal is **not** just burning down mypy entries — it's defining the types _up front_ before wiring, to avoid the reverse-engineering pattern from the catalog-app refactor.
 
-The 45 errors cluster into four root causes:
-
-1. **`_annotate_priority(qs)` is untyped** — ~9 `no-untyped-call` errors across every resolver.
-2. **`claim.value` is `object`** (JSONField payload) and is accessed with string keys across ~10 resolvers. Shape knowledge is implicit at every call site.
-3. **Tuple-shape variable reuse** in [\_relationships.py](../../../backend/apps/catalog/resolve/_relationships.py) and [\_media.py](../../../backend/apps/catalog/resolve/_media.py): loop variables get assigned from `values_list(...)` tuples of different arities (or a tuple and a model instance) in the same scope, tripping `Incompatible types in assignment` + `Need more than N values to unpack`.
-4. **Untyped keystone helpers** — `validate_check_constraints`, `_coerce`, `_resolve_fk_generic`, `_sync_markdown_references`, `_resolve_aliases`, `_resolve_parents`, `resolve_entity`, `resolve_all_entities` all missing annotations.
+Today, `claim.value` is `object` (JSONField payload) and is accessed with string keys across ~10 resolvers. Shape knowledge is implicit at every call site. This step makes that knowledge explicit: 7 TypedDicts, one per distinct relationship-claim payload shape, mirrored to the registry Step 2 ([ProvenanceValidationTightening.md](ProvenanceValidationTightening.md)) establishes, with a consistency test enforcing the mirror.
 
 [\_media.py](../../../backend/apps/catalog/resolve/_media.py) is already the cleanest file — 5 NamedTuples in place — and serves as the shape target for the rest.
 
 ## Scope — behavior-preserving
 
-Pure typing cleanup. No resolver logic changes. The only baseline movement is downward.
+Pure typing work. No resolver logic changes. `.get()` reads stay byte-identical — the subscript flip for Required keys is Step 5's work ([ResolverReadsTightening.md](ResolverReadsTightening.md)), not this step's. Helper-signature and tuple-reuse cleanup also stay out — that's Step 4.
 
 ## Prerequisites
 
-[ProvenanceValidationTightening.md](ProvenanceValidationTightening.md) (Step 10.2) lands first. This plan's TypedDicts mirror the registry schemas 10.2 establishes — required/optional/type per value_key must match. Serializing the two steps means the contract is settled at implementation time, not guessed at design time.
+[ProvenanceValidationTightening.md](ProvenanceValidationTightening.md) (Step 2) lands first. This plan's TypedDicts mirror the registry schemas Step 2 establishes — required/optional/type per value_key must match. Serializing the two steps means the contract is settled at implementation time, not guessed at design time.
 
-The TypedDicts mark `exists` and FK keys as Required — that's the post-10.2 wire contract. 10.3's Phase B still reads with `cast + .get()` (not subscript) to keep the runtime-adjacent subscript flip out of this large typing diff — Step 10.4 ([ResolverReadsTightening.md](ResolverReadsTightening.md)) is a focused follow-up that does the flip in isolation.
+The TypedDicts mark `exists` and FK keys as Required — that's the post-Step-2 wire contract. This step still reads with `cast + .get()` (not subscript) to keep the runtime-adjacent subscript flip out of this typing diff — Step 5 does the flip in isolation.
 
 ## Approach
 
@@ -41,15 +36,17 @@ New module `backend/apps/catalog/resolve/_claim_values.py` with **7 TypedDicts**
 | `MediaAttachmentClaimValue` | `resolve_media_attachments`                                          | `media_asset: int`, `exists: bool`         | `category: str \| None`, `is_primary: bool` |
 | `LocationClaimValue`        | `resolve_all_corporate_entity_locations`                             | `location: int`, `exists: bool`            | —                                           |
 
-**`exists` is Required on all 7 TypedDicts.** Post-10.2, [classify_claim](../../../backend/apps/provenance/validation.py#L86) + the shared relationship validator guarantee every relationship-claim row has `exists: bool`.
+**`exists` is Required on all 7 TypedDicts.** Post-Step-2, [classify_claim](../../../backend/apps/provenance/validation.py#L86) + the shared relationship validator guarantee every relationship-claim row has `exists: bool`.
 
-**`LocationClaimValue` is a relationship claim, not DIRECT.** `CorporateEntity` at [manufacturer.py:129](../../../backend/apps/catalog/models/manufacturer.py#L129) has no `location` column; the payload materializes `CorporateEntityLocation` rows. 10.1 (commit `e1d8886e`) added the `exists=False` retraction handling; the TypedDict models the post-10.1 wire shape.
+**`LocationClaimValue` is a relationship claim, not DIRECT.** `CorporateEntity` at [manufacturer.py:129](../../../backend/apps/catalog/models/manufacturer.py#L129) has no `location` column; the payload materializes `CorporateEntityLocation` rows. Step 1 (commit `e1d8886e`) added the `exists=False` retraction handling; the TypedDict models the post-Step-1 wire shape.
 
 **No `M2MClaimValue` TypedDict.** The generic resolver [\_resolve_machine_model_m2m](../../../backend/apps/catalog/resolve/_relationships.py#L86) reads the payload with a runtime key (`val[spec.field_name]`), which TypedDict can't express. Use `Mapping[str, object]` + `type(target_pk) is int` narrowing in that one helper. The field-specific TypedDicts above cover the non-generic relationship resolvers.
 
-**Placement** — `resolve/_claim_values.py` for now. These are read-side only. If a future step types the claim _builders_ in `apps.catalog.claims`, moving the types to `apps.catalog.claims.types` is a rename. (10.2's registry additions for literal schemas live separately from these TypedDicts — the registry is write-side metadata; these are read-side shape names.)
+**Placement** — `resolve/_claim_values.py` for now. These are read-side only. If a future step types the claim _builders_ in `apps.catalog.claims`, moving the types to `apps.catalog.claims.types` is a rename.
 
-**Consistency test.** Add a unit test in `backend/apps/catalog/resolve/tests/test_claim_values.py` (new file) that iterates each TypedDict in `_claim_values.py`, looks up the matching `RelationshipSchema` from `provenance.validation.get_relationship_schema(namespace)`, and asserts the key sets + types + required/optional flags match. Catches TypedDict-vs-schema drift at test time rather than leaving it to bite at runtime during Step 10.4's subscript flip. This is the single mechanism that makes "two hand-maintained shapes" drift-proof.
+**Consistency test.** Add a unit test in `backend/apps/catalog/resolve/tests/test_claim_values.py` (new file) that iterates each TypedDict in `_claim_values.py`, looks up the matching `RelationshipSchema` from `provenance.validation.get_relationship_schema(namespace)`, and asserts the key sets + types + required/optional flags match. Catches TypedDict-vs-schema drift at test time rather than leaving it to bite at runtime during Step 5's subscript flip.
+
+**Limit of the consistency test — state it explicitly.** The test proves that _each defined TypedDict_ matches its registry namespace. It does NOT prove that every resolver uses the _right_ TypedDict for the namespace it's resolving. A resolver writing `cast(CreditClaimValue, claim.value)` on a `theme` claim would pass mypy and pass this test. That gap is fixable (e.g. a namespace→TypedDict dispatch) but not in scope; for now, the cast site itself is the editorial checkpoint.
 
 **Done when:** `_claim_values.py` exists, the consistency test passes, mypy + tests pass, no baseline delta.
 
@@ -64,7 +61,7 @@ Per-resolver-family commits in this order (smallest blast radius first):
 5. `_relationships.py` aliases + parents — `_resolve_aliases` → `AliasClaimValue`, `_resolve_parents` → `ParentClaimValue`.
 6. `_relationships.py` CE locations — `resolve_all_corporate_entity_locations` → `LocationClaimValue`.
 
-**`cast` names the shape; keep every `.get()`.** Defensive reads for required keys stay in place — the write-path validator won't guarantee them until 10.2 lands, and flipping `.get("person")` to `val["person"]` would turn a legacy malformed row into a KeyError mid-bulk-resolve. `cast` is documentation-only for now; Step 10.4 of MypyFixing.md does the subscript flip once 10.2's runtime guarantees are in place.
+**`cast` names the shape; keep every `.get()`.** Defensive reads for required keys stay in place — flipping `.get("person")` to `val["person"]` would turn any pre-Step-2 row into a KeyError mid-bulk-resolve. `cast` is documentation-only for now; Step 5 does the subscript flip once Step 2's runtime guarantees are in place _and_ the post-Step-2 wipe + re-ingest has rebuilt stored rows.
 
 ```python
 val = cast(CreditClaimValue, claim.value)
@@ -83,98 +80,50 @@ category = val.get("category")
 is_primary = val.get("is_primary", False)
 ```
 
-The TypedDict Required/NotRequired split still encodes the true post-10.2 wire shape — that's what mypy sees when it checks `val.get("person")` (returns `int | None` here because `.get()` without default widens the type). Callers doing `if person_pk is None: continue` or `if person_pk not in valid_person_pks` narrow from there, same as today.
+The TypedDict Required/NotRequired split still encodes the true post-Step-2 wire shape — that's what mypy sees when it checks `val.get("person")` (returns `int | None` here because `.get()` without default widens the type). Callers doing `if person_pk is None: continue` or `if person_pk not in valid_person_pks` narrow from there, same as today.
 
-**Done when:** each resolver has `cast(<Schema>, claim.value)` at the top of its loop body. Every existing `.get()` call, skip-on-None check, and PK-validity narrow stays byte-identical — the subscript flip for Required keys is Step 10.4's work, not Phase B's.
-
-### Phase C — Type keystone helpers
-
-Annotate in callee-before-caller order:
-
-- [\_helpers.py](../../../backend/apps/catalog/resolve/_helpers.py): `validate_check_constraints(obj: models.Model) -> None`; `_coerce(model_class: type[models.Model], attr: str, value: object) -> object`; `_resolve_fk_generic(..., value: object, ...)`; **`_annotate_priority(qs: QuerySet[Claim]) -> QuerySet[Claim]`** (kills ~9 `no-untyped-call` errors). Only [\_media.py:181](../../../backend/apps/catalog/resolve/_media.py#L181) reads `effective_priority`, and it already uses `cast(HasEffectivePriority, claim)` — keep it.
-- [\_entities.py](../../../backend/apps/catalog/resolve/_entities.py): `_sync_markdown_references(obj: models.Model)`; `_resolve_single(obj: models.Model, ...)`; `_resolve_bulk(model_class: type[models.Model], ...)`; `resolve_entity(obj: models.Model) -> models.Model`; `resolve_all_entities(model_class: type[models.Model], *, object_ids: set[int] | None = None)`. Flip `extra_data: dict | None = {} if has_extra_data else None` to `JsonBody | None` — both locals mutate the dict, so the covariant `JsonData = Mapping[str, object]` is wrong; invariant `JsonBody = dict[str, object]` is correct per [core/types.py:19-20](../../../backend/apps/core/types.py#L19).
-- [\_relationships.py](../../../backend/apps/catalog/resolve/_relationships.py): `_resolve_aliases(parent_model: type[models.Model], claim_field_name: str)`; `_resolve_parents(parent_model: type[models.Model], *, claim_field_prefix: str | None = None)`. Reverse-relation accessors (`parent_model.aliases.rel`, `parent_model.parents.through`) are category-#3 `Any` per the idiom — Django's descriptor API genuinely discards the info. Confine the ignores to two small helpers:
-  - `_get_alias_rel_info(parent: type[models.Model]) -> tuple[type[models.Model], str]` — returns `(alias_model, fk_col)` from `parent.aliases.rel` with a single `# type: ignore[attr-defined]` + comment naming the GenericRelation reverse-accessor constraint.
-  - `_get_parents_through(parent: type[models.Model]) -> type[models.Model]` — returns `parent.parents.through`, same pattern.
-
-  A Protocol can't express `parents.through` (or the `.rel.field.name` path), so helper-with-ignore is the minimum-touch option; scattering the ignores across `_resolve_aliases` / `_resolve_parents` loop bodies would be easier to accidentally normalize.
-
-- [\_\_init\_\_.py](../../../backend/apps/catalog/resolve/__init__.py): the `dict | None` / `dict` generics on `sfl_map`, `extra_data`, `_apply_resolution` signatures.
-
-**Done when:** every function in `resolve/` has a full signature; `no-untyped-call` entries on `_annotate_priority` are gone across all five files.
-
-### Phase D — Clean up tuple-reuse in `_relationships.py` and `_media.py`
-
-Two files, same pattern: a loop variable gets assigned from `values_list(...)` with one tuple arity and then reassigned in a later scope (either a different values_list, or a model instance from `in_bulk`). Mypy locks in the first-seen type and flags every divergence.
-
-- `_relationships.py` — baseline lines 81–92 and siblings. ~6 loops across `_resolve_machine_model_m2m`, `resolve_all_gameplay_features`, `resolve_all_credits`, both abbreviation resolvers, `_resolve_aliases`, `_resolve_parents`. `resolve_all_gameplay_features` in particular has the same tuple-vs-instance collision as `_media.py`: [line 253-258](../../../backend/apps/catalog/resolve/_relationships.py#L253) uses `row` for a `values_list` tuple, then [line 294](../../../backend/apps/catalog/resolve/_relationships.py#L294) reassigns `row = rows[pk]` to a `MachineModelGameplayFeature` instance and writes `row.count = count` — this triggers three baseline entries (`[assignment]`, `[method-assign]`, second `[assignment]`) that all collapse when the inner-loop local is renamed (`mgf_row` or similar). Same rename-the-inner-local fix as `_media.py`, not just the inline-unpack fix.
-- `_media.py` — baseline entries at [\_media.py:244-250](../../../backend/apps/catalog/resolve/_media.py#L244) (values_list row) colliding with [\_media.py:293](../../../backend/apps/catalog/resolve/_media.py#L293) (`row = rows[update.row_pk]` — the `EntityMedia` instance). Rename the inner-loop local (`media_row` or similar).
-
-Fix by inline-unpacking the tuple at the loop header and renaming any colliding inner-scope reuse:
-
-```python
-# before
-for row in MachineModelGameplayFeature.objects.filter(...).values_list(
-    "pk", "machinemodel_id", "gameplayfeature_id", "count"
-):
-    pk, mid, fk_id, count = row
-    ...
-
-# after
-for pk, mid, fk_id, count in MachineModelGameplayFeature.objects.filter(...).values_list(
-    "pk", "machinemodel_id", "gameplayfeature_id", "count"
-):
-    ...
-```
-
-Order after Phase C so collateral `no-untyped-call` errors are already gone.
-
-**Done when:** baseline for `resolve/_relationships.py` and `resolve/_media.py` is zero.
+**Done when:** each resolver has `cast(<Schema>, claim.value)` at the top of its loop body. Every existing `.get()` call, skip-on-None check, and PK-validity narrow stays byte-identical.
 
 ## Ordering
 
-A → B → C → D.
-
-- A is independent, small, reviewable.
-- B depends on A (needs the TypedDicts to exist).
-- C is technically independent of A/B but sequenced here so C's collateral errors don't mask B review.
-- D after C (C removes the `no-untyped-call` noise that otherwise clutters D's diff).
+A → B. A is independent, small, reviewable. B depends on A.
 
 ## Critical files
 
 - `backend/apps/catalog/resolve/_claim_values.py` — **new**, the vocabulary module.
-- `backend/apps/catalog/resolve/_helpers.py` — `_annotate_priority` annotation is the keystone.
-- `backend/apps/catalog/resolve/_relationships.py` — 915 lines, bulk of the wiring + tuple cleanup.
-- `backend/apps/catalog/resolve/_entities.py`, `_media.py`, `__init__.py` — smaller wiring passes.
+- `backend/apps/catalog/resolve/_relationships.py` — bulk of the wiring.
+- `backend/apps/catalog/resolve/_media.py`, `_entities.py`, `__init__.py` — smaller wiring passes.
+- `backend/apps/catalog/resolve/tests/test_claim_values.py` — **new**, consistency test.
 
 ## Reuse
 
-- `JsonBody` from [apps/core/types.py](../../../backend/apps/core/types.py) — invariant `dict[str, object]` alias for mutable JSON-shaped dicts. Use for `extra_data` locals and signatures that build up the dict. `JsonData` (covariant `Mapping[str, object]`) is for read-only params; don't use it where the code assigns into the dict.
 - `HasEffectivePriority` from [apps/provenance/typing.py](../../../backend/apps/provenance/typing.py) — existing protocol, one read site in `_media.py` keeps its `cast`.
 - `ClaimIdentity` / `EntityKey` from [apps/core/types.py](../../../backend/apps/core/types.py) — already used in `_media.py`; carry the pattern.
-- NamedTuple shapes in `_media.py` (`CtInfo`, `PrimaryCandidate`, `AttachmentTimestamp`, `MediaRowState`, `EntityCategoryKey`) — the template for any incidental tuple-shape cleanup that falls out of Phase D.
+- NamedTuple shapes in `_media.py` (`CtInfo`, `PrimaryCandidate`, `AttachmentTimestamp`, `MediaRowState`, `EntityCategoryKey`) — the template for any incidental tuple-shape cleanup that falls out.
 
 ## Non-goals
 
-- Not introducing dataclass factories or Pydantic Schemas for claim values. Rejected: once 10.2 lands, the write path validates every shape; a read-side validator would be a second source of truth with no correctness win. Until 10.2 lands, the existing `.get()`-based defensive reads already do minimal shape checking at the read side.
+- Not introducing dataclass factories or Pydantic Schemas for claim values. Rejected: once Step 2 lands, the write path validates every shape; a read-side validator would be a second source of truth with no correctness win.
 - Not refactoring `_resolve_single` / `_resolve_bulk` / `_apply_resolution` architecturally.
-- Not consolidating the three parallel M2M / abbreviation / alias diff-and-apply patterns — larger refactor, out of mypy scope.
+- Not consolidating the three parallel M2M / abbreviation / alias diff-and-apply patterns — larger refactor, out of scope.
+- Not touching helper signatures or tuple-reuse cleanup — those are Step 4 ([CatalogResolveBaselineCleanup.md](CatalogResolveBaselineCleanup.md)).
+- Not flipping required-key reads to subscript — that's Step 5 ([ResolverReadsTightening.md](ResolverReadsTightening.md)).
+- Not closing the cast-site correctness gap (wrong TypedDict for the namespace being resolved). Acknowledged in the Phase A consistency-test note.
 
 ## Verification
 
-- `./scripts/mypy` — expect baseline `new: 0` at every phase, `fixed: >0` at B/C/D.
+- `./scripts/mypy` — expect baseline `new: 0`.
   - After A: unchanged baseline (no wiring).
-  - After C: the ~9 `no-untyped-call` entries on `_annotate_priority` gone; `no-untyped-def` entries on `_helpers.py` / `_entities.py` gone.
-  - After D: `_relationships.py` and `_media.py` baselines at zero.
-- `uv run --directory backend pytest apps/catalog/tests/test_resolve*.py apps/catalog/tests/test_bulk_resolve*.py` — behavior-preserving; all resolver tests pass.
+  - After B: claim-value-shape entries on resolver files cleared; helper-signature + tuple-reuse entries still outstanding (Step 4 clears those).
+- `uv run --directory backend pytest apps/catalog/tests/test_resolve*.py apps/catalog/tests/test_bulk_resolve*.py apps/catalog/resolve/tests/test_claim_values.py` — behavior-preserving plus the new consistency test.
 - `make ingest` end-to-end — exercises real bulk-resolution paths against R2 data. Not gating, but the natural integration test.
 - After each phase, sync baseline with `uv run --directory backend mypy --config-file pyproject.toml . 2>&1 | uv run --directory backend mypy-baseline sync` once `./scripts/mypy` reports `new: 0`.
 
 ## Design decisions locked in after review
 
-- **TypedDicts (not dataclass factories or Pydantic Schemas).** Read-side shape documentation only; zero runtime cost. Factories would duplicate write-path validation (post-10.2).
-- **`cast` is documentation-only in 10.3.** `.get()` stays everywhere, required and optional alike. Subscript flip for required keys happens in Step 10.4 after [ProvenanceValidationTightening.md](ProvenanceValidationTightening.md) lands.
+- **TypedDicts (not dataclass factories or Pydantic Schemas).** Read-side shape documentation only; zero runtime cost. Factories would duplicate write-path validation (post-Step-2).
+- **`cast` is documentation-only in this step.** `.get()` stays everywhere, required and optional alike. Subscript flip for required keys happens in Step 5.
 - **`exists` is Required on all 7 TypedDicts.**
 - **No `M2MClaimValue` TypedDict.** Generic M2M resolver uses `Mapping[str, object]` + `isinstance`.
-- **Introspection confined to helpers.** `_get_alias_rel_info` and `_get_parents_through` isolate the `# type: ignore[attr-defined]` to one line each.
 - **TypedDicts live in `resolve/_claim_values.py` for now.** Move to `apps.catalog.claims.types` later if claim builders get typed.
+- **Consistency test does not cover cast-site correctness.** See Phase A note — that gap is acknowledged and not closed here.

--- a/docs/plans/types/MypyFixing.md
+++ b/docs/plans/types/MypyFixing.md
@@ -250,16 +250,7 @@ Same pattern as Step 2 — helpers first, endpoints after, `make api-gen` betwee
 
 ## Step 10: `catalog/resolve/*`
 
-Type the resolver package and clean up adjacent behavior issues surfaced along the way. Each of the following is its own PR.
-
-**Sequencing.** 10.2 → 10.3 → 10.4 is strictly serial — 10.3's TypedDicts mirror 10.2's registry (contract drift must be caught at implementation time, not design time), and 10.4 depends on 10.3's Phase B wiring. 10.1 is already done.
-
-- **10.1** — DONE (commit `e1d8886e`). `resolve_all_corporate_entity_locations` `exists=False` handling. See [LocationRetractionFix.md](LocationRetractionFix.md).
-- **10.2** — Provenance write-path validation tightening. See [ProvenanceValidationTightening.md](ProvenanceValidationTightening.md).
-- **10.3** — Typing pass on `catalog/resolve/*`. See [CatalogResolveTyping.md](CatalogResolveTyping.md). Depends on 10.2.
-- **10.4** — Subscript flip. See [ResolverReadsTightening.md](ResolverReadsTightening.md). Depends on 10.3.
-
-Typing scope (~44 mypy entries, cleared in 10.3): `_relationships.py` (18), `_entities.py` (10), `__init__.py` (7), `_helpers.py` (5), `_media.py` (4).
+See [ResolveHardening.md](ResolveHardening.md). Multi-PR sequence that tightens the claim-value contract across the write path, registry, read-path types, and resolver reads. Typing motivation is one of several — the reasoning wins justify the sequence independently — but baseline reduction still counts here: ~44 mypy entries in `catalog/resolve/*` clear across Steps 3–4, plus downstream subscript-flip entries in Step 5.
 
 ## Step 11: `media/*`
 

--- a/docs/plans/types/ProvenanceValidationTightening.md
+++ b/docs/plans/types/ProvenanceValidationTightening.md
@@ -2,17 +2,40 @@
 
 ## Context
 
-The provenance write path admits malformed relationship claims through three independent holes. Each one is a silent-data-loss path today:
+This is **Step 2** of [ResolveHardening.md](ResolveHardening.md) — the write-path foundation of a multi-step sequence that tightens the claim-value contract across `catalog/resolve/*`:
+
+- **Step 2 (this doc)** — unify the three registries that hand-maintain catalog relationship namespace knowledge today, and tighten the write-path shape validation that the unified registry now makes expressible.
+- **Step 3** — [Claim-value TypedDicts + resolver casts + consistency test](CatalogResolveTyping.md). Introduces TypedDicts over the resolver read path that mirror this doc's registry, plus a consistency test enforcing the mirror holds.
+- **Step 4** — [Mypy baseline burn-down on `catalog/resolve/*`](CatalogResolveBaselineCleanup.md). Helper signatures + tuple-reuse cleanup. Not load-bearing for the hardening story, bundled because it touches the same files.
+- **Step 5** — [Subscript flip](ResolverReadsTightening.md). Flips resolver reads from `cast + .get()` to subscript access for required keys — sound only because Step 2's write-path validation now guarantees required keys are present, _and_ because Step 2's post-merge wipe + re-ingest has rebuilt stored rows under the new validator.
+
+### Primary work: unify three hand-maintained registries
+
+Namespace knowledge for catalog relationships lives in three registries today, covering overlapping ground:
+
+- `_entity_ref_targets` in [catalog/claims.py](../../../backend/apps/catalog/claims.py) — `namespace → [RefKey(name, model)]`. Drives FK claim construction.
+- `_literal_schemas` in [catalog/claims.py](../../../backend/apps/catalog/claims.py) — `namespace → LiteralKey(value_key, identity_key)`. Drives literal claim construction.
+- `_relationship_target_registry` in [apps/provenance/validation.py](../../../backend/apps/provenance/validation.py) — namespace → FK existence targets. Drives batch validation.
+
+Adding or changing an FK namespace means touching two of these in lockstep; there's no cross-check that they agree. Step 3 is about to introduce a fourth source of truth: TypedDicts over the resolver read path, which must agree with the write-path schema for Step 5's subscript flip to be sound. Adding that fourth without unifying first is strictly worse than today — four hand-maintained registries, drift risk every time a namespace is added, no mechanical way to enforce agreement.
+
+**Unify to one registry** (`_relationship_schemas` in `provenance/validation.py`) that drives claim construction (`build_relationship_claim`), namespace enumeration (`get_relationship_namespaces`), write-path validation (shape + existence), and — via Step 3's consistency test — the read-side TypedDicts in `_claim_values.py`. After this work, adding a namespace is one `register_relationship_schema(...)` call + one TypedDict (test-enforced to match). Two places.
+
+The unified registry is what earns Step 3's consistency test its keep: it's the single authority the TypedDicts are tested against. Without unification, the TypedDicts would have three disagreeing registries to reconcile with, and the test would either not exist or silently gloss over the disagreements.
+
+### Along for the ride: three silent-data-loss bugs
+
+The unified registry makes shape validation expressible in one place, and three pre-existing holes in the write path get closed as a natural consequence rather than as standalone tightening:
 
 - **`assert_claim` bypasses relationship validation.** [claim.py:121-127](../../../backend/apps/provenance/models/claim.py#L121) classifies each claim and only validates `DIRECT` payloads; `RELATIONSHIP` passes through untouched. User edits via `execute_claims` → `assert_claim` therefore never reach any relationship shape check.
 - **Malformed payloads misclassify as EXTRA.** [classify_claim](../../../backend/apps/provenance/validation.py#L86) returns `RELATIONSHIP` only if `"exists" in value`. On any model with an `extra_data` field (MachineModel, Title, …), a malformed credit/theme/alias payload lacking `"exists"` falls through to `EXTRA` and gets silently stored as free-form staging data — never hitting the relationship validator at all.
 - **Literal namespaces have no schema.** [validate_relationship_claims_batch](../../../backend/apps/provenance/validation.py#L359) only validates namespaces registered via `register_relationship_targets`, which covers FK value_keys. Aliases (`alias_value`, `alias_display`) and abbreviations (`value`) are intentionally unregistered today and pass through without any schema check.
 
+Closing these is also load-bearing for Step 5: the subscript flip only becomes safe once the write path guarantees required keys are present on stored claims. So the bug-fixes aren't just opportunistic — they're the other half of what unblocks Step 5.
+
 We're pre-launch. Loosening later is a one-line change; tightening later requires auditing every production row. **Err tight.**
 
 **Data posture.** The DB can be dropped and all migrations reset to 0001. The remediation path for any malformed legacy rows surfaced by the new validator is: wipe the DB, reset migrations, `make pull-ingest`, `make ingest`. No audit script, no row-level cleanup, no `is_active=False` sweeps. If re-ingestion produces rejections, that is an extractor bug — fix at the source (where the malformed shape originated), re-ingest, repeat.
-
-This work also unblocks [Step 10.4 of MypyFixing.md](MypyFixing.md#step-104-subscript-flip-in-catalogresolve) — the resolver read path can flip from `cast + .get()` to subscript access for required keys once the write path guarantees them.
 
 ## Non-goals
 
@@ -21,12 +44,6 @@ This work also unblocks [Step 10.4 of MypyFixing.md](MypyFixing.md#step-104-subs
 - **Not touching DIRECT claim validation.** `validate_claim_value` stays as-is.
 - **Not collapsing bespoke resolvers into a generic spec-driven resolver.** The registry added here is intentionally consumed by `classify_claim`, `validate_single_relationship_claim`, `validate_relationship_claims_batch`, and `build_relationship_claim` only. Folding `_parent_dispatch` / `_custom_dispatch` / `M2M_FIELDS` into one generic resolver is a plausible follow-up that can consume the same registry, but keeping it out of scope here bounds the PR and avoids bundling a latent behavior change in `resolve_all_corporate_entity_locations` (which today filters `is_active=True` before winner selection) with an otherwise behavior-preserving refactor.
 - **Not lifting the identity-vs-UC cross-check from [CatalogRelationshipSpec](../model_driven_metadata/ModelDrivenCatalogRelationshipMetadata.md).** That guard — verifying `subject_fks ∪ identity_fields` matches one `UniqueConstraint` per through-model at `ready()` — is genuinely useful, but it belongs with the model-driven metadata work it was drafted for. Pulling it in here would motivate `through_model` and `subject_fks` on the schema, which would force `(namespace, subject_content_type)` keying and the "abbreviation registers twice" complication — all scaffolding for a check the rest of this PR does not use. Deferred as a whole.
-
-### Registry unification — in scope (added after initial draft)
-
-Originally flagged as a follow-up, now folded in. `catalog/claims.py` today carries `_entity_ref_targets` (`namespace → [RefKey(name, model)]`) and `_literal_schemas` (`namespace → LiteralKey(value_key, identity_key)`) driving claim construction and namespace enumeration. `provenance/validation.py` carries `_relationship_target_registry` (FK existence checks only). Adding a fourth `_relationship_schemas` registry without unifying would mean three hand-maintained registries covering overlapping namespace knowledge — strictly worse than today, drift risk every time a namespace is added.
-
-Unification kills `_entity_ref_targets`, `_literal_schemas`, and `_relationship_target_registry`. **One registry** (`_relationship_schemas`) drives construction (`build_relationship_claim`), namespace enumeration (`get_relationship_namespaces`), validation (shape + existence), and — via a consistency test in Step 10.3 — the read-side TypedDicts in `_claim_values.py`. After this work, adding a new namespace is: one `register_relationship_schema(...)` call + one TypedDict (test-enforced to match). Two places.
 
 ## Design
 
@@ -163,7 +180,7 @@ Commit A is larger than a pure "scaffolding" commit would be, but the blast radi
 
 ### Registered schemas
 
-Every catalog relationship gets a `register_relationship_schema(...)` call in `register_catalog_relationship_schemas()`, once per namespace. Identity keys (`identity is not None`) drive `build_relationship_claim`'s claim_key composition; non-identity keys are shape-validated only. Missing any of these means resolver reads for that namespace stay unvalidated and Step 10.4 of MypyFixing.md can't subscript those keys safely.
+Every catalog relationship gets a `register_relationship_schema(...)` call in `register_catalog_relationship_schemas()`, once per namespace. Identity keys (`identity is not None`) drive `build_relationship_claim`'s claim_key composition; non-identity keys are shape-validated only. Missing any of these means resolver reads for that namespace stay unvalidated and [Step 5 of ResolveHardening.md](ResolveHardening.md) can't subscript those keys safely.
 
 - **Alias (7 schemas, one per alias namespace):** `theme_alias` (valid_subjects=(Theme,)), `manufacturer_alias` ((Manufacturer,)), `person_alias` ((Person,)), `gameplay_feature_alias` ((GameplayFeature,)), `reward_type_alias` ((RewardType,)), `corporate_entity_alias` ((CorporateEntity,)), `location_alias` ((Location,)). Each → `alias_value: str (identity="alias")`, `alias_display: str (optional)`. Dynamic discovery via `discover_alias_types()` still happens — it just calls `register_relationship_schema` instead of populating `_literal_schemas`.
 - **Abbreviation (1 schema):** `abbreviation`, `valid_subjects=(Title, MachineModel)`. → `value: str (identity="value")`.
@@ -211,10 +228,12 @@ Assumes the "Commit sequence" above: Commit A (registry) → Commit B (classifie
 - `./scripts/mypy` — baseline unchanged (this step has no mypy impact).
 - **Pre-merge dry-run:** wipe localhost DB, reset migrations to 0001, `make pull-ingest`, `make ingest`. No rejections on clean data. If rejections appear, they're real malformed payloads upstream ingest is producing and must be fixed at the source before merging.
 - **Post-merge:** same wipe + re-ingest against the shared environment.
-- After landing, Step 10.4 of MypyFixing.md (resolver subscript flip) is unblocked.
+- After landing (and after the post-merge wipe + re-ingest), [Step 5 of ResolveHardening.md](ResolveHardening.md) (resolver subscript flip) is unblocked.
 
 ## Relation to model-driven metadata
 
-This registry is intentionally hand-maintained. The model-driven metadata umbrella ([ModelDrivenMetadata.md](../model_driven_metadata/ModelDrivenMetadata.md)) proposes moving these declarations onto the through-model classes as a typed `catalog_relationship_spec` ClassVar ([ModelDrivenCatalogRelationshipMetadata.md](../model_driven_metadata/ModelDrivenCatalogRelationshipMetadata.md)), derived at `ready()` and pushed into a registry that looks very much like this one. That move is deferred until a genuinely second independent consumer materializes — e.g. frontend edit metadata being actually built, not hypothetical. Today's consumers (`classify_claim`, `validate_single_relationship_claim`, `validate_relationship_claims_batch`, `build_relationship_claim`) all live on the same backend write/read path and don't yet meet the umbrella's ≥2-consumers test.
+This registry is intentionally hand-maintained. The model-driven metadata umbrella ([ModelDrivenMetadata.md](../model_driven_metadata/ModelDrivenMetadata.md)) proposes moving these declarations onto the through-model classes as a typed `catalog_relationship_spec` ClassVar ([ModelDrivenCatalogRelationshipMetadata.md](../model_driven_metadata/ModelDrivenCatalogRelationshipMetadata.md)), derived at `ready()` and pushed into a registry that looks very much like this one. That move is deferred until a genuinely _independent_ consumer materializes — e.g. frontend edit metadata being actually built, not hypothetical.
+
+Note the distinction: this PR's consumers (`classify_claim`, `validate_single_relationship_claim`, `validate_relationship_claims_batch`, `build_relationship_claim`, and — via Step 3's consistency test — the read-side TypedDicts) are what make the _unified registry_ pay off today. They don't meet the spec-move's ≥2-consumers bar because they're all facets of the same backend write/read path, tested against each other. The spec move is waiting for a second consumer that would motivate the richer `through_model` / `subject_fks` fields and `(namespace, subject_content_type)` keying, which this PR's consumers don't need.
 
 The spec doc's identity-vs-UC cross-check (verifying `subject_fks ∪ identity_fields` matches one `UniqueConstraint` per through-model at `ready()`) is the piece worth lifting eventually, but it's deferred with the rest of the spec work — lifting it alone would require `through_model` and `subject_fks` on the schema and `(namespace, subject_content_type)` keying, which this PR otherwise doesn't need. When the second consumer arrives and the spec move lands, `register_catalog_relationship_schemas()` is replaced with a walk over a `ClaimThroughModel` marker base that emits the same `RelationshipSchema` objects plus the richer fields the cross-check needs. The registry interface (`get_relationship_schema`, `is_valid_subject`) stays the same; consumers don't change.

--- a/docs/plans/types/ResolveHardening.md
+++ b/docs/plans/types/ResolveHardening.md
@@ -1,0 +1,53 @@
+# Claim-Value Shape Hardening
+
+## Context
+
+Sequence that tightens the claim-value _shape_ layer — the surfaces that decide what a relationship claim's payload can carry and how resolvers read it back:
+
+1. **Write path** — what can be stored (enforced at runtime).
+2. **Registry** — single source of truth for namespace shape.
+3. **Read-path types** — TypedDicts that mirror the registry (enforced by a consistency test).
+4. **Baseline cleanup** — mypy burn-down on resolver helpers and tuple reuse, bundled here because it touches the same files.
+5. **Cleanup** — subscript flip on required keys, plus anything else surfaced while landing Steps 2–4.
+
+The motivation is reasoning clarity. Today, a claim value is opaque JSON and four surfaces can disagree arbitrarily about what it should contain — writers, three separate registries, resolver reads, and each resolver's defensive fallback code. After this sequence there's one runtime write-path authority (the registry + validator) and a tested read-side mirror (the Step 3 consistency test ties TypedDicts to the registry). Mypy then checks the cast-bound resolver reads. What is _not_ mechanically verified: that a resolver casts to the _right_ TypedDict for the namespace it's resolving — a wrong cast would pass mypy and the consistency test. Closing that gap is possible (e.g. a namespace→TypedDict dispatch) but out of scope.
+
+Scope is deliberately narrow to the value-shape layer. Winner selection, priority tiebreaking, dispatch, and `extra_data` semantics are untouched — see Out of scope.
+
+Mypy baseline reduction (~44 entries in `catalog/resolve/*` plus the downstream subscript-flip entries) is a **scoreboard**, not the motivation. Step 4 is where that scoreboard work explicitly lives, bundled with the sequence because it touches the same files as Steps 2–3, not because it's load-bearing for the hardening story. This sequence was originally conceived as Step 10 of [MypyFixing.md](MypyFixing.md); it lives here as its own plan because the reasoning wins justify it independently of the baseline.
+
+## Reasoning wins
+
+The sequence specifically improves the claim-_value-shape_ layer of resolution:
+
+- **"What can this claim carry?" gets one answer.** Today: three registries (`_entity_ref_targets`, `_literal_schemas`, `_relationship_target_registry`) plus per-resolver defensive checking. After Step 2: one `_relationship_schemas` registry. After Step 3: read-path TypedDicts mirror the registry, test-enforced.
+- **Required vs. optional becomes explicit at the type level.** `value.get("count", 0)` today tells a reader nothing about whether `count` is guaranteed. After Step 3 the TypedDicts record the distinction; Step 5 flips required-key reads to subscript so intent is visible at the read site too.
+- **Silent-drift classes are closed.** Unknown value keys can't accumulate in stored claims. Wrong-subject claims can't silently route to `extra_data`. Malformed retractions that previously bypassed shape validation now go through the same check as positive claims. A future extractor adding a new field forces a schema update rather than making resolvers silently blind to the new data.
+- **The write-path contract is mechanically enforced; the read side has a tested mirror.** Writer ↔ registry is tied by write-time validation; registry ↔ TypedDict is tied by the Step 3 consistency test; resolver reads follow via mypy once the casts land. The one link _not_ mechanically verified is cast-site correctness (which TypedDict a resolver casts to for its namespace) — called out in the Context, not closed by this sequence.
+
+## Out of scope
+
+Named so the sequence isn't sold as something it isn't:
+
+- **Resolver business logic is untouched.** Winner selection, priority tiebreaking, and active-vs-all target filtering (e.g. `resolve_all_corporate_entity_locations` filtering `is_active=True` before winner selection) are not in scope. "Why did this source win?" is as hard to reason about as it was.
+- **Resolver dispatch stays bespoke.** `_parent_dispatch`, `_custom_dispatch`, `M2M_FIELDS` are explicitly deferred from unification (see [ProvenanceValidationTightening.md](ProvenanceValidationTightening.md) non-goals). "Which resolver runs for this claim?" is still answered by reading scattered code.
+- **`extra_data` remains a parallel universe.** Claims with unknown _field_names_ still fall into EXTRA (correctly — that's the staging path). Only unknown _value keys within a registered namespace_ get rejected. **Policy implication for extractor authors:** relationship value payloads are closed schemas. Useful-but-unmodeled relationship data has three paths — register a new namespace, drop the data at the extractor, or store it on the subject's `extra_data`. Adding it to an existing relationship payload will fail validation and block ingest.
+- **No meta-invariant against the next Step 1.** The location retraction bug was a point fix. The sequence does not build a property-style test covering "every resolver correctly handles `exists=False`" — if a future resolver gets retractions wrong, nothing in Steps 2–5 catches it.
+
+## Steps
+
+**Sequencing.** Done in order. Each step's landing informs re-planning of the next, so the sub-plans shouldn't be treated as frozen — expect Steps 3–5 to get re-read against what actually shipped upstream.
+
+**Gate before Step 5's subscript flip.** Step 2's validator only constrains rows _written after_ it lands. Any pre-validator row missing a required key would KeyError on subscript access. Pre-launch the gate is cheap: Step 2 includes a post-merge wipe + re-ingest ([ProvenanceValidationTightening.md § Data posture](ProvenanceValidationTightening.md)). Step 5 must not land until that wipe has happened; if it was somehow skipped, a row audit is required first.
+
+- **Step 1** — DONE (commit `e1d8886e`). `resolve_all_corporate_entity_locations` `exists=False` handling. See [LocationRetractionFix.md](LocationRetractionFix.md).
+- **Step 2** — Provenance write-path validation tightening + registry unification. See [ProvenanceValidationTightening.md](ProvenanceValidationTightening.md).
+- **Step 3** — Claim-value TypedDicts + resolver casts + consistency test. See [CatalogResolveTyping.md](CatalogResolveTyping.md).
+- **Step 4** — Mypy baseline burn-down on `catalog/resolve/*` (helper annotations + tuple reuse cleanup). See [CatalogResolveBaselineCleanup.md](CatalogResolveBaselineCleanup.md).
+- **Step 5** — Cleanup. Subscript flip on required keys ([ResolverReadsTightening.md](ResolverReadsTightening.md)) plus anything else surfaced while landing Steps 2–4.
+
+Typing scope covered across Steps 3–4 (~44 mypy entries): `_relationships.py` (18), `_entities.py` (10), `__init__.py` (7), `_helpers.py` (5), `_media.py` (4). Downstream subscript-flip entries clear in Step 5.
+
+## Relation to MypyFixing.md
+
+[MypyFixing.md](MypyFixing.md) references this doc for the `catalog/resolve/*` work rather than owning it. Step numbering in sub-plans inherits from when this was Step 10 of MypyFixing.md — Step 2 was formerly 10.2, Steps 3–4 were carved out of 10.3, and Step 5 was formerly 10.4. The baseline reduction still counts against MypyFixing.md's scoreboard; what moved is the framing, not the measurement.

--- a/docs/plans/types/ResolverReadsTightening.md
+++ b/docs/plans/types/ResolverReadsTightening.md
@@ -2,11 +2,12 @@
 
 Follow-up to [ProvenanceValidationTightening.md](ProvenanceValidationTightening.md): once the write-path validator guarantees relationship-claim payloads have all their required keys at the right scalar types, the read side in `catalog/resolve/*.py` can drop defensive `.get()` calls in favor of subscript access. Behavior-preserving; the runtime contract didn't change, only mypy's knowledge of it did.
 
-This is Step 10.4 of [MypyFixing.md](MypyFixing.md). Its own PR with its own gate (ProvenanceValidationTightening landed).
+This is Step 5 of [ResolveHardening.md](ResolveHardening.md) (originally Step 10.4 of [MypyFixing.md](MypyFixing.md)). Its own PR with its own gates — see Prerequisites.
 
 ## Prerequisites
 
-- **[ProvenanceValidationTightening.md](ProvenanceValidationTightening.md) landed.** Both Commit A (registry scaffolding) and Commit B (classifier + validator + cleanup). The write path must now reject payloads missing any required registered key, so a `val["person"]` read can't KeyError on a legacy malformed row.
+- **[ProvenanceValidationTightening.md](ProvenanceValidationTightening.md) landed.** Both Commit A (registry scaffolding) and Commit B (classifier + validator + cleanup). The write path must now reject payloads missing any required registered key, so a `val["person"]` read can't KeyError on a freshly written malformed row.
+- **Post-Step-2 wipe + re-ingest done.** The validator only constrains rows _written after_ it lands. Any pre-validator row missing a required key would KeyError on subscript access here. Step 2's commit sequence includes a post-merge wipe + re-ingest ([ProvenanceValidationTightening.md § Data posture](ProvenanceValidationTightening.md)); this step must not land until that has happened.
 - **[CatalogResolveTyping.md](CatalogResolveTyping.md) Phase B landed.** Every resolver loop already has `cast(<Schema>, claim.value)` at the top. This step only flips the reads, not the types.
 
 If a key is subscript-accessed here but the corresponding namespace isn't registered in the write-path validator, the flip is unsafe. Double-check coverage against the registration list in [ProvenanceValidationTightening.md § "New register_relationship_schema call sites"](ProvenanceValidationTightening.md) before flipping.


### PR DESCRIPTION
## Summary

- Extracts the former Step 10.3 of `MypyFixing.md` into a standalone sequence under `docs/plans/types/ResolveHardening.md`.
- Splits the work into separate sub-plans: `CatalogResolveTyping.md` (TypedDicts + casts + consistency test) and `CatalogResolveBaselineCleanup.md` (mypy burn-down on resolver helpers and tuple reuse).
- Updates `MypyFixing.md`, `ProvenanceValidationTightening.md`, and `ResolverReadsTightening.md` to point at the new sequence and reflect the reframed numbering (Steps 2–5).

The motivation: frame the claim-value shape hardening around its reasoning wins (single write-path authority, tested read-side mirror, explicit required/optional at the type level) rather than as a mypy scoreboard burn-down. The baseline reduction still counts — it just lives in its own step.

## Test plan

- [ ] Docs-only change; verify rendered markdown and cross-links resolve on GitHub.