### PR TITLE
refactor(provenance): unify registries + tighten relationship claim validation

### DIFF
--- a/backend/apps/catalog/apps.py
+++ b/backend/apps/catalog/apps.py
@@ -10,10 +10,10 @@ class CatalogConfig(AppConfig):
 
     def ready(self) -> None:
         from . import signals
-        from .claims import register_relationship_targets
+        from .claims import register_catalog_relationship_schemas
 
         signals.connect()
-        register_relationship_targets()
+        register_catalog_relationship_schemas()
         self._register_link_types()
         self._register_reference_cleanup()
 

--- a/backend/apps/catalog/claims.py
+++ b/backend/apps/catalog/claims.py
@@ -1,157 +1,290 @@
 """Catalog-level helpers for relationship claims.
 
-Domain knowledge about relationship claim types lives here, keeping the
-provenance layer fully generic.  Ingestion commands and the resolution layer
-import from this module rather than constructing claim_keys directly.
+Domain knowledge about relationship claim shapes lives here via
+``register_catalog_relationship_schemas()``, called from
+``CatalogConfig.ready()``. The unified registry is owned by
+``apps.provenance.validation``; this module only declares catalog
+namespaces and provides the ``build_relationship_claim`` helper that
+ingest commands and the resolution layer use.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from typing import NamedTuple
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 from apps.core.types import JsonBody
 from apps.provenance.models import IdentityPart, make_claim_key
+from apps.provenance.validation import (
+    RelationshipSchema,
+    ValueKeySpec,
+    get_all_relationship_schemas,
+    get_relationship_schema,
+    register_relationship_schema,
+)
+from apps.provenance.validation import (
+    get_relationship_namespaces as _get_relationship_namespaces,
+)
 
 # A (claim_key, value_dict) pair ready to write as a relationship Claim row.
 # claim_key is the canonical compound string; value_dict is the JSONField
 # payload — identity fields plus "exists", optionally "category"/"is_primary".
 RelationshipClaim = tuple[str, JsonBody]
 
+
 # ---------------------------------------------------------------------------
-# Relationship schema registry
+# Registration
 # ---------------------------------------------------------------------------
-# Two kinds of relationship namespace:
-#
-# Entity-reference — value dict keys are PKs referencing target models.
-#   ENTITY_REF_TARGETS is the single source of truth: schema keys,
-#   validation target registration, and RELATIONSHIP_NAMESPACES are all
-#   derived from it.
-#
-# Literal-value — value dict keys store literal strings (aliases,
-#   abbreviations) where value_key differs from identity_key.
 
 
-class RefKey(NamedTuple):
-    """An entity-reference key in a relationship claim value dict."""
+def register_catalog_relationship_schemas() -> None:
+    """Register every catalog relationship namespace. Called from ``ready()``.
 
-    name: str  # key in both value dict and claim_key ("person", "theme")
-    model: type[models.Model]  # target model for PK validation
-
-
-class LiteralKey(NamedTuple):
-    """A literal-value key where the value dict key differs from the claim_key key."""
-
-    value_key: str  # key in claim value dict ("alias_value")
-    identity_key: str  # key in claim_key string ("alias")
-
-
-def _build_entity_ref_targets() -> dict[str, list[RefKey]]:
-    """Deferred import to avoid circular dependency at module load."""
+    Each namespace is declared exactly once with its value-keys and the set
+    of subject models it applies to.
+    """
     from apps.catalog.models import (
+        CorporateEntity,
         CreditRole,
         GameplayFeature,
         Location,
+        MachineModel,
         Person,
         RewardType,
+        Series,
         Tag,
         Theme,
+        Title,
     )
+    from apps.core.models import MediaSupported
     from apps.media.models import MediaAsset
 
-    return {
-        "credit": [RefKey("person", Person), RefKey("role", CreditRole)],
-        "theme": [RefKey("theme", Theme)],
-        "tag": [RefKey("tag", Tag)],
-        "gameplay_feature": [RefKey("gameplay_feature", GameplayFeature)],
-        "reward_type": [RefKey("reward_type", RewardType)],
-        "location": [RefKey("location", Location)],
-        "theme_parent": [RefKey("parent", Theme)],
-        "gameplay_feature_parent": [RefKey("parent", GameplayFeature)],
-        "media_attachment": [RefKey("media_asset", MediaAsset)],
-    }
+    from ._alias_registry import discover_alias_types
+
+    # Credit: Person + CreditRole on MachineModel and Series.
+    register_relationship_schema(
+        namespace="credit",
+        value_keys=(
+            ValueKeySpec(
+                name="person",
+                scalar_type=int,
+                required=True,
+                identity="person",
+                fk_target=(Person, "pk"),
+            ),
+            ValueKeySpec(
+                name="role",
+                scalar_type=int,
+                required=True,
+                identity="role",
+                fk_target=(CreditRole, "pk"),
+            ),
+        ),
+        valid_subjects=frozenset({MachineModel, Series}),
+    )
+
+    # Gameplay feature M2M on MachineModel — with optional integer count.
+    register_relationship_schema(
+        namespace="gameplay_feature",
+        value_keys=(
+            ValueKeySpec(
+                name="gameplay_feature",
+                scalar_type=int,
+                required=True,
+                identity="gameplay_feature",
+                fk_target=(GameplayFeature, "pk"),
+            ),
+            ValueKeySpec(
+                name="count",
+                scalar_type=int,
+                required=False,
+                nullable=True,
+            ),
+        ),
+        valid_subjects=frozenset({MachineModel}),
+    )
+
+    # Simple M2Ms on MachineModel — theme / tag / reward_type.
+    register_relationship_schema(
+        namespace="theme",
+        value_keys=(
+            ValueKeySpec(
+                name="theme",
+                scalar_type=int,
+                required=True,
+                identity="theme",
+                fk_target=(Theme, "pk"),
+            ),
+        ),
+        valid_subjects=frozenset({MachineModel}),
+    )
+    register_relationship_schema(
+        namespace="tag",
+        value_keys=(
+            ValueKeySpec(
+                name="tag",
+                scalar_type=int,
+                required=True,
+                identity="tag",
+                fk_target=(Tag, "pk"),
+            ),
+        ),
+        valid_subjects=frozenset({MachineModel}),
+    )
+    register_relationship_schema(
+        namespace="reward_type",
+        value_keys=(
+            ValueKeySpec(
+                name="reward_type",
+                scalar_type=int,
+                required=True,
+                identity="reward_type",
+                fk_target=(RewardType, "pk"),
+            ),
+        ),
+        valid_subjects=frozenset({MachineModel}),
+    )
+
+    # Abbreviation (literal) on Title + MachineModel.
+    register_relationship_schema(
+        namespace="abbreviation",
+        value_keys=(
+            ValueKeySpec(
+                name="value",
+                scalar_type=str,
+                required=True,
+                identity="value",
+            ),
+        ),
+        valid_subjects=frozenset({Title, MachineModel}),
+    )
+
+    # Location on CorporateEntity.
+    register_relationship_schema(
+        namespace="location",
+        value_keys=(
+            ValueKeySpec(
+                name="location",
+                scalar_type=int,
+                required=True,
+                identity="location",
+                fk_target=(Location, "pk"),
+            ),
+        ),
+        valid_subjects=frozenset({CorporateEntity}),
+    )
+
+    # Hierarchy parents (self-referential).
+    register_relationship_schema(
+        namespace="theme_parent",
+        value_keys=(
+            ValueKeySpec(
+                name="parent",
+                scalar_type=int,
+                required=True,
+                identity="parent",
+                fk_target=(Theme, "pk"),
+            ),
+        ),
+        valid_subjects=frozenset({Theme}),
+    )
+    register_relationship_schema(
+        namespace="gameplay_feature_parent",
+        value_keys=(
+            ValueKeySpec(
+                name="parent",
+                scalar_type=int,
+                required=True,
+                identity="parent",
+                fk_target=(GameplayFeature, "pk"),
+            ),
+        ),
+        valid_subjects=frozenset({GameplayFeature}),
+    )
+
+    # Alias namespaces — one schema per AliasBase subclass.
+    for alias_type in discover_alias_types():
+        register_relationship_schema(
+            namespace=alias_type.claim_field,
+            value_keys=(
+                ValueKeySpec(
+                    name="alias_value",
+                    scalar_type=str,
+                    required=True,
+                    identity="alias",
+                ),
+                ValueKeySpec(
+                    name="alias_display",
+                    scalar_type=str,
+                    required=False,
+                ),
+            ),
+            valid_subjects=frozenset({alias_type.parent_model}),
+        )
+
+    # Media attachment — derived at registration by walking all concrete
+    # ``MediaSupported`` subclasses. ``apps.get_models()`` handles transitive
+    # subclasses that ``__subclasses__()`` would miss if an intermediate
+    # abstract base is ever introduced.
+    from django.apps import apps as _apps
+
+    media_subjects = frozenset(
+        m
+        for m in _apps.get_models()
+        if issubclass(m, MediaSupported) and not m._meta.abstract
+    )
+    register_relationship_schema(
+        namespace="media_attachment",
+        value_keys=(
+            ValueKeySpec(
+                name="media_asset",
+                scalar_type=int,
+                required=True,
+                identity="media_asset",
+                fk_target=(MediaAsset, "pk"),
+            ),
+            ValueKeySpec(
+                name="category",
+                scalar_type=str,
+                required=False,
+                nullable=True,
+            ),
+            ValueKeySpec(
+                name="is_primary",
+                scalar_type=bool,
+                required=False,
+            ),
+        ),
+        valid_subjects=media_subjects,
+    )
 
 
-# Populated lazily by _get_entity_ref_targets().
-_entity_ref_targets: dict[str, list[RefKey]] | None = None
-
-
-def _get_entity_ref_targets() -> dict[str, list[RefKey]]:
-    global _entity_ref_targets
-    if _entity_ref_targets is None:
-        _entity_ref_targets = _build_entity_ref_targets()
-    return _entity_ref_targets
-
-
-_literal_schemas: dict[str, LiteralKey] | None = None
-
-
-def _get_literal_schemas() -> dict[str, LiteralKey]:
-    """Return literal namespace schemas, auto-discovering alias types.
-
-    Lazy — safe to call at any time; caches after first call.
-    Follows the same pattern as ``_get_entity_ref_targets()``.
-    """
-    global _literal_schemas
-    if _literal_schemas is None:
-        from ._alias_registry import discover_alias_types
-
-        _literal_schemas = {"abbreviation": LiteralKey("value", "value")}
-        for at in discover_alias_types():
-            _literal_schemas[at.claim_field] = LiteralKey("alias_value", "alias")
-    return _literal_schemas
-
-
-_relationship_namespaces: frozenset[str] | None = None
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
 
 
 def get_relationship_namespaces() -> frozenset[str]:
-    """Return the full set of relationship namespace names.
+    """Return the full set of registered relationship namespace names.
 
-    Lazy — safe to call at any time; caches after first call.
+    Thin re-export of the cached provenance-layer function, kept at this
+    module path for existing import sites.
     """
-    global _relationship_namespaces
-    if _relationship_namespaces is None:
-        _relationship_namespaces = frozenset(_get_entity_ref_targets()) | frozenset(
-            _get_literal_schemas()
-        )
-    return _relationship_namespaces
-
-
-def register_relationship_targets() -> None:
-    """Push catalog target-model knowledge into the provenance registry.
-
-    Called once from ``CatalogConfig.ready()``.  Derived from
-    ``ENTITY_REF_TARGETS`` — no hand-maintained second dict.
-    """
-    from apps.provenance.validation import register_relationship_targets as _register
-
-    _register(
-        {
-            namespace: [(rk.name, rk.model, "pk") for rk in ref_keys]
-            for namespace, ref_keys in _get_entity_ref_targets().items()
-        }
-    )
-
-
-# ---------------------------------------------------------------------------
-# Claim construction helpers
-# ---------------------------------------------------------------------------
+    return _get_relationship_namespaces()
 
 
 def get_all_namespace_keys() -> dict[str, list[str]]:
-    """Return namespace → list of identity key names for every relationship namespace.
+    """Return namespace → list of identity value-key names for every namespace.
 
     Used by tests to verify that every namespace classifies correctly.
     """
     result: dict[str, list[str]] = {}
-    for ns, ref_keys in _get_entity_ref_targets().items():
-        result[ns] = [rk.name for rk in ref_keys]
-    for ns, lit in _get_literal_schemas().items():
-        result[ns] = [lit.value_key]
+    for namespace, schema in get_all_relationship_schemas().items():
+        result[namespace] = [
+            spec.name for spec in schema.value_keys if spec.identity is not None
+        ]
     return result
 
 
@@ -163,31 +296,24 @@ def build_relationship_claim(
     """Return ``(claim_key, value)`` for a relationship claim.
 
     ``identity`` contains the identity fields for this relationship, e.g.,
-    ``{"person": 42, "role": 5}``.
+    ``{"person": 42, "role": 5}`` or ``{"alias_value": "foo"}``. Keys are
+    value-dict names (``alias_value``), not identity labels (``alias``) —
+    the mapping is resolved via ``ValueKeySpec.identity``.
 
-    The claim_key is derived from identity using the registry for *field_name*.
-    The value dict includes identity fields plus ``exists``.
+    The claim_key is derived from identity using the registered schema for
+    *field_name*. The value dict includes all identity fields plus ``exists``.
     """
-    entity_refs = _get_entity_ref_targets()
-    ref_keys = entity_refs.get(field_name)
-    if ref_keys is not None:
-        # Entity-reference namespace: key names are identity keys.
-        expected = sorted(rk.name for rk in ref_keys)
-        for key in expected:
-            if key not in identity:
-                raise ValueError(f"Missing required key {key!r} for {field_name!r}")
-        identity_parts = {k: identity[k] for k in expected}
-    else:
-        literal = _get_literal_schemas().get(field_name)
-        if literal is None:
-            raise ValueError(f"Unknown relationship namespace: {field_name!r}")
-        # Literal namespace: map value_key → identity_key.
-        if literal.value_key not in identity:
-            raise ValueError(
-                f"Missing required key {literal.value_key!r} for {field_name!r}"
-            )
-        identity_parts = {literal.identity_key: identity[literal.value_key]}
+    schema = get_relationship_schema(field_name)
+    if schema is None:
+        raise ValueError(f"Unknown relationship namespace: {field_name!r}")
 
+    identity_parts: dict[str, IdentityPart] = {}
+    for spec in schema.value_keys:
+        if spec.identity is None:
+            continue
+        if spec.name not in identity:
+            raise ValueError(f"Missing required key {spec.name!r} for {field_name!r}")
+        identity_parts[spec.identity] = identity[spec.name]
     claim_key = make_claim_key(field_name, **identity_parts)
     value: JsonBody = {**identity, "exists": exists}
     return claim_key, value
@@ -245,3 +371,19 @@ def make_authoritative_scope(
     """
     ct_id = ContentType.objects.get_for_model(model_class).pk
     return {(ct_id, obj_id) for obj_id in object_ids}
+
+
+# Public surface. ``RelationshipSchema`` / ``ValueKeySpec`` are re-exported
+# because this module instantiates them; downstream code should import from
+# whichever module they already use.
+__all__ = [
+    "RelationshipClaim",
+    "RelationshipSchema",
+    "ValueKeySpec",
+    "build_media_attachment_claim",
+    "build_relationship_claim",
+    "get_all_namespace_keys",
+    "get_relationship_namespaces",
+    "make_authoritative_scope",
+    "register_catalog_relationship_schemas",
+]

--- a/backend/apps/catalog/tests/test_claims.py
+++ b/backend/apps/catalog/tests/test_claims.py
@@ -107,3 +107,91 @@ class TestRelationshipNamespaces:
         ns = get_relationship_namespaces()
         assert "credit" in ns
         assert "theme" in ns
+
+
+# ---------------------------------------------------------------------------
+# Registry invariants
+# ---------------------------------------------------------------------------
+
+
+class TestEagerAliasDiscovery:
+    """Alias schemas are registered eagerly during ``CatalogConfig.ready()``.
+
+    Pin the contract that every alias namespace is queryable the moment
+    Django finishes startup, without any resolver-path call required to
+    trigger discovery.
+    """
+
+    def test_theme_alias_registered_without_prior_resolver_access(self):
+        from apps.provenance.validation import get_relationship_schema
+
+        assert get_relationship_schema("theme_alias") is not None
+
+
+class TestMediaAttachmentValidSubjectsPin:
+    """``media_attachment.valid_subjects`` is derived from ``apps.get_models()``.
+
+    Pin the expected set so a new ``MediaSupported`` subclass (or the
+    removal of an existing one) fails in CI rather than silently drifting.
+    Update this test when the set genuinely changes.
+    """
+
+    def test_expected_subjects(self):
+        from apps.catalog.models import (
+            GameplayFeature,
+            MachineModel,
+            Manufacturer,
+            Person,
+        )
+        from apps.provenance.validation import get_relationship_schema
+
+        schema = get_relationship_schema("media_attachment")
+        assert schema is not None
+        assert schema.valid_subjects == frozenset(
+            {GameplayFeature, MachineModel, Manufacturer, Person}
+        )
+
+
+class TestBuildRelationshipClaimCanonicalKey:
+    """``build_relationship_claim`` output agrees with ``make_claim_key``.
+
+    Write-path validation rejects any relationship claim whose ``claim_key``
+    doesn't match ``make_claim_key`` composed from the value's identity
+    fields. This test pins that every registered schema round-trips cleanly
+    through ``build_relationship_claim`` into the canonical key form, so a
+    refactor of either composition can't silently start failing validation
+    on every production write.
+    """
+
+    def test_every_schema_produces_canonical_claim_key(self, db):
+        from apps.provenance.models import IdentityPart
+        from apps.provenance.validation import get_all_relationship_schemas
+
+        for namespace, schema in get_all_relationship_schemas().items():
+            identity_kwargs: dict[str, IdentityPart] = {}
+            for spec in schema.value_keys:
+                if spec.identity is None:
+                    continue
+                # No current identity spec uses scalar_type=bool, so int|str
+                # covers every case. If that ever changes, extend here.
+                if spec.scalar_type is int:
+                    identity_kwargs[spec.name] = 1
+                elif spec.scalar_type is str:
+                    identity_kwargs[spec.name] = "x"
+                else:
+                    raise AssertionError(
+                        f"identity spec {namespace}.{spec.name} has "
+                        f"unexpected scalar_type {spec.scalar_type!r}"
+                    )
+
+            claim_key, _value = build_relationship_claim(
+                namespace, identity_kwargs, exists=True
+            )
+            expected_parts = {
+                spec.identity: identity_kwargs[spec.name]
+                for spec in schema.value_keys
+                if spec.identity is not None
+            }
+            assert claim_key == make_claim_key(namespace, **expected_parts), (
+                f"build_relationship_claim/make_claim_key drift on {namespace!r}"
+            )

--- a/backend/apps/catalog/tests/test_resolve_dispatch.py
+++ b/backend/apps/catalog/tests/test_resolve_dispatch.py
@@ -3,7 +3,7 @@
 import pytest
 
 from apps.catalog._alias_registry import discover_alias_types
-from apps.catalog.claims import _get_literal_schemas, build_relationship_claim
+from apps.catalog.claims import build_relationship_claim
 from apps.catalog.models import (
     CorporateEntity,
     GameplayFeature,
@@ -18,6 +18,7 @@ from apps.catalog.models import (
 from apps.catalog.resolve._dispatch import resolve_after_mutation
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.models import Claim, Source
+from apps.provenance.validation import get_relationship_schema
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -99,15 +100,23 @@ class TestDiscoverAliasTypes:
 
 class TestLiteralSchemasAutoPopulated:
     def test_contains_abbreviation(self):
-        schemas = _get_literal_schemas()
-        assert "abbreviation" in schemas
+        schema = get_relationship_schema("abbreviation")
+        assert schema is not None
 
     def test_contains_all_alias_types(self):
-        schemas = _get_literal_schemas()
         for _, field_name in discover_alias_types():
-            assert field_name in schemas
-            assert schemas[field_name].value_key == "alias_value"
-            assert schemas[field_name].identity_key == "alias"
+            schema = get_relationship_schema(field_name)
+            assert schema is not None
+            # The alias value-key is named "alias_value" and participates in
+            # the claim_key under the identity label "alias".
+            alias_value_spec = next(
+                (s for s in schema.value_keys if s.name == "alias_value"),
+                None,
+            )
+            assert alias_value_spec is not None
+            assert alias_value_spec.identity == "alias"
+            assert alias_value_spec.scalar_type is str
+            assert alias_value_spec.required is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/core/tests/test_validators.py
+++ b/backend/apps/core/tests/test_validators.py
@@ -158,19 +158,20 @@ class TestMojibakeBulkAssertClaims:
         mfr = Manufacturer.objects.create(name="Williams", slug="williams")
         ct_id = ContentType.objects.get_for_model(mfr).pk
 
+        from apps.catalog.claims import build_relationship_claim
         from apps.provenance.models import Claim
 
+        claim_key, value = build_relationship_claim(
+            "manufacturer_alias",
+            {"alias_value": "GÃ¶ttlieb", "alias_display": "GÃ¶ttlieb"},
+        )
         pending = [
             Claim(
                 content_type_id=ct_id,
                 object_id=mfr.pk,
                 field_name="manufacturer_alias",
-                claim_key="manufacturer_alias|alias_value:garbled",
-                value={
-                    "alias_value": "GÃ¶ttlieb",
-                    "alias_display": "GÃ¶ttlieb",
-                    "exists": True,
-                },
+                claim_key=claim_key,
+                value=value,
             ),
         ]
         # Should NOT raise — alias values are exempt from mojibake validation

--- a/backend/apps/media/tests/test_media_claims.py
+++ b/backend/apps/media/tests/test_media_claims.py
@@ -637,8 +637,11 @@ class TestResolverValidation:
         _resolve_media(machine_model)
         assert EntityMedia.objects.count() == 0
 
-    def test_non_media_supported_entity_skipped(self, db, asset, source):
-        """Claim on a non-MediaSupported entity doesn't materialize."""
+    def test_non_media_supported_entity_rejected(self, db, asset, source):
+        """Writing a ``media_attachment`` claim on a non-MediaSupported entity
+        is rejected at the write path, not silently ignored at resolve time."""
+        from django.core.exceptions import ValidationError
+
         from apps.catalog.models import Theme
         from apps.provenance.models import make_claim_key
 
@@ -650,16 +653,11 @@ class TestResolverValidation:
             "is_primary": False,
             "exists": True,
         }
-        Claim.objects.assert_claim(
-            theme,
-            "media_attachment",
-            value,
-            source=source,
-            claim_key=claim_key,
-        )
-
-        ct = ContentType.objects.get_for_model(Theme)
-        from apps.catalog.resolve import resolve_media_attachments
-
-        resolve_media_attachments(content_type_id=ct.id, subject_ids={theme.pk})
-        assert EntityMedia.objects.count() == 0
+        with pytest.raises(ValidationError, match="media_attachment"):
+            Claim.objects.assert_claim(
+                theme,
+                "media_attachment",
+                value,
+                source=source,
+                claim_key=claim_key,
+            )

--- a/backend/apps/provenance/models/claim.py
+++ b/backend/apps/provenance/models/claim.py
@@ -107,14 +107,16 @@ class ClaimManager(models.Manager):
         if not claim_key:
             claim_key = field_name
 
-        # Classify and validate. Direct claims get scalar/FK validation.
-        # Relationship and extra-data claims pass through. Unrecognized
-        # claims are rejected outright.
+        # Classify and validate. DIRECT claims get scalar/FK validation.
+        # RELATIONSHIP claims get shape validation. EXTRA claims pass through.
+        # UNRECOGNIZED claims are rejected outright.
         from apps.provenance.validation import (
             DIRECT,
+            RELATIONSHIP,
             UNRECOGNIZED,
             classify_claim,
             validate_claim_value,
+            validate_single_relationship_claim,
         )
 
         model_class = type(subject)
@@ -125,6 +127,13 @@ class ClaimManager(models.Manager):
             )
         if ct_result == DIRECT:
             value = validate_claim_value(field_name, value, model_class)
+        elif ct_result == RELATIONSHIP:
+            validate_single_relationship_claim(
+                subject_model=model_class,
+                field_name=field_name,
+                claim_key=claim_key,
+                value=value,
+            )
 
         ct = ContentType.objects.get_for_model(subject)
         with transaction.atomic():

--- a/backend/apps/provenance/tests/test_validation.py
+++ b/backend/apps/provenance/tests/test_validation.py
@@ -346,28 +346,34 @@ class TestClassifyClaim:
         """Undotted unknown field on model with extra_data → EXTRA."""
         assert classify_claim(MachineModel, "manufacturer", "", "williams") == EXTRA
 
-    def test_relationship_convention_enforced(self):
-        """Every relationship namespace produces a RELATIONSHIP claim.
+    def test_every_registered_namespace_classifies_as_relationship(self):
+        """Integration check: registry and classifier agree.
 
-        This turns the structural convention into a tested invariant: if
-        build_relationship_claim ever stops producing compound claim_key
-        or dict values with 'exists', this test breaks.
+        Two properties in one walk:
+        (1) ``build_relationship_claim`` accepts every namespace surfaced by
+            ``get_all_namespace_keys()`` — drift between the two helpers
+            surfaces as a ``ValueError`` here.
+        (2) ``classify_claim`` returns ``RELATIONSHIP`` for every registered
+            namespace (when not shadowed by a DIRECT field on the subject).
+
+        The claim_key / value *contract* — canonical key shape, required
+        ``exists``, dict payload — is pinned by ``TestBuildRelationshipClaim
+        CanonicalKey`` in ``test_claims.py`` and by the rejection-mode tests
+        below, not by the classifier (which is registry-driven and does not
+        inspect ``claim_key`` or ``value``).
         """
         from apps.catalog.claims import build_relationship_claim, get_all_namespace_keys
 
-        # Build a minimal identity dict for each namespace.
         for namespace, keys in get_all_namespace_keys().items():
             identity = dict.fromkeys(keys, "test-value")
             claim_key, value = build_relationship_claim(namespace, identity)
 
-            # Determine a model class that hosts this namespace. For the
-            # purpose of this test, the model doesn't matter — what matters
-            # is that the claim_key/value structure classifies as RELATIONSHIP
-            # on any model (since field_name won't be in get_claim_fields).
+            # MachineModel isn't in every namespace's valid_subjects, but
+            # classify_claim is subject-agnostic for RELATIONSHIP routing —
+            # wrong-subject is the validator's concern, not the classifier's.
             result = classify_claim(MachineModel, namespace, claim_key, value)
             assert result == RELATIONSHIP, (
-                f"Namespace {namespace!r} classified as {result!r}, expected RELATIONSHIP. "
-                f"claim_key={claim_key!r}, value={value!r}"
+                f"Namespace {namespace!r} classified as {result!r}, expected RELATIONSHIP."
             )
 
 
@@ -630,3 +636,396 @@ class TestValidateClaimsBatchRelationships:
         valid, rejected = validate_claims_batch([good_scalar, good_rel, bad_rel])
         assert rejected == 1
         assert len(valid) == 2
+
+    @pytest.mark.parametrize(
+        "mode",
+        [
+            "wrong-subject",
+            "missing-exists",
+            "unknown-key",
+            "default-claim-key",
+        ],
+    )
+    def test_shape_rejection_propagates_through_batch(
+        self, model, credit_targets, mode
+    ):
+        """One parametrized test pinning the batch-path glue for shape rejections.
+
+        Each mode exercises a different rule in ``validate_single_relationship_claim``
+        (wrong-subject, missing exists, unknown keys, non-canonical claim_key).
+        Alongside each bad claim we include a *valid* companion claim, which
+        pins the property that the batch loop continues past a rejection
+        rather than aborting — the single-validator tests can't verify that,
+        and the pre-existing FK-existence batch test exercises a different
+        rejection path.
+        """
+        pat_pk = credit_targets["persons"]["pat-lawlor"].pk
+        design_pk = credit_targets["roles"]["design"].pk
+        good_claim_key = f"credit|person:{pat_pk}|role:{design_pk}"
+        good_value = {"person": pat_pk, "role": design_pk, "exists": True}
+
+        good = Claim.for_object(
+            model, field_name="credit", value=good_value, claim_key=good_claim_key
+        )
+
+        if mode == "wrong-subject":
+            # Route a "credit" claim at a Title, which isn't in credit.valid_subjects.
+            from apps.catalog.models import Title
+
+            title = Title.objects.create(name="T", slug="t")
+            bad = Claim.for_object(
+                title,
+                field_name="credit",
+                value=good_value,
+                claim_key=good_claim_key,
+            )
+        elif mode == "missing-exists":
+            bad = Claim.for_object(
+                model,
+                field_name="credit",
+                value={"person": pat_pk, "role": design_pk},
+                claim_key=good_claim_key,
+            )
+        elif mode == "unknown-key":
+            bad = Claim.for_object(
+                model,
+                field_name="credit",
+                value={**good_value, "bogus": 1},
+                claim_key=good_claim_key,
+            )
+        elif mode == "default-claim-key":
+            # Caller forgot to pass claim_key → defaulted to field_name.
+            bad = Claim.for_object(
+                model,
+                field_name="credit",
+                value=good_value,
+                claim_key="credit",
+            )
+        else:
+            raise AssertionError(f"unhandled mode {mode!r}")
+
+        valid, rejected_count = validate_claims_batch([good, bad])
+
+        assert rejected_count == 1
+        # The malformed claim is absent from ``valid``, the good one is present.
+        valid_ids = {id(c) for c in valid}
+        assert id(bad) not in valid_ids
+        assert id(good) in valid_ids
+
+
+# ---------------------------------------------------------------------------
+# validate_single_relationship_claim — shape-rejection rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestValidateSingleRelationshipClaim:
+    """Direct coverage of each shape-rejection rule in validator order.
+
+    The batch-path integration tests below exercise the same rules through
+    ``validate_claims_batch`` so both entry points are covered.
+    """
+
+    @pytest.fixture
+    def model(self):
+        return make_machine_model(name="Test", slug="test")
+
+    @pytest.fixture
+    def canonical(self, credit_targets):
+        pat_pk = credit_targets["persons"]["pat-lawlor"].pk
+        design_pk = credit_targets["roles"]["design"].pk
+        return {
+            "person_pk": pat_pk,
+            "role_pk": design_pk,
+            "value": {"person": pat_pk, "role": design_pk, "exists": True},
+            "claim_key": f"credit|person:{pat_pk}|role:{design_pk}",
+        }
+
+    def _validate(self, **kwargs):
+        from apps.provenance.validation import validate_single_relationship_claim
+
+        return validate_single_relationship_claim(**kwargs)
+
+    def test_valid_claim_passes(self, model, canonical):
+        # Sanity baseline — if this ever fails the other rejection tests are
+        # meaningless.
+        self._validate(
+            subject_model=MachineModel,
+            field_name="credit",
+            claim_key=canonical["claim_key"],
+            value=canonical["value"],
+        )
+
+    def test_wrong_subject_rejected(self, canonical):
+        with pytest.raises(ValidationError, match="not valid on Title"):
+            self._validate(
+                subject_model=Title,
+                field_name="credit",
+                claim_key=canonical["claim_key"],
+                value=canonical["value"],
+            )
+
+    def test_non_dict_value_rejected(self):
+        with pytest.raises(ValidationError, match="must be a dict"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key="credit",
+                value="not a dict",
+            )
+
+    def test_missing_exists_rejected(self, canonical):
+        value = {"person": canonical["person_pk"], "role": canonical["role_pk"]}
+        with pytest.raises(ValidationError, match="missing required 'exists'"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key=canonical["claim_key"],
+                value=value,
+            )
+
+    def test_non_bool_exists_rejected(self, canonical):
+        value = {**canonical["value"], "exists": "true"}
+        with pytest.raises(ValidationError, match="'exists' must be bool"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key=canonical["claim_key"],
+                value=value,
+            )
+
+    def test_missing_required_key_rejected(self, canonical):
+        value = {"person": canonical["person_pk"], "exists": True}
+        with pytest.raises(ValidationError, match="missing required key 'role'"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key=canonical["claim_key"],
+                value=value,
+            )
+
+    def test_wrong_scalar_type_required_key_rejected(self, canonical):
+        value = {**canonical["value"], "person": "not-an-int"}
+        with pytest.raises(ValidationError, match="'person' must be int"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key=canonical["claim_key"],
+                value=value,
+            )
+
+    def test_bool_as_int_rejected(self, canonical):
+        # `isinstance(True, int)` is True; the `type(v) is T` rule rejects it.
+        value = {**canonical["value"], "person": True}
+        with pytest.raises(ValidationError, match="'person' must be int"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key=canonical["claim_key"],
+                value=value,
+            )
+
+    def test_wrong_scalar_type_optional_key_rejected(self, credit_targets):
+        # `gameplay_feature.count` is optional + nullable int.
+        from apps.catalog.models import GameplayFeature
+
+        gf = GameplayFeature.objects.create(name="Multiball", slug="multiball")
+        with pytest.raises(ValidationError, match="'count' must be int"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="gameplay_feature",
+                claim_key=f"gameplay_feature|gameplay_feature:{gf.pk}",
+                value={"gameplay_feature": gf.pk, "count": "5", "exists": True},
+            )
+
+    def test_nullable_optional_accepts_none(self):
+        from apps.catalog.models import GameplayFeature
+
+        gf = GameplayFeature.objects.create(name="Multiball", slug="multiball")
+        self._validate(
+            subject_model=MachineModel,
+            field_name="gameplay_feature",
+            claim_key=f"gameplay_feature|gameplay_feature:{gf.pk}",
+            value={"gameplay_feature": gf.pk, "count": None, "exists": True},
+        )
+
+    def test_non_nullable_optional_rejects_none(self):
+        # `media_attachment.is_primary` is optional, non-nullable bool.
+        # Schema-only check — no DB row needed; the validator operates on
+        # the (namespace, subject_model, claim_key, value) tuple.
+        with pytest.raises(ValidationError, match="'is_primary' may not be null"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="media_attachment",
+                claim_key="media_attachment|media_asset:1",
+                value={
+                    "media_asset": 1,
+                    "is_primary": None,
+                    "exists": True,
+                },
+            )
+
+    def test_unknown_key_rejected(self, canonical):
+        value = {**canonical["value"], "bogus": 1}
+        with pytest.raises(ValidationError, match="unknown keys"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key=canonical["claim_key"],
+                value=value,
+            )
+
+    def test_unknown_key_rejected_on_retraction(self, canonical):
+        # Retractions aren't carved out from shape rules (only FK existence).
+        value = {**canonical["value"], "exists": False, "bogus": 1}
+        with pytest.raises(ValidationError, match="unknown keys"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key=canonical["claim_key"],
+                value=value,
+            )
+
+    def test_default_claim_key_rejected(self, canonical):
+        # Caller passes no claim_key → assert_claim defaults to field_name;
+        # the canonical form is the compound key.
+        with pytest.raises(ValidationError, match="not canonical"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key="credit",
+                value=canonical["value"],
+            )
+
+    def test_mismatched_claim_key_rejected(self, canonical):
+        wrong = f"credit|person:99999|role:{canonical['role_pk']}"
+        with pytest.raises(ValidationError, match="not canonical"):
+            self._validate(
+                subject_model=MachineModel,
+                field_name="credit",
+                claim_key=wrong,
+                value=canonical["value"],
+            )
+
+
+# ---------------------------------------------------------------------------
+# assert_claim — shape rejection end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestAssertClaimRelationshipShape:
+    """``assert_claim`` routes RELATIONSHIP claims through the shape validator."""
+
+    @pytest.fixture
+    def model(self):
+        return make_machine_model(name="Test", slug="test")
+
+    @pytest.fixture
+    def source(self):
+        return Source.objects.create(
+            name="Test Source", source_type="database", priority=50
+        )
+
+    def test_malformed_payload_on_extra_data_model_rejected(self, model, source):
+        # Before the classifier change, a credit claim missing "exists" on a
+        # model with extra_data would fall through to EXTRA and silently land.
+        # Now it routes to RELATIONSHIP and the validator rejects it.
+        with pytest.raises(ValidationError, match="missing required 'exists'"):
+            Claim.objects.assert_claim(
+                model,
+                "credit",
+                {"person": 1, "role": 1},  # no "exists"
+                source=source,
+                claim_key="credit|person:1|role:1",
+            )
+
+    def test_default_claim_key_rejected(self, model, source, credit_targets):
+        pat_pk = credit_targets["persons"]["pat-lawlor"].pk
+        design_pk = credit_targets["roles"]["design"].pk
+        with pytest.raises(ValidationError, match="not canonical"):
+            # No claim_key= → assert_claim defaults it to field_name.
+            Claim.objects.assert_claim(
+                model,
+                "credit",
+                {"person": pat_pk, "role": design_pk, "exists": True},
+                source=source,
+            )
+
+    def test_wrong_subject_rejected(self, source):
+        title = Title.objects.create(name="T", slug="t")
+        with pytest.raises(ValidationError, match="not valid on Title"):
+            Claim.objects.assert_claim(
+                title,
+                "credit",
+                {"person": 1, "role": 1, "exists": True},
+                source=source,
+                claim_key="credit|person:1|role:1",
+            )
+
+
+# ---------------------------------------------------------------------------
+# register_relationship_schema — invariants
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterRelationshipSchemaGuards:
+    """Registration-time invariants fail at startup, not at write time."""
+
+    def test_non_required_identity_rejected(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        from apps.provenance.validation import (
+            ValueKeySpec,
+            _relationship_schemas,
+            register_relationship_schema,
+        )
+
+        with pytest.raises(
+            ImproperlyConfigured, match="identity keys must be required"
+        ):
+            register_relationship_schema(
+                namespace="_test_bad_identity",
+                value_keys=(
+                    ValueKeySpec(
+                        name="x",
+                        scalar_type=int,
+                        required=False,
+                        identity="x",
+                    ),
+                ),
+                valid_subjects=frozenset({Theme}),
+            )
+        # Pin "raise before insert" — a future refactor that inserts and
+        # then validates would pass the exception assertion but pollute the
+        # registry across tests.
+        assert "_test_bad_identity" not in _relationship_schemas
+
+    def test_collision_with_direct_field_rejected(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        from apps.provenance.validation import (
+            ValueKeySpec,
+            _relationship_schemas,
+            register_relationship_schema,
+        )
+
+        # ``name`` is a concrete claim field on Theme — collision guard fires.
+        existing = _relationship_schemas.get("name")
+        with pytest.raises(ImproperlyConfigured, match="collides with a concrete"):
+            register_relationship_schema(
+                namespace="name",
+                value_keys=(
+                    ValueKeySpec(
+                        name="x",
+                        scalar_type=int,
+                        required=True,
+                        identity="x",
+                    ),
+                ),
+                valid_subjects=frozenset({Theme}),
+            )
+        # Same "raise before insert" invariant. Compared against any
+        # pre-existing entry (there shouldn't be one) to stay robust if a
+        # future catalog namespace happens to be called "name".
+        assert _relationship_schemas.get("name") == existing

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -13,9 +13,14 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from django.core.exceptions import FieldDoesNotExist, ValidationError
+from django.core.exceptions import (
+    FieldDoesNotExist,
+    ImproperlyConfigured,
+    ValidationError,
+)
 from django.db import models
 
 if TYPE_CHECKING:
@@ -29,27 +34,132 @@ RELATIONSHIP = "relationship"
 EXTRA = "extra"
 UNRECOGNIZED = "unrecognized"
 
+
 # ---------------------------------------------------------------------------
-# Relationship target registry
+# Relationship schema registry
 # ---------------------------------------------------------------------------
-# Populated by catalog.apps.CatalogConfig.ready() — the provenance layer owns
-# the data structure, the catalog layer provides the concrete mappings.
-#
-# Format: {namespace: [(value_key, target_model, lookup_field), ...]}
-#   e.g. {"credit": [("person", Person, "pk"), ("role", CreditRole, "pk")]}
-_relationship_target_registry: dict[str, list[tuple[str, type[models.Model], str]]] = {}
+# Single source of truth for relationship namespaces. Drives claim
+# construction, namespace enumeration, write-path shape validation, and
+# batch FK existence checks.
 
 
-def register_relationship_targets(
-    mapping: dict[str, list[tuple[str, type[models.Model], str]]],
-) -> None:
-    """Register target models for relationship claim validation.
+@dataclass(frozen=True, slots=True)
+class ValueKeySpec:
+    """One key in a relationship claim's value dict.
 
-    Called once from ``CatalogConfig.ready()``.  Each entry maps a
-    relationship namespace to the value-dict keys that reference external
-    models and the field used for the existence check.
+    ``name`` is the key as it appears in the value dict. ``identity``, when
+    set, is the label used in the canonical ``claim_key`` identity parts —
+    typically equal to ``name`` (e.g. ``"person"``) but occasionally different
+    (e.g. ``identity="alias"`` for ``name="alias_value"``). ``None`` means
+    this key is non-identity (e.g. ``count``, ``category``, ``alias_display``).
+
+    **INVARIANT**: ``identity is not None`` ⇒ ``required=True``. Enforced at
+    registration time in ``register_relationship_schema``.
     """
-    _relationship_target_registry.update(mapping)
+
+    name: str
+    scalar_type: type
+    required: bool
+    nullable: bool = False
+    identity: str | None = None
+    fk_target: tuple[type[models.Model], str] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RelationshipSchema:
+    """Shape of one relationship namespace: value-key list + valid subjects."""
+
+    namespace: str
+    value_keys: tuple[ValueKeySpec, ...]
+    valid_subjects: frozenset[type[models.Model]]
+
+
+_relationship_schemas: dict[str, RelationshipSchema] = {}
+
+# Cached frozenset of registered namespace names. Invalidated on every
+# ``register_relationship_schema`` call and rebuilt lazily by
+# ``get_relationship_namespaces``. Registration happens once during
+# ``CatalogConfig.ready()``, so the cache is effectively permanent after
+# startup — worth caching because ``get_relationship_namespaces`` is
+# called inside per-winner loops during resolve.
+_namespaces_cache: frozenset[str] | None = None
+
+
+def register_relationship_schema(
+    namespace: str,
+    value_keys: tuple[ValueKeySpec, ...],
+    valid_subjects: frozenset[type[models.Model]],
+) -> None:
+    """Register a relationship schema. Idempotent; conflicting re-registration raises.
+
+    Invariants enforced here (not at the validator):
+    - ``identity is not None`` ⇒ ``required=True`` on every value-key.
+    - ``namespace`` must not collide with a concrete claim-controlled field
+      name on any class in ``valid_subjects`` (keeps ``classify_claim``'s
+      DIRECT-vs-RELATIONSHIP routing structurally disjoint).
+    """
+    from apps.core.models import get_claim_fields
+
+    for spec in value_keys:
+        if spec.identity is not None and not spec.required:
+            raise ImproperlyConfigured(
+                f"namespace {namespace!r}, value_key {spec.name!r}: "
+                f"identity keys must be required "
+                f"(identity={spec.identity!r}, required=False)"
+            )
+
+    for subject_model in valid_subjects:
+        if namespace in get_claim_fields(subject_model):
+            raise ImproperlyConfigured(
+                f"namespace {namespace!r} collides with a concrete claim field "
+                f"on {subject_model.__name__}"
+            )
+
+    new = RelationshipSchema(
+        namespace=namespace,
+        value_keys=value_keys,
+        valid_subjects=valid_subjects,
+    )
+    existing = _relationship_schemas.get(namespace)
+    if existing is not None:
+        if existing == new:
+            return
+        raise ImproperlyConfigured(
+            f"namespace {namespace!r} already registered with a different schema"
+        )
+    _relationship_schemas[namespace] = new
+    global _namespaces_cache
+    _namespaces_cache = None
+
+
+def get_relationship_schema(namespace: str) -> RelationshipSchema | None:
+    """Return the schema for a namespace, or ``None`` if unregistered."""
+    return _relationship_schemas.get(namespace)
+
+
+def get_all_relationship_schemas() -> dict[str, RelationshipSchema]:
+    """Return the registry keyed by namespace (read-only snapshot)."""
+    return dict(_relationship_schemas)
+
+
+def get_relationship_namespaces() -> frozenset[str]:
+    """Return the cached frozenset of registered namespace names.
+
+    Hot path: called inside per-winner loops during entity resolve. The
+    frozenset is rebuilt once after registration (or on first access) and
+    reused until another ``register_relationship_schema`` call invalidates it.
+    """
+    global _namespaces_cache
+    if _namespaces_cache is None:
+        _namespaces_cache = frozenset(_relationship_schemas)
+    return _namespaces_cache
+
+
+def is_valid_subject(
+    schema: RelationshipSchema, subject_model: type[models.Model]
+) -> bool:
+    """Whether ``subject_model`` is a registered subject for this schema."""
+    return subject_model in schema.valid_subjects
 
 
 def classify_claim(
@@ -365,11 +475,12 @@ def validate_relationship_claims_batch(
     query per group — the same grouped-query pattern used by
     ``validate_fk_claims_batch`` for FK claims.
 
-    Only namespaces registered via ``register_relationship_targets`` are
-    checked. Unregistered namespaces (aliases, abbreviations) pass through
-    because their value dicts contain literal data, not foreign references.
+    Reads target models from ``ValueKeySpec.fk_target`` on each registered
+    schema. Non-FK value-keys (literals like ``alias_value``) have
+    ``fk_target=None`` and pass through without an existence check.
+    Unregistered namespaces also pass through.
     """
-    if not _relationship_target_registry:
+    if not _relationship_schemas:
         return []
 
     # (namespace, value_key) → [(claim, ref_value), ...]
@@ -379,8 +490,8 @@ def validate_relationship_claims_batch(
 
     for claim in rel_claims:
         namespace = claim.field_name
-        targets = _relationship_target_registry.get(namespace)
-        if not targets:
+        schema = _relationship_schemas.get(namespace)
+        if schema is None:
             continue
         value = claim.value
         if not isinstance(value, dict):
@@ -389,20 +500,24 @@ def validate_relationship_claims_batch(
         # target may have been deleted, and the claim is being removed.
         if not value.get("exists", True):
             continue
-        for value_key, target_model, lookup_field in targets:
-            ref = value.get(value_key)
-            if ref is not None:
-                key = (namespace, value_key)
-                groups[key].append((claim, ref))
-                if key not in group_meta:
-                    group_meta[key] = (target_model, lookup_field)
+        for spec in schema.value_keys:
+            if spec.fk_target is None:
+                continue
+            ref = value.get(spec.name)
+            if ref is None:
+                continue
+            target_model, lookup_field = spec.fk_target
+            key = (namespace, spec.name)
+            groups[key].append((claim, ref))
+            if key not in group_meta:
+                group_meta[key] = (target_model, lookup_field)
 
     rejected: list[Claim] = []
     rejected_ids: set[int] = set()
 
     for key, group in groups.items():
         target_model, lookup_field = group_meta[key]
-        namespace, value_key = key
+        namespace, _value_key = key
 
         refs = {ref for _, ref in group}
         existing = set(

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -95,8 +95,17 @@ def register_relationship_schema(
     Invariants enforced here (not at the validator):
     - ``identity is not None`` ⇒ ``required=True`` on every value-key.
     - ``namespace`` must not collide with a concrete claim-controlled field
-      name on any class in ``valid_subjects`` (keeps ``classify_claim``'s
-      DIRECT-vs-RELATIONSHIP routing structurally disjoint).
+      name on any class in ``valid_subjects`` — ensures ``classify_claim``
+      step 1 (DIRECT) and step 2 (RELATIONSHIP) never both match for a
+      subject the namespace applies to.
+
+    Note: the collision guard only iterates ``valid_subjects``. If a future
+    model outside ``valid_subjects`` grows a concrete field matching an
+    already-registered namespace, classify step 1 correctly routes it to
+    DIRECT for that model; the RELATIONSHIP validator (and its wrong-subject
+    check) never sees such claims. That's the intended routing, but it
+    means this guard does not protect every (namespace, model) pair — only
+    those where the namespace is registered for the subject.
     """
     from apps.core.models import get_claim_fields
 
@@ -166,20 +175,31 @@ def classify_claim(
     model_class: type[models.Model],
     field_name: str,
     claim_key: str,
-    value: Any,  # noqa: ANN401 - claim value is arbitrary JSON (scalar/dict/list/null)
+    value: Any,  # noqa: ANN401 - signature preserved for call-site stability
     *,
     claim_fields: dict[str, str] | None = None,
 ) -> str:
-    """Classify a claim from its structural properties.
+    """Classify a claim from its ``field_name`` and the registered schemas.
 
     Returns one of ``DIRECT``, ``RELATIONSHIP``, ``EXTRA``, or
-    ``UNRECOGNIZED``. Uses only generic provenance conventions — no
-    catalog-specific imports.
+    ``UNRECOGNIZED``.
 
     - **DIRECT**: ``field_name`` is a concrete claim-controlled Django field.
-    - **RELATIONSHIP**: compound ``claim_key``, dict value with ``exists`` key.
-    - **EXTRA**: unrecognized field on a model with an ``extra_data`` JSONField.
+    - **RELATIONSHIP**: ``field_name`` is a registered relationship namespace.
+    - **EXTRA**: neither, but the model has an ``extra_data`` JSONField.
     - **UNRECOGNIZED**: none of the above — likely a typo or stale field name.
+
+    Wrong-subject (namespace registered but this ``model_class`` is not in
+    ``valid_subjects``) still routes to ``RELATIONSHIP``; the validator
+    rejects it with a clear error.
+
+    Routing precedence is "DIRECT first, then RELATIONSHIP". The registration
+    collision guard in ``register_relationship_schema`` prevents both from
+    matching at once for any ``model_class`` in the namespace's
+    ``valid_subjects``. Outside that set, DIRECT precedence is what keeps
+    routing unambiguous — e.g. if a future model grows a concrete field
+    matching an already-registered namespace it isn't part of, step 1
+    correctly claims the write for DIRECT on that model.
 
     Pass ``claim_fields`` to avoid repeated ``get_claim_fields()`` calls in
     batch contexts. When omitted, it is computed on each call (fine for
@@ -193,18 +213,121 @@ def classify_claim(
     if field_name in claim_fields:
         return DIRECT
 
-    if (
-        claim_key
-        and claim_key != field_name
-        and isinstance(value, dict)
-        and "exists" in value
-    ):
+    if field_name in _relationship_schemas:
         return RELATIONSHIP
 
     if _has_extra_data(model_class):
         return EXTRA
 
     return UNRECOGNIZED
+
+
+def validate_single_relationship_claim(
+    *,
+    subject_model: type[models.Model],
+    field_name: str,
+    claim_key: str,
+    value: Any,  # noqa: ANN401 - claim value is arbitrary JSON
+) -> None:
+    """Validate one relationship claim's shape. Raises ``ValidationError``.
+
+    Shared by ``assert_claim`` and ``validate_claims_batch``. Rules are
+    applied in a fixed order (see implementation) — each rule assumes its
+    predecessors have passed; reordering trades a clean ``ValidationError``
+    for a ``TypeError``/``KeyError`` that masks the real problem.
+    """
+    from apps.provenance.models import make_claim_key
+
+    schema = _relationship_schemas.get(field_name)
+    # By invariant, ``classify_claim`` only routes a claim to RELATIONSHIP
+    # when the namespace is registered, so a missing schema here means the
+    # caller invoked the validator directly with an unknown namespace —
+    # a programming error, not a rejectable user input. Surface as such.
+    assert schema is not None, (
+        f"No relationship schema registered for namespace {field_name!r}"
+    )
+
+    # 1. Wrong subject — refuse before checking shape so the error names the
+    # routing problem directly.
+    if subject_model not in schema.valid_subjects:
+        allowed = sorted(m.__name__ for m in schema.valid_subjects)
+        raise ValidationError(
+            f"Namespace {field_name!r} is not valid on "
+            f"{subject_model.__name__}. Allowed subjects: {allowed}."
+        )
+
+    # 2. Non-dict value — every remaining rule indexes into `value`.
+    if type(value) is not dict:
+        raise ValidationError(
+            f"Value for {field_name!r} must be a dict, got {type(value).__name__}."
+        )
+
+    # 3. Missing / non-bool `exists`. `type(v) is bool` (not isinstance):
+    # `isinstance(True, int)` is True, which would let `{"exists": 1}`
+    # through on the mirror-image scalar_type=bool rule below.
+    if "exists" not in value:
+        raise ValidationError(
+            f"Value for {field_name!r} missing required 'exists' key."
+        )
+    if type(value["exists"]) is not bool:
+        raise ValidationError(
+            f"Value for {field_name!r} 'exists' must be bool, "
+            f"got {type(value['exists']).__name__}."
+        )
+
+    # 4. Missing any required key. Must precede rule 7 (canonical claim_key),
+    # which composes identity parts via `value[spec.name]`.
+    for spec in schema.value_keys:
+        if spec.required and spec.name not in value:
+            raise ValidationError(
+                f"Value for {field_name!r} missing required key {spec.name!r}."
+            )
+
+    # 5. Wrong scalar type for any present registered key. `type(v) is T`
+    # rather than `isinstance(v, T)` rejects `bool` where `int` is expected
+    # (PKs, counts) and rejects enum / numpy scalars that would slip past
+    # `isinstance`. For `nullable=True`, accept `None` in addition.
+    specs_by_name = {spec.name: spec for spec in schema.value_keys}
+    for spec in schema.value_keys:
+        if spec.name not in value:
+            continue
+        v = value[spec.name]
+        if v is None:
+            if not spec.nullable:
+                raise ValidationError(
+                    f"Value for {field_name!r} key {spec.name!r} may not be null."
+                )
+            continue
+        if type(v) is not spec.scalar_type:
+            raise ValidationError(
+                f"Value for {field_name!r} key {spec.name!r} must be "
+                f"{spec.scalar_type.__name__}, got {type(v).__name__}."
+            )
+
+    # 6. Unknown keys (other than "exists" and registered names). Applies
+    # uniformly to retractions — a retraction carrying a stale extra key is
+    # rejected the same as a positive claim.
+    known = {"exists"} | specs_by_name.keys()
+    unknown = value.keys() - known
+    if unknown:
+        raise ValidationError(
+            f"Value for {field_name!r} has unknown keys "
+            f"{sorted(unknown)!r}. Allowed: {sorted(known)!r}."
+        )
+
+    # 7. Non-canonical claim_key. `make_claim_key` sorts its kwargs, so the
+    # dict-comprehension order doesn't matter.
+    identity_parts = {
+        spec.identity: value[spec.name]
+        for spec in schema.value_keys
+        if spec.identity is not None
+    }
+    expected_claim_key = make_claim_key(field_name, **identity_parts)
+    if claim_key != expected_claim_key:
+        raise ValidationError(
+            f"claim_key {claim_key!r} for namespace {field_name!r} is "
+            f"not canonical; expected {expected_claim_key!r}."
+        )
 
 
 def _has_extra_data(model_class: type[models.Model]) -> bool:
@@ -358,6 +481,23 @@ def validate_claims_batch(
         )
 
         if ct == RELATIONSHIP:
+            try:
+                validate_single_relationship_claim(
+                    subject_model=model_class,
+                    field_name=fn,
+                    claim_key=claim.claim_key,
+                    value=claim.value,
+                )
+            except ValidationError as exc:
+                logger.warning(
+                    "Rejected relationship claim %s.%s (object_id=%s): %s",
+                    model_class.__name__,
+                    fn,
+                    claim.object_id,
+                    "; ".join(exc.messages),
+                )
+                rejected.append(claim)
+                continue
             rel_claims.append(claim)
             continue
         if ct == EXTRA:

--- a/docs/plans/types/ProvenanceValidationTightening.md
+++ b/docs/plans/types/ProvenanceValidationTightening.md
@@ -37,13 +37,17 @@ We're pre-launch. Loosening later is a one-line change; tightening later require
 
 **Data posture.** The DB can be dropped and all migrations reset to 0001. The remediation path for any malformed legacy rows surfaced by the new validator is: wipe the DB, reset migrations, `make pull-ingest`, `make ingest`. No audit script, no row-level cleanup, no `is_active=False` sweeps. If re-ingestion produces rejections, that is an extractor bug — fix at the source (where the malformed shape originated), re-ingest, repeat.
 
+The validator runs on new writes only; it does **not** re-validate already-stored rows. What makes the posture safe is the wipe+re-ingest, not the validator itself — the validator is the tripwire that catches future malformed writes, the wipe is what guarantees every currently-stored claim was written under the new rules. Pre-launch there are no user-edit claims in shared env, so nothing is lost by wiping. Before merge, confirm that assumption still holds (no one has started using `execute_claims` against staging); if it doesn't, this posture needs revisiting.
+
 ## Non-goals
 
 - **Not adding target-existence validation to the single-write path.** Existence stays batch-only. `validate_relationship_claims_batch` already groups claims by namespace and issues one SQL query per group — cheap amortized. Doing the same check in `assert_claim` would be one query per claim, and `execute_claims` writes many claims per user edit (e.g. editing a Title's gameplay features). The brief window of tolerated stale FK targets is an explicit trade-off: stale targets get caught at the next bulk resolve. If we later see drift in practice, benchmark before changing.
 - **Not reworking `extra_data` semantics.** Claims that genuinely belong in `EXTRA` (unrecognized field names on models with `extra_data`) still flow through untouched.
 - **Not touching DIRECT claim validation.** `validate_claim_value` stays as-is.
-- **Not collapsing bespoke resolvers into a generic spec-driven resolver.** The registry added here is intentionally consumed by `classify_claim`, `validate_single_relationship_claim`, `validate_relationship_claims_batch`, and `build_relationship_claim` only. Folding `_parent_dispatch` / `_custom_dispatch` / `M2M_FIELDS` into one generic resolver is a plausible follow-up that can consume the same registry, but keeping it out of scope here bounds the PR and avoids bundling a latent behavior change in `resolve_all_corporate_entity_locations` (which today filters `is_active=True` before winner selection) with an otherwise behavior-preserving refactor.
+- **Not collapsing bespoke resolvers into a generic spec-driven resolver.** The registry added here is intentionally consumed by `classify_claim`, `validate_single_relationship_claim`, `validate_relationship_claims_batch`, and `build_relationship_claim` only. Folding `_parent_dispatch` / `_custom_dispatch` / `M2M_FIELDS` into one generic resolver is a plausible follow-up that can consume the same registry. Commit `2eea1ebaf` standardized every bespoke resolver on `(subject_ids: set[int] | None = None) -> None`, so the signature-divergence obstacle is already gone — what remains is the latent behavior change in `resolve_all_corporate_entity_locations` (which today filters `is_active=True` before winner selection) that must not be bundled into an otherwise behavior-preserving registry unification. Keeping the collapse out of scope here bounds the PR and defers the `is_active` decision.
 - **Not lifting the identity-vs-UC cross-check from [CatalogRelationshipSpec](../model_driven_metadata/ModelDrivenCatalogRelationshipMetadata.md).** That guard — verifying `subject_fks ∪ identity_fields` matches one `UniqueConstraint` per through-model at `ready()` — is genuinely useful, but it belongs with the model-driven metadata work it was drafted for. Pulling it in here would motivate `through_model` and `subject_fks` on the schema, which would force `(namespace, subject_content_type)` keying and the "abbreviation registers twice" complication — all scaffolding for a check the rest of this PR does not use. Deferred as a whole.
+- **Not collapsing the separate `identity` label into the value-key `name`.** `ValueKeySpec.identity: str | None` exists to preserve today's divergence where e.g. alias namespaces use value-key `"alias_value"` with identity label `"alias"` (matching the current `LiteralKey("alias_value", "alias")` shape). A simpler design would drop `identity` entirely, use `is_identity: bool`, and always compose `claim_key` from the value-key `name` — one fewer invariant to enforce at registration, one fewer concept for future readers. The post-merge wipe + re-ingest rebuilds every `claim_key` under the new rules, so the _stored_ format isn't constrained by backwards compatibility. What _is_ constrained: `build_relationship_claim` accepts identity-label kwargs today (e.g. `build_relationship_claim("theme_alias", alias="foo", exists=True)`), and collapsing the label means flipping every such call site to the value-key name (`alias_value="foo"`). That's a caller-side rewrite touching adapters, management commands, and tests — the same ~40-site blast radius as threading `subject_model` through, and with no safety payoff. Keeping the indirection is the cheaper choice today; if a future pass collapses the registry for clarity, the `claim_key` format is still free to change under the same wipe+re-ingest posture.
+- **Not threading `subject_model` through `build_relationship_claim`.** The wrong-subject check moves from _build time_ (where, today, calling `build_relationship_claim("credit", …)` on a Title-bound adapter would have no registered entity*ref_targets to match) to \_write time* (`assert_claim` / batch validation both reject). That's a regression in failure locality — a buggy adapter can now construct a well-formed-but-wrong-subject `Claim` object that only fails on persist. Accepted because: (a) the write-path rejection still catches it before the row lands, (b) threading `subject_model` would touch ~40 call sites across adapters, management commands, and tests in Commit A, defeating the "mechanical rewrite" posture, and (c) the two call sites that matter for safety — `assert_claim` and `validate_claims_batch` — already have the subject model in hand and pass it to the validator. **Debugging note:** if a test constructs a Claim object that's well-formed but never persists, and the error is "ValidationError: subject not in schema.valid_subjects", check `build_relationship_claim` — the subject model wasn't in the registered namespace's valid_subjects.
 
 ## Design
 
@@ -68,6 +72,11 @@ class ValueKeySpec:
     # Use a different string when they differ (e.g. identity="alias" for
     # value_key "alias_value" — matches today's LiteralKey("alias_value", "alias")).
     # None means this key is non-identity (e.g. count, category, alias_display).
+    # **INVARIANT:** identity is not None ⇒ required=True. Identity keys must
+    # be required, otherwise the canonical claim_key formula depends on whether
+    # the caller chose to include optional identity keys, and two well-formed
+    # writes for the same entity could land under different claim_keys. Enforced
+    # at registration time in register_relationship_schema.
     fk_target: tuple[type[models.Model], str] | None = None
     # If set, (target_model, lookup_field) — this value_key is an FK reference
     # and batch-path existence checks apply via validate_relationship_claims_batch.
@@ -76,43 +85,74 @@ class ValueKeySpec:
 class RelationshipSchema:
     namespace: str                                     # claim field_name, e.g. "credit", "theme_alias", "abbreviation"
     value_keys: tuple[ValueKeySpec, ...]
-    valid_subjects: tuple[type[models.Model], ...]     # subject models this namespace applies to
+    valid_subjects: frozenset[type[models.Model]]      # subject model classes this namespace applies to
 
 # Registry keyed by namespace. Shared-namespace cases (abbreviation, credit,
 # media_attachment) register once with multiple valid_subjects.
 _relationship_schemas: dict[str, RelationshipSchema] = {}
 
-def register_relationship_schema(schema: RelationshipSchema) -> None:
-    if schema.namespace in _relationship_schemas:
-        raise ImproperlyConfigured(f"namespace {schema.namespace!r} registered twice")
-    _relationship_schemas[schema.namespace] = schema
+def register_relationship_schema(
+    namespace: str,
+    value_keys: tuple[ValueKeySpec, ...],
+    valid_subjects: frozenset[type[models.Model]],
+) -> None:
+    # Invariant: identity keys must be required, otherwise the canonical
+    # claim_key formula depends on whether optional identity keys are present.
+    for spec in value_keys:
+        if spec.identity is not None and not spec.required:
+            raise ImproperlyConfigured(
+                f"namespace {namespace!r}, value_key {spec.name!r}: "
+                f"identity keys must be required (identity={spec.identity!r}, required=False)"
+            )
+    new = RelationshipSchema(namespace=namespace, value_keys=value_keys, valid_subjects=valid_subjects)
+    existing = _relationship_schemas.get(namespace)
+    if existing is not None:
+        # Idempotent re-registration (Django may run ready() more than once
+        # in some test/app-registry scenarios). Identical schemas are a no-op;
+        # conflicting schemas are a genuine drift bug and must raise.
+        if existing == new:
+            return
+        raise ImproperlyConfigured(
+            f"namespace {namespace!r} already registered with a different schema"
+        )
+    _relationship_schemas[namespace] = new
 
 def get_relationship_schema(namespace: str) -> RelationshipSchema | None:
     return _relationship_schemas.get(namespace)
 
-def is_valid_subject(schema: RelationshipSchema, subject_content_type: ContentType) -> bool:
-    target_id = subject_content_type.id
-    return any(
-        ContentType.objects.get_for_model(m).id == target_id for m in schema.valid_subjects
-    )
+def is_valid_subject(schema: RelationshipSchema, subject_model: type[models.Model]) -> bool:
+    return subject_model in schema.valid_subjects
 ```
+
+**Registration is DB-free.** `RelationshipSchema` stores model classes, not ContentType IDs. `register_relationship_schema` never touches the DB, so `CatalogConfig.ready()` is safe to call during `migrate` on a fresh DB (contenttypes table absent) or during test setup — matching the existing `register_relationship_targets` contract. The collision guard's `get_claim_fields(subject_model)` call is also DB-free — it iterates `model._meta.get_fields()` (app-registry introspection, verified at [core/models.py:317](../../../backend/apps/core/models.py#L317)) with no ORM calls. Subject validation operates on model classes throughout:
+
+- `assert_claim` path already has `model_class = type(subject)` in hand — passes directly.
+- Batch path reuses the existing `model_cache: dict[int, type[models.Model]]` keyed by `content_type_id` (populated via `ContentType.objects.get_for_id(ct_id).model_class()`). Do not use `claim.content_type.model_class()` — bulk-ingest builds unsaved `Claim` objects with only `content_type_id` set, and the FK descriptor would issue a query per claim.
+
+No CT-ID caching on the schema; no lazy post-ready precomputation; no subtle ordering bug when schemas are registered before the `django_content_type` table exists.
+
+**Idempotent registration** preserves the existing `register_relationship_targets` posture (dict-assignment idempotency) while still catching genuine drift (conflicting re-registration raises). Requires `RelationshipSchema` and `ValueKeySpec` equality to work, which `@dataclass(frozen=True, slots=True)` gives us automatically — `frozenset[type[Model]]` compares by membership, `tuple[ValueKeySpec, ...]` compares element-wise. Equality on `fk_target: tuple[type[Model], str]` is identity-on-the-class-object, which holds because Django's app registry guarantees model classes are singletons within a process — the same `Person` class object is handed back on every `apps.get_model("catalog", "Person")` call and every `from apps.catalog.models import Person`. For the `media_attachment` schema specifically, `apps.get_models()` returns models deterministically ordered by app loading order; if `ready()` fires twice in a test scenario, both walks produce the same frozenset membership, so re-registration equality holds.
+
+**Edge case.** `override_settings(INSTALLED_APPS=...)` and similar app-registry reload patterns in tests can produce fresh model class objects that fail identity equality with the originally-registered ones, turning an idempotent re-registration into a spurious conflict. No current test does this, but if it ever bites, switch the equality basis from `type[Model]` identity to `(app_label, model_name)` labels (e.g. `frozenset(m._meta.label_lower for m in valid_subjects)`) rather than loosening the conflict guard.
+
+**Registration-time collision guard.** `register_relationship_schema` additionally rejects any `namespace` that collides with any concrete field (as returned by `get_claim_fields()` — see [apps.core.models.get_claim_fields](../../../backend/apps/core/models.py)) on any class in `valid_subjects`. Implementation: for each `subject_model in valid_subjects`, check `namespace not in get_claim_fields(subject_model)`. Raises `ImproperlyConfigured` on collision. This matches the classifier's actual lookup — both consult the same field set (concrete fields, excluding reverse relations, primary keys, and infrastructure fields). Today no catalog namespace collides with any concrete field name, but nothing in the rest of this design prevents someone from adding one; without this guard, the classifier silently routes the collision to DIRECT (see "Classification change" below) and the relationship schema becomes dead code on that subject. Catching at `ready()` is free and makes the invariant a failure mode the reviewer can't miss.
 
 `ValueKeySpec.identity` subsumes what `RefKey` and `LiteralKey` carry today. An FK reference like `{"person": int}` uses `identity="person"` (label equals name). An alias key like `alias_value: str` uses `identity="alias"` — matching the current `LiteralKey("alias_value", "alias")` shape. Non-identity optional keys (`count`, `category`, `is_primary`, `alias_display`) leave `identity=None`.
 
 ### Registry is keyed by namespace
 
-One schema per namespace, not per `(namespace, subject)`. Shared-namespace cases (`abbreviation` on Title vs MachineModel, `credit` on MachineModel vs Series, `media_attachment` on N subjects) register once with multiple `valid_subjects`; this works because the value-key shapes are identical across those subjects today. The subject content type is carried on the claim itself and enters via `is_valid_subject(schema, subject_content_type)` — a check owned by the validator, not a registry-key discriminator. This keying is what a pre-launch hand-maintained registry needs; the `(namespace, subject_ct)` keying required for the UC cross-check belongs with the deferred spec work (see Non-goals).
+One schema per namespace, not per `(namespace, subject)`. Shared-namespace cases (`abbreviation` on Title vs MachineModel, `credit` on MachineModel vs Series, `media_attachment` on N subjects) register once with multiple `valid_subjects`; this works because the value-key shapes are identical across those subjects today. **This is a structural assumption with no enforcement** — if a future requirement makes e.g. Title's `abbreviation` grow an optional field MachineModel's doesn't have, namespace-only keying breaks and the registry has to refactor to `(namespace, subject)` keying (the shape the deferred CatalogRelationshipSpec work lands on anyway). Accept this: today's shapes genuinely are identical across subjects, and the refactor when it happens is mechanical. The subject model class is resolved per claim (from `type(subject)` in `assert_claim`; from the existing `model_cache` in the batch path, populated via `ContentType.objects.get_for_id(ct_id).model_class()`) and passed to `is_valid_subject(schema, model_class)` — a check owned by the validator, not a registry-key discriminator. This keying is what a pre-launch hand-maintained registry needs; the `(namespace, subject_ct)` keying required for the UC cross-check belongs with the deferred spec work (see Non-goals).
 
 ### Catalog-side consolidation
 
 [apps/catalog/claims.py](../../../backend/apps/catalog/claims.py) loses `_entity_ref_targets`, `_literal_schemas`, `RefKey`, `LiteralKey`, `_get_entity_ref_targets`, `_get_literal_schemas`, and `register_relationship_targets`. In their place:
 
-- `register_catalog_relationship_schemas()` — one function called from `CatalogConfig.ready()`. Replaces `register_relationship_targets()`. Body is a series of `register_relationship_schema(RelationshipSchema(...))` calls, one per namespace. The schemas are _the_ source: no intermediate dict.
-- `build_relationship_claim(field_name, subject_content_type, identity, exists)` — reworked to read from `get_relationship_schema(field_name)` and iterate `schema.value_keys` where `identity is not None`, using `spec.identity` as the claim_key label and `spec.name` as the value_dict key. Subject `content_type` still flows through call sites (needed for the wrong-subject rejection below), but the lookup itself is subject-independent.
+- `register_catalog_relationship_schemas()` — one function called from `CatalogConfig.ready()`. Replaces `register_relationship_targets()`. Body is a series of `register_relationship_schema(namespace=..., value_keys=..., valid_subjects=...)` calls, one per namespace. The schemas are _the_ source: no intermediate dict.
+- `build_relationship_claim(field_name, identity, exists)` — signature unchanged. Reworked internally to read from `get_relationship_schema(field_name)` and iterate `schema.value_keys` where `identity is not None`, using `spec.identity` as the claim_key label and `spec.name` as the value_dict key. Subject model is **not** threaded through this function — the wrong-subject rejection runs in the validator, which receives `subject_model` explicitly from its two call sites (`type(subject)` in `assert_claim`; cached `model_class` in the batch path). Keeping the signature stable avoids touching ~40 call sites across adapters, management commands, and tests in Commit A.
 - `get_relationship_namespaces()` — returns `frozenset(_relationship_schemas)`.
 - `get_all_namespace_keys()` — derived from the registry via a similar iteration. Used only in tests today; safe to rewrite.
 
-Alias types added dynamically via `discover_alias_types()` must now call `register_relationship_schema` at discovery time instead of populating `_literal_schemas`. That hook lives in `register_catalog_relationship_schemas()` — same spot, same `ready()`-time timing, different target registry.
+Alias types added dynamically via `discover_alias_types()` must now call `register_relationship_schema` at discovery time instead of populating `_literal_schemas`. That hook lives in `register_catalog_relationship_schemas()` — same target registry, but the **timing shifts from lazy to eager**: today `_get_literal_schemas()` calls `discover_alias_types()` on first access (cached); under this plan it runs inside `ready()`. This is safe because every `AliasBase` subclass lives in `apps.catalog.models.*` and is imported by Django's model registry before `CatalogConfig.ready()` fires — verified today as 7 subclasses: `ThemeAlias`, `ManufacturerAlias`, `CorporateEntityAlias`, `PersonAlias`, `GameplayFeatureAlias`, `RewardTypeAlias`, `LocationAlias`. If a future contributor adds an `AliasBase` subclass outside the `apps.catalog.models` package (or defines one lazily post-`ready()`), the eager walk will miss it — the `alias_claim_field` validation in `AliasBase.__init_subclass__` already exists as the forcing function, but the eager-registration shift means missing aliases surface as "unknown namespace" rejections at write time rather than silent fallthrough. That's the intended posture.
 
 No behavior change for any consumer of the public surface (`build_relationship_claim`, `get_relationship_namespaces`, `get_all_namespace_keys`). Existing call-site tests stay green.
 
@@ -123,33 +163,71 @@ Registered schemas (full coverage — must match the read-side TypedDicts in `ca
 - `"theme"` / `"tag"` / `"reward_type"` — `valid_subjects=(MachineModel,)`. Value keys: `{<namespace>: int (identity=<namespace>, fk=<target>.pk)}`.
 - Alias namespaces (7) — one schema each. `valid_subjects=(<owner>,)`. Value keys: `{alias_value: str (identity="alias"), alias_display: str (optional)}`.
 - `"abbreviation"` — `valid_subjects=(Title, MachineModel)`. Value keys: `{value: str (identity="value")}`.
-- `"media_attachment"` — `valid_subjects=(<all supported subjects>)`. Value keys: `{media_asset: int (identity="media_asset", fk=MediaAsset.pk), category: str | None (optional), is_primary: bool (optional)}`.
+- `"media_attachment"` — `valid_subjects` is derived at registration time by walking `django.apps.apps.get_models()` and filtering to concrete (`not m._meta.abstract`) subclasses of `MediaSupported`. Matches the repo pattern used at [apps.py:28](../../../backend/apps/catalog/apps.py#L28) and [signals.py:35](../../../backend/apps/catalog/signals.py#L35). `__subclasses__()` would miss transitive subclasses if an intermediate abstract base is ever introduced; `get_models()` handles that case. Today this produces four concrete models: `GameplayFeature`, `MachineModel`, `Manufacturer`, `Person` — **all currently in [apps.catalog.models](../../../backend/apps/catalog/models/)**. Value keys: `{media_asset: int (identity="media_asset", fk=MediaAsset.pk), category: str | None (optional), is_primary: bool (optional)}`. **App-load ordering:** `apps.get_models()` only returns models whose app has had `AppConfig` loaded; Django loads all `INSTALLED_APPS` before firing any `ready()`, so every `MediaSupported` subclass defined in an installed app is visible by the time `CatalogConfig.ready()` runs. Before this PR lands, verify the four concrete subclasses (GameplayFeature, MachineModel, Manufacturer, Person) are all in installed apps and live in `apps.catalog.models` or another app listed before catalog in `INSTALLED_APPS`. If a future contributor adds a `MediaSupported` subclass in an app that isn't in `INSTALLED_APPS` (or in a module Django never imports), the walk misses it — same failure mode as any `get_models()` consumer and surfaced by the same existing patterns at apps.py:28 / signals.py:35.
 - `"location"` — `valid_subjects=(CorporateEntity,)`. Value keys: `{location: int (identity="location", fk=Location.pk)}`.
 - `"theme_parent"` / `"gameplay_feature_parent"` — `valid_subjects=(Theme,)` / `(GameplayFeature,)`. Value keys: `{parent: int (identity="parent", fk=<self>.pk)}`.
 
 ### Classification change
 
-Preserve DIRECT precedence. Keep the existing `field_name in claim_fields → DIRECT` check first. **After** DIRECT detection, classify any remaining claim as `RELATIONSHIP` iff `get_relationship_schema(field_name)` returns a schema — regardless of whether `"exists"` is present and regardless of whether this subject is in the schema's `valid_subjects`. The wrong-subject case (e.g. `field_name="credit"` on `Title`) routes to the relationship validator and is rejected there, not silently routed to `EXTRA`. The new registry check **replaces** the old structural relationship check (`claim_key != field_name and isinstance(value, dict) and "exists" in value`) for non-direct fields; it does **not** override legitimate direct fields whose name collides with a relationship namespace.
+**Full decision tree for `classify_claim(model_class, field_name, claim_key, value)`:**
+
+1. If `field_name in get_claim_fields(model_class)` — i.e., a concrete DIRECT field (see [apps.core.models.get_claim_fields](../../../backend/apps/core/models.py)) which excludes reverse relations, primary keys, and infrastructure fields — return `DIRECT`. The registration-time collision guard (see "Registry API") guarantees no registered namespace shares a name with any DIRECT field on its `valid_subjects`, so step 1 and step 2 are structurally disjoint — this is routing, not precedence.
+2. Else if `get_relationship_schema(field_name)` returns a schema, return `RELATIONSHIP`. **Regardless** of whether this subject is in the schema's `valid_subjects` (wrong-subject rejection happens in the validator, not here), **regardless** of whether `"exists"` is present in `value`. This replaces the old structural check (`claim_key != field_name and isinstance(value, dict) and "exists" in value`) for non-direct fields.
+3. Else if the model has an `extra_data` field, return `EXTRA`.
+4. Else return `UNRECOGNIZED` — unchanged from today. `assert_claim` raises `ValueError` on UNRECOGNIZED at [claim.py:122-125](../../../backend/apps/provenance/models/claim.py#L122); `validate_claims_batch` logs and rejects at [validation.py:255](../../../backend/apps/provenance/validation.py#L255).
+
+The key changes: (a) registry lookup replaces the structural `claim_key != field_name and "exists" in value` heuristic; (b) wrong-subject case now routes to the validator instead of silent EXTRA fallthrough; (c) malformed relationship payloads on models with `extra_data` that used to collapse to EXTRA now route to RELATIONSHIP → validator → rejection; (d) the `UNRECOGNIZED` terminal state is preserved exactly as today — this plan does not change what happens when a field name is genuinely unknown.
+
+**No separate DIRECT-precedence test.** The registration guard and the classifier consult the same field set (`get_claim_fields`), so the "what if both match?" case cannot occur under any non-monkey-patched state. Testing it would mean mutating `_relationship_schemas` directly to violate the guard's invariant, which is a test of the guard (that its invariant holds) rather than a test of the classifier. Guard coverage belongs with `register_relationship_schema` — see the TDD section.
 
 ### Single-claim validator
 
-Factor a new `validate_single_relationship_claim(claim: Claim) -> None` out of `validate_relationship_claims_batch`. Raises `ValidationError` on shape violation. Called from:
+Factor a new `validate_single_relationship_claim` out of `validate_relationship_claims_batch`. Raises `ValidationError` on shape violation.
 
-- `ClaimManager.assert_claim` at [claim.py:127](../../../backend/apps/provenance/models/claim.py#L127), in a new branch for `ct_result == RELATIONSHIP` that propagates the `ValidationError`.
-- `validate_claims_batch` at [validation.py:251](../../../backend/apps/provenance/validation.py#L251), replacing the accumulate-then-batch-validate path for shape. Existence checks remain batched in `validate_relationship_claims_batch`.
+Signature accepts the pieces both paths actually have, not a `Claim` object — because `ClaimManager.assert_claim` validates _before_ the `Claim` row is built (see [claim.py:121](../../../backend/apps/provenance/models/claim.py#L121) where `classify_claim` is called with `(model_class, field_name, claim_key, value)`, and the `Claim` isn't created until line 140):
+
+```python
+def validate_single_relationship_claim(
+    *,
+    subject_model: type[models.Model],
+    field_name: str,
+    claim_key: str,
+    value: Any,
+) -> None:
+    ...
+```
+
+Called from:
+
+- `ClaimManager.assert_claim` at [claim.py:127](../../../backend/apps/provenance/models/claim.py#L127), in a new branch for `ct_result == RELATIONSHIP` that passes `subject_model=type(subject)` (already in scope as `model_class`) and propagates the `ValidationError`.
+- `validate_claims_batch` at [validation.py:251](../../../backend/apps/provenance/validation.py#L251), replacing the accumulate-then-batch-validate path for shape. Reuse the existing `model_cache: dict[int, type[models.Model]]` at [validation.py:220](../../../backend/apps/provenance/validation.py#L220) (populated via `ContentType.objects.get_for_id(ct_id).model_class()`) and pass the cached `model_class` into the validator. Do **not** use `claim.content_type.model_class()` — bulk-ingest builds unsaved `Claim` objects with only `content_type_id` set, and the FK descriptor would issue a query per claim. Per-claim validation (O(N) registry dict lookups + O(N) `make_claim_key` calls) is negligible overhead — bulk ingest is I/O bound on the DB queries for FK-existence checks, which remain batched in `validate_relationship_claims_batch`. Existence checks remain batched in `validate_relationship_claims_batch`.
 
 ### Rejection conditions (shape)
 
-Applied by `validate_single_relationship_claim` in both paths:
+Applied by `validate_single_relationship_claim` in both paths.
 
-- **Wrong subject**: claim's subject `content_type` is not in `schema.valid_subjects` (e.g. `field_name="credit"` on a `Title`). Closes the silent-EXTRA-fallthrough class for misrouted namespaces. Checked first — before the shape rules below — because a namespace that doesn't belong on this subject can't be validated against the schema's value-key expectations.
-- `value` is not a `dict`.
-- `value` is missing `"exists"`, or `value["exists"]` is not a `bool`.
-- Missing any **required** registered `ValueKeySpec` for the namespace. Optional keys are type-checked only when present.
-- Wrong scalar type for any present registered key (required or optional). Applies to identity keys (`person: int`, `alias_value: str`) and non-identity keys (`count: int | None`, `category: str | None`, `is_primary: bool`, `alias_display: str`).
-- **Unknown keys**: any key in `value` other than `"exists"` or a name in `schema.value_keys`. Prevents typos (`{person, role, rol}`) and stale fields from accumulating indefinitely in stored claim payloads. Same class of silent-drift as the silent-EXTRA-fallthrough — if extractors or adapters produce typos or leftover keys, nothing else rejects them today.
+**Check order is load-bearing**, not cosmetic. Each rule below assumes its predecessors have passed — reordering trades a clean `ValidationError` for a `TypeError` / `KeyError` that masks the real problem. The validator must evaluate them top-to-bottom and return on the first failure:
+
+1. **Wrong subject**: `subject_model not in schema.valid_subjects` (e.g. `field_name="credit"` on a `Title`). Closes the silent-EXTRA-fallthrough class for misrouted namespaces. First because continuing to shape-check a misrouted namespace produces a less informative error than naming the routing problem directly.
+2. **Non-dict `value`**: `type(value) is not dict`. Must precede every subsequent rule — they all index into `value`.
+3. **Missing/non-bool `"exists"`**: `"exists" not in value` or `type(value["exists"]) is not bool`. (Deliberately `type(...) is bool`, not `isinstance` — same reasoning as scalar_type below; the whole point of the strict rule is that `True`/`False` are `int` subclasses.)
+4. **Missing required key**: any `ValueKeySpec` with `required=True` whose `name` is not in `value`. Must precede the canonical `claim_key` check, which composes identity parts via `value[spec.name]` and would `KeyError` on a missing required identity key.
+5. **Wrong scalar type for any present registered key** (required or optional). `type(v) is spec.scalar_type`, or `v is None` when `spec.nullable=True`. Applies to identity keys (`person: int`, `alias_value: str`) and non-identity keys (`count: int | None`, `category: str | None`, `is_primary: bool`, `alias_display: str`).
+6. **Unknown keys**: any key in `value` other than `"exists"` or a name in `schema.value_keys`. Prevents typos (`{person, role, rol}`) and stale fields from accumulating indefinitely in stored claim payloads. Same class of silent-drift as the silent-EXTRA-fallthrough — if extractors or adapters produce typos or leftover keys, nothing else rejects them today. **Applies uniformly to retractions (`exists=False`)** — a retraction carrying a stale extra key is rejected the same as a positive claim. The retraction carve-out below is scoped to FK-target _existence_, not shape. Safe because every retraction path in-repo constructs the value dict from canonical identity inputs (PK or alias value), never by echoing a prior claim's stored value — audited at [edit_claims.py:342,390,453,517,599,732](../../../backend/apps/catalog/api/edit_claims.py) and [media/api.py:330](../../../backend/apps/media/api.py#L330). If a future retraction path echoes stored values, it must reshape through the registry first.
+7. **Non-canonical `claim_key`**: `claim_key != make_claim_key(field_name, **{spec.identity: value[spec.name] for spec in schema.value_keys if spec.identity is not None})`. Runs last because it depends on rules 2, 4, and 5 having passed (value is a dict, every identity `spec.name` is present, and the values are well-typed). `make_claim_key` internally sorts its kwargs (see [claim.py:61](../../../backend/apps/provenance/models/claim.py#L61) `for k in sorted(identity_parts)`), so the dict-comprehension order doesn't matter — the canonical form is pinned. Covers two failure modes that slip past value-shape rejections today: (a) caller passes no `claim_key` at all, so `assert_claim` defaults it to `field_name` ([claim.py:107-108](../../../backend/apps/provenance/models/claim.py#L107)) — a scalar key that collapses every `credit`/`theme`/`media_attachment` on the subject into a single identity for winner selection and supersession; (b) caller passes a `claim_key` whose identity parts drift from the value's identity fields (wrong PK, stale alias). The value is well-formed but lands under the wrong identity, so a later correct write doesn't supersede it.
+
+**`None` handling.** A key is "present" iff its name appears in `value` — including when its value is `None`. For a spec with `nullable=True`, a present `None` is accepted (in addition to `type(v) is scalar_type`). For a spec with `nullable=False`, a present `None` is rejected. This applies uniformly to required and optional keys: `required=True, nullable=True` accepts `None`; `required=False, nullable=False` rejects `{key: None}` but accepts absence.
+
+**Caller audit (completed 2026-04-24).** Every production `Claim.objects.assert_claim(...)` call for a relationship namespace passes `claim_key=` explicitly: three sites in [apps/media/api.py](../../../backend/apps/media/api.py) (`"media_attachment"`) and one in [apps/catalog/api/edit_claims.py:771](../../../backend/apps/catalog/api/edit_claims.py#L771) (forwards `spec.claim_key`). [scrape_images.py:215](../../../backend/apps/catalog/management/commands/scrape_images.py#L215) omits `claim_key=` but writes a DIRECT scalar (`image_urls`), which bypasses this check. So the non-canonical-claim_key rejection does **not** silently break any current caller. Any future caller that forgets `claim_key=` on a relationship namespace gets a clean `ValidationError` — that's the intended tightening, not a regression.
+
+**`execute_claims` audit (complete before Commit B).** The direct-`assert_claim` audit above covers the two sites that call `assert_claim` directly, but the primary user-edit entry point is `execute_claims(entity, specs, user=..., action=...)`, which forwards `spec.claim_key` into `assert_claim` internally. Two follow-ups needed before Commit B lands:
+
+1. **Spec producers must emit canonical `claim_key`s.** Grep every `ClaimSpec(...)` / spec-dict producer in [apps/catalog/api/edit_claims.py](../../../backend/apps/catalog/api/edit_claims.py) and any other caller of `execute_claims`, and confirm each relationship-namespace spec either (a) sets `claim_key` via `build_relationship_claim(...).claim_key`, or (b) sets it via an equivalent canonical composition. Any producer that hand-builds a relationship-namespace `claim_key` string starts raising `ValidationError` post-Commit B. Expected to be clean today (Commit A's claim_key equivalence test pins `build_relationship_claim` output to `make_claim_key`), but the producer side is a separate surface from the `assert_claim` caller side and needs its own walk.
+2. **Partial-failure posture inside `execute_claims` must be explicit.** `execute_claims` writes many claims per user edit. If one spec fails shape validation mid-edit, the options are (a) abort the whole ChangeSet transactionally, (b) skip the bad spec and commit the rest. Today's code runs inside a `transaction.atomic()` block, so a raised `ValidationError` aborts the whole edit; that's the right posture (partial edits are worse than rejected edits — a user seeing "save failed" and retrying is cleaner than silently losing half a form submission). Confirm the atomic wrapper is still in place when Commit B wires the validator in, and add a regression test asserting that a multi-spec edit with one malformed relationship spec rolls back all the others. Document the posture in `execute_claims`'s docstring so a future refactor can't silently flip it.
 
 **Why `type(value) is scalar_type`, not `isinstance(value, scalar_type)`.** `bool` is a subclass of `int` in Python, so `isinstance(True, int)` is `True`. A payload carrying `{"person": True}` or `{"count": False}` should be rejected, not silently accepted as PK `1` / count `0`. The primary threat is Python-side code (tests, ingest adapters) passing bools where ints belong; `json.loads` of `{"x": true}` also produces `bool`, so the rule catches wire payloads too. Future readers should not loosen this to `isinstance`. For `nullable=True` specs, accept `None` in addition to `type(v) is scalar_type`.
+
+`IntEnum` / `StrEnum` / numpy scalar types (`numpy.int64`, etc.) pass `isinstance` but fail `type(v) is …`. **Grep performed 2026-04-24**: `grep -rn "import numpy\|import pandas\|from numpy\|from pandas\|IntEnum\|StrEnum" backend/apps/catalog/adapters/ backend/apps/catalog/management/commands/` returns zero matches. No unwrap work needed in Commit A. If a future adapter lands with enum/numpy values, the right fix is unwrapping at the adapter boundary (e.g. `int(numpy.int64(...))`), not loosening the check.
 
 ### Rejection conditions (existence — batch only)
 
@@ -161,18 +239,42 @@ Test coverage for the retraction carve-out lives in [`test_validation.py`](../..
 
 ## Commit sequence
 
-Two commits in one PR. Commit A is a mechanical registry rewrite, Commit B is the tightening proper. Keeping them separate matters even in one PR — reviewers can check A against today's behavior ("same inputs, same outputs") without tangling that against the shape-rejection rules B introduces.
+### Before writing any code
 
-1. **Commit A — unified registry (no behavior change).**
+Two gates that must pass before Commit A begins. Both are mechanical, both take under a minute:
+
+1. **Confirm shared-env data posture.** Run `Claim.objects.filter(user__isnull=False).exists()` via `python manage.py shell` against the shared environment. `False` ⇒ proceed; the post-merge wipe is guaranteed clean. `True` ⇒ stop and revisit the "Data posture" section with the doc owner — user-edit claims exist that will be destroyed by the wipe, and the recovery path (re-ingest) won't reproduce them.
+2. **Confirm no new adapter hazards.** Re-run the 2026-04-24 grep: `grep -rn "import numpy\|import pandas\|from numpy\|from pandas\|IntEnum\|StrEnum" backend/apps/catalog/adapters/ backend/apps/catalog/management/commands/`. Zero matches ⇒ proceed. Non-zero ⇒ the `type(v) is scalar_type` rule needs an unwrap-at-boundary fix in Commit A (see "Rejection conditions (shape)").
+
+### The two commits
+
+Two commits in one PR. Commit A is a mostly-mechanical registry rewrite, Commit B is the tightening proper. Keeping them separate matters even in one PR — reviewers can check A against today's behavior ("same inputs, same outputs") without tangling that against the shape-rejection rules B introduces.
+
+**Commit A has two non-negotiable regression tests** (detailed in the TDD plan): the eager-alias-discovery test and the `media_attachment.valid_subjects` pin. These land in Commit A, not Commit B. They exist specifically because Commit A is not purely mechanical — two behavior changes ride in it (below) and these tests are what keep them honest. A Commit A that ships without both tests is incomplete; push back on any sequencing that defers them.
+
+**Commit A is not purely mechanical** — two live behavior changes hide inside it. Call them out explicitly so reviewers know to look:
+
+- **Alias discovery timing: lazy → eager.** Today `_get_literal_schemas()` walks `discover_alias_types()` on first access and caches. Under Commit A, the walk runs inside `CatalogConfig.ready()`. Safe because every `AliasBase` subclass lives in `apps.catalog.models.*` (7 subclasses, verified), and Django imports all model modules before any `ready()` fires. If a future contributor adds an `AliasBase` subclass outside `apps.catalog.models`, the eager walk misses it — same failure mode as today's lazy walk would have on that subclass, just surfaced at startup instead of first access.
+- **`media_attachment.valid_subjects` frozen at `ready()` time.** Today each `MediaSupported` subject is implicit (resolved per-claim via ContentType). Under Commit A the set is snapshot once via `apps.get_models()`. If a subclass is added via plugin-style dynamic import after `ready()` completes, it won't be registered. Not a regression in practice (no such pattern exists in-repo), but add a `ready()`-time log line listing the discovered subjects so drift is greppable.
+
+1. **Commit A — unified registry (behavior-preserving modulo the two items above).**
    - Add `ValueKeySpec` / `RelationshipSchema` (namespace + `value_keys` + `valid_subjects`) / `register_relationship_schema` / `get_relationship_schema` / `is_valid_subject` to [validation.py](../../../backend/apps/provenance/validation.py). Registry keyed by `namespace: str`.
    - Rewrite [catalog/claims.py](../../../backend/apps/catalog/claims.py): delete `_entity_ref_targets`, `_literal_schemas`, `RefKey`, `LiteralKey`, `_get_entity_ref_targets`, `_get_literal_schemas`, `register_relationship_targets`. Add `register_catalog_relationship_schemas()` with one `register_relationship_schema(...)` call per namespace (list below). Rework `build_relationship_claim`, `get_relationship_namespaces`, `get_all_namespace_keys` to read from the unified registry.
    - Rewrite `validate_relationship_claims_batch` internals to read `fk_target` tuples off `ValueKeySpec` entries (same existence-check semantics, new source).
    - Delete `_relationship_target_registry` and the old `register_relationship_targets` function in validation.py.
+   - Rewrite [test_resolve_dispatch.py](../../../backend/apps/catalog/tests/test_resolve_dispatch.py) `TestLiteralSchemasAutoPopulated` (imports `_get_literal_schemas` which is deleted) — move assertions from `LiteralKey.value_key` / `.identity_key` shape to `ValueKeySpec` shape via `get_relationship_schema()`. Not a behavior change, just a form shift required to unblock the test-collection. Does not extend the regression gate — still only checking that alias discovery works.
    - `classify_claim` still uses the old structural check, no new rejections fire — claim-shape runtime behavior is identical. Mypy passes, full test suite passes, baseline unchanged.
 
-2. **Commit B — classifier + validator.** Flip `classify_claim` to registry-driven classification (preserving DIRECT precedence, using `get_relationship_schema(field_name)` lookup). Add `validate_single_relationship_claim` including the wrong-subject check. Wire it into `assert_claim` and `validate_claims_batch`. No data-cleanup step bundled in — see "Data posture".
+2. **Commit B — classifier + validator + audit.**
+   - Flip `classify_claim` to registry-driven classification (preserving DIRECT precedence, using `get_relationship_schema(field_name)` lookup).
+   - Add `validate_single_relationship_claim` including the wrong-subject check.
+   - **Pre-implementation audit (two parts):**
+     - Direct `assert_claim` sites: grep all non-test `assert_claim(` calls in `apps/catalog`, `apps/media`, `apps/provenance` for calls that omit `claim_key=` when passing a relationship-namespace `field_name`. Current patterns use `build_relationship_claim` which returns a canonical key, so this is likely clean, but any bare `assert_claim(..., field_name="credit", ...)` will start raising `ValidationError` post-Commit B. Fix any such calls before proceeding (wrap them in `build_relationship_claim` or hand-craft the canonical key).
+     - `execute_claims` spec producers: walk every `ClaimSpec(...)` producer in [apps/catalog/api/edit_claims.py](../../../backend/apps/catalog/api/edit_claims.py) and any other caller of `execute_claims`, and confirm each relationship-namespace spec sets `claim_key` via `build_relationship_claim(...).claim_key` or an equivalent canonical composition. Also confirm `execute_claims` still runs under `transaction.atomic()` so a mid-edit shape rejection rolls back the whole ChangeSet rather than committing a partial edit; add a regression test pinning that posture and a docstring note on `execute_claims`.
+   - Wire the validator into `assert_claim` and `validate_claims_batch`.
+   - No data-cleanup step bundled in — see "Data posture".
 
-3. **Pre-merge dry-run (local).** With Commit B applied locally: `make reset-db` (or equivalent — wipe the localhost DB and reset migrations to 0001), then `make pull-ingest` + `make ingest`. Observe any validator rejections. Clean ⇒ merge. Dirty ⇒ rejections name the offending namespace + reason; fix at the extractor source, re-ingest, repeat until clean. This replaces the removed audit script as the "how bad is it" preview.
+3. **Pre-merge dry-run (local).** With Commit B applied locally: `make reset-db` (or equivalent — wipe the localhost DB and reset migrations to 0001), then `make pull-ingest` + `make ingest`. Observe any validator rejections. Clean ⇒ merge. Dirty ⇒ rejections name the offending namespace + reason; fix at the extractor source, re-ingest, repeat until clean. This replaces the removed audit script as the "how bad is it" preview. **Scope caveat:** the dry-run is a smoke test over the canonical ingest inputs, not a completeness guarantee for shared-env state. It does not exercise user-edit paths (`execute_claims`), partial/hand-fixed ingests, or any divergence between localhost and shared env. **Before merge, confirm that no one has started using `execute_claims` in shared env.** Run against shared env (not localhost): `Claim.objects.filter(user__isnull=False).exists()` via `python manage.py shell` — `False` means no user-edit claims exist and the post-merge wipe is guaranteed clean. `True` means user-edit claims exist and they escape the pre-merge validator; same recovery (re-ingest) applies, just post-merge rather than pre-merge. This is a mechanical check; don't rely on asking around.
 
 4. **Post-merge: wipe + re-ingest.** Same sequence against the shared environment so the DB is rebuilt fresh under the new validator. Behavior should match the pre-merge dry-run exactly.
 
@@ -189,7 +291,7 @@ Every catalog relationship gets a `register_relationship_schema(...)` call in `r
 - **Credit (1 schema):** `credit`, `valid_subjects=(MachineModel, Series)`. → `person: int (identity="person", fk=Person.pk)`, `role: int (identity="role", fk=CreditRole.pk)`.
 - **Gameplay feature (1 schema):** `gameplay_feature` ((MachineModel,)) → `gameplay_feature: int (identity="gameplay_feature", fk=GameplayFeature.pk)`, `count: int | None (optional)`.
 - **Simple M2M (3 schemas):** `theme`, `tag`, `reward_type` each with `valid_subjects=(MachineModel,)`. → `<namespace>: int (identity=<namespace>, fk=<target>.pk)`.
-- **Media attachment (1 schema):** `media_attachment`, `valid_subjects=(<all supported subjects>)`. → `media_asset: int (identity="media_asset", fk=MediaAsset.pk)`, `category: str | None (optional)`, `is_primary: bool (optional)`.
+- **Media attachment (1 schema):** `media_attachment`, `valid_subjects` derived at registration by walking `django.apps.apps.get_models()` and filtering to concrete subclasses of `MediaSupported` (today: `GameplayFeature`, `MachineModel`, `Manufacturer`, `Person`). → `media_asset: int (identity="media_asset", fk=MediaAsset.pk)`, `category: str | None (optional)`, `is_primary: bool (optional)`.
 
 All registered fresh in the unified API — no migration shim needed because the old registries are deleted wholesale in the same commit.
 
@@ -197,12 +299,26 @@ All registered fresh in the unified API — no migration shim needed because the
 
 Assumes the "Commit sequence" above: Commit A (registry) → Commit B (classifier + validator) → pre-merge dry-run → post-merge wipe + re-ingest. Tests land with Commit B.
 
-1. **Commit A is not TDD-gated for new behavior** (there isn't any), but **existing `catalog/claims.py` tests are the regression gate**. The full test suite must pass green — `build_relationship_claim`, `get_relationship_namespaces`, `get_all_namespace_keys`, and all their downstream callers are rewritten to read from the unified registry, and their existing tests are what prove the rewrite preserves behavior. If a test fails, the rewrite has drifted from today's semantics — fix the rewrite, not the test.
+1. **Commit A is not TDD-gated for new behavior** (there isn't any), but **existing tests are the regression gate**. The full test suite must pass green, and the following modules specifically cover the rewritten surface and must stay green:
+   - [apps/catalog/tests/test_claims.py](../../../backend/apps/catalog/tests/test_claims.py) — `build_relationship_claim` call-shape, `get_relationship_namespaces` / `get_all_namespace_keys` return sets, `register_relationship_targets` entry points.
+   - [apps/catalog/tests/test_bulk_assert_claims.py](../../../backend/apps/catalog/tests/test_bulk_assert_claims.py) — bulk-path `build_relationship_claim` usage.
+   - [apps/catalog/tests/test_api_claims_title.py](../../../backend/apps/catalog/tests/test_api_claims_title.py) — API-path namespace emission.
+   - [apps/catalog/tests/test_resolve.py](../../../backend/apps/catalog/tests/test_resolve.py), [test_resolve_parents.py](../../../backend/apps/catalog/tests/test_resolve_parents.py), [test_resolve_aliases.py](../../../backend/apps/catalog/tests/test_resolve_aliases.py), [test_resolve_credits.py](../../../backend/apps/catalog/tests/test_resolve_credits.py), [test_resolve_dispatch.py](../../../backend/apps/catalog/tests/test_resolve_dispatch.py) — downstream consumers of namespace enumeration.
+   - [apps/catalog/tests/test_validate_catalog.py](../../../backend/apps/catalog/tests/test_validate_catalog.py), [test_source_enabled.py](../../../backend/apps/catalog/tests/test_source_enabled.py) — cross-cutting validators that iterate namespaces.
+   - [apps/provenance/tests/test_validation.py](../../../backend/apps/provenance/tests/test_validation.py) — `validate_relationship_claims_batch` existence-check semantics (new source, same behavior).
+
+   If any test in these files fails, the rewrite has drifted from today's semantics — fix the rewrite, not the test.
+
+   **Three required regression tests added in Commit A** (do not defer to Commit B):
+   - _Eager alias discovery._ A test in `test_claims.py` that asserts `get_relationship_schema("theme_alias")` returns a non-`None` schema _immediately after Django startup_ without any prior resolver-path access — pinning the lazy→eager discovery timing shift. Today's test suite doesn't distinguish lazy from eager (the lazy cache populates on first access regardless), so without this test the behavior change rides in untested.
+   - _`media_attachment.valid_subjects` pin._ A test that asserts `get_relationship_schema("media_attachment").valid_subjects == frozenset({GameplayFeature, MachineModel, Manufacturer, Person})`. Catches in CI the drift case where a new `MediaSupported` subclass lands without being picked up by the `apps.get_models()` walk (or the inverse: an existing subclass is removed). A log line at `ready()` time doesn't catch this — a test does. Update the test when the expected set genuinely changes; the edit is the forcing function.
+   - _`build_relationship_claim` ↔ `make_claim_key` equivalence._ A parametrized test that, for every registered schema, builds a claim via `build_relationship_claim(namespace, **identity_kwargs, exists=True)` and asserts `claim.claim_key == make_claim_key(namespace, **identity_kwargs)`. Commit B's non-canonical-`claim_key` rejection (rule 7 above) assumes these two producers stay in lockstep — every production `ClaimSpec` ultimately sources its `claim_key` from one and every validator call composes via the other. Without this test, a refactor of `build_relationship_claim`'s internal composition (e.g. changing how identity labels are derived from `ValueKeySpec.identity`) could silently start failing the validator's canonical check on every production write, and the failure would first surface as "every edit rejects" in the pre-merge dry-run. The test is the cheap guard; land it in Commit A so Commit B can rely on it.
+
 2. **Failing tests, one per rejection mode, per path:**
-   - `assert_claim` path: assert `ValidationError` raised for each of — wrong subject (`field_name` registered but `subject.content_type not in schema.valid_subjects`), non-dict value, missing `exists`, non-bool `exists`, missing required key, wrong-scalar-type required key, wrong-scalar-type optional key, `bool` passed where `int` expected, unknown key.
-   - Batch path: `validate_claims_batch(...)` returns `(valid, rejected_count)` — assert `rejected_count == 1` and the malformed claim is **not** in `valid`. For rejection-reason assertions, call `validate_relationship_claims_batch(...)` directly (that function returns the rejected `list[Claim]`).
+   - `assert_claim` path: assert `ValidationError` raised for each of — wrong subject (`field_name` registered but `subject.content_type not in schema.valid_subjects`), non-dict value, missing `exists`, non-bool `exists`, missing required key, wrong-scalar-type required key, wrong-scalar-type optional key, `bool` passed where `int` expected, unknown key, **non-canonical `claim_key` (omitted — defaults to `field_name`), non-canonical `claim_key` (hand-crafted with wrong PK or reordered identity parts)**.
+   - Batch path: `validate_claims_batch(...)` returns `(valid, rejected_count)` — assert `rejected_count == 1` and the malformed claim is **not** in `valid`, for each of the same rejection modes as the `assert_claim` path (including both `claim_key` cases — omitted and mismatched). For shape rejection-reason assertions, call `validate_single_relationship_claim(...)` directly and assert on the `ValidationError` — shape validation now lives there, not in the batch function. For FK-existence rejection-reason assertions (batch-only concern), keep calling `validate_relationship_claims_batch(...)` directly (that function returns the rejected `list[Claim]`).
    - Classify-by-registry fix: a malformed relationship payload on a model with `extra_data` must reach the relationship validator (and be rejected), not land as `EXTRA`.
-   - DIRECT precedence preserved: a `field_name` that is both a DIRECT claim field on the model **and** a name in the relationship registry must classify as `DIRECT`. (Likely synthetic — no real collision today, but pin the ordering.)
+   - Registration collision guard: `register_relationship_schema(namespace="name", ...)` where `"name"` is a concrete field on any `valid_subjects` member raises `ImproperlyConfigured` at registration time. Covers the whole "DIRECT and RELATIONSHIP cannot both match" invariant at its actual enforcement point. No classifier-side precedence test — step 1 and step 2 of `classify_claim` are structurally disjoint under the guard.
 3. Implement the tightenings. Tests go green.
 4. **Pre-merge dry-run:** wipe localhost DB + reset migrations, `make pull-ingest`, `make ingest`. Any rejections name an extractor bug — fix at source, re-ingest, repeat until clean.
 5. **Post-merge:** same wipe + re-ingest against the shared environment.
@@ -215,16 +331,18 @@ Assumes the "Commit sequence" above: Commit A (registry) → Commit B (classifie
 - [apps/catalog/claims.py](../../../backend/apps/catalog/claims.py) — delete `RefKey`, `LiteralKey`, `_entity_ref_targets`, `_literal_schemas`, `_get_entity_ref_targets`, `_get_literal_schemas`, `register_relationship_targets`. Add `register_catalog_relationship_schemas()` with one `register_relationship_schema(...)` call per namespace. Rewrite `build_relationship_claim`, `get_relationship_namespaces`, `get_all_namespace_keys` to read from the unified registry. Alias-type dynamic discovery hooks into the new registration function.
 - [apps/catalog/apps.py](../../../backend/apps/catalog/apps.py) — `CatalogConfig.ready()` calls `register_catalog_relationship_schemas()`.
 - [apps/catalog/tests/test_claims.py](../../../backend/apps/catalog/tests/test_claims.py) (or wherever the existing claim-building tests live) — behavior-preserving; trivial touches if any.
+- [apps/catalog/tests/test_resolve_dispatch.py](../../../backend/apps/catalog/tests/test_resolve_dispatch.py) — **not optional.** The top-level import `from apps.catalog.claims import _get_literal_schemas, build_relationship_claim` and the `TestLiteralSchemasAutoPopulated` class both reference symbols that Commit A deletes (`_get_literal_schemas`, `LiteralKey.value_key`, `LiteralKey.identity_key`). Rewrite the import to drop `_get_literal_schemas`, and rewrite the two test methods to assert via the new registry — e.g. `schema = get_relationship_schema("abbreviation")` + `assert schema is not None` for `test_contains_abbreviation`, and for `test_contains_all_alias_types`, walk `discover_alias_types()` and assert `get_relationship_schema(field_name)` returns a schema whose `value_keys` includes a `ValueKeySpec(name="alias_value", identity="alias", scalar_type=str, required=True)`. This rewrite is part of Commit A, not Commit B — without it the import fails at collection time and nothing else in the suite runs.
 
 **Commit B — classifier + validator:**
 
 - [apps/provenance/validation.py](../../../backend/apps/provenance/validation.py) — `classify_claim` registry-driven; new `validate_single_relationship_claim` (including wrong-subject check).
 - [apps/provenance/models/claim.py](../../../backend/apps/provenance/models/claim.py) — `assert_claim` new `RELATIONSHIP` branch calling `validate_single_relationship_claim`.
-- [apps/provenance/tests/test_validation.py](../../../backend/apps/provenance/tests/test_validation.py) — new rejection-mode tests (including wrong-subject).
+- [apps/provenance/tests/test_validation.py](../../../backend/apps/provenance/tests/test_validation.py) — new rejection-mode tests (including wrong-subject and non-canonical `claim_key`).
+- [apps/media/tests/test_media_claims.py](../../../backend/apps/media/tests/test_media_claims.py) — **`test_non_media_supported_entity_skipped` flips from "write succeeds, resolver skips" to "write raises `ValidationError`".** Today this test calls `Claim.objects.assert_claim(theme, "media_attachment", …)` and asserts the resolver produces no `EntityMedia`; under the plan the `assert_claim` call itself raises (Theme ∉ `media_attachment.valid_subjects`). Rewrite to `pytest.raises(ValidationError)` around the `assert_claim` call and drop the resolver assertion — the write-path rejection supersedes the "silently skipped" posture. Other tests in this module use `MachineModel` / `Manufacturer` / `Person` / `GameplayFeature` (all supported) and stay green.
 
 ## Verification
 
-- `uv run --directory backend pytest apps/provenance/tests/test_validation.py apps/catalog/tests/test_bulk_resolve*.py` — all tests pass.
+- `uv run --directory backend pytest apps/provenance/tests/test_validation.py apps/catalog/tests/test_claims.py apps/catalog/tests/test_bulk_assert_claims.py apps/catalog/tests/test_resolve_bulk.py apps/catalog/tests/test_resolve.py apps/catalog/tests/test_resolve_aliases.py apps/catalog/tests/test_resolve_credits.py apps/catalog/tests/test_resolve_parents.py apps/catalog/tests/test_resolve_dispatch.py apps/media/tests/test_media_claims.py` — all tests pass. (Broader `make test` also, but this is the focused set.)
 - `./scripts/mypy` — baseline unchanged (this step has no mypy impact).
 - **Pre-merge dry-run:** wipe localhost DB, reset migrations to 0001, `make pull-ingest`, `make ingest`. No rejections on clean data. If rejections appear, they're real malformed payloads upstream ingest is producing and must be fixed at the source before merging.
 - **Post-merge:** same wipe + re-ingest against the shared environment.


### PR DESCRIPTION
## Summary

Implements [ProvenanceValidationTightening.md](docs/plans/types/ProvenanceValidationTightening.md) — Step 2 of [ResolveHardening.md](docs/plans/types/ResolveHardening.md). Two commits:

- **Commit A (registry unification):** collapses the three hand-maintained registries (`_entity_ref_targets`, `_literal_schemas`, `_relationship_target_registry`) into one `RelationshipSchema` registry keyed by namespace, owned by `apps.provenance.validation`. `build_relationship_claim` / `get_relationship_namespaces` / `classify_claim` / batch existence checks all read from the unified source. Adding a namespace is now one `register_relationship_schema(...)` call.
- **Commit B (shape validation):** registry-driven `classify_claim`; new `validate_single_relationship_claim` with seven ordered rejection rules (wrong-subject → non-dict → missing/non-bool exists → missing required → wrong scalar type → unknown keys → non-canonical claim_key); wired into `assert_claim` and `validate_claims_batch`. Closes three pre-existing write-path holes (assert_claim bypass, extra_data misclassify, literal namespaces unvalidated).

## Why

The plan describes the motivation in detail, but the short version:

- **Unification:** Step 3 (claim-value TypedDicts) is about to add a fourth source of truth. Four hand-maintained registries is strictly worse than today without unification first.
- **Tightening:** pre-launch — loosening later is a one-line change, tightening later requires auditing every production row. Err tight.
- **Unblocks:** Step 5 of ResolveHardening.md (resolver subscript flip) becomes sound once the write path guarantees required keys are present.

## Test plan

- [x] Backend test suite green (2244 passed, 1 skipped).
- [x] Mypy baseline unchanged (`new: 0`).
- [x] Pre-merge local dry-run: wiped localhost SQLite, reset migrations, `make pull-ingest` + `make ingest`. **220,363 active claims written across pinbase + IPDB + OPDB + resolve, 0 validator rejections.**
- [x] New regression tests: eager alias discovery pinned, `media_attachment.valid_subjects` pinned, `build_relationship_claim` / `make_claim_key` equivalence pinned.
- [x] New rejection-mode tests: per-rule coverage via `validate_single_relationship_claim`; parametrized batch-path coverage pinning batch glue (rejected_count, valid-list accounting, loop-continues-past-rejection); assert_claim integration; registration invariants with "raise before insert" state pins.

## Post-merge

Wipe + re-ingest against shared env (Railway DB) — same sequence as the local dry-run. Pre-merge shared-env user-claim check skipped per user — Railway DB is being wiped regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)