### PR TITLE
refactor(resolve): claim-value TypedDict vocabulary

### DIFF
--- a/backend/apps/catalog/resolve/_claim_values.py
+++ b/backend/apps/catalog/resolve/_claim_values.py
@@ -1,0 +1,75 @@
+"""Read-side TypedDict vocabulary for relationship-claim JSON payloads.
+
+One TypedDict per distinct payload shape consumed by resolvers in this
+package. Each TypedDict mirrors a :class:`RelationshipSchema` registered
+in :mod:`apps.catalog.claims` — the consistency test in
+``tests/test_claim_values.py`` enforces that mirror.
+
+Resolvers ``cast(<Shape>, claim.value)`` at the top of their loop body;
+reads stay on ``.get()`` until Step 5 of ResolveHardening flips required
+keys to subscript.
+
+``from __future__ import annotations`` is deliberately omitted — TypedDict
+computes ``__required_keys__`` at class-creation time and cannot see
+through stringified ``Required``/``NotRequired`` wrappers.
+"""
+
+from typing import NotRequired, Required, TypedDict
+
+
+class GameplayFeatureClaimValue(TypedDict):
+    """Payload for ``gameplay_feature`` relationship claims on MachineModel."""
+
+    gameplay_feature: Required[int]
+    exists: Required[bool]
+    count: NotRequired[int | None]
+
+
+class CreditClaimValue(TypedDict):
+    """Payload for ``credit`` relationship claims on MachineModel / Series."""
+
+    person: Required[int]
+    role: Required[int]
+    exists: Required[bool]
+
+
+class AbbreviationClaimValue(TypedDict):
+    """Payload for ``abbreviation`` relationship claims on Title / MachineModel."""
+
+    value: Required[str]
+    exists: Required[bool]
+
+
+class AliasClaimValue(TypedDict):
+    """Payload for ``*_alias`` relationship claims across all AliasBase subjects."""
+
+    alias_value: Required[str]
+    exists: Required[bool]
+    alias_display: NotRequired[str]
+
+
+class ParentClaimValue(TypedDict):
+    """Payload for ``*_parent`` self-referential hierarchy claims."""
+
+    parent: Required[int]
+    exists: Required[bool]
+
+
+class MediaAttachmentClaimValue(TypedDict):
+    """Payload for ``media_attachment`` claims on every MediaSupported subject."""
+
+    media_asset: Required[int]
+    exists: Required[bool]
+    category: NotRequired[str | None]
+    is_primary: NotRequired[bool]
+
+
+class LocationClaimValue(TypedDict):
+    """Payload for ``location`` relationship claims on CorporateEntity.
+
+    Materializes CorporateEntityLocation rows; CorporateEntity has no
+    ``location`` column. ``exists=False`` retracts the row.
+    """
+
+    location: Required[int]
+    exists: Required[bool]

--- a/backend/apps/catalog/resolve/_media.py
+++ b/backend/apps/catalog/resolve/_media.py
@@ -15,6 +15,7 @@ from apps.media.models import EntityMedia, MediaAsset
 from apps.provenance.models import Claim
 from apps.provenance.typing import HasEffectivePriority
 
+from ._claim_values import MediaAttachmentClaimValue
 from ._helpers import _annotate_priority
 
 logger = logging.getLogger(__name__)
@@ -140,7 +141,7 @@ def resolve_media_attachments(
 
         desired: dict[int, tuple[str | None, bool]] = {}
         for claim in claims_list:
-            val = claim.value
+            val = cast(MediaAttachmentClaimValue, claim.value)
             if not val.get("exists", True):
                 continue
 

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -7,8 +7,9 @@ Includes both single-object and bulk variants for each relationship type.
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import NamedTuple, cast
 
 from django.db.models import Model
 
@@ -32,6 +33,14 @@ from ..models import (
     Theme,
     Title,
     TitleAbbreviation,
+)
+from ._claim_values import (
+    AbbreviationClaimValue,
+    AliasClaimValue,
+    CreditClaimValue,
+    GameplayFeatureClaimValue,
+    LocationClaimValue,
+    ParentClaimValue,
 )
 from ._helpers import _annotate_priority
 
@@ -120,11 +129,11 @@ def _resolve_machine_model_m2m(
     for model_id, claims_list in winners_by_model.items():
         desired: set[int] = set()
         for claim in claims_list:
-            val = claim.value
+            val = cast(Mapping[str, object], claim.value)
             if not val.get("exists", True):
                 continue
             target_pk = val.get(spec.field_name)
-            if target_pk not in valid_pks:
+            if type(target_pk) is not int or target_pk not in valid_pks:
                 logger.warning(
                     "Unresolved %s pk %r in claim (model pk=%s)",
                     spec.field_name,
@@ -231,7 +240,7 @@ def resolve_all_gameplay_features(
     for mid, claims_list in winners_by_model.items():
         desired: dict[int, int | None] = {}
         for claim in claims_list:
-            val = claim.value
+            val = cast(GameplayFeatureClaimValue, claim.value)
             if not val.get("exists", True):
                 continue
             feature_pk = val.get("gameplay_feature")
@@ -356,7 +365,7 @@ def resolve_all_credits(
     for model_id, claims_list in winners_by_model.items():
         desired: set[CreditAssignment] = set()
         for claim in claims_list:
-            val = claim.value
+            val = cast(CreditClaimValue, claim.value)
             if not val.get("exists", True):
                 continue
             person_pk = val.get("person")
@@ -452,7 +461,7 @@ def resolve_all_title_abbreviations(
     for title_id, claims_list in winners_by_title.items():
         desired: set[str] = set()
         for claim in claims_list:
-            val = claim.value
+            val = cast(AbbreviationClaimValue, claim.value)
             if not val.get("exists", True):
                 continue
             desired.add(val["value"])
@@ -550,7 +559,7 @@ def resolve_all_model_abbreviations(
     for model_id, claims_list in winners_by_model.items():
         desired: set[str] = set()
         for claim in claims_list:
-            val = claim.value
+            val = cast(AbbreviationClaimValue, claim.value)
             if not val.get("exists", True):
                 continue
             desired.add(val["value"])
@@ -644,7 +653,7 @@ def _resolve_aliases(
     for parent_id, claims_list in winners_by_parent.items():
         desired: dict[str, str] = {}
         for claim in claims_list:
-            val = claim.value
+            val = cast(AliasClaimValue, claim.value)
             if not val.get("exists", True):
                 continue
             alias_val = val.get("alias_value", "")
@@ -775,7 +784,7 @@ def _resolve_parents(parent_model, *, claim_field_prefix: str | None = None) -> 
     for child_id, claims_list in winners_by_child.items():
         desired: set[int] = set()
         for claim in claims_list:
-            val = claim.value
+            val = cast(ParentClaimValue, claim.value)
             if not val.get("exists", True):
                 continue
             parent_pk = val.get("parent")
@@ -877,7 +886,7 @@ def resolve_all_corporate_entity_locations(
 
     desired: dict[int, set[int]] = defaultdict(set)
     for row in active_claims:
-        val = row["value"] or {}
+        val = cast(LocationClaimValue, row["value"] or {})
         if not val.get("exists", True):
             continue
         loc_pk = val.get("location")

--- a/backend/apps/catalog/resolve/tests/test_claim_values.py
+++ b/backend/apps/catalog/resolve/tests/test_claim_values.py
@@ -1,0 +1,139 @@
+"""Consistency test: TypedDicts in ``_claim_values`` mirror their registered schema.
+
+Proves that for each TypedDict in :mod:`apps.catalog.resolve._claim_values`,
+the registered :class:`RelationshipSchema` for its namespace(s) agrees on
+key set, scalar type, required/optional flag, and nullability.
+
+Limit — see CatalogResolveTyping.md Phase A: this test does NOT prove
+that every resolver uses the right TypedDict for the namespace it's
+resolving. A resolver casting to the wrong shape passes mypy and passes
+this test. The cast site itself is the editorial checkpoint.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Union, get_args, get_origin, get_type_hints
+
+from apps.catalog._alias_registry import discover_alias_types
+from apps.catalog.resolve._claim_values import (
+    AbbreviationClaimValue,
+    AliasClaimValue,
+    CreditClaimValue,
+    GameplayFeatureClaimValue,
+    LocationClaimValue,
+    MediaAttachmentClaimValue,
+    ParentClaimValue,
+)
+from apps.provenance.validation import RelationshipSchema, get_relationship_schema
+
+
+def _alias_namespaces() -> tuple[str, ...]:
+    return tuple(at.claim_field for at in discover_alias_types())
+
+
+TYPEDDICT_NAMESPACES: list[tuple[type, tuple[str, ...]]] = [
+    (GameplayFeatureClaimValue, ("gameplay_feature",)),
+    (CreditClaimValue, ("credit",)),
+    (AbbreviationClaimValue, ("abbreviation",)),
+    (AliasClaimValue, _alias_namespaces()),
+    (ParentClaimValue, ("theme_parent", "gameplay_feature_parent")),
+    (MediaAttachmentClaimValue, ("media_attachment",)),
+    (LocationClaimValue, ("location",)),
+]
+
+
+def _is_nullable(annotation: object) -> bool:
+    """True iff ``annotation`` is a union including ``type(None)``."""
+    origin = get_origin(annotation)
+    if origin is Union or origin is types.UnionType:
+        return type(None) in get_args(annotation)
+    return False
+
+
+def _unwrap_nullable(annotation: object) -> object:
+    """Return the sole non-``None`` branch of a ``T | None`` union, else the annotation.
+
+    Raises if the union has more than one non-``None`` branch — current
+    schemas never produce that shape, and this test is the place to
+    notice if one ever does.
+    """
+    if not _is_nullable(annotation):
+        return annotation
+    non_none = [a for a in get_args(annotation) if a is not type(None)]
+    assert len(non_none) == 1, (
+        f"expected single non-None branch, got {non_none!r} for {annotation!r}"
+    )
+    return non_none[0]
+
+
+def _check_against_schema(td: type, schema: RelationshipSchema) -> None:
+    hints = get_type_hints(td)
+    required = td.__required_keys__  # type: ignore[attr-defined]
+    optional = td.__optional_keys__  # type: ignore[attr-defined]
+
+    # exists is required on every TypedDict and implicit in the validator
+    # (not a registered value-key).
+    assert "exists" in required, f"{td.__name__} missing Required[exists]"
+    assert hints["exists"] is bool, (
+        f"{td.__name__}.exists must be bool, got {hints['exists']!r}"
+    )
+
+    # Key set (excluding exists) must match registered value_keys.
+    td_keys = (required | optional) - {"exists"}
+    schema_keys = {spec.name for spec in schema.value_keys}
+    assert td_keys == schema_keys, (
+        f"{td.__name__} keys {td_keys} != schema {schema.namespace!r} keys {schema_keys}"
+    )
+
+    for spec in schema.value_keys:
+        annotation = hints[spec.name]
+        is_required = spec.name in required
+        assert is_required == spec.required, (
+            f"{td.__name__}.{spec.name}: required={is_required} "
+            f"but schema {schema.namespace!r} has required={spec.required}"
+        )
+        is_nullable = _is_nullable(annotation)
+        assert is_nullable == spec.nullable, (
+            f"{td.__name__}.{spec.name}: nullable={is_nullable} "
+            f"but schema {schema.namespace!r} has nullable={spec.nullable}"
+        )
+        scalar = _unwrap_nullable(annotation)
+        assert scalar is spec.scalar_type, (
+            f"{td.__name__}.{spec.name}: scalar {scalar!r} "
+            f"!= schema {schema.namespace!r} scalar {spec.scalar_type!r}"
+        )
+
+
+def test_every_typeddict_has_at_least_one_namespace() -> None:
+    for td, namespaces in TYPEDDICT_NAMESPACES:
+        assert namespaces, f"{td.__name__} has no associated namespaces"
+
+
+def test_alias_namespaces_discovered() -> None:
+    # Guards against an empty discover_alias_types() silently skipping the
+    # AliasClaimValue mirror check.
+    assert _alias_namespaces(), "expected at least one alias namespace"
+
+
+def test_typeddicts_mirror_schemas() -> None:
+    for td, namespaces in TYPEDDICT_NAMESPACES:
+        for namespace in namespaces:
+            schema = get_relationship_schema(namespace)
+            assert schema is not None, (
+                f"namespace {namespace!r} (for {td.__name__}) not registered"
+            )
+            _check_against_schema(td, schema)
+
+
+def test_typeddicts_are_typeddicts() -> None:
+    # Sanity: each entry is an actual TypedDict subclass with the
+    # __required_keys__ / __optional_keys__ introspection attributes.
+    for td, _ in TYPEDDICT_NAMESPACES:
+        assert issubclass(td, dict), f"{td.__name__} is not a TypedDict"
+        assert hasattr(td, "__required_keys__"), (
+            f"{td.__name__} missing __required_keys__"
+        )
+        assert hasattr(td, "__optional_keys__"), (
+            f"{td.__name__} missing __optional_keys__"
+        )


### PR DESCRIPTION
## Summary

Step 3 of [ResolveHardening.md](docs/plans/types/ResolveHardening.md) — defines the read-side TypedDict vocabulary for relationship-claim JSON payloads and wires each resolver to `cast` to its shape.

- **Phase A** (`158f96595`) — new `resolve/_claim_values.py` with 7 TypedDicts mirroring the schemas registered in `apps.catalog.claims`; new consistency test asserts key set, scalar type, required/optional, and nullability match per namespace.
- **Phase B** (`c59e4c860`) — `cast(<Shape>, claim.value)` at the top of each resolver loop in `_media.py` and `_relationships.py`. Every `.get()` call, skip-on-None check, and PK-validity narrow stays byte-identical; the subscript flip for required keys is Step 5's work.

The generic M2M helper uses `Mapping[str, object]` + `type(target_pk) is int` narrowing rather than a TypedDict, since it reads the payload with a runtime key (`val[spec.field_name]`) that TypedDict can't express.

## Test plan

- [x] `uv run --directory backend pytest apps/catalog/resolve/tests/test_claim_values.py` — 4 passing
- [x] `uv run --directory backend pytest apps/catalog/tests/test_resolve*.py apps/catalog/tests/test_manufacturer_resolver.py apps/media/tests/` — 333 passing, 1 skipped
- [x] `./scripts/mypy` — baseline `new: 0`
- [ ] `make ingest` — natural integration test against R2 data

🤖 Generated with [Claude Code](https://claude.com/claude-code)