### PR TITLE
fix(resolve): skip slug-conflict revert when slug field isn't globally unique

### DIFF
--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -287,11 +287,17 @@ def resolve_entity[T: CatalogModel](obj: T) -> T:
     # Single-object slug conflict guard — only slug gets silent revert.
     # Other unique fields (e.g. name) rely on save() → IntegrityError
     # which execute_claims() catches and returns as 422.
-    # django-stubs checks the ``slug=`` filter keyword against the model's
-    # declared fields; abstract CatalogModel._meta lists none.  The concrete
-    # subclass always has slug.  See plans/types/ClaimControlledEntity.md.
+    # Skip when slug isn't globally unique (e.g. Location, where slug is
+    # unique-per-location_path); mirrors the bulk path's has_unique_slug
+    # check.  django-stubs checks the ``slug=`` filter keyword against the
+    # model's declared fields; abstract CatalogModel._meta lists none.  The
+    # concrete subclass always has slug.  See plans/types/ClaimControlledEntity.md.
+    slug_field = model_class._meta.get_field("slug") if "slug" in fields else None
+    slug_is_unique = slug_field is not None and bool(
+        getattr(slug_field, "unique", False)
+    )
     if (
-        "slug" in fields
+        slug_is_unique
         and obj.slug
         and obj.slug != original_slug
         and model_class.objects.filter(slug=obj.slug)  # type: ignore[misc]

--- a/backend/apps/catalog/tests/test_resolve.py
+++ b/backend/apps/catalog/tests/test_resolve.py
@@ -524,3 +524,29 @@ class TestResolveCorporateEntityLocations:
         resolve_all_corporate_entity_locations()
 
         assert CorporateEntityLocation.objects.count() == 2
+
+
+@pytest.mark.django_db
+class TestResolveEntitySlugConflictGuard:
+    def test_slug_change_not_reverted_when_slug_field_not_unique(self):
+        """resolve_entity must not silently revert a slug change when the
+        model's slug field is not globally unique (e.g. Location, where
+        slug is unique-per-location_path only).
+        """
+        from apps.catalog.resolve._entities import resolve_entity
+
+        editorial = Source.objects.create(
+            name="The Flip Editorial", source_type="editorial", priority=100
+        )
+        Location.objects.create(location_path="usa/il/springfield", slug="springfield")
+        target = Location.objects.create(location_path="usa/oh/oldslug", slug="oldslug")
+
+        Claim.objects.assert_claim(target, "slug", "springfield", source=editorial)
+
+        # Bypass the dispatcher so the bug is reachable without widening
+        # resolve_entity's signature; the type ignore goes away in step 7
+        # of plans/types/ClaimControlledEntity.md.
+        resolve_entity(target)  # type: ignore[type-var]
+        target.refresh_from_db()
+
+        assert target.slug == "springfield"


### PR DESCRIPTION
## Summary

- `resolve_entity` unconditionally checked for a same-slug peer and silently reverted the change when one existed. Safe for `CatalogModel` subclasses (slug is globally unique), wrong for entities like `Location` where slug is unique-per-`location_path`.
- Mirrors the bulk path's `has_unique_slug` check ([_entities.py:197-199](../blob/main/backend/apps/catalog/resolve/_entities.py#L197-L199)) on the single-object path so the guard only fires when the slug field is actually unique.
- Step 6 of [docs/plans/types/ClaimControlledEntity.md](../blob/main/docs/plans/types/ClaimControlledEntity.md) — prerequisite for widening `resolve_entity` from `CatalogModel` to `ClaimControlledEntity` in step 7.

## Why the test calls `resolve_entity` directly

The bug isn't reachable from the dispatcher today — every caller passes a `CatalogModel`. Per the discussion on the plan doc, the test bypasses the dispatcher and calls `resolve_entity` directly with a `Location` (with a `# type: ignore[type-var]` on the call site). This avoids a transient "one helper widened, others not" state and keeps this PR to a pure bug fix + test. The type ignore comes out in step 7 when the signature widens for real.

## Test plan

- [x] New test fails before the fix with the documented log: `Cannot resolve slug='springfield' on Location pk=2 ... reverting to 'oldslug'`
- [x] New test passes after the fix
- [x] Full resolve suite (107 tests across `test_resolve*.py`) passes — no regression for existing `CatalogModel` callers
- [x] Pre-commit hook (full backend suite) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)