### PR TITLE
refactor(catalog): move CatalogModel to catalog and bake in ClaimControlledModel

### DIFF
--- a/backend/apps/catalog/api/entity_crud.py
+++ b/backend/apps/catalog/api/entity_crud.py
@@ -16,7 +16,7 @@ stability — consumers already depend on
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
 
 from django.db import models as db_models
 from django.db.models import Q, QuerySet
@@ -26,9 +26,9 @@ from ninja import Router, Schema
 from ninja.responses import Status
 from ninja.security import django_auth
 
+from apps.catalog.models import CatalogModel
 from apps.catalog.naming import normalize_catalog_name
-from apps.core.models import CatalogModel
-from apps.provenance.models import ChangeSetAction, ClaimControlledModel
+from apps.provenance.models import ChangeSetAction
 from apps.provenance.rate_limits import (
     CREATE_RATE_LIMIT_SPEC,
     DELETE_RATE_LIMIT_SPEC,
@@ -266,7 +266,7 @@ def register_entity_delete_restore[ModelT: CatalogModel, SchemaT: Schema](
                 )
 
         execute_claims(
-            cast(ClaimControlledModel, obj),
+            obj,
             [ClaimSpec(field_name="status", value="active")],
             user=request.user,
             action=ChangeSetAction.EDIT,
@@ -383,7 +383,7 @@ def register_entity_create[ModelT: CatalogModel, SchemaT: Schema](
             claim_specs.append(ClaimSpec(field_name=parent_field, value=parent.slug))
 
         create_entity_with_claims(
-            cast(type[ClaimControlledModel], model_cls),
+            model_cls,
             row_kwargs=row_kwargs,
             claim_specs=claim_specs,
             user=request.user,

--- a/backend/apps/catalog/api/soft_delete.py
+++ b/backend/apps/catalog/api/soft_delete.py
@@ -42,8 +42,9 @@ from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.db import models as db_models
 
-from apps.core.models import CatalogModel, EntityStatusMixin
-from apps.provenance.models import ChangeSet, ChangeSetAction, ClaimControlledModel
+from apps.catalog.models import CatalogModel
+from apps.core.models import EntityStatusMixin
+from apps.provenance.models import ChangeSet, ChangeSetAction
 from apps.provenance.schemas import EditCitationInput
 
 from .edit_claims import ClaimSpec, execute_multi_entity_claims
@@ -317,13 +318,8 @@ def execute_soft_delete(
         # Entity is already soft-deleted; no-op.
         return None, []
 
-    # Concrete CatalogModel subclasses also inherit ClaimControlledModel, but
-    # the abstract bases are independent — cast for the typed call.
-    entries: list[tuple[ClaimControlledModel, list[ClaimSpec]]] = [
-        (
-            cast(ClaimControlledModel, entity),
-            [ClaimSpec(field_name="status", value="deleted")],
-        )
+    entries = [
+        (entity, [ClaimSpec(field_name="status", value="deleted")])
         for entity in active_entities
     ]
     changeset = execute_multi_entity_claims(

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -14,12 +14,13 @@ from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
 from apps.core.licensing import get_minimum_display_rank
-from apps.core.models import CatalogModel, active_status_q
+from apps.core.models import active_status_q
 from apps.provenance.helpers import claims_prefetch
 from apps.provenance.schemas import RichTextSchema
 
 from ..models import (
     Cabinet,
+    CatalogModel,
     Credit,
     CreditRole,
     DisplaySubtype,

--- a/backend/apps/catalog/management/commands/ingest_pinbase.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase.py
@@ -27,6 +27,7 @@ from apps.catalog.claims import build_relationship_claim, make_authoritative_sco
 from apps.catalog.ingestion.bulk_utils import generate_unique_slug
 from apps.catalog.models import (
     Cabinet,
+    CatalogModel,
     CorporateEntity,
     Credit,
     CreditRole,
@@ -69,7 +70,7 @@ from apps.catalog.resolve import (
     resolve_theme_aliases,
     resolve_theme_parents,
 )
-from apps.core.models import CatalogModel, LinkableModel
+from apps.core.models import LinkableModel
 from apps.core.validators import bulk_create_validated
 from apps.provenance.models import Claim, Source
 

--- a/backend/apps/catalog/models/__init__.py
+++ b/backend/apps/catalog/models/__init__.py
@@ -4,6 +4,7 @@ The catalog represents the resolved/materialized view of each entity.
 Field values are derived by resolving claims from the provenance layer.
 """
 
+from ._base import CatalogModel
 from .gameplay_feature import (
     GameplayFeature,
     GameplayFeatureAlias,

--- a/backend/apps/catalog/models/_base.py
+++ b/backend/apps/catalog/models/_base.py
@@ -1,0 +1,41 @@
+"""CatalogModel abstract base — marker for top-level catalog entities."""
+
+from __future__ import annotations
+
+from typing import ClassVar, Self
+
+from apps.core.models import CatalogManager, EntityStatusMixin, LinkableModel
+from apps.provenance.models import ClaimControlledModel
+
+__all__ = ["CatalogModel"]
+
+
+class CatalogModel(LinkableModel, EntityStatusMixin, ClaimControlledModel):
+    """Abstract marker for top-level catalog entities.
+
+    Combines URL-addressability (``LinkableModel``), claim-controlled
+    lifecycle status (``EntityStatusMixin``), and claim-driven display
+    fields (``ClaimControlledModel``). Used to distinguish catalog-specific
+    code paths (e.g. ``ingest_pinbase``, soft-delete wire format) that must
+    not widen to other ``LinkableModel`` subclasses.
+
+    Concrete subclasses inherit all three capabilities transitively and do
+    not relist them in their own bases. Each concrete subclass must still
+    carry its own ``status_valid()`` constraint in ``Meta`` because Django
+    does not inherit abstract-parent constraints when a concrete model
+    defines its own ``Meta``.
+    """
+
+    # Re-declare ``objects`` here (originally on ``EntityStatusMixin``) so
+    # ``Self`` rebinds at the catalog level. Without this, mypy resolves
+    # ``model_cls.objects.active()`` (where ``model_cls: type[ModelT:
+    # CatalogModel]``) by walking the type bound and binds ``Self`` to
+    # ``EntityStatusMixin`` — the class where the descriptor is declared —
+    # rather than ``ModelT``. Runtime is unaffected: same ``CatalogManager``
+    # class, Django's ManagerDescriptor rebinds per concrete model anyway.
+    # ``EntityStatusMixin.objects`` stays put so ``Location`` (which uses
+    # the mixin without ``CatalogModel``) keeps its ``.active()`` queryset.
+    objects: ClassVar[CatalogManager[Self]] = CatalogManager()
+
+    class Meta:
+        abstract = True

--- a/backend/apps/catalog/models/gameplay_feature.py
+++ b/backend/apps/catalog/models/gameplay_feature.py
@@ -11,8 +11,6 @@ from django.db.models.functions import Lower
 
 from apps.core.models import (
     AliasBase,
-    CatalogModel,
-    EntityStatusMixin,
     MarkdownField,
     MediaSupported,
     SluggedModel,
@@ -22,15 +20,14 @@ from apps.core.models import (
     status_valid,
 )
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import ClaimControlledModel
+
+from ._base import CatalogModel
 
 __all__ = ["GameplayFeature", "GameplayFeatureAlias", "MachineModelGameplayFeature"]
 
 
 class GameplayFeature(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     MediaSupported,
     TimeStampedModel,

--- a/backend/apps/catalog/models/machine_model.py
+++ b/backend/apps/catalog/models/machine_model.py
@@ -9,8 +9,6 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
 from apps.core.models import (
-    CatalogModel,
-    EntityStatusMixin,
     MarkdownField,
     MediaSupported,
     SluggedModel,
@@ -21,7 +19,8 @@ from apps.core.models import (
     status_valid,
 )
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import ClaimControlledModel
+
+from ._base import CatalogModel
 
 __all__ = ["MachineModel", "ModelAbbreviation"]
 
@@ -48,8 +47,6 @@ EXTERNAL_ID_MIN = 1
 
 class MachineModel(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     MediaSupported,
     TimeStampedModel,

--- a/backend/apps/catalog/models/manufacturer.py
+++ b/backend/apps/catalog/models/manufacturer.py
@@ -9,8 +9,6 @@ from django.db.models.functions import Lower
 
 from apps.core.models import (
     AliasBase,
-    CatalogModel,
-    EntityStatusMixin,
     MarkdownField,
     MediaSupported,
     SluggedModel,
@@ -21,7 +19,8 @@ from apps.core.models import (
     status_valid,
 )
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import ClaimControlledModel
+
+from ._base import CatalogModel
 
 __all__ = [
     "CorporateEntity",
@@ -36,8 +35,6 @@ EXTERNAL_ID_MIN = 1
 
 class Manufacturer(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     MediaSupported,
     TimeStampedModel,
@@ -131,8 +128,6 @@ class ManufacturerAlias(AliasBase):
 
 class CorporateEntity(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):

--- a/backend/apps/catalog/models/person.py
+++ b/backend/apps/catalog/models/person.py
@@ -9,8 +9,6 @@ from django.db.models.functions import Lower
 
 from apps.core.models import (
     AliasBase,
-    CatalogModel,
-    EntityStatusMixin,
     MarkdownField,
     MediaSupported,
     SluggedModel,
@@ -21,7 +19,8 @@ from apps.core.models import (
     status_valid,
 )
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import ClaimControlledModel
+
+from ._base import CatalogModel
 
 __all__ = ["Credit", "Person", "PersonAlias"]
 
@@ -32,8 +31,6 @@ DAY_MIN, DAY_MAX = 1, 31
 
 class Person(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     MediaSupported,
     TimeStampedModel,

--- a/backend/apps/catalog/models/series.py
+++ b/backend/apps/catalog/models/series.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 from django.db import models
 
 from apps.core.models import (
-    CatalogModel,
-    EntityStatusMixin,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -17,7 +15,8 @@ from apps.core.models import (
     status_valid,
 )
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import ClaimControlledModel
+
+from ._base import CatalogModel
 
 __all__ = ["Franchise", "Series"]
 
@@ -27,8 +26,6 @@ if TYPE_CHECKING:
 
 class Franchise(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):
@@ -56,8 +53,6 @@ class Franchise(
 
 class Series(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):

--- a/backend/apps/catalog/models/system.py
+++ b/backend/apps/catalog/models/system.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from django.db import models
 
 from apps.core.models import (
-    CatalogModel,
-    EntityStatusMixin,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -15,15 +13,14 @@ from apps.core.models import (
     status_valid,
 )
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import ClaimControlledModel
+
+from ._base import CatalogModel
 
 __all__ = ["System", "SystemMpuString"]
 
 
 class System(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):

--- a/backend/apps/catalog/models/taxonomy.py
+++ b/backend/apps/catalog/models/taxonomy.py
@@ -9,8 +9,6 @@ from django.db.models.functions import Lower
 
 from apps.core.models import (
     AliasBase,
-    CatalogModel,
-    EntityStatusMixin,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -19,7 +17,8 @@ from apps.core.models import (
     status_valid,
 )
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import ClaimControlledModel
+
+from ._base import CatalogModel
 
 if TYPE_CHECKING:
     from .machine_model import MachineModel
@@ -44,8 +43,6 @@ __all__ = [
 
 class TechnologyGeneration(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):
@@ -73,8 +70,6 @@ class TechnologyGeneration(
 
 class TechnologySubgeneration(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):
@@ -108,8 +103,6 @@ class TechnologySubgeneration(
 
 class DisplayType(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):
@@ -137,8 +130,6 @@ class DisplayType(
 
 class DisplaySubtype(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):
@@ -172,8 +163,6 @@ class DisplaySubtype(
 
 class Cabinet(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):
@@ -198,8 +187,6 @@ class Cabinet(
 
 class GameFormat(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):
@@ -224,8 +211,6 @@ class GameFormat(
 
 class RewardType(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):
@@ -293,8 +278,6 @@ class RewardTypeAlias(AliasBase):
 
 class Tag(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):
@@ -342,8 +325,6 @@ class MachineModelTag(TimeStampedModel):
 
 class CreditRole(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):

--- a/backend/apps/catalog/models/theme.py
+++ b/backend/apps/catalog/models/theme.py
@@ -9,8 +9,6 @@ from django.db.models.functions import Lower
 
 from apps.core.models import (
     AliasBase,
-    CatalogModel,
-    EntityStatusMixin,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -19,15 +17,14 @@ from apps.core.models import (
     status_valid,
 )
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import ClaimControlledModel
+
+from ._base import CatalogModel
 
 __all__ = ["MachineModelTheme", "Theme", "ThemeAlias"]
 
 
 class Theme(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):

--- a/backend/apps/catalog/models/title.py
+++ b/backend/apps/catalog/models/title.py
@@ -8,8 +8,6 @@ from django.core.validators import MinValueValidator
 from django.db import models
 
 from apps.core.models import (
-    CatalogModel,
-    EntityStatusMixin,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -19,7 +17,8 @@ from apps.core.models import (
     status_valid,
 )
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import ClaimControlledModel
+
+from ._base import CatalogModel
 
 __all__ = ["Title", "TitleAbbreviation"]
 
@@ -31,8 +30,6 @@ if TYPE_CHECKING:
 
 class Title(
     CatalogModel,
-    EntityStatusMixin,
-    ClaimControlledModel,
     SluggedModel,
     TimeStampedModel,
 ):

--- a/backend/apps/catalog/signals.py
+++ b/backend/apps/catalog/signals.py
@@ -28,9 +28,7 @@ def _cache_invalidating_models() -> list[type[models.Model]]:
     """
     from django.apps import apps
 
-    from apps.core.models import CatalogModel
-
-    from .models import CorporateEntityLocation, Credit, Location
+    from .models import CatalogModel, CorporateEntityLocation, Credit, Location
 
     catalog_app = apps.get_app_config("catalog")
     derived = [

--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -387,7 +387,7 @@ class LinkableModel(models.Model):
         # __init_subclass__ fires before Django's ModelBase sets up ``_meta``,
         # so abstract/concrete cannot be determined via ``_meta.abstract`` here.
         # Instead, treat ``entity_type`` declaration as the concrete-class
-        # marker: abstract intermediates (CatalogModel) must NOT declare
+        # marker: abstract intermediates (e.g. ``CatalogModel``) must NOT declare
         # ``entity_type``; any subclass that does is treated as concrete and
         # must also declare ``entity_type_plural``. If a future abstract
         # intermediate needs ``entity_type`` set for some reason, this hook's
@@ -413,35 +413,6 @@ class LinkableModel(models.Model):
         cls.link_url_pattern = f"/{entity_type_plural}/{{slug}}"
         # Collision detection happens lazily in get_linkable_model's map
         # builder, not here, to avoid depending on import order.
-
-
-# ---------------------------------------------------------------------------
-# CatalogModel abstract base — marker for catalog-specific code paths
-# ---------------------------------------------------------------------------
-
-
-class CatalogModel(LinkableModel, EntityStatusMixin):
-    """Abstract marker for top-level catalog entities.
-
-    Subclass of ``LinkableModel`` + ``EntityStatusMixin``; exists to identify
-    catalog-specific code paths (e.g. ``ingest_pinbase``, soft-delete wire
-    format) that must not widen to other ``LinkableModel`` subclasses, and
-    to carry the ``CatalogManager[Self]`` descriptor so ``type[CatalogModel]``
-    introspection code sees ``.objects.active()`` without per-callsite casts.
-
-    Concrete subclasses continue to list ``EntityStatusMixin`` explicitly in
-    their own bases even though they now inherit it transitively. The
-    redundancy is intentional: it keeps the lifecycle capability visible at
-    the class declaration site, keeps ``grep EntityStatusMixin`` in the
-    models layer accurate as an inventory, matches the ``status_valid()``
-    constraint still carried in each subclass's ``Meta``, and forces any
-    future refactor that removes the mixin from ``CatalogModel`` to touch
-    each concrete subclass deliberately. Python MRO dedupes, Django treats
-    the repeated abstract parent as a no-op, so there is no runtime cost.
-    """
-
-    class Meta:
-        abstract = True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/provenance/tests/test_claim_controlled_model.py
+++ b/backend/apps/provenance/tests/test_claim_controlled_model.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 from django.apps import apps
 from django.db.models import Model
 
-from apps.catalog.models import Location
-from apps.core.models import CatalogModel
+from apps.catalog.models import CatalogModel, Location
 from apps.provenance.models import Claim, ClaimControlledModel
 
 


### PR DESCRIPTION
## Summary

- Relocate `CatalogModel` from `apps/core/models.py` to `apps/catalog/models/_base.py` and add `ClaimControlledModel` to its bases. "Every catalog entity is claim-controlled" becomes a structural fact.
- Eliminates `cast(ClaimControlledModel, ...)` workarounds (2 in `entity_crud.py`, 1 in `soft_delete.py`) and lets every concrete catalog model drop both `EntityStatusMixin` and `ClaimControlledModel` from its base list — they're inherited transitively via `CatalogModel` now.
- Re-declares `EntityStatusMixin`'s `objects: ClassVar[CatalogManager[Self]]` descriptor on `CatalogModel` so `Self` rebinds at the catalog level. Without this, `model_cls.objects.active()` (where `model_cls: type[ModelT: CatalogModel]`) types as `CatalogManager[EntityStatusMixin]` because mypy walks the TypeVar's upper bound, not the concrete class. `EntityStatusMixin` keeps its own declaration so `Location` (which uses the mixin without `CatalogModel`) retains `.active()` typing.
- Pure structural refactor — `makemigrations --dry-run` reports no changes.

## Test plan

- [x] `make migrations --dry-run` → "No changes detected"
- [x] Full backend suite: 2251 passed, 1 skipped
- [x] mypy clean across project (pre-existing errors in `claim.py` / `markdown.py` unchanged)
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)