### PR TITLE
refactor(catalog): build detail Schemas immutably via accumulator dataclasses

### DIFF
--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 from django.db import models
@@ -108,6 +109,16 @@ class PersonDetailSchema(Schema):
 # ---------------------------------------------------------------------------
 
 
+@dataclass
+class _PersonTitleAccum:
+    name: str
+    slug: str
+    year: int | None
+    manufacturer_name: str | None
+    thumbnail_url: str | None
+    roles: list[str] = field(default_factory=list)
+
+
 def _serialize_person_detail(person: Person) -> PersonDetailSchema:
     """Serialize a Person into the detail response schema.
 
@@ -116,17 +127,17 @@ def _serialize_person_detail(person: Person) -> PersonDetailSchema:
     (to_attr="active_claims").
     """
     min_rank = get_minimum_display_rank()
-    titles: dict[str, PersonTitleSchema] = {}
+    accum: dict[str, _PersonTitleAccum] = {}
     for c in person.credits.all():
         if c.model is None or c.model.title is None:
             continue
         title = c.model.title
         key = title.slug
-        if key not in titles:
-            thumbnail_url = _extract_image_urls(
-                c.model.extra_data or {}, min_rank=min_rank
-            )[0]
-            titles[key] = PersonTitleSchema(
+        thumbnail_url = _extract_image_urls(
+            c.model.extra_data or {}, min_rank=min_rank
+        )[0]
+        if key not in accum:
+            accum[key] = _PersonTitleAccum(
                 name=title.name,
                 slug=title.slug,
                 year=c.model.year,
@@ -137,17 +148,23 @@ def _serialize_person_detail(person: Person) -> PersonDetailSchema:
                     else None
                 ),
                 thumbnail_url=thumbnail_url,
-                roles=[],
             )
-        elif titles[key].thumbnail_url is None:
-            thumbnail_url = _extract_image_urls(
-                c.model.extra_data or {}, min_rank=min_rank
-            )[0]
-            if thumbnail_url:
-                titles[key].thumbnail_url = thumbnail_url
+        elif accum[key].thumbnail_url is None and thumbnail_url:
+            accum[key].thumbnail_url = thumbnail_url
         role_display = c.role.name
-        if role_display not in titles[key].roles:
-            titles[key].roles.append(role_display)
+        if role_display not in accum[key].roles:
+            accum[key].roles.append(role_display)
+    titles = [
+        PersonTitleSchema(
+            name=a.name,
+            slug=a.slug,
+            year=a.year,
+            manufacturer_name=a.manufacturer_name,
+            thumbnail_url=a.thumbnail_url,
+            roles=a.roles,
+        )
+        for a in accum.values()
+    ]
     return PersonDetailSchema(
         name=person.name,
         slug=person.slug,
@@ -161,7 +178,7 @@ def _serialize_person_detail(person: Person) -> PersonDetailSchema:
         birth_place=person.birth_place,
         nationality=person.nationality,
         photo_url=person.photo_url,
-        titles=list(titles.values()),
+        titles=titles,
         uploaded_media=_serialize_uploaded_media(all_media(person)),
     )
 

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import cast
 
 from django.db import models
@@ -104,35 +105,48 @@ def _system_detail_qs() -> QuerySet[System]:
     )
 
 
+@dataclass
+class _RelatedTitleAccum:
+    name: str
+    slug: str
+    year: int | None
+    manufacturer_name: str | None
+    thumbnail_url: str | None
+
+
 def _serialize_system_detail(system: System) -> SystemDetailSchema:
     min_rank = get_minimum_display_rank()
-    titles: dict[str, RelatedTitleSchema] = {}
+    accum: dict[str, _RelatedTitleAccum] = {}
     for m in system.machine_models.all():
         if m.title is None:
             continue
         key = m.title.slug
-        if key not in titles:
-            thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[
-                0
-            ]
+        thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[0]
+        if key not in accum:
             mfr = (
                 m.corporate_entity.manufacturer
                 if m.corporate_entity and m.corporate_entity.manufacturer
                 else None
             )
-            titles[key] = RelatedTitleSchema(
+            accum[key] = _RelatedTitleAccum(
                 name=m.title.name,
                 slug=m.title.slug,
                 year=m.year,
                 manufacturer_name=mfr.name if mfr else None,
                 thumbnail_url=thumbnail_url,
             )
-        elif titles[key].thumbnail_url is None:
-            thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[
-                0
-            ]
-            if thumbnail_url:
-                titles[key].thumbnail_url = thumbnail_url
+        elif accum[key].thumbnail_url is None and thumbnail_url:
+            accum[key].thumbnail_url = thumbnail_url
+    titles = [
+        RelatedTitleSchema(
+            name=a.name,
+            slug=a.slug,
+            year=a.year,
+            manufacturer_name=a.manufacturer_name,
+            thumbnail_url=a.thumbnail_url,
+        )
+        for a in accum.values()
+    ]
 
     sibling_systems: list[SiblingSystemSchema] = []
     if system.manufacturer:
@@ -163,7 +177,7 @@ def _serialize_system_detail(system: System) -> SystemDetailSchema:
             if system.technology_subgeneration
             else None
         ),
-        titles=list(titles.values()),
+        titles=titles,
         sibling_systems=sibling_systems,
     )
 

--- a/docs/plans/types/MypyFixing.md
+++ b/docs/plans/types/MypyFixing.md
@@ -220,11 +220,11 @@ The two `Cannot infer type of lambda` entries on `taxonomy.py`'s `_register_*` w
 
 Baseline: 353 → 310.
 
-## Step 7.1: return-Schema follow-ups surfaced by Step 7
+## Step 7.1: return-Schema follow-ups surfaced by Step 7 - DONE
 
 Remaining "return Schema, not dict" debt in `catalog/api`. No baseline impact — drift cleanup on files that already satisfy `disallow_untyped_defs`.
 
-- **Restructure the accumulator-then-mutate pattern in `_serialize_system_detail` and `_serialize_person_detail`.** Both helpers build a `dict[str, SomeSchema]` and then mutate the Schema instances in place (`titles[key].thumbnail_url = ...`, `titles[key].roles.append(...)`) as more data arrives in the loop. Pydantic v2 allows this (no `validate_assignment`), but it's off-idiom — pydantic models are usually treated as immutable after construction. Build mutable state (dataclass or plain dict) during accumulation, then construct the Schema once at the end.
+- **Restructured the accumulator-then-mutate pattern in `_serialize_system_detail` and `_serialize_person_detail`.** Both helpers built a `dict[str, SomeSchema]` and then mutated the Schema instances in place (`titles[key].thumbnail_url = ...`, `titles[key].roles.append(...)`) as more data arrived in the loop. Replaced with private mutable dataclasses (`_RelatedTitleAccum`, `_PersonTitleAccum`) used during accumulation; the Pydantic Schema is now constructed once per entry at the end of the loop. Schemas are never mutated post-construction.
 
 ## Step 8: `citation/api` - DONE
 


### PR DESCRIPTION
## Summary
- Step 7.1 of [MypyFixing.md](docs/plans/types/MypyFixing.md): restructure the accumulator-then-mutate pattern in `_serialize_system_detail` and `_serialize_person_detail`.
- Both helpers used to build a `dict[str, Schema]` and mutate Schema instances in place (`thumbnail_url = ...`, `roles.append(...)`) as the loop progressed. Pydantic v2 permits this without `validate_assignment`, but it's off-idiom and would silently bypass validation if `validate_assignment` were ever enabled.
- Introduces private `_RelatedTitleAccum` / `_PersonTitleAccum` dataclasses for loop-local mutable state. The Pydantic Schema is constructed once per entry at the end. Schemas are no longer mutated post-construction.
- No baseline impact (mypy already clean on these files).

## Test plan
- [x] `uv run mypy apps/catalog/api/systems.py apps/catalog/api/people.py` — clean
- [x] `uv run pytest apps/catalog/tests/ -k "system or person or people or detail"` — 203 passed
- [x] Pre-commit hooks (ruff, mypy, full backend test suite) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)