### PR TITLE
refactor: type API error responses

### DIFF
--- a/backend/apps/catalog/api/corporate_entities.py
+++ b/backend/apps/catalog/api/corporate_entities.py
@@ -13,6 +13,7 @@ from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
 from apps.core.models import active_status_q
+from apps.core.schemas import ValidationErrorSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
 from apps.provenance.schemas import RichTextSchema
 
@@ -161,7 +162,7 @@ def list_corporate_entities(
 @corporate_entities_router.patch(
     "/{slug}/claims/",
     auth=django_auth,
-    response=CorporateEntityDetailSchema,
+    response={200: CorporateEntityDetailSchema, 422: ValidationErrorSchema},
     tags=["private"],
 )
 def patch_corporate_entity_claims(

--- a/backend/apps/catalog/api/entity_crud.py
+++ b/backend/apps/catalog/api/entity_crud.py
@@ -29,7 +29,11 @@ from ninja.security import django_auth
 
 from apps.catalog.models import CatalogModel
 from apps.catalog.naming import normalize_catalog_name
-from apps.core.schemas import ErrorDetailSchema
+from apps.core.schemas import (
+    ErrorDetailSchema,
+    RateLimitErrorSchema,
+    ValidationErrorSchema,
+)
 from apps.provenance.models import ChangeSetAction
 from apps.provenance.rate_limits import (
     CREATE_RATE_LIMIT_SPEC,
@@ -192,6 +196,7 @@ def register_entity_delete_restore[ModelT: CatalogModel, SchemaT: Schema](
         response={
             200: DeleteResponseSchema,
             422: SoftDeleteBlockedSchema | AlreadyDeletedSchema,
+            429: RateLimitErrorSchema,
         },
         tags=["private"],
     )(_delete)
@@ -235,6 +240,7 @@ def register_entity_delete_restore[ModelT: CatalogModel, SchemaT: Schema](
             200: response_schema,
             422: ErrorDetailSchema,
             404: ErrorDetailSchema,
+            429: RateLimitErrorSchema,
         },
         tags=["private"],
     )(_restore)
@@ -357,7 +363,11 @@ def register_entity_create[ModelT: CatalogModel, SchemaT: Schema](
         router.post(
             f"/{{parent_slug}}/{route_suffix}/",
             auth=django_auth,
-            response={201: response_schema},
+            response={
+                201: response_schema,
+                422: ValidationErrorSchema,
+                429: RateLimitErrorSchema,
+            },
             tags=["private"],
         )(_create_parented)
     else:
@@ -369,6 +379,10 @@ def register_entity_create[ModelT: CatalogModel, SchemaT: Schema](
         router.post(
             "/",
             auth=django_auth,
-            response={201: response_schema},
+            response={
+                201: response_schema,
+                422: ValidationErrorSchema,
+                429: RateLimitErrorSchema,
+            },
             tags=["private"],
         )(_create_unparented)

--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -14,6 +14,7 @@ from ninja.security import django_auth
 
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
+from apps.core.schemas import ValidationErrorSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
 from apps.provenance.schemas import RichTextSchema
 
@@ -117,7 +118,7 @@ def _serialize_franchise_detail(franchise: Franchise) -> FranchiseDetailSchema:
 @franchises_router.patch(
     "/{slug}/claims/",
     auth=django_auth,
-    response=FranchiseDetailSchema,
+    response={200: FranchiseDetailSchema, 422: ValidationErrorSchema},
     tags=["private"],
 )
 def patch_franchise_claims(

--- a/backend/apps/catalog/api/gameplay_features.py
+++ b/backend/apps/catalog/api/gameplay_features.py
@@ -10,6 +10,7 @@ from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
+from apps.core.schemas import ValidationErrorSchema
 from apps.media.helpers import all_media
 from apps.media.schemas import UploadedMediaSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
@@ -132,7 +133,7 @@ def list_gameplay_features(
 @gameplay_features_router.patch(
     "/{slug}/claims/",
     auth=django_auth,
-    response=GameplayFeatureDetailSchema,
+    response={200: GameplayFeatureDetailSchema, 422: ValidationErrorSchema},
     tags=["private"],
 )
 def patch_gameplay_feature_claims(

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -16,7 +16,11 @@ from ninja.responses import Status
 from ninja.security import django_auth
 
 from apps.core.licensing import get_minimum_display_rank
-from apps.core.schemas import ErrorDetailSchema
+from apps.core.schemas import (
+    ErrorDetailSchema,
+    RateLimitErrorSchema,
+    ValidationErrorSchema,
+)
 from apps.core.types import JsonBody
 from apps.media.helpers import all_media, primary_media
 from apps.media.models import EntityMedia
@@ -924,7 +928,7 @@ _SELF_REF_FIELDS = frozenset({"variant_of", "converted_from", "remake_of"})
 @models_router.patch(
     "/{slug}/claims/",
     auth=django_auth,
-    response=MachineModelDetailSchema,
+    response={200: MachineModelDetailSchema, 422: ValidationErrorSchema},
     tags=["private"],
 )
 def patch_model_claims(
@@ -1036,6 +1040,7 @@ def model_delete_preview(request: HttpRequest, slug: str) -> ModelDeletePreviewS
     response={
         200: DeleteResponseSchema,
         422: SoftDeleteBlockedSchema | AlreadyDeletedSchema,
+        429: RateLimitErrorSchema,
     },
     tags=["private"],
 )
@@ -1083,6 +1088,7 @@ def delete_model(
         200: MachineModelDetailSchema,
         422: ErrorDetailSchema,
         404: ErrorDetailSchema,
+        429: RateLimitErrorSchema,
     },
     tags=["private"],
 )

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -17,6 +17,7 @@ from ninja.security import django_auth
 
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
+from apps.core.schemas import ValidationErrorSchema
 from apps.media.helpers import all_media
 from apps.media.schemas import UploadedMediaSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
@@ -468,7 +469,7 @@ def list_all_manufacturers(
 @manufacturers_router.patch(
     "/{slug}/claims/",
     auth=django_auth,
-    response=ManufacturerDetailSchema,
+    response={200: ManufacturerDetailSchema, 422: ValidationErrorSchema},
     tags=["private"],
 )
 def patch_manufacturer_claims(

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -19,7 +19,11 @@ from ninja.security import django_auth
 from apps.catalog.naming import normalize_catalog_name
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
-from apps.core.schemas import ErrorDetailSchema
+from apps.core.schemas import (
+    ErrorDetailSchema,
+    RateLimitErrorSchema,
+    ValidationErrorSchema,
+)
 from apps.media.helpers import all_media
 from apps.media.schemas import UploadedMediaSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
@@ -283,7 +287,10 @@ def list_all_people(
 
 
 @people_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=PersonDetailSchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: PersonDetailSchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_person_claims(
     request: HttpRequest, slug: str, data: ClaimPatchSchema
@@ -309,7 +316,11 @@ def patch_person_claims(
 @people_router.post(
     "/",
     auth=django_auth,
-    response={201: PersonDetailSchema},
+    response={
+        201: PersonDetailSchema,
+        422: ValidationErrorSchema,
+        429: RateLimitErrorSchema,
+    },
     tags=["private"],
 )
 def create_person(
@@ -420,6 +431,7 @@ def person_delete_preview(request: HttpRequest, slug: str) -> PersonDeletePrevie
     response={
         200: DeleteResponseSchema,
         422: PersonSoftDeleteBlockedSchema | AlreadyDeletedSchema,
+        429: RateLimitErrorSchema,
     },
     tags=["private"],
 )
@@ -486,6 +498,7 @@ def delete_person(
         200: PersonDetailSchema,
         422: ErrorDetailSchema,
         404: ErrorDetailSchema,
+        429: RateLimitErrorSchema,
     },
     tags=["private"],
 )

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -14,6 +14,7 @@ from ninja.security import django_auth
 
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
+from apps.core.schemas import ValidationErrorSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
 from apps.provenance.schemas import RichTextSchema
 
@@ -158,7 +159,10 @@ def list_series(request: HttpRequest) -> list[SeriesListSchema]:
 
 
 @series_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=SeriesDetailSchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: SeriesDetailSchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_series_claims(
     request: HttpRequest, slug: str, data: ClaimPatchSchema

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -18,6 +18,7 @@ from ninja.security import django_auth
 from apps.catalog.naming import normalize_catalog_name
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
+from apps.core.schemas import RateLimitErrorSchema, ValidationErrorSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
 from apps.provenance.rate_limits import CREATE_RATE_LIMIT_SPEC, check_and_record
 from apps.provenance.schemas import RichTextSchema
@@ -213,7 +214,10 @@ def list_all_systems(request: HttpRequest) -> list[SystemListSchema]:
 
 
 @systems_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=SystemDetailSchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: SystemDetailSchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_system_claims(
     request: HttpRequest, slug: str, data: ClaimPatchSchema
@@ -238,7 +242,11 @@ def patch_system_claims(
 @systems_router.post(
     "/",
     auth=django_auth,
-    response={201: SystemDetailSchema},
+    response={
+        201: SystemDetailSchema,
+        422: ValidationErrorSchema,
+        429: RateLimitErrorSchema,
+    },
     tags=["private"],
 )
 def create_system(

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -15,6 +15,7 @@ from ninja.security import django_auth
 
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
+from apps.core.schemas import ValidationErrorSchema
 from apps.provenance.helpers import claims_prefetch
 from apps.provenance.schemas import RichTextSchema
 
@@ -317,7 +318,10 @@ def _bulk_title_counts_for_subgenerations(
 
 
 @technology_generations_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=TaxonomySchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: TaxonomySchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_technology_generation(
     request: HttpRequest, slug: str, data: ClaimPatchSchema
@@ -368,7 +372,10 @@ def list_display_types(request: HttpRequest) -> list[DisplayTypeListSchema]:
 
 
 @display_types_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=TaxonomySchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: TaxonomySchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_display_type(
     request: HttpRequest, slug: str, data: ClaimPatchSchema
@@ -384,7 +391,10 @@ technology_subgenerations_router = Router(tags=["technology-subgenerations"])
 
 
 @technology_subgenerations_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=TaxonomySchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: TaxonomySchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_technology_subgeneration(
     request: HttpRequest, slug: str, data: ClaimPatchSchema
@@ -400,7 +410,10 @@ display_subtypes_router = Router(tags=["display-subtypes"])
 
 
 @display_subtypes_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=TaxonomySchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: TaxonomySchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_display_subtype(
     request: HttpRequest, slug: str, data: ClaimPatchSchema
@@ -422,7 +435,10 @@ def list_cabinets(request: HttpRequest) -> list[TaxonomyWithTitleCountSchema]:
 
 
 @cabinets_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=TaxonomySchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: TaxonomySchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_cabinet(
     request: HttpRequest, slug: str, data: ClaimPatchSchema
@@ -446,7 +462,10 @@ def list_game_formats(request: HttpRequest) -> list[TaxonomyWithTitleCountSchema
 
 
 @game_formats_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=TaxonomySchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: TaxonomySchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_game_format(
     request: HttpRequest, slug: str, data: ClaimPatchSchema
@@ -499,7 +518,7 @@ def list_reward_types(request: HttpRequest) -> list[TaxonomyWithTitleCountSchema
 @reward_types_router.patch(
     "/{slug}/claims/",
     auth=django_auth,
-    response=RewardTypeDetailSchema,
+    response={200: RewardTypeDetailSchema, 422: ValidationErrorSchema},
     tags=["private"],
 )
 def patch_reward_type(
@@ -530,7 +549,10 @@ def list_tags(request: HttpRequest) -> list[TaxonomyWithTitleCountSchema]:
 
 
 @tags_router.patch(
-    "/{slug}/claims/", auth=django_auth, response=TaxonomySchema, tags=["private"]
+    "/{slug}/claims/",
+    auth=django_auth,
+    response={200: TaxonomySchema, 422: ValidationErrorSchema},
+    tags=["private"],
 )
 def patch_tag(
     request: HttpRequest, slug: str, data: ClaimPatchSchema
@@ -673,7 +695,7 @@ def get_credit_role(request: HttpRequest, slug: str) -> CreditRoleDetailSchema:
 @credit_roles_router.patch(
     "/{slug}/claims/",
     auth=django_auth,
-    response=CreditRoleDetailSchema,
+    response={200: CreditRoleDetailSchema, 422: ValidationErrorSchema},
     tags=["private"],
 )
 def patch_credit_role(

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -11,6 +11,7 @@ from ninja.decorators import decorate_view
 from ninja.security import django_auth
 
 from apps.core.licensing import get_minimum_display_rank
+from apps.core.schemas import ValidationErrorSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
 from apps.provenance.schemas import RichTextSchema
 
@@ -137,7 +138,7 @@ def list_themes(request: HttpRequest) -> list[ThemeListSchema]:
 @themes_router.patch(
     "/{slug}/claims/",
     auth=django_auth,
-    response=ThemeDetailSchema,
+    response={200: ThemeDetailSchema, 422: ValidationErrorSchema},
     tags=["private"],
 )
 def patch_theme_claims(

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -30,7 +30,11 @@ from ninja.security import django_auth
 from apps.catalog.naming import MAX_CATALOG_NAME_LENGTH, normalize_catalog_name
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
-from apps.core.schemas import ErrorDetailSchema
+from apps.core.schemas import (
+    ErrorDetailSchema,
+    RateLimitErrorSchema,
+    ValidationErrorSchema,
+)
 from apps.media.helpers import all_media
 from apps.media.schemas import MediaRenditionsSchema
 from apps.media.storage import build_public_url, build_storage_key
@@ -911,7 +915,7 @@ def list_all_titles(request: HttpRequest) -> HttpResponse:
 @titles_router.patch(
     "/{slug}/claims/",
     auth=django_auth,
-    response=TitleDetailSchema,
+    response={200: TitleDetailSchema, 422: ValidationErrorSchema},
     tags=["private"],
 )
 def patch_title_claims(
@@ -961,7 +965,11 @@ def patch_title_claims(
 @titles_router.post(
     "/",
     auth=django_auth,
-    response={201: TitleDetailSchema},
+    response={
+        201: TitleDetailSchema,
+        422: ValidationErrorSchema,
+        429: RateLimitErrorSchema,
+    },
     tags=["private"],
 )
 def create_title(request: HttpRequest, data: CreateSchema) -> Status[TitleDetailSchema]:
@@ -1001,7 +1009,11 @@ def create_title(request: HttpRequest, data: CreateSchema) -> Status[TitleDetail
 @titles_router.post(
     "/{title_slug}/models/",
     auth=django_auth,
-    response={201: MachineModelDetailSchema},
+    response={
+        201: MachineModelDetailSchema,
+        422: ValidationErrorSchema,
+        429: RateLimitErrorSchema,
+    },
     tags=["private"],
 )
 def create_model(
@@ -1104,6 +1116,7 @@ def title_delete_preview(request: HttpRequest, slug: str) -> TitleDeletePreviewS
     response={
         200: TitleDeleteResponseSchema,
         422: SoftDeleteBlockedSchema | AlreadyDeletedSchema,
+        429: RateLimitErrorSchema,
     },
     tags=["private"],
 )
@@ -1155,6 +1168,7 @@ def delete_title(
         200: TitleDetailSchema,
         422: ErrorDetailSchema,
         404: ErrorDetailSchema,
+        429: RateLimitErrorSchema,
     },
     tags=["private"],
 )

--- a/backend/apps/catalog/tests/test_api_claims.py
+++ b/backend/apps/catalog/tests/test_api_claims.py
@@ -79,6 +79,24 @@ class TestPatchClaimsValidation:
         body = resp.json()
         assert "title" in body["detail"]["field_errors"]
 
+    def test_malformed_nested_body_uses_structured_422_envelope(self, client, user, pm):
+        """Pydantic's malformed-body 422 reshapes to ``{detail: {message,
+        field_errors, form_errors}}`` via the global ``ValidationError``
+        handler, with field keys derived from ``loc[-1]``."""
+        client.force_login(user)
+        resp = client.patch(
+            f"/api/models/{pm.slug}/claims/",
+            data='{"gameplay_features": [{"slug": "tilt", "count": "not-an-int"}]}',
+            content_type="application/json",
+        )
+        assert resp.status_code == 422
+        body = resp.json()
+        detail = body["detail"]
+        assert set(detail.keys()) == {"message", "field_errors", "form_errors"}
+        # ``loc`` is ("body", "gameplay_features", 0, "count") — leaf wins.
+        assert "count" in detail["field_errors"]
+        assert "gameplay_features" not in detail["field_errors"]
+
 
 @pytest.mark.django_db
 class TestPatchClaimsPersistence:

--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -23,6 +23,7 @@ from ninja.throttling import AuthRateThrottle
 from pydantic import field_validator
 
 from apps.core.api_helpers import authed_user
+from apps.core.schemas import ErrorDetailSchema
 
 from .extraction import classify_input, extract_isbn, normalize_isbn
 from .extractors import EXTRACTORS, Recognition, recognize_url
@@ -418,7 +419,7 @@ def search_citation_sources(request: HttpRequest, q: str = "") -> SearchResponse
 
 @citation_sources_router.post(
     "/",
-    response={201: CitationSourceDetailSchema},
+    response={201: CitationSourceDetailSchema, 422: ErrorDetailSchema},
     auth=django_auth,
 )
 def create_citation_source(
@@ -498,7 +499,11 @@ class _ExtractThrottle(AuthRateThrottle):
 
 @citation_sources_router.post(
     "/extract/",
-    response=ExtractResponseSchema,
+    response={
+        200: ExtractResponseSchema,
+        422: ErrorDetailSchema,
+        429: ErrorDetailSchema,
+    },
     auth=django_auth,
     throttle=[_ExtractThrottle("10/m")],
 )
@@ -575,7 +580,7 @@ def get_citation_source(
 
 @citation_sources_router.patch(
     "/{source_id}/",
-    response=CitationSourceDetailSchema,
+    response={200: CitationSourceDetailSchema, 422: ErrorDetailSchema},
     auth=django_auth,
 )
 def update_citation_source(
@@ -609,7 +614,7 @@ def update_citation_source(
 
 @citation_sources_router.post(
     "/{source_id}/links/",
-    response={201: CitationSourceLinkSchema},
+    response={201: CitationSourceLinkSchema, 422: ErrorDetailSchema},
     auth=django_auth,
 )
 def create_citation_source_link(
@@ -635,7 +640,7 @@ def create_citation_source_link(
 
 @citation_sources_router.patch(
     "/{source_id}/links/{link_id}/",
-    response=CitationSourceLinkSchema,
+    response={200: CitationSourceLinkSchema, 422: ErrorDetailSchema},
     auth=django_auth,
 )
 def update_citation_source_link(

--- a/backend/apps/core/schemas.py
+++ b/backend/apps/core/schemas.py
@@ -17,6 +17,31 @@ class ErrorDetailSchema(Schema):
     detail: str
 
 
+class ValidationErrorBodySchema(Schema):
+    message: str
+    field_errors: dict[str, str]
+    form_errors: list[str]
+
+
+class ValidationErrorSchema(Schema):
+    """Structured 422 body produced by ``StructuredValidationError`` and by
+    Ninja's malformed-body handler (see ``config/api.py``)."""
+
+    detail: ValidationErrorBodySchema
+
+
+class RateLimitErrorBodySchema(Schema):
+    message: str
+    bucket: str
+    retry_after: int
+
+
+class RateLimitErrorSchema(Schema):
+    """Structured 429 body produced by ``RateLimitExceededError``."""
+
+    detail: RateLimitErrorBodySchema
+
+
 class LinkTypeSchema(Schema):
     """One entry in the autocomplete type picker."""
 

--- a/backend/apps/media/api.py
+++ b/backend/apps/media/api.py
@@ -21,6 +21,7 @@ from apps.catalog.claims import build_media_attachment_claim
 from apps.catalog.resolve import resolve_media_attachments
 from apps.core.api_helpers import authed_user
 from apps.core.entity_types import get_linkable_model
+from apps.core.schemas import ErrorDetailSchema
 from apps.media.constants import (
     ALLOWED_IMAGE_EXTENSIONS,
     DISPLAY_MAX_DIMENSION,
@@ -143,7 +144,11 @@ def _resolve_entity(entity_type: str, slug: str) -> tuple[ContentType, MediaSupp
     return ct, entity
 
 
-@media_router.post("/upload/", response=UploadOut, auth=django_auth)
+@media_router.post(
+    "/upload/",
+    response={200: UploadOut, 429: ErrorDetailSchema},
+    auth=django_auth,
+)
 def upload_media(
     request: HttpRequest,
     file: File[UploadedFile],

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -4,7 +4,7 @@ from django.apps import apps
 from django.db import connection
 from django.http import HttpRequest, JsonResponse
 from ninja import NinjaAPI, Schema
-from ninja.errors import HttpError
+from ninja.errors import HttpError, ValidationError
 
 from apps.catalog.api.edit_claims import FieldConstraint, StructuredValidationError
 from apps.provenance.rate_limits import RateLimitExceededError
@@ -86,11 +86,63 @@ _discover_routers()
 # ---------------------------------------------------------------------------
 
 
+def _structured_422_body(
+    *, message: str, field_errors: dict[str, str], form_errors: list[str]
+) -> dict[str, object]:
+    return {
+        "detail": {
+            "message": message,
+            "field_errors": field_errors,
+            "form_errors": form_errors,
+        }
+    }
+
+
+# Pydantic ``loc`` paths begin with the request source — strip these so the
+# leaf names align with StructuredValidationError's flat field keys.
+_REQUEST_SOURCES = frozenset({"body", "query", "path", "header", "cookie", "form"})
+
+
 @api.exception_handler(StructuredValidationError)
 def _handle_structured_validation_error(
     request: HttpRequest, exc: StructuredValidationError
 ) -> JsonResponse:
-    return JsonResponse({"detail": exc.to_response_body()}, status=422)
+    return JsonResponse(_structured_422_body(**exc.to_response_body()), status=422)
+
+
+@api.exception_handler(ValidationError)
+def _handle_pydantic_validation_error(
+    request: HttpRequest, exc: ValidationError
+) -> JsonResponse:
+    field_errors: dict[str, str] = {}
+    form_errors: list[str] = []
+    for err in exc.errors:
+        loc = err.get("loc") or ()
+        msg = err.get("msg", "Invalid value.")
+        # Use the last loc segment as the field key. Pinbase's per-field
+        # error renderer keys on bare names ("year", "slug") — matching
+        # what application-thrown StructuredValidationError uses. Loc
+        # paths from Pydantic include request source + nesting
+        # ("body", "gameplay_features", 0, "slug"); collapsing to the leaf
+        # preserves UI compatibility. Trade-off: leaf-name collisions in
+        # nested payloads (two fields named "slug") map to the same key.
+        # Acceptable because malformed-body errors are programmer bugs,
+        # not user-facing field corrections; the inline-render path that
+        # *does* care about per-field accuracy is fed by
+        # StructuredValidationError, which produces flat keys directly.
+        leaf = str(loc[-1]) if loc else ""
+        if leaf and leaf not in _REQUEST_SOURCES:
+            field_errors[leaf] = msg
+        else:
+            form_errors.append(msg)
+    return JsonResponse(
+        _structured_422_body(
+            message="Invalid request.",
+            field_errors=field_errors,
+            form_errors=form_errors,
+        ),
+        status=422,
+    )
 
 
 @api.exception_handler(RateLimitExceededError)

--- a/docs/ApiDesign.md
+++ b/docs/ApiDesign.md
@@ -2,10 +2,11 @@
 
 This document defines how backend APIs should be designed for the web application, and how the frontend should consume them.
 
-It covers two concerns:
+It covers three concerns:
 
 - **Endpoint design** — how to shape endpoints (page-oriented vs resource), where data should come from, and how SvelteKit pages should obtain it from Django.
 - **Schema design** — how to structure individual Django Ninja schemas: when to consolidate, when to keep separate, and what inheritance patterns smell.
+- **Error response declarations** — which 4xx/429 shapes to declare in `response={…}` and which to leave silent.
 
 ## Endpoint design
 
@@ -225,3 +226,33 @@ The cost isn't free, though: every named schema is another OpenAPI component, an
 When two response schemas participate in a union and Pydantic discriminates between them by shape (presence/absence of fields, `extra="forbid"` to reject sibling fields), document it in the schema's docstring. These constraints look like noise without context and are easy to break in an unrelated refactor.
 
 See `AlreadyDeletedSchema` and `SoftDeleteBlockedSchema` in [`backend/apps/catalog/api/schemas.py`](../backend/apps/catalog/api/schemas.py) for the pattern: required fields and `extra="forbid"` together force union dispatch to route the right body to the right arm.
+
+## Error response declarations
+
+Mutating endpoints should declare their 4xx/429 failure shapes in `response={…}` so the OpenAPI doc reflects what callers can actually receive. Stock 400/401/403/404 from `HttpError(...)` don't need declaration — they always produce `{"detail": str}` and every contract reader knows that. Read paths (authenticated or not) stay silent on 4xx.
+
+### Error schemas
+
+Three shared shapes live in [`backend/apps/core/schemas.py`](../backend/apps/core/schemas.py):
+
+| Schema                  | Wire shape                                         | Produced by                                                         |
+| ----------------------- | -------------------------------------------------- | ------------------------------------------------------------------- |
+| `ErrorDetailSchema`     | `{"detail": str}`                                  | Plain `HttpError(…)`, throttle middleware                           |
+| `ValidationErrorSchema` | `{"detail": {message, field_errors, form_errors}}` | `StructuredValidationError`, Ninja's malformed-body 422 (see below) |
+| `RateLimitErrorSchema`  | `{"detail": {message, bucket, retry_after}}`       | `check_and_record(…)` (`RateLimitExceededError`)                    |
+
+A global handler in [`backend/config/api.py`](../backend/config/api.py) reshapes Ninja's stock malformed-body 422 (`{"detail": [{loc, msg}, …]}`) into the `ValidationErrorSchema` envelope so the frontend has one fewer wire shape to parse.
+
+### When to declare each
+
+Apply the rule that fits what your view body (and one level of helpers) can produce. Don't over-declare — `response={200: Foo, 422: ValidationErrorSchema}` on an endpoint that can't produce 422 lies to contract readers.
+
+- **422 structured** (`ValidationErrorSchema`): endpoint calls `execute_claims`, or any helper that can raise `StructuredValidationError` (`validate_name`, `validate_slug_format`, `assert_name_available`, `create_entity_with_claims`).
+- **422 plain** (`ErrorDetailSchema`): endpoint raises `HttpError(422, "msg")` directly, or returns `(422, ErrorDetailSchema(...))` explicitly.
+- **422 union** (`ErrorDetailSchema | ValidationErrorSchema`): endpoint can produce both shapes.
+- **429 structured** (`RateLimitErrorSchema`): endpoint calls `check_and_record`.
+- **429 plain** (`ErrorDetailSchema`): endpoint raises `HttpError(429, "msg")` directly, or is decorated with `throttle=[…]` (Ninja's `Throttled` subclasses `HttpError`).
+
+### Known gap: body-validation 422s
+
+Ninja's body validation runs _before_ the view and produces `ValidationErrorSchema` on any body-accepting endpoint, regardless of whether the view explicitly raises 422. The rules above enumerate by what views raise, not by whether they accept a body, so endpoints whose only 422 path is body-validation are currently silent in the OpenAPI doc. Tracked in [`docs/plans/types/apiboundary/ApiSvelteBoundaryFollowups.md`](plans/types/apiboundary/ApiSvelteBoundaryFollowups.md). The convention above was established by [`ApiErrors.md`](plans/types/apiboundary/ApiErrors.md).

--- a/docs/plans/types/apiboundary/ApiErrors.md
+++ b/docs/plans/types/apiboundary/ApiErrors.md
@@ -142,6 +142,15 @@ internals.
 
 ## Approach
 
+The four sections below are written in a logical order, but the
+recommended **implementation order** is §1 → §2 → §4 → §3.
+Landing the parser rewrite (§4) before the backend sweep (§3)
+means the sweep is pure contract annotation — no behavior change
+left to verify after each declaration. Ninja's response-map
+validation is runtime-only, so misclassifications during §3 are
+silent until the failure path executes; a stable parser before
+the sweep gives the spot-checks in Verification a fixed target.
+
 ### 1. Add the schemas
 
 Edit [backend/apps/core/schemas.py](../../../../backend/apps/core/schemas.py):
@@ -258,7 +267,7 @@ behavior in before the sweep.
 Per-endpoint, expand `response={…}` based on what the function
 body (and the helpers it calls one level deep) can raise.
 
-**Status-code-first rules:**
+**Status-code-first rules** (canonical reference: [docs/ApiDesign.md](../../../ApiDesign.md#error-response-declarations)):
 
 - **422 structured** (`ValidationErrorSchema`): endpoint calls
   `execute_claims`, or any helper that can raise
@@ -277,6 +286,13 @@ body (and the helpers it calls one level deep) can raise.
 - **429 plain** (`ErrorDetailSchema`): endpoint raises
   `HttpError(429, "msg")` directly. Currently only
   [media/api.py:76](../../../../backend/apps/media/api.py).
+- **429 plain from throttle decorator** (`ErrorDetailSchema`):
+  endpoint decorated with `throttle=[…]`. Ninja's `Throttled`
+  subclasses `HttpError` and produces `{"detail": "Too many
+requests."}` via the stock `HttpError` handler — same shape
+  as `HttpError(429, …)`. Currently only
+  [citation/api.py:499](../../../../backend/apps/citation/api.py)
+  (`_ExtractThrottle`).
 
 Read each view carefully and apply the rule that fits. Don't
 over-declare to be safe — `response={200: Foo, 422: ValidationErrorSchema}`
@@ -305,24 +321,50 @@ AlreadyDeletedSchema`; restore already declares
 declarations to change.
 
 **Bespoke catalog endpoints (structured 422 via `execute_claims`)
-→ add `422: ValidationErrorSchema`:**
+→ add `422: ValidationErrorSchema`. Apply the rule per-endpoint;
+the counts below are guidance, not a checklist — read each file
+and declare based on what each view actually produces.**
 
-- [titles.py](../../../../backend/apps/catalog/api/titles.py) (3 mutating views)
-- [people.py](../../../../backend/apps/catalog/api/people.py) (3)
-- [machine_models.py](../../../../backend/apps/catalog/api/machine_models.py) (3)
-- [systems.py](../../../../backend/apps/catalog/api/systems.py) (1 bespoke create; delete/restore inherit from the generator)
+The big "named-fields" entities have multiple bespoke mutating
+views (patch claims + bespoke creates for sub-entities like
+aliases, credits, etc.):
+
+- [titles.py](../../../../backend/apps/catalog/api/titles.py) — `execute_claims` at lines 948, 1179
+- [people.py](../../../../backend/apps/catalog/api/people.py) — `execute_claims` at lines 296, 507
+- [machine_models.py](../../../../backend/apps/catalog/api/machine_models.py) — `execute_claims` at line 1000, 1105; raises `StructuredValidationError` at 955
+- [systems.py](../../../../backend/apps/catalog/api/systems.py) — `execute_claims` at 225; raises `StructuredValidationError` at 267, 273 (bespoke create); delete/restore inherit from the generator
+
+The simpler entities each have one bespoke
+`@*_router.patch("/{slug}/claims/")` edit view that calls
+`execute_claims` directly. Creates and delete/restore for these
+flow through the generators (covered above), but the **edits are
+bespoke** and need declaration:
+
+- [franchises.py:117](../../../../backend/apps/catalog/api/franchises.py)
+- [series.py:160](../../../../backend/apps/catalog/api/series.py)
+- [gameplay_features.py:132](../../../../backend/apps/catalog/api/gameplay_features.py)
+- [themes.py:137](../../../../backend/apps/catalog/api/themes.py)
+- [corporate_entities.py:161](../../../../backend/apps/catalog/api/corporate_entities.py)
+- [manufacturers.py:468](../../../../backend/apps/catalog/api/manufacturers.py)
+- [taxonomy.py](../../../../backend/apps/catalog/api/taxonomy.py) — 9 bespoke patch views, one per taxonomy router: `technology_generations` (L319), `display_types` (L370), `technology_subgenerations` (L386), `display_subtypes` (L402), `cabinets` (L424), `game_formats` (L448), `reward_types` (L499), `tags` (L532), `credit_roles` (L673). All route through the shared `_patch_taxonomy` helper (L177) which calls `execute_claims`.
 
 **Bespoke endpoints with plain `HttpError(422, …)` raises → add
 `422: ErrorDetailSchema`:**
 
 - [citation/api.py](../../../../backend/apps/citation/api.py)
-  (8 raise sites — lines 267, 273, 274, 444, 511, 519, 589, 654).
+  (8 raise sites — lines 267, 273, 274, 443, 511, 519, 589, 654;
+  line 443 is a multi-line raise spanning 443–446).
 - [provenance/api.py](../../../../backend/apps/provenance/api.py)
-  — already declares `422: ErrorDetailSchema` on lines 174, 220,
-  303, 350. Verified (grep): zero `StructuredValidationError`
-  raises and zero `execute_claims` calls. Audit and add
-  `422: ErrorDetailSchema` to any mutating endpoint that raises
-  but doesn't yet declare it. **Do not swap any existing
+  — **no §3 changes needed**. All three POST endpoints
+  (`revert_claim` L167, `undo_changeset` L213,
+  `create_citation_instance` L348) already declare
+  `422: ErrorDetailSchema` at lines 174, 220, and 350. The fourth
+  declaration at line 303 sits on a GET (`batch_citation_instances`)
+  that's strictly out of scope but already covered. The remaining
+  raise at L269 (`list_citation_instances`) is on a GET — out of
+  scope per the GET exclusion. Verified (grep): zero
+  `StructuredValidationError` raises and zero `execute_claims`
+  calls in this file. **Do not swap any existing
   `ErrorDetailSchema` to `ValidationErrorSchema`** — provenance
   produces only plain bodies.
 
@@ -376,19 +418,37 @@ types from there; otherwise use the indexed-access form
 
 Update [parse-api-error.test.ts](../../../../frontend/src/lib/api/parse-api-error.test.ts):
 
-- Add a test asserting that a malformed-body 422 (the kind Ninja
-  used to produce as an array) now arrives as
-  `ValidationErrorSchema` after the override.
-- **Keep one Pydantic-array test case** that asserts the parser
-  falls through gracefully to the unknown-shape fallback. Defensive
-  coverage in case a future Ninja upgrade reintroduces the array
-  shape through a path the override doesn't intercept.
-- Cover both branches plus the unknown-shape fallback.
+- **Keep all existing structured-validation, string-detail,
+  plain-string, and unknown-shape tests** — they cover the two
+  retained branches and the fallback unchanged.
+- **Delete the existing Pydantic-array test** at lines 50–62 that
+  asserts the array shape parses into a structured error. After
+  §2 lands, no API path produces the array, so this assertion is
+  no longer the contract.
+- **Add a replacement Pydantic-array test** that asserts the
+  parser falls through to the unknown-shape JSON-stringify
+  fallback when handed an array `detail`. Defensive coverage in
+  case a future Ninja upgrade reintroduces the array shape
+  through a path the override doesn't intercept.
+- **Add a malformed-body test** asserting that the structured
+  envelope produced by §2's override (with `field_errors` keyed
+  on `loc[-1]`) parses cleanly through the structured branch.
 
 ## Out of scope
 
 - **Sweep of 400 / 401 / 403 / 404 declarations.** Stock Ninja
   shape; not worth the verbosity.
+- **Body-validation 422 sweep.** §2's global override means _any_
+  body-accepting endpoint can produce `ValidationErrorSchema`
+  when Pydantic rejects the input — independent of whether the
+  view explicitly raises 422. §3 enumerates targets by what views
+  raise, not by whether they accept a body, so ~15–20 endpoints
+  declare a 422 shape that doesn't include `ValidationErrorSchema`
+  (or declare none). Tracked in
+  [ApiSvelteBoundaryFollowups.md](ApiSvelteBoundaryFollowups.md).
+  Deferred because it's a categorically different sweep — "declare
+  what Pydantic body validation can raise on every body-accepting
+  endpoint" — that's easier to review as its own PR than mixed in.
 - **Authenticated GET endpoints.** Read paths are silent on 4xx
   today and can stay that way.
 - **Converting raises to explicit `Status[…]` returns** at the

--- a/docs/plans/types/apiboundary/ApiSvelteBoundaryFollowups.md
+++ b/docs/plans/types/apiboundary/ApiSvelteBoundaryFollowups.md
@@ -34,6 +34,47 @@ or could a single schema cover both uses with optional/computed
 fields? Deferred because consolidation is an API-shape decision that
 benefits from seeing the renamed contract in place first.
 
+## Sweep body-validation 422s onto every request-body endpoint
+
+[ApiErrors.md](ApiErrors.md)'s §2 made a global behavioral change:
+Ninja's malformed-body 422 now reshapes to `ValidationErrorSchema`.
+That means _any_ endpoint that accepts a request body can produce
+`ValidationErrorSchema` when Pydantic rejects the input —
+independent of whether the view explicitly raises 422.
+
+§3's sweep enumerated targets by what views _raise_
+(`execute_claims`, `HttpError(422, …)`), not by whether they
+accept a body. Roughly 15–20 endpoints declare a 422 shape that
+doesn't include `ValidationErrorSchema`, or declare no 422 at
+all:
+
+- Catalog delete endpoints (generator + bespoke): currently
+  `422: SoftDeleteBlockedSchema | AlreadyDeletedSchema`.
+- Catalog restore endpoints (generator + bespoke): currently
+  `422: ErrorDetailSchema`.
+- Citation writes (5 endpoints in
+  [citation/api.py](../../../../backend/apps/citation/api.py)):
+  currently `422: ErrorDetailSchema`.
+- Provenance `revert_claim`, `undo_changeset`,
+  `create_citation_instance`: currently `422: ErrorDetailSchema`.
+- Media `upload`, `detach`, `set_primary`: 0 / 0 / 0 declared.
+
+The fix is mechanical: union `ValidationErrorSchema` into each
+endpoint's 422 declaration (or add it where 422 is undeclared).
+
+**Why deferred.** ApiErrors.md's §3 was a coherent sweep —
+"declare what views explicitly raise." Body-validation 422s are
+a categorically different sweep — "declare what Pydantic body
+validation can raise on every body-accepting endpoint." Two PRs
+with clear charters are easier to review than one mixed.
+
+**No runtime breakage today.** The frontend parser dispatches by
+body shape, not status code, and no frontend code imports error
+schemas at type level. The miscoverage shows up as `/api/docs`
+inaccuracy and as wrong types if a future consumer narrows on
+the declared 422 shape. Worth fixing for contract honesty; not
+urgent.
+
 ## Split schema per-tag
 
 If after the boundary work lands, `frontend/src/lib/api/schema.d.ts`

--- a/frontend/src/lib/api/media-api.ts
+++ b/frontend/src/lib/api/media-api.ts
@@ -7,6 +7,7 @@
 
 import type { components } from './schema';
 import { getCsrfToken } from './client';
+import { parseApiError } from './parse-api-error';
 
 export type UploadResult = components['schemas']['UploadOut'];
 
@@ -69,7 +70,8 @@ export function uploadMedia(
         let message = `Upload failed (${xhr.status})`;
         try {
           const body = JSON.parse(xhr.responseText);
-          if (body.detail) message = body.detail;
+          const parsed = parseApiError(body).message;
+          if (parsed) message = parsed;
         } catch {
           // ignore parse errors
         }
@@ -112,7 +114,8 @@ async function mediaAction(
     let message = `Request failed (${resp.status})`;
     try {
       const body = await resp.json();
-      if (body.detail) message = body.detail;
+      const parsed = parseApiError(body).message;
+      if (parsed) message = parsed;
     } catch {
       // ignore parse errors
     }

--- a/frontend/src/lib/api/parse-api-error.test.ts
+++ b/frontend/src/lib/api/parse-api-error.test.ts
@@ -47,7 +47,25 @@ describe('parseApiError', () => {
     expect(result.fieldErrors).toEqual({});
   });
 
-  it('handles Pydantic validation array', () => {
+  it('handles a malformed-body 422 reshaped by the global ValidationError handler', () => {
+    // After the backend ValidationError override, malformed bodies arrive
+    // in the structured envelope with field keys derived from `loc[-1]`.
+    const result = parseApiError({
+      detail: {
+        message: 'Invalid request.',
+        field_errors: { count: 'Input should be a valid integer' },
+        form_errors: [],
+      },
+    });
+    expect(result.fieldErrors).toEqual({ count: 'Input should be a valid integer' });
+    expect(result.message).toBe('count: Input should be a valid integer');
+  });
+
+  it('falls back to JSON for the legacy Pydantic-array shape', () => {
+    // The ValidationError override (config/api.py) intercepts malformed
+    // bodies before they can produce this shape, so it should never reach
+    // the parser. This test pins the defensive fallback in case a future
+    // upgrade reintroduces the array shape through an uncovered path.
     const result = parseApiError({
       detail: [
         {
@@ -57,8 +75,8 @@ describe('parseApiError', () => {
         },
       ],
     });
-    expect(result.message).toBe('year: value is not a valid integer');
-    expect(result.fieldErrors).toEqual({ year: 'value is not a valid integer' });
+    expect(result.fieldErrors).toEqual({});
+    expect(result.message).toContain('value is not a valid integer');
   });
 
   it('handles plain string error', () => {

--- a/frontend/src/lib/api/parse-api-error.ts
+++ b/frontend/src/lib/api/parse-api-error.ts
@@ -8,10 +8,15 @@ export type FieldErrors = Record<string, string>;
 type ParsedError = { message: string; fieldErrors: FieldErrors };
 
 /**
- * Handles three response shapes:
+ * Handles two response shapes:
  * 1. Structured validation: `{ detail: { message, field_errors, form_errors } }`
- * 2. Legacy string: `{ detail: "message" }`
- * 3. Pydantic array: `{ detail: [{ loc, msg }] }`
+ *    — produced by `StructuredValidationError` and by Ninja's malformed-body
+ *    handler (see `backend/config/api.py`).
+ * 2. Plain detail: `{ detail: "message" }` — produced by `HttpError(...)`
+ *    raises and stock Ninja 401/404/etc.
+ *
+ * The 422 and 429 statuses can arrive in either envelope; dispatch is by
+ * body shape, not by status code.
  */
 export function parseApiError(error: unknown): ParsedError {
   if (typeof error === 'object' && error !== null && 'detail' in error) {
@@ -21,6 +26,7 @@ export function parseApiError(error: unknown): ParsedError {
       typeof detail === 'object' &&
       detail !== null &&
       'message' in detail &&
+      typeof (detail as { message: unknown }).message === 'string' &&
       'field_errors' in detail
     ) {
       const d = detail as {
@@ -38,22 +44,6 @@ export function parseApiError(error: unknown): ParsedError {
     }
 
     if (typeof detail === 'string') return { message: detail, fieldErrors: {} };
-
-    if (Array.isArray(detail)) {
-      const fieldErrors: FieldErrors = {};
-      const messages: string[] = [];
-      for (const e of detail) {
-        const loc = Array.isArray(e.loc) ? String(e.loc[e.loc.length - 1]) : '';
-        const msg: string = e.msg ?? String(e);
-        if (loc) {
-          fieldErrors[loc] = msg;
-          messages.push(`${loc}: ${msg}`);
-        } else {
-          messages.push(msg);
-        }
-      }
-      return { message: messages.join('; '), fieldErrors };
-    }
   }
 
   if (typeof error === 'string') return { message: error, fieldErrors: {} };

--- a/frontend/src/lib/components/CreatePage.dom.test.ts
+++ b/frontend/src/lib/components/CreatePage.dom.test.ts
@@ -189,10 +189,14 @@ describe('CreatePage', () => {
     const submit = vi.fn().mockResolvedValue({
       data: undefined,
       error: {
-        detail: [
-          { loc: ['body', 'payload', 'name'], msg: 'Name already exists.' },
-          { loc: ['body', 'payload', 'slug'], msg: 'Slug already taken.' },
-        ],
+        detail: {
+          message: 'Validation failed.',
+          field_errors: {
+            name: 'Name already exists.',
+            slug: 'Slug already taken.',
+          },
+          form_errors: [],
+        },
       },
       response: makeResponse(422),
     });
@@ -300,12 +304,11 @@ describe('CreatePage extras', () => {
     const submit = vi.fn().mockResolvedValue({
       data: undefined,
       error: {
-        detail: [
-          {
-            loc: ['body', 'payload', 'manufacturer_slug'],
-            msg: 'Manufacturer not found.',
-          },
-        ],
+        detail: {
+          message: 'Validation failed.',
+          field_errors: { manufacturer_slug: 'Manufacturer not found.' },
+          form_errors: [],
+        },
       },
       response: makeResponse(422),
     });

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { invalidateAll } from '$app/navigation';
   import client from '$lib/api/client';
+  import { parseApiError } from '$lib/api/parse-api-error';
   import type { components } from '$lib/api/schema';
   import { auth } from '$lib/auth.svelte';
   import FocusContentShell from './FocusContentShell.svelte';
@@ -111,7 +112,7 @@
     revertLoading = false;
 
     if (error) {
-      revertError = (error as { detail?: string }).detail ?? 'Revert failed.';
+      revertError = parseApiError(error).message || 'Revert failed.';
     } else {
       revertingClaimId = null;
       revertNote = '';

--- a/frontend/src/lib/components/editors/save-model-claims.test.ts
+++ b/frontend/src/lib/components/editors/save-model-claims.test.ts
@@ -81,17 +81,18 @@ describe('saveModelClaims', () => {
     });
   });
 
-  it('joins array-of-objects detail into a readable message', async () => {
+  it('parses a malformed-body 422 reshaped by the global ValidationError handler', async () => {
+    // The backend ValidationError handler (config/api.py) reshapes
+    // Pydantic's malformed-body errors into the structured envelope
+    // with field keys derived from `loc[-1]`.
     PATCH.mockResolvedValue({
       data: undefined,
       error: {
-        detail: [
-          {
-            loc: ['body', 'fields', 'year'],
-            msg: 'value is not a valid integer',
-            type: 'type_error',
-          },
-        ],
+        detail: {
+          message: 'Invalid request.',
+          field_errors: { year: 'Input should be a valid integer' },
+          form_errors: [],
+        },
       },
     });
 
@@ -101,8 +102,8 @@ describe('saveModelClaims', () => {
 
     expect(result).toEqual({
       ok: false,
-      error: 'year: value is not a valid integer',
-      fieldErrors: { year: 'value is not a valid integer' },
+      error: 'year: Input should be a valid integer',
+      fieldErrors: { year: 'Input should be a valid integer' },
     });
   });
 

--- a/frontend/src/routes/systems/new/systems-new.dom.test.ts
+++ b/frontend/src/routes/systems/new/systems-new.dom.test.ts
@@ -57,12 +57,11 @@ describe('systems/new route', () => {
     mockPost.mockResolvedValue({
       data: undefined,
       error: {
-        detail: [
-          {
-            loc: ['body', 'payload', 'manufacturer_slug'],
-            msg: 'Manufacturer not found.',
-          },
-        ],
+        detail: {
+          message: 'Validation failed.',
+          field_errors: { manufacturer_slug: 'Manufacturer not found.' },
+          form_errors: [],
+        },
       },
       response: { status: 422, headers: new Headers() } as Response,
     });


### PR DESCRIPTION
## Summary

Make the OpenAPI contract honest about 4xx/429 failure shapes and consolidate the frontend's runtime parser branches.

- Adds `ValidationErrorSchema` and `RateLimitErrorSchema` to `apps.core.schemas` for the structured 422/429 envelopes.
- Overrides Ninja's malformed-body 422 in `config/api.py` to share the structured envelope, dropping `parse-api-error.ts` from three runtime branches to two.
- Sweeps mutating endpoints across catalog (generator + 11 bespoke files), citation, and media to declare what each view actually produces.
- Codifies the rules in [docs/ApiDesign.md](docs/ApiDesign.md) so future endpoints have a canonical reference; queues the body-validation 422 sweep in [ApiSvelteBoundaryFollowups.md](docs/plans/types/apiboundary/ApiSvelteBoundaryFollowups.md).

Plan: [docs/plans/types/apiboundary/ApiErrors.md](docs/plans/types/apiboundary/ApiErrors.md)

## Test plan

- [ ] `make api-gen` regenerates `schema.d.ts` with the four new schemas under `components.schemas`
- [ ] `make lint` and `make test` pass (verified locally: backend 2255 + frontend 985)
- [ ] Spot-check via `make dev`:
  - [ ] Submit an edit with an invalid year on a machine model → frontend renders inline field errors (structured-422 path through `StructuredValidationError`)
  - [ ] POST a malformed JSON body with a nested-payload error → frontend renders the same structured-422 UI; field key matches the leaf name (confirms §2's override and `loc[-1]` decision)
  - [ ] Trigger a structured rate-limit 429 (rapid-fire creates against a `check_and_record`-protected endpoint) → toast intact via `RateLimitErrorSchema`
  - [ ] Trigger a plain 429 (upload that hits `media/api.py:76`) → toast renders via the `ErrorDetailSchema` branch
  - [ ] Hit a 404 (unknown slug on a detail-page mutate) → error rendering unchanged
- [ ] Inspect `/api/docs` for one endpoint per swept file — confirm 422/429 responses appear with the expected schema refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)