### PR TITLE
refactor(frontend): emit top-level type aliases from openapi-typescript

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "test:unit": "vitest run --project unit",
     "test:dom": "vitest run --project dom",
     "test:dom:watch": "vitest --project dom",
-    "api:gen": "openapi-typescript ../backend/openapi.json -o src/lib/api/schema.d.ts",
+    "api:gen": "openapi-typescript ../backend/openapi.json --root-types --root-types-no-schema-prefix --empty-objects-unknown --default-non-nullable -o src/lib/api/schema.d.ts",
     "knip": "knip"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Add `--root-types --root-types-no-schema-prefix` to `api:gen` so generated schemas are exposed as top-level `export type Foo` aliases. Consumers can now `import type { Foo } from '$lib/api/schema'` with IDE autocomplete instead of `components['schemas']['Foo']` indexed access. Existing indexed-access call sites continue to work — the aliases are purely additive, so consumer migration can happen incrementally.
- Add `--empty-objects-unknown` as a tripwire for response schemas that resolve to `Record<string, never>` (no-op today; useful if a future endpoint returns untyped `dict`).
- Add `--default-non-nullable` so response fields with defaults aren't typed as optional — matches Ninja's runtime behavior.

Tried `--immutable` alongside these; backed out at 341 svelte-check errors across 151 files (mostly request-body construction sites spreading typed response objects). Deferred to its own PR if revisited.

## Test plan

- [x] `make api-gen` regenerates `schema.d.ts` cleanly
- [x] `pnpm check` passes (0 errors)
- [x] `pnpm test` passes (985/985)
- [x] Manually tested by author

🤖 Generated with [Claude Code](https://claude.com/claude-code)