### PR TITLE
refactor(api): move inline ninja Schemas to schemas.py

### DIFF
--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -15,12 +15,11 @@ from django.db import IntegrityError, models, transaction
 from django.db.models import Exists, OuterRef, Q, QuerySet
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
-from ninja import Router, Schema
+from ninja import Router
 from ninja.errors import HttpError
 from ninja.responses import Status
 from ninja.security import django_auth
 from ninja.throttling import AuthRateThrottle
-from pydantic import field_validator
 
 from apps.core.api_helpers import authed_user
 from apps.core.schemas import ErrorDetailSchema
@@ -28,6 +27,23 @@ from apps.core.schemas import ErrorDetailSchema
 from .extraction import classify_input, extract_isbn, normalize_isbn
 from .extractors import EXTRACTORS, Recognition, recognize_url
 from .models import CitationSource, CitationSourceLink
+from .schemas import (
+    CitationExtractDraftSchema,
+    CitationExtractInputSchema,
+    CitationExtractResultSchema,
+    CitationRecognitionSchema,
+    CitationSourceChildSchema,
+    CitationSourceCreateSchema,
+    CitationSourceDetailSchema,
+    CitationSourceLinkCreateSchema,
+    CitationSourceLinkSchema,
+    CitationSourceLinkUpdateSchema,
+    CitationSourceMatchSchema,
+    CitationSourceParentSchema,
+    CitationSourceSearchResponseSchema,
+    CitationSourceSearchSchema,
+    CitationSourceUpdateSchema,
+)
 from .url_extraction import extract_url
 
 # ---------------------------------------------------------------------------
@@ -39,184 +55,6 @@ citation_sources_router = Router(tags=["citation-sources", "private"])
 routers = [
     ("/citation-sources/", citation_sources_router),
 ]
-
-# ---------------------------------------------------------------------------
-# Schemas
-# ---------------------------------------------------------------------------
-
-NONNULLABLE_STR_FIELDS = (
-    "name",
-    "source_type",
-    "author",
-    "publisher",
-    "date_note",
-    "description",
-)
-
-
-class CitationSourceSearchSchema(Schema):
-    id: int
-    name: str
-    source_type: str
-    author: str
-    publisher: str
-    year: int | None = None
-    isbn: str | None = None
-    parent_id: int | None = None
-    has_children: bool = False
-    is_abstract: bool = False
-    skip_locator: bool = False
-    identifier_key: str = ""
-
-
-class CitationSourceMatchSchema(Schema):
-    id: int
-    name: str
-    skip_locator: bool = False
-
-
-class CitationSourceParentSchema(Schema):
-    id: int
-    name: str
-
-
-class CitationRecognitionSchema(Schema):
-    parent: CitationSourceParentSchema
-    child: CitationSourceMatchSchema | None = None
-    identifier: str | None = None
-
-
-class CitationSourceSearchResponseSchema(Schema):
-    results: list[CitationSourceSearchSchema]
-    recognition: CitationRecognitionSchema | None = None
-
-
-class CitationSourceCreateSchema(Schema):
-    name: str
-    source_type: str
-    author: str = ""
-    publisher: str = ""
-    year: int | None = None
-    month: int | None = None
-    day: int | None = None
-    date_note: str = ""
-    isbn: str | None = None
-    description: str = ""
-    parent_id: int | None = None
-    identifier: str = ""
-    # Optional: atomically create a CitationSourceLink alongside the source.
-    url: str | None = None
-    link_label: str = ""
-    link_type: str = "homepage"
-
-    @field_validator("isbn", mode="before")
-    @classmethod
-    def coerce_empty_isbn_to_none(cls, v: object) -> object:
-        """Empty string → None for nullable unique field."""
-        return None if v == "" else v
-
-
-class CitationSourceUpdateSchema(Schema):
-    name: str | None = None
-    source_type: str | None = None
-    author: str | None = None
-    publisher: str | None = None
-    year: int | None = None
-    month: int | None = None
-    day: int | None = None
-    date_note: str | None = None
-    isbn: str | None = None
-    description: str | None = None
-
-    @field_validator(*NONNULLABLE_STR_FIELDS, mode="before")
-    @classmethod
-    def coerce_null_to_empty(cls, v: object) -> object:
-        """None → empty string for non-nullable CharFields."""
-        return "" if v is None else v
-
-    @field_validator("isbn", mode="before")
-    @classmethod
-    def coerce_empty_isbn_to_none(cls, v: object) -> object:
-        """Empty string → None for nullable unique field."""
-        return None if v == "" else v
-
-
-class CitationSourceChildSchema(Schema):
-    id: int
-    name: str
-    source_type: str
-    year: int | None = None
-    isbn: str | None = None
-    skip_locator: bool = False
-    urls: list[str] = []
-
-
-class CitationSourceLinkSchema(Schema):
-    id: int
-    link_type: str
-    url: str
-    label: str
-
-
-class CitationSourceDetailSchema(Schema):
-    id: int
-    name: str
-    source_type: str
-    author: str
-    publisher: str
-    year: int | None = None
-    month: int | None = None
-    day: int | None = None
-    date_note: str
-    isbn: str | None = None
-    description: str
-    identifier_key: str = ""
-    skip_locator: bool = False
-    parent: CitationSourceParentSchema | None = None
-    links: list[CitationSourceLinkSchema] = []
-    children: list[CitationSourceChildSchema] = []
-    created_at: str
-    updated_at: str
-
-
-class CitationSourceLinkCreateSchema(Schema):
-    link_type: str
-    url: str
-    label: str = ""
-
-
-class CitationSourceLinkUpdateSchema(Schema):
-    link_type: str | None = None
-    url: str | None = None
-    label: str | None = None
-
-    @field_validator("label", mode="before")
-    @classmethod
-    def coerce_null_to_empty(cls, v: object) -> object:
-        return "" if v is None else v
-
-
-class CitationExtractInputSchema(Schema):
-    input: str
-
-
-class CitationExtractDraftSchema(Schema):
-    name: str
-    source_type: str
-    author: str
-    publisher: str
-    year: int | None = None
-    isbn: str | None = None
-    url: str | None = None
-
-
-class CitationExtractResultSchema(Schema):
-    draft: CitationExtractDraftSchema | None = None
-    match: CitationSourceMatchSchema | None = None
-    error: str | None = None
-    confidence: str = ""
-    source_api: str = ""
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/backend/apps/citation/schemas.py
+++ b/backend/apps/citation/schemas.py
@@ -1,0 +1,179 @@
+"""API schemas for the citation app."""
+
+from __future__ import annotations
+
+from ninja import Schema
+from pydantic import field_validator
+
+NONNULLABLE_STR_FIELDS = (
+    "name",
+    "source_type",
+    "author",
+    "publisher",
+    "date_note",
+    "description",
+)
+
+
+class CitationSourceSearchSchema(Schema):
+    id: int
+    name: str
+    source_type: str
+    author: str
+    publisher: str
+    year: int | None = None
+    isbn: str | None = None
+    parent_id: int | None = None
+    has_children: bool = False
+    is_abstract: bool = False
+    skip_locator: bool = False
+    identifier_key: str = ""
+
+
+class CitationSourceMatchSchema(Schema):
+    id: int
+    name: str
+    skip_locator: bool = False
+
+
+class CitationSourceParentSchema(Schema):
+    id: int
+    name: str
+
+
+class CitationRecognitionSchema(Schema):
+    parent: CitationSourceParentSchema
+    child: CitationSourceMatchSchema | None = None
+    identifier: str | None = None
+
+
+class CitationSourceSearchResponseSchema(Schema):
+    results: list[CitationSourceSearchSchema]
+    recognition: CitationRecognitionSchema | None = None
+
+
+class CitationSourceCreateSchema(Schema):
+    name: str
+    source_type: str
+    author: str = ""
+    publisher: str = ""
+    year: int | None = None
+    month: int | None = None
+    day: int | None = None
+    date_note: str = ""
+    isbn: str | None = None
+    description: str = ""
+    parent_id: int | None = None
+    identifier: str = ""
+    # Optional: atomically create a CitationSourceLink alongside the source.
+    url: str | None = None
+    link_label: str = ""
+    link_type: str = "homepage"
+
+    @field_validator("isbn", mode="before")
+    @classmethod
+    def coerce_empty_isbn_to_none(cls, v: object) -> object:
+        """Empty string → None for nullable unique field."""
+        return None if v == "" else v
+
+
+class CitationSourceUpdateSchema(Schema):
+    name: str | None = None
+    source_type: str | None = None
+    author: str | None = None
+    publisher: str | None = None
+    year: int | None = None
+    month: int | None = None
+    day: int | None = None
+    date_note: str | None = None
+    isbn: str | None = None
+    description: str | None = None
+
+    @field_validator(*NONNULLABLE_STR_FIELDS, mode="before")
+    @classmethod
+    def coerce_null_to_empty(cls, v: object) -> object:
+        """None → empty string for non-nullable CharFields."""
+        return "" if v is None else v
+
+    @field_validator("isbn", mode="before")
+    @classmethod
+    def coerce_empty_isbn_to_none(cls, v: object) -> object:
+        """Empty string → None for nullable unique field."""
+        return None if v == "" else v
+
+
+class CitationSourceChildSchema(Schema):
+    id: int
+    name: str
+    source_type: str
+    year: int | None = None
+    isbn: str | None = None
+    skip_locator: bool = False
+    urls: list[str] = []
+
+
+class CitationSourceLinkSchema(Schema):
+    id: int
+    link_type: str
+    url: str
+    label: str
+
+
+class CitationSourceDetailSchema(Schema):
+    id: int
+    name: str
+    source_type: str
+    author: str
+    publisher: str
+    year: int | None = None
+    month: int | None = None
+    day: int | None = None
+    date_note: str
+    isbn: str | None = None
+    description: str
+    identifier_key: str = ""
+    skip_locator: bool = False
+    parent: CitationSourceParentSchema | None = None
+    links: list[CitationSourceLinkSchema] = []
+    children: list[CitationSourceChildSchema] = []
+    created_at: str
+    updated_at: str
+
+
+class CitationSourceLinkCreateSchema(Schema):
+    link_type: str
+    url: str
+    label: str = ""
+
+
+class CitationSourceLinkUpdateSchema(Schema):
+    link_type: str | None = None
+    url: str | None = None
+    label: str | None = None
+
+    @field_validator("label", mode="before")
+    @classmethod
+    def coerce_null_to_empty(cls, v: object) -> object:
+        return "" if v is None else v
+
+
+class CitationExtractInputSchema(Schema):
+    input: str
+
+
+class CitationExtractDraftSchema(Schema):
+    name: str
+    source_type: str
+    author: str
+    publisher: str
+    year: int | None = None
+    isbn: str | None = None
+    url: str | None = None
+
+
+class CitationExtractResultSchema(Schema):
+    draft: CitationExtractDraftSchema | None = None
+    match: CitationSourceMatchSchema | None = None
+    error: str | None = None
+    confidence: str = ""
+    source_api: str = ""

--- a/backend/apps/core/tests/test_openapi_boundaries.py
+++ b/backend/apps/core/tests/test_openapi_boundaries.py
@@ -49,9 +49,9 @@ NO_4XX_ALLOWLIST = frozenset(
 # baseline (i.e. migrating inline schemas into schemas.py) is welcome.
 INLINE_SCHEMA_BASELINES = {
     "apps.accounts.api": 4,
-    "apps.citation.api": 15,
-    "apps.media.api": 4,
-    "apps.provenance.api": 8,
+    "apps.citation.api": 0,
+    "apps.media.api": 0,
+    "apps.provenance.api": 0,
 }
 
 

--- a/backend/apps/media/api.py
+++ b/backend/apps/media/api.py
@@ -13,7 +13,7 @@ from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http import HttpRequest
-from ninja import File, Form, Router, Schema, Status, UploadedFile
+from ninja import File, Form, Router, Status, UploadedFile
 from ninja.errors import HttpError
 from ninja.security import django_auth
 
@@ -36,6 +36,12 @@ from apps.media.processing import (
     generate_rendition,
     process_original,
     validate_image,
+)
+from apps.media.schemas import (
+    AttachmentMetaSchema,
+    MediaAssetInputSchema,
+    RenditionUrlsSchema,
+    UploadSchema,
 )
 from apps.media.storage import (
     build_public_url,
@@ -84,36 +90,6 @@ def _incr_rate_limit(user_id: int) -> None:
         cache.incr(key)
     except ValueError:
         cache.set(key, 1, 3600)
-
-
-class RenditionUrlsSchema(Schema):
-    original: str
-    thumb: str
-    display: str
-
-
-class AttachmentMetaSchema(Schema):
-    entity_type: str
-    slug: str
-    category: str | None
-    is_primary: bool
-
-
-class UploadSchema(Schema):
-    asset_uuid: str
-    kind: str
-    status: str
-    original_filename: str
-    width: int
-    height: int
-    renditions: RenditionUrlsSchema
-    attachment: AttachmentMetaSchema
-
-
-class MediaAssetInputSchema(Schema):
-    entity_type: str
-    slug: str
-    asset_uuid: str
 
 
 def _resolve_entity(entity_type: str, slug: str) -> tuple[ContentType, MediaSupported]:

--- a/backend/apps/media/schemas.py
+++ b/backend/apps/media/schemas.py
@@ -20,3 +20,33 @@ class UploadedMediaSchema(Schema):
     is_primary: bool
     uploaded_by_username: str | None = None
     renditions: MediaRenditionsSchema
+
+
+class RenditionUrlsSchema(Schema):
+    original: str
+    thumb: str
+    display: str
+
+
+class AttachmentMetaSchema(Schema):
+    entity_type: str
+    slug: str
+    category: str | None
+    is_primary: bool
+
+
+class UploadSchema(Schema):
+    asset_uuid: str
+    kind: str
+    status: str
+    original_filename: str
+    width: int
+    height: int
+    renditions: RenditionUrlsSchema
+    attachment: AttachmentMetaSchema
+
+
+class MediaAssetInputSchema(Schema):
+    entity_type: str
+    slug: str
+    asset_uuid: str

--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -14,7 +14,7 @@ from django.db.models import Q
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from django.views.decorators.cache import cache_control
-from ninja import Router, Schema
+from ninja import Router
 from ninja.decorators import decorate_view
 from ninja.errors import HttpError
 from ninja.responses import Status
@@ -26,37 +26,17 @@ from apps.core.schemas import ErrorDetailSchema
 
 from .models import CitationInstance, ClaimControlledModel, Source
 from .page_endpoints import pages_router
-from .schemas import CitationLinkSchema, ReviewLinkSchema
-
-
-class CitationSourceSchema(Schema):
-    name: str
-    slug: str
-    source_type: str
-    priority: int
-    url: str
-    description: str
-
-
-class ReviewClaimSchema(Schema):
-    id: int
-    source_name: str
-    field_name: str
-    # ``value`` is the raw JSONField payload of a claim — scalar, dict, list,
-    # or null depending on the field — and stays ``object`` for the same
-    # reason the shared schemas in ``schemas.py`` do.
-    value: object
-    needs_review_notes: str
-    created_at: str
-    # Context about the subject (the entity this claim targets).
-    # Canonical hyphenated CatalogModel.entity_type, e.g. "manufacturer".
-    subject_type: str
-    subject_name: str
-    subject_slug: str | None = None
-    # Title that this claim created (for group claims).
-    title_slug: str | None = None
-    review_links: list[ReviewLinkSchema] = []
-
+from .schemas import (
+    CitationInstanceBatchSchema,
+    CitationInstanceCreateSchema,
+    CitationInstanceSchema,
+    CitationLinkSchema,
+    CitationSourceSchema,
+    RevertNoteSchema,
+    ReviewClaimSchema,
+    UndoChangeSetSchema,
+    UndoResultSchema,
+)
 
 sources_router = Router(tags=["sources", "private"])
 review_router = Router(tags=["review", "private"])
@@ -148,18 +128,6 @@ def list_review_claims(request):
 # ── Claim and ChangeSet mutations (revert, undo) ───────────────────
 
 
-class RevertNoteSchema(Schema):
-    note: str
-
-
-class UndoChangeSetSchema(Schema):
-    note: str = ""
-
-
-class UndoResultSchema(Schema):
-    changeset_id: int
-
-
 claims_router = Router(tags=["claims", "private"])
 changesets_router = Router(tags=["changesets", "private"])
 
@@ -247,15 +215,6 @@ def undo_changeset(
 citation_instances_router = Router(tags=["citation-instances", "private"])
 
 
-class CitationInstanceSchema(Schema):
-    id: int
-    citation_source_id: int
-    citation_source_name: str
-    claim_id: int | None = None
-    locator: str
-    created_at: str
-
-
 @citation_instances_router.get(
     "/",
     response=list[CitationInstanceSchema],
@@ -286,16 +245,6 @@ def list_citation_instances(
         )
         for ci in qs
     ]
-
-
-class CitationInstanceBatchSchema(Schema):
-    id: int
-    source_name: str
-    source_type: str
-    author: str
-    year: int | None = None
-    locator: str
-    links: list[CitationLinkSchema] = []
 
 
 @citation_instances_router.get(
@@ -338,11 +287,6 @@ def batch_citation_instances(
         )
         for ci in qs
     ]
-
-
-class CitationInstanceCreateSchema(Schema):
-    citation_source_id: int
-    locator: str = ""
 
 
 @citation_instances_router.post(

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -1,7 +1,6 @@
-"""Shared API schemas for the provenance app.
+"""API schemas for the provenance app.
 
-These schemas are used by both the edit-history endpoints (api.py) and the
-page-oriented changes endpoints (page_endpoints.py).
+Used by api.py and the page-oriented changes endpoints (page_endpoints.py).
 
 Claim payloads are stored as JSON (``Claim.value`` is a ``JSONField``), so
 ``old_value`` / ``new_value`` / ``value`` fields are typed as ``object`` —
@@ -125,3 +124,68 @@ class RichTextSchema(Schema):
     html: str = ""
     citations: list[InlineCitationSchema] = []
     attribution: AttributionSchema | None = None
+
+
+class CitationSourceSchema(Schema):
+    name: str
+    slug: str
+    source_type: str
+    priority: int
+    url: str
+    description: str
+
+
+class ReviewClaimSchema(Schema):
+    id: int
+    source_name: str
+    field_name: str
+    # ``value`` is the raw JSONField payload of a claim — scalar, dict, list,
+    # or null depending on the field — and stays ``object`` for the same
+    # reason the shared schemas above do.
+    value: object
+    needs_review_notes: str
+    created_at: str
+    # Context about the subject (the entity this claim targets).
+    # Canonical hyphenated CatalogModel.entity_type, e.g. "manufacturer".
+    subject_type: str
+    subject_name: str
+    subject_slug: str | None = None
+    # Title that this claim created (for group claims).
+    title_slug: str | None = None
+    review_links: list[ReviewLinkSchema] = []
+
+
+class RevertNoteSchema(Schema):
+    note: str
+
+
+class UndoChangeSetSchema(Schema):
+    note: str = ""
+
+
+class UndoResultSchema(Schema):
+    changeset_id: int
+
+
+class CitationInstanceSchema(Schema):
+    id: int
+    citation_source_id: int
+    citation_source_name: str
+    claim_id: int | None = None
+    locator: str
+    created_at: str
+
+
+class CitationInstanceBatchSchema(Schema):
+    id: int
+    source_name: str
+    source_type: str
+    author: str
+    year: int | None = None
+    locator: str
+    links: list[CitationLinkSchema] = []
+
+
+class CitationInstanceCreateSchema(Schema):
+    citation_source_id: int
+    locator: str = ""


### PR DESCRIPTION
## Summary

- Moved request/response ninja `Schema` classes out of `api.py` and into each app's `schemas.py` for **citation** (15), **media** (4), and **provenance** (8).
- Created `apps/citation/schemas.py` (new); appended to existing `apps/media/schemas.py` and `apps/provenance/schemas.py`.
- Dropped the corresponding baselines in `test_openapi_boundaries.py::TestInlineSchemaRegression` to 0.
- **accounts** intentionally left alone — 4 small response wrappers in a 346-line file with no existing `schemas.py`; locality wins for now.

No behavior changes; this is purely an organizational move. None of the moved schemas were imported from outside their own `api.py`.

## Test plan

- [x] `pytest apps/core/tests/test_openapi_boundaries.py` passes
- [x] `pytest apps/citation apps/media apps/provenance` passes (698 passed)
- [x] ruff check + format clean
- [x] mypy (dmypy) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)