### PR TITLE
docs(model-driven-metadata): expand plan with per-aspect breakdowns

### DIFF
--- a/docs/plans/model_driven_metadata/ModelDrivenClaimFkLookupsMetadata.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenClaimFkLookupsMetadata.md
@@ -1,0 +1,41 @@
+# Claim FK Lookups
+
+## Context
+
+This work is part of the family described in [ModelDrivenClaimsMetadata.md](ModelDrivenClaimsMetadata.md), and an instance of the broader pattern in [ModelDrivenMetadata.md](ModelDrivenMetadata.md): encode per-model behavior on the model itself, consume it generically from shared infrastructure.
+
+`claim_fk_lookups` is the per-model knob that maps FK fields to the lookup field on the related model. By default the claims layer assumes every FK claim value is the related row's `slug`. When that assumption is wrong — typically because the related model's URL identifier isn't `slug` — the writing model declares an override.
+
+The need is exposed by [ModelDrivenLinkability.md](ModelDrivenLinkability.md): as soon as a related model's `public_id_field` isn't `slug`, the FK claim value must follow.
+
+## The contract
+
+`ClaimControlledModel` declares:
+
+```python
+claim_fk_lookups: ClassVar[dict[str, str]] = {}
+```
+
+Default empty — every FK claim resolves through `slug` (the historical assumption). Location declares:
+
+```python
+claim_fk_lookups: ClassVar[dict[str, str]] = {"parent": "location_path"}
+```
+
+When writing the `parent` FK claim, the resolver reads `getattr(parent, "location_path")` rather than `parent.slug`. The same map drives FK resolution at materialization time: `_resolve_fk_generic` in `apps/catalog/resolve/_helpers.py` looks up the related row by its `location_path` instead of its `slug`.
+
+## Current state and hoist plan
+
+Today `claim_fk_lookups` is typed (`ClassVar[dict[str, str]]`, per [ModelDrivenMetadataCleanup.md](ModelDrivenMetadataCleanup.md)) but only declared on subclasses that need it (Location is the only one). Consumers in `apps/catalog/resolve/_helpers.py` (two call sites) and `apps/catalog/management/commands/validate_catalog.py` read it via `getattr(model_class, "claim_fk_lookups", {})` — the [field-on-model antipattern](ModelDrivenMetadata.md#antipattern-field-on-model) shape, three call sites with no typed contract.
+
+Hoist:
+
+- Declare `claim_fk_lookups: ClassVar[dict[str, str]] = {}` on `ClaimControlledModel`.
+- Subclass declarations remain — they become overrides of the base default rather than ad-hoc additions.
+- Replace the three `getattr(model_class, "claim_fk_lookups", {})` reads with direct attribute access (`model_class.claim_fk_lookups`).
+- The shared write factories described in [ModelDrivenLinkability.md](ModelDrivenLinkability.md) also read this map when constructing parent FK claims; that read becomes direct attribute access too.
+- No semantic change. Existing test coverage of FK claim writes and FK resolution carries over.
+
+## Why this lives on `ClaimControlledModel`
+
+FK claim lookups are meaningful only for models that participate in claim control — claim writes resolve FKs by some lookup key, and claim materialization reverses that. `ClaimControlledModel` is the smallest base that captures the audience. Hoisting puts the contract on the class the consumer already knows about, lets the type checker enforce the shape, and lines up with the rest of the [claims metadata family](ModelDrivenClaimsMetadata.md) — same base, same hoist recipe.

--- a/docs/plans/model_driven_metadata/ModelDrivenClaimsExemptMetadata.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenClaimsExemptMetadata.md
@@ -1,0 +1,40 @@
+# Claims Exempt
+
+## Context
+
+This work is part of the family described in [ModelDrivenClaimsMetadata.md](ModelDrivenClaimsMetadata.md), and an instance of the broader pattern in [ModelDrivenMetadata.md](ModelDrivenMetadata.md): encode per-model behavior on the model itself, consume it generically from shared infrastructure.
+
+`claims_exempt` is the per-model knob that excludes specific fields from claim control entirely. The fields named here keep whatever Django shape they have on the row but aren't discovered, materialized, or validated by the claims layer.
+
+## The contract
+
+`ClaimControlledModel` declares:
+
+```python
+claims_exempt: ClassVar[frozenset[str]] = frozenset()
+```
+
+Default empty — every existing model is unaffected. Location declares:
+
+```python
+claims_exempt: ClassVar[frozenset[str]] = frozenset({"location_path"})
+```
+
+`location_path` is materialized from `parent` + `slug` at create time, never edited afterward, and never carries a claim. Listing it in `claims_exempt` keeps `get_claim_fields` from treating it as a claim-controlled field.
+
+`get_claim_fields(model_class)` in `apps/core/models.py` reads `claims_exempt` to filter the discovered claim fields. Downstream consumers (resolvers, validators, the claim executor) see only the unfiltered set; nothing else needs to know about exemption.
+
+## Current state and hoist plan
+
+Today `claims_exempt` is typed (`ClassVar[frozenset[str]]`, per [ModelDrivenMetadataCleanup.md](ModelDrivenMetadataCleanup.md)) but only declared on subclasses that need it. `get_claim_fields` reads it via `getattr(model_class, "claims_exempt", frozenset())` — the [field-on-model antipattern](ModelDrivenMetadata.md#antipattern-field-on-model) shape.
+
+Hoist:
+
+- Declare `claims_exempt: ClassVar[frozenset[str]] = frozenset()` on `ClaimControlledModel`.
+- Subclass declarations remain — they become overrides of the base default rather than ad-hoc additions.
+- Replace the `getattr(model_class, "claims_exempt", frozenset())` read in `get_claim_fields` with a direct attribute access (`model_class.claims_exempt`).
+- No semantic change. Existing test coverage of `get_claim_fields` carries over.
+
+## Why this lives on `ClaimControlledModel`
+
+The set of fields exempt from claim control is meaningful only for models that participate in claim control. `ClaimControlledModel` is the smallest base that captures the audience. Hoisting puts the contract on the class the consumer already knows about, lets the type checker enforce the shape, and makes a fourth or fifth ClassVar in this family (see [ModelDrivenClaimsMetadata.md](ModelDrivenClaimsMetadata.md)) cheap to add — same shape, same home, same hoist recipe.

--- a/docs/plans/model_driven_metadata/ModelDrivenClaimsMetadata.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenClaimsMetadata.md
@@ -1,0 +1,13 @@
+# Model-Driven Claims Metadata
+
+A small family of `ClassVar`s on `ClaimControlledModel` that customize per-model behavior of the claims layer. Each is declared on the base with an empty default and overridden where needed by subclasses; each is consumed generically by claim infrastructure (no `isinstance` checks anywhere downstream).
+
+This is one facet of the broader goal in [ModelDrivenMetadata.md](ModelDrivenMetadata.md): encode per-model behavior on the model itself, consumed generically by shared infrastructure. See the umbrella for the underlying pattern ([base class / mixin](ModelDrivenMetadata.md#pattern-base-class--mixin)) and the antipattern ([field-on-model](ModelDrivenMetadata.md#antipattern-field-on-model)) this family of work fixes.
+
+## The ClassVars
+
+Each item is its own piece of work — typing, hoist to the base, consumer cleanup, tests — and gets its own doc.
+
+- **`immutable_after_create`** — which fields, once set, cannot change. Default `frozenset()`. See [ModelDrivenImmutableAfterCreate.md](ModelDrivenImmutableAfterCreate.md).
+- **`claims_exempt`** — which fields are excluded from claim control. Default `frozenset()`. See [ModelDrivenClaimsExemptMetadata.md](ModelDrivenClaimsExemptMetadata.md).
+- **`claim_fk_lookups`** — per-FK override of the lookup field used in claim writes and resolution. Default `{}`. See [ModelDrivenClaimFkLookupsMetadata.md](ModelDrivenClaimFkLookupsMetadata.md).

--- a/docs/plans/model_driven_metadata/ModelDrivenImmutableAfterCreate.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenImmutableAfterCreate.md
@@ -1,0 +1,35 @@
+# Immutable After Create
+
+## Context
+
+This work is a pre-condition for [ModelDrivenLinkability.md](ModelDrivenLinkability.md), and an instance of the broader pattern described in [ModelDrivenMetadata.md](ModelDrivenMetadata.md): encode per-model behavior on the model itself and consume it generically from shared infrastructure.
+
+`ModelDrivenLinkability.md` proposes a `LinkableModel` that supports models with multi-segment URL identity — specifically Location, whose `public_id` is the materialized `location_path` (encoding ancestry). Once a row's URL is materialized from `parent` + `slug`, re-parenting becomes prohibitively expensive: it would invalidate the entity's URL and every descendant's URL, and force every reference to chase the change. We opt out of re-parenting Location entirely.
+
+This doc specifies the generic mechanism that lets Location declare that opt-out without leaking `isinstance(model, Location)` into the claims executor. It's a [base class / mixin](ModelDrivenMetadata.md#pattern-base-class--mixin) ClassVar on `ClaimControlledModel`, defaulted empty, consumed by the claims executor before each write.
+
+## The contract
+
+`ClaimControlledModel` declares:
+
+```python
+immutable_after_create: ClassVar[frozenset[str]] = frozenset()
+```
+
+Default empty — every existing model is unaffected. Location declares:
+
+```python
+immutable_after_create: ClassVar[frozenset[str]] = frozenset({"parent"})
+```
+
+The claims executor, before writing each spec, checks: if the field is in `entity.immutable_after_create` and the **current row value** is non-null and would change, raise `ValidationError` and abort the transaction.
+
+## Row value, not prior-claim, is the discriminator
+
+"Reject if a prior claim exists" breaks for legitimate first-time writes; "reject if the row already has a value" captures the actual invariant — _this field, once it has a value, cannot change_.
+
+For nullable fields where `None → value` is allowed (Location's top-level countries have `parent=None`), the check is `current is not None and current != new`. A consequence: a top-level country with `parent=None` is also frozen at `None` — a country can't later become a state of another country. That's the desired semantic.
+
+## Why this lives on `ClaimControlledModel`
+
+Like `claim_fk_lookups`, this is a claim-write concern, not a linkability concern. It's documented separately from the broader linkability work because Location's path materialization is what forces the opt-out, and the linkability contract is what makes re-parenting expensive in the first place. The mechanism itself is generic — any future model that needs immutable-after-create fields gets it for free, with no `isinstance` checks anywhere in the claims code.

--- a/docs/plans/model_driven_metadata/ModelDrivenLinkability.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenLinkability.md
@@ -1,0 +1,103 @@
+# Model-Driven Linkability
+
+## Context
+
+### The Ultimate Goal
+
+This doc is one facet of the broader goal described in [ModelDrivenMetadata.md](ModelDrivenMetadata.md): make the system as model-agnostic as possible. We do that by encoding what varies between models on the models themselves and reading it generically from shared infrastructure.
+
+### Sub-goal: Generic Linkability
+
+For all the catalog models that are URL-addressable, we want that capability to be handled generically. Right now this is partly accomplished via `LinkableModel`: if the model has a slug that's unique within that entity type, it works. The problem is that `LinkableModel` does NOT currently work for `Location`, which is only unique within its parent Location.
+
+This doc outlines an architecture that will support a `LinkableModel` that works for ALL URL-addressable models.
+
+## The Contracts
+
+- **[`LinkableModel`](#linkablemodel)**: declares URL identity.
+- **[`ClaimControlledModel.immutable_after_create`](ImmutableAfterCreate.md)**: a new capability on `ClaimControlledModel` to block updates on a field. Location neeeds to block re-parenting, since re-parenting would invalidate the materialized `location_path` on the row and every descendant. This gives Location the ability to freeze its `parent` field. This is a pre-condition for this doc; the work lives in [ImmutableAfterCreate.md](ImmutableAfterCreate.md).
+
+## LinkableModel
+
+A linkable catalog model inherits `LinkableModel` and declares three ClassVars:
+
+- `entity_type: ClassVar[str]` — the singular entity-type token (e.g. `"theme"`, `"location"`).
+- `entity_type_plural: ClassVar[str]` — the URL-segment plural (e.g. `"themes"`, `"locations"`).
+- `public_id_field: ClassVar[str] = "slug"` — the name of the field that carries URL identity. Defaults to `"slug"` so existing models declare nothing. Location overrides to `"location_path"`.
+
+`LinkableModel` provides, for free:
+
+- `public_id` — `@property` returning `getattr(self, self.public_id_field)`.
+- `get_absolute_url()` — formats `link_url_pattern` with `{public_id}`.
+- `link_url_pattern` — defaults to `/{entity_type_plural}/{public_id}`; a model may override.
+
+This is a [base class / mixin](ModelDrivenMetadata.md#pattern-base-class--mixin) — discovery is `LinkableModel.__subclasses__()`, no hand-maintained registry of who participates.
+
+Wikilink-picker presentation (label, sort order, autocomplete config) is a separate, opt-in capability layered on top of `LinkableModel` — see [ModelDrivenWikilinkableMetadata.md](ModelDrivenWikilinkableMetadata.md). A `LinkableModel` subclass that doesn't mix in `WikilinkableModel` simply doesn't appear in the wikilink picker.
+
+## `public_id` is a presentation alias, not a stored column
+
+`public_id` is **not a new field** and **not claim-controlled**. It's a computed alias over whichever field already carries URL identity for that model:
+
+- Most models: `public_id` resolves to `self.slug`.
+- Location: `public_id` resolves to `self.location_path` — already materialized on the row because Location's slug is only unique within its parent, so the path-encoded form is what's globally unique.
+
+Consequences:
+
+- No new migrations, no denormalization, no slug↔public_id sync logic.
+- The underlying field keeps whatever claim-control status it already has. `slug` stays claim-controlled; `location_path` stays claims-exempt (it's derived from `parent` + `slug` at create time).
+- A model whose URL identity is multi-segment plugs in by materializing the path into a single `unique=True` field and pointing `public_id_field` at it. The linkability layer doesn't know or care about segment count.
+
+## URL convention
+
+Every LinkableModel-aware route uses Django's `:path` converter and the uniform param name `public_id`:
+
+- Page-level provenance: `/api/pages/edit-history/{entity_type}/{public_id:path}/`, `/api/pages/sources/{entity_type}/{public_id:path}/`
+- Per-entity write: `PATCH /api/{plural}/{public_id:path}/claims/`, `DELETE /api/{plural}/{public_id:path}/`, `POST /api/{plural}/{public_id:path}/restore/`
+- Parented create: `POST /api/{plural}/{parent_public_id:path}/children/`
+
+The `:path` converter matches single-segment ids without ceremony, so existing single-segment entities aren't affected. It also widens to multi-segment automatically — `/api/pages/edit-history/location/usa/il/chicago/` resolves the same way `/api/pages/edit-history/theme/sci-fi/` does.
+
+A widened route must 404 cleanly when a single-segment model is hit with extra segments (the lookup misses), not 500.
+
+## Startup enforcement
+
+`apps.core.checks` walks `LinkableModel.__subclasses__()` at boot and verifies that each model's `public_id_field` resolves to a real field with `unique=True`. Missing declarations, typos, or non-unique target fields fail `manage.py check` — not at first request. New linkable models inherit the check by virtue of subclassing.
+
+This is the [base class / mixin + startup check](ModelDrivenMetadata.md#pattern-base-class--mixin) pattern: the model class itself is the contract, and the contract is enforced before any request lands.
+
+## The generic write surface
+
+The shared write factories — `register_entity_create`, `register_entity_restore`, `register_entity_delete_with_preview` — must be model-agnostic against the linkability contract. Concretely:
+
+- **Lookups go through `public_id_field`**, not a hardcoded `slug` kwarg. Collision checks query `model.objects.filter(**{model.public_id_field: value})`; post-create fetches do the same.
+- **FK claim values respect `claim_fk_lookups`** (a `ClaimControlledModel` ClassVar — see [`claim_fk_lookups`](#claim_fk_lookups) below). When the factory writes a parent FK claim, it reads `getattr(parent, model.claim_fk_lookups[parent_field])`, not `parent.slug`.
+- **Extension hooks** let models with derived fields plug in without forking the factory:
+  - `extra_claim_specs_builder(data, parent) -> list[ClaimSpec]` — additional claims (Location: `location_type`, `divisions`).
+  - `extra_row_kwargs_builder(data, parent) -> dict` — non-claim row kwargs computed from input (Location: `location_path`).
+  - `body_schema` — alternate Pydantic schema for endpoints that accept extra fields.
+
+The validation criterion: a new linkable model reaches create / restore / delete-with-preview through these factories with **zero model-specific overrides**. If it can't, the factory has a gap and the factory gets fixed — not the model.
+
+Bespoke handlers are acceptable only where semantics genuinely differ from the linkability contract. Location's delete-preview subtree walk and DELETE cascade are hierarchy semantics, not linkability gaps.
+
+## The generic read/provenance surface
+
+`/api/pages/edit-history/{entity_type}/{public_id:path}/` and `/api/pages/sources/{entity_type}/{public_id:path}/` resolve the entity via `get_linkable_model(entity_type)` + `get_object_or_404(model, **{model.public_id_field: public_id})`. No per-model branches, no per-model endpoint files.
+
+The same shape applies to any future page-level endpoint that takes an entity reference: keyed on `(entity_type, public_id)`, dispatched through the registry, looked up via `public_id_field`.
+
+## `claim_fk_lookups`
+
+When a linkable model has an FK to another linkable model whose URL identifier isn't `slug`, the writing model declares the mapping:
+
+```python
+class Location(ClaimControlledModel, LinkableModel):
+    claim_fk_lookups: ClassVar[dict[str, str]] = {"parent": "location_path"}
+```
+
+This tells the claims layer: "when writing the `parent` FK claim, the value is the related row's `location_path`, not its `slug`." The default is `{}`, meaning every FK claim value is the related row's `slug` (the historical assumption).
+
+Strictly speaking `claim_fk_lookups` is a `ClaimControlledModel` ClassVar — it governs claim writes, not linkability. It's documented here because the linkability layer is the consumer that exposes the need: as soon as a related model's `public_id_field` isn't `slug`, the FK claim value must follow.
+
+The shared factories and the claims executor both read this map. Hardcoding `parent.slug` anywhere in the write path is a [field-on-model antipattern](ModelDrivenMetadata.md#antipattern-field-on-model) waiting to happen.

--- a/docs/plans/model_driven_metadata/ModelDrivenMetadata.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenMetadata.md
@@ -1,115 +1,95 @@
 # Model-Driven Metadata
 
+## Goal: make the system as model-agnostic as possible
+
+The project has accumulated model-specific knowledge in subsystems that have no business knowing which catalog model they're dealing with. It shows up across every layer: the claims and provenance core, the URL/href layer, the API surface, the media pipeline, validation, and substantial portions of the frontend.
+
+The signature is uniform: explicit `if isinstance(entity, X)` / `entity_type == "y"` branches; hardcoded field names that happen to be right for most models but not all (`slug`, `name`); parallel hand-maintained registries that enumerate the same model set Django already knows about; and pairs of files that are 95% identical with the model import at the top doing the only real work.
+
+Every new catalog model pays this tax. Adding one means touching the provenance core, adding a write router, wiring an edit-history loader, wiring a sources loader, adding a delete-flow submitter, editing several enumerating registries, building a frontend section registry, building an editor switch, and laying out a route tree — most of which is mechanical reproduction of the previous model's setup.
+
+The cost compounds, and the code that should be most stable — the provenance core, the link layer, the media pipeline — keeps growing branches where it shouldn't. We need those systems to be hardened and easy to reason about.
+
 ## Principle: the model is the source of truth
 
-**The Django model is the source of truth. Derive metadata from Django introspection whenever possible; declare only the minimum that Django can't express — and declare it as a class attribute on the model itself.**
+The goal is to encode as much of the knowledge that varies as possible **into the Django models themselves**. The models are the source of truth. Derive metadata from Django introspection whenever possible; declare only the minimum that Django can't express.
 
-Consequence: parallel hand-maintained registries for things Django already knows are an anti-pattern. When we encounter one, the fix is to replace it with introspection + (at most) a small class-level attr on the owning model.
+## Desired end state
 
-This principle is the umbrella. It applies to _any_ purpose — claim serialization, link/URL construction, resolver dispatch, media behavior, frontend edit affordances, validation — not just claims. What it does **not** permit is a single grab-bag class attr that accumulates everything; that would just relocate the drift surface onto the model.
+- **The provenance and claims core is fully model-agnostic.** The resolver, the FK lookup machinery, the materialization path, `execute_claims`, the page-level edit-history and sources endpoints, the validation pipeline — none of them contain per-model branches. They read declarations off the model and act accordingly.
+- **The URL/href and routing layer is fully model-agnostic.** Link construction reads the model's declared URL pattern; route lookups go through `entity_type` + `public_id`; nothing hardcodes `slug` as the URL key.
+- **Most of the frontend is model-agnostic.** Shared CRUD components, editor base components, edit-history page, sources page, delete flow, and create flow operate against generic API contracts keyed on `entity_type` and `public_id`. Per-model files exist only where there are **legitimate UI differences** — a hierarchy needs a parent picker, curated divisions need a divisions editor, a thumbnail needs an uploader. Everything else collapses into the shared layer.
+- **Adding a new catalog model is a declaration, not a code expansion.** A new model declares its ClassVars, registers in the entity-type registry, exposes a write router that calls shared factories, and provides a frontend section registry plus any genuinely model-specific editor components. The provenance plumbing, URL layer, edit-history / sources / delete endpoints, and the bulk of the frontend route tree all light up automatically.
 
-### Why
+## Smells
 
-Every registry that duplicates model metadata becomes a drift surface. Adding a new catalog model today touches many places because we maintain parallel views of what's already on the model. The current inventory, grouped analytically into four clusters, lives in [ModelDrivenMetadataViolations.md](ModelDrivenMetadataViolations.md).
+### Code-shape smells
 
-## One axis, one typed spec
+- a specific catalog model name (`Theme`, `Location`, `Manufacturer`, `CorporateEntity`, etc.) appears in shared infrastructure (`apps/provenance/`, `apps/core/`, shared frontend components) outside docstring or example contexts. `grep -rn "Theme\|Location" backend/apps/provenance/ backend/apps/core/` returning hits is the diagnostic. Common flavors:
+  - **Branching on type.** `isinstance(entity, X)` / `entity_type == "y"` to choose behavior. Hidden form: a `dict` keyed on model class or entity-type string used as a dispatch table.
+  - **Model-named functions in shared code.** `build_theme_url`, `resolve_location_path`, `serialize_manufacturer_for_history`. The shared function should take `model` or `entity_type` as a parameter; the model-named version is the smell.
+  - **Direct model imports.** `from apps.catalog.models import Theme` inside a shared module that's supposed to work for every catalog model.
+- a hand-maintained list, set, dict, or constant enumerates the same model set Django already knows about. Examples: signal lists that subscribe handlers to "every catalog model", cache-invalidation registries, frontend route-dir skip lists, `_SOURCE_FIELDS`-style per-model field maps. The fix is `__subclasses__()` walk + (at most) a marker base class.
+- per-model API files in `apps/catalog/api/` contain bespoke handler bodies that replicate logic already in another model's file. If two write-router files diff mostly in their model imports, the shared logic hasn't been extracted to a factory yet.
+- per-model frontend route trees contain page logic instead of thin wrappers around shared components — a `+page.svelte` that does anything more than pass `path` / `entity_type` to a shared component is suspicious.
+- a hardcoded field name (e.g. `slug`) in shared code where the right answer is a declared ClassVar (e.g. `public_id_field`). The signature is "this works for every model except the one that breaks the convention."
 
-The rule: each orthogonal concern gets its own **typed, narrowly-scoped** class attr. A concern earns a spec when it is consumed by a well-defined subsystem (the claim resolver, the link builder, the media pipeline, etc.) and has a stable shape.
+### Test-shape smells
 
-### Already in the codebase
+- the parameterized test suite that walks the entity-type registry has a per-model skip list (e.g. `UNMAPPED_ROUTE_DIRS` in `catalog-meta.test.ts`). Every entry in such a list is an admission of an unfixed gap.
+- per-model test files duplicate the same provenance/URL/CRUD assertions across models with only the model import changed. The generic suite should cover those; per-model tests should only cover genuine UI/semantic differences.
 
-- `claim_fk_lookups` — per-model FK lookup override ("use `slug`, not `pk`").
-- `MEDIA_CATEGORIES` — media-supported models only.
-- `entity_type` — `LinkableModel` public identifier.
+### Process and tooling smells
 
-### Evaluated and deferred
+- adding a new catalog model produces a PR that diffs `apps/provenance/`, `apps/core/`, or shared frontend components. The diff to those layers should be zero; if it isn't, a generic seam is missing.
+- a bug fix has to be applied N times — once per model — instead of once in shared infrastructure. "I fixed this for Theme, now let me apply the same fix to Location and Manufacturer" is the diagnostic.
+- a missing or malformed model declaration only surfaces at first request, not at startup. `manage.py check` should catch it; if it doesn't, the system check for that axis is missing.
+- [ModelDrivenMetadataViolations.md](ModelDrivenMetadataViolations.md) is non-empty. Its size is a direct measurement of distance from the goal.
 
-#### Catalog Relationships
+## Design patterns
 
-`CatalogRelationshipSpec` — move catalog through-model relationship metadata onto the model classes. Deferred pending a second independent consumer.
+The toolkit for moving knowledge onto models. The patterns are in order of increasing commitment. **Pick the smallest one that fits**; don't reach for a typed spec when a `_meta` walk will do.
 
-The acute wins the spec was built to capture — silent-data-loss fixes on the provenance write path, consolidation of `_entity_ref_targets` + `_literal_schemas` + `_relationship_target_registry` into one unified registry, and the identity-vs-`UniqueConstraint` cross-check at startup — are being landed by [ProvenanceValidationTightening.md](../types/ProvenanceValidationTightening.md) as a hand-maintained unified registry. That registry's shape is deliberately spec-compatible: if/when this axis is revived, the migration is mechanical (replace the 17-line registration function body with a walk over a `ClaimThroughModel` marker base that builds the same schema objects from model-declared specs).
+### Pattern: `_meta` walk
 
-By the four-test bar in "Avoiding axis drift" below, CRS doesn't clear today. Current consumers (`classify_claim`, `validate_single_relationship_claim`, `validate_relationship_claims_batch`, `build_relationship_claim`, plus the materialization resolvers) all live on the same backend pipeline — same subsystem, same release cadence. Revisit when frontend edit metadata is actually being built, not hypothetical: different subsystem, different cadence, clears ≥2 consumers unambiguously.
-
-Design as of the deferral: [ModelDrivenCatalogRelationshipMetadata.md](ModelDrivenCatalogRelationshipMetadata.md) (status note on that doc explains what landed in PVT instead).
-
-### Evaluated and deferred
-
-#### Citation Sources
-
-A `CitationSourceSpec` was considered for unifying citation-source-family metadata (IPDB, OPDB, Fandom). Deferred — revisit when a 3rd structured-parser source family is imminent. Two reasons, detailed in [ModelDrivenCitationSourceMetadata.md](ModelDrivenCitationSourceMetadata.md):
-
-- **Not the same shape as `CatalogRelationshipSpec`.** Citation source families aren't models; they're rows in `CitationSource` with per-family behavior (a URL regex and a callable builder). The right pattern is a class-per-family behavior registry with a sidecar data table, not model-owned metadata. It reuses the Shape 3 machinery but isn't an instance of this doc's umbrella principle.
-- **Scale doesn't warrant it yet.** Only 2 structured-parser source families exist today (IPDB, OPDB), and the backend extractor registry already absorbed part of the drift surface. A field audit against the ≥2-consumers rule shrinks the spec to `identifier_key` + `display_name` + URL-recogniser methods — real but narrow ROI.
-
-### Possible future axes
-
-- `edit_spec` — if/when frontend edit metadata outgrows derivation from `CatalogRelationshipSpec`.
-- `link_spec` — if URL construction needs more than `entity_type` + slug.
-- `media_attachment_spec` — would live in `apps.media`, not catalog. `EntityMedia`'s polymorphic `content_type` + `object_id` attachment doesn't fit `CatalogRelationshipSpec` (different app, different shape); give it its own axis in the media app if and when it earns one.
-
-### Avoiding axis drift
-
-Two failure modes to guard against: within-spec drift (a single spec grows grab-bag fields) and across-spec drift (a model accumulates so many specs that the _set of declarations_ is itself the drift surface).
-
-**Within-spec drift.** If you want to add a field to an existing spec, ask whether the consumer is the same subsystem the spec was built for. If not, it's a new axis and deserves its own attr. If a field could plausibly live in two specs, put it in the narrower one and let the broader consumer read through.
-
-**Across-spec drift — when a new axis is justified.** "One axis, one spec" prevents grab-bag specs but says nothing about axis count. A model carrying six orthogonal specs still accumulates six things-to-remember-when-adding-a-model; the failure mode just moved. A new Shape 3 axis must pass all four tests:
-
-1. **≥2 genuinely independent consumers.** "Validator + dispatcher in the same resolution pipeline" does not count — same subsystem, same read path, same cadence of change. "Backend claim resolver + frontend edit metadata" does — different subsystems, different release cycles.
-2. **Orthogonal to existing axes.** No field overlap; different question answered. If a proposed field could plausibly live on an existing axis, it belongs there — or the slicing between axes is wrong and needs rethinking before adding another.
-3. **Stable shape.** The field set converges as consumers grow, not diverges. If each new consumer adds a field, it's a grab bag in slow motion.
-4. **Alternative explicitly considered.** Before a Shape 3 spec, confirm Shape 1 (pure `_meta` walk) and Shape 2 (single-purpose class attr) genuinely can't do it. Shape 2 handles more than you'd guess.
-
-Meta-norm: no model carries a spec it doesn't apply to. Absence is default; declaration is opt-in per axis.
-
-**Profile objects.** A related temptation: when frontend editing or page behavior gets complicated, it can look attractive to define a per-entity **profile object** that bundles API names, edit affordances, relationship sections, etc. into one UI-facing structure. That is fine _only_ if the profile is a derived view composed from the underlying specs + `_meta`, and stays a narrow UI/API concern. It must not become a second hand-maintained catalog registry. Defer introducing any such layer until the duplication it would eliminate is real, not speculative.
-
-## How derivation works
-
-### Derivation shapes
-
-There are three derivation shapes, in increasing structure. Pick the smallest one that fits; don't reach for a typed spec when a `_meta` walk will do.
-
-| Need                                                 | Shape             | Canonical example                                            |
-| ---------------------------------------------------- | ----------------- | ------------------------------------------------------------ |
-| Filter or transform of fields Django already exposes | Shape 1           | [`get_claim_fields`](../../backend/apps/core/models.py#L281) |
-| One datum per model, one consumer                    | Shape 2           | `MEDIA_CATEGORIES`                                           |
-| Structured metadata, multiple consumers              | Shape 3           | `CatalogRelationshipSpec`                                    |
-| Metadata consumed outside Python                     | Shape 3 + codegen | `catalog-meta.ts` generator                                  |
-
-### Shape 1 — Pure `_meta` walks (optional class-attr inputs)
-
-When the answer is a filter or transform of information Django already carries. May also read small Shape 2 class attrs as per-model inputs (`claims_exempt` is the canonical case). Common idioms:
+**When to use it.** The answer is a filter or transform of information Django already carries. Common idioms:
 
 - **Field shape** (name, type, nullability, unique, default) → `_meta.get_field(name)`.
 - **FK target + lookup** → `field.related_model` + convention ("pk" unless overridden).
 - **M2M through-models** → `Model.m2m_attr.through` or explicit `through="..."` declarations.
 - **Reverse relations** → `_meta.get_fields()` / attribute access.
 
-Canonical example in the codebase: [`get_claim_fields(model)`](../../backend/apps/core/models.py#L281) — walks `_meta.get_fields()`, filters by field type and per-model `claims_exempt`, returns a dict. No registry, no caching (cheap enough to recompute), no base class. Hand-maintained lists like the cache-invalidation signal list and `_SOURCE_FIELDS` are the natural targets for this shape.
+Canonical example in the codebase: [`get_claim_fields(model)`](../../backend/apps/core/models.py) — walks `_meta.get_fields()`, filters by field type and per-model `claims_exempt`, returns a dict. No registry, no caching (cheap enough to recompute), no base class. Hand-maintained lists like the cache-invalidation signal list and `_SOURCE_FIELDS` are the natural targets for this pattern.
 
-### Shape 2 — Single-purpose class attr, ad-hoc read
+A `_meta` walk can also read ClassVars inherited from a [base class / mixin](#pattern-base-class--mixin) as per-model inputs — `claims_exempt` declared on `ClaimControlledModel` is the canonical case, used as a filter input by `get_claim_fields` above.
 
-When one extra datum per model is enough and a single consumer reads it directly. Template:
+### Pattern: base class / mixin
 
-```python
-class Location(CatalogModel):
-    claim_fk_lookups: ClassVar[dict[str, str]] = {"parent": "location_path"}
-```
+**When to use it.** The default home for any ClassVar that customizes per-model behavior. The base declares the ClassVar with a default and (optionally) shared methods; subclasses inherit and override the ClassVar where needed. Discovery is `__subclasses__()` of the base — no hand-maintained list of who participates.
 
-Consumers do `getattr(model, "claim_fk_lookups", {})`. Minimal ceremony, good for narrow needs (`MEDIA_CATEGORIES`, `claim_fk_lookups`, `claims_exempt`). **Not appropriate when multiple subsystems consume the same metadata** — that's the Shape 3 case.
+This pattern covers the full range, from "marker base with one ClassVar and zero methods" to "behavior-providing mixin." The minimum is just: a typed default declared on a base, so the model class itself is the contract, not a `getattr` call in the consumer. (The opposite shape — bare ClassVar on a subclass, read via `getattr` — is the [field-on-model antipattern](#antipattern-field-on-model).)
+
+Examples in the codebase:
+
+- **`LinkableModel`**: provides `get_absolute_url()`, the `public_id` property, and a default `link_url_pattern` derivation; subclasses declare `entity_type`, `entity_type_plural`, `public_id_field`.
+- **`ClaimControlledModel`**: provides claim-related machinery shared across catalog models; the natural home for `claims_exempt`, `claim_fk_lookups`, and `immutable_after_create` ClassVars (with defaults of `frozenset()` / `{}` / `frozenset()` respectively), letting every claim-controlled model be reasoned about generically.
+- **`AliasBase`**: provides alias-table conventions; subclasses declare the FK to their owning entity.
+- **`MediaSupported`**: marker base whose only job is to host `MEDIA_CATEGORIES` declarations and let the media pipeline enumerate participants.
+
+Use [base class / mixin](#pattern-base-class--mixin) whenever the [`_meta` walk](#pattern-_meta-walk) isn't enough. Use [typed spec](#pattern-typed-spec) instead when the metadata is structured data consumed by multiple independent subsystems and you need startup-time validation. The two compose: `LinkableModel` uses [base class / mixin](#pattern-base-class--mixin), and [`core/entity_types.py`](../../backend/apps/core/entity_types.py) is a [typed spec](#pattern-typed-spec) registry built by walking `LinkableModel.__subclasses__()`.
 
 Rules:
 
-- Always use `ClassVar[...]` typing on the attr.
-- Default via `getattr(..., default)` so models don't have to opt in.
-- No registry, no discovery helper — consumers read per-model on demand.
+- Keep the base narrow: one capability per base. `LinkableModel` doesn't try to also be the claim-control base; that's a separate mixin.
+- Avoid grab-bag bases that bundle several unrelated capabilities. If a model would inherit only to get one of three orthogonal capabilities, split the base.
 
-### Shape 3 — Typed spec + registry-via-introspection
+The cross-cutting rules in [Rules of thumb](#rules-of-thumb) — _Base annotates, subclasses assign_; _Hoist to the smallest base that captures the audience_; _Enforce at startup, not at first request_ — also apply to this pattern.
 
-When a structured piece of metadata is consumed by multiple subsystems, or when its absence should fail at startup rather than at first request. This is the pattern proposed for `CatalogRelationshipSpec`.
+### Pattern: typed spec
+
+**When to use it.** A concern earns a typed spec when it's consumed by multiple subsystems, when its absence should fail at startup rather than at first request, or when it has a stable shape worth declaring once and validating centrally. Each orthogonal concern gets its own typed, narrowly-scoped class attr.
+
+**Shape.** Typed `ClassVar[Spec]` on the model + introspection registry over an abstract base. Proposed for `CatalogRelationshipSpec`.
 
 #### Why one typed spec object and not N separate class attrs
 
@@ -135,20 +115,37 @@ Rank-ordering the existing "correct examples" surfaced inconsistencies; this is 
 #### Existing examples, ranked
 
 - **Gold — [`core/entity_types.py`](../../backend/apps/core/entity_types.py)** — class attr + subclass walk + cache + `check_apps_ready()` + duplicate validation + typed return + tight API. Closest template to copy.
-- **Silver — [`_alias_registry.py`](../../backend/apps/catalog/_alias_registry.py)** — same shape, cleaner caching (`lru_cache`), `NamedTuple` return. But derives identity from `_meta.verbose_name` (fragile) and lacks the explicit `check_apps_ready()` guard. Copy the `lru_cache` + `NamedTuple` ideas; don't copy the verbose_name convention. Follow-up for when the registry is next touched: replace the verbose_name lookup with an explicit `alias_target: ClassVar[type[Model]]` class attr on each alias model, and add the missing `check_apps_ready()` guard. No full `AliasSpec` axis is warranted — aliases don't have enough metadata to bundle, and the single-consumer Shape 3 machinery already fits; it's just the identity convention that needs fixing. Treat as independent from the `CatalogRelationshipSpec` work.
+- **Silver — [`_alias_registry.py`](../../backend/apps/catalog/_alias_registry.py)** — same shape, cleaner caching (`lru_cache`), `NamedTuple` return. Identity is fragile (derived from `_meta.verbose_name`) and the `check_apps_ready()` guard is missing — copy the caching and return-type ideas, not the identity convention. Planned fix lives in [ModelDrivenMetadataCleanup.md](ModelDrivenMetadataCleanup.md).
 - **Don't copy:** `MEDIA_CATEGORIES` + `MediaSupported` (no discovery helper, no validator); `claim_fk_lookups` (untyped ad-hoc `getattr`); `export_catalog_meta` (different axis — codegen/distribution).
 
 #### Worked example
 
-One Shape 3 spec is proposed, in its own sibling doc holding the concrete dataclass, per-model declarations, and derivation function:
+One typed spec is designed but deferred:
 
 - `CatalogRelationshipSpec` → [ModelDrivenCatalogRelationshipMetadata.md](ModelDrivenCatalogRelationshipMetadata.md) (claim-relationship metadata).
 
-A second candidate (`CitationSourceSpec`) was evaluated and deferred — see "Evaluated and deferred" above.
+A second candidate, `CitationSourceSpec`, was also evaluated and deferred — see [ModelDrivenCitationSourceMetadata.md](ModelDrivenCitationSourceMetadata.md).
 
-## Distribution to non-Python consumers
+#### When to add a new typed spec axis
 
-Shapes 1/2/3 cover how Django exposes model metadata to Python runtime consumers. A separate concern: **how does that metadata reach consumers that can't import Python** — the SvelteKit frontend, the OpenAPI schema, external tools, any sibling service. Codegen is the answer; any of the three shapes can feed it.
+Two failure modes to guard against: within-spec drift (a single spec grows grab-bag fields) and across-spec drift (a model accumulates so many specs that the _set of declarations_ is itself the drift surface).
+
+**Within-spec drift.** If you want to add a field to an existing spec, ask whether the consumer is the same subsystem the spec was built for. If not, it's a new axis and deserves its own attr. If a field could plausibly live in two specs, put it in the narrower one and let the broader consumer read through.
+
+**Across-spec drift — when a new axis is justified.** "One axis, one spec" prevents grab-bag specs but says nothing about axis count. A model carrying six orthogonal specs still accumulates six things-to-remember-when-adding-a-model; the failure mode just moved. A new typed spec axis must pass all four tests:
+
+1. **≥2 genuinely independent consumers.** "Validator + dispatcher in the same resolution pipeline" does not count — same subsystem, same read path, same cadence of change. "Backend claim resolver + frontend edit metadata" does — different subsystems, different release cycles.
+2. **Orthogonal to existing axes.** No field overlap; different question answered. If a proposed field could plausibly live on an existing axis, it belongs there — or the slicing between axes is wrong and needs rethinking before adding another.
+3. **Stable shape.** The field set converges as consumers grow, not diverges. If each new consumer adds a field, it's a grab bag in slow motion.
+4. **Alternative explicitly considered.** Confirm [`_meta` walk](#pattern-_meta-walk) and [base class / mixin](#pattern-base-class--mixin) genuinely can't do it. [Base class / mixin](#pattern-base-class--mixin) handles more than you'd guess.
+
+Meta-norm: no model carries a spec it doesn't apply to. Absence is default; declaration is opt-in per axis.
+
+**Profile objects.** A related temptation: when frontend editing or page behavior gets complicated, it can look attractive to define a per-entity **profile object** that bundles API names, edit affordances, relationship sections, etc. into one UI-facing structure. That is fine _only_ if the profile is a derived view composed from the underlying specs + `_meta`, and stays a narrow UI/API concern. It must not become a second hand-maintained catalog registry. Defer introducing any such layer until the duplication it would eliminate is real, not speculative.
+
+### Pattern: codegen
+
+**When to use it.** Model metadata needs to reach consumers that can't import Python — the SvelteKit frontend, the OpenAPI schema, external tools, any sibling service. The patterns above cover Python runtime consumers; codegen extends any of them to non-Python consumers.
 
 The canonical example already in the codebase: `export_catalog_meta` generates `frontend/src/lib/api/catalog-meta.ts` from Django models. The rules generalize to any upstream shape → any downstream artifact:
 
@@ -157,6 +154,43 @@ The canonical example already in the codebase: `export_catalog_meta` generates `
 - Each generator carries a parity test that fails when the upstream shape drifts from the emitted artifact.
 
 Reuse this pattern when a new spec has to reach another language or runtime. Do not build a parallel hand-maintained schema on the consumer side.
+
+## Antipatterns
+
+### Antipattern: field-on-model
+
+Declaring a ClassVar on a single model subclass and reading it from a generic consumer via `getattr(model, "thing", default)`.
+
+Why it's an antipattern: the contract lives in the consumer's `getattr` — which picks the attribute name, default, and type — not on any class. The system can't:
+
+- enumerate which models opted in (no base to walk via `__subclasses__()`),
+- type-check the declarations (no shared type to conform to),
+- catch typos at startup (a misspelled or absent attribute silently returns the default),
+- evolve the contract without visiting every consumer (rename = grep risk).
+
+The fix is the same in every case: hoist the ClassVar onto the relevant base or mixin with a typed default, so the model class itself is the contract. See [base class / mixin](#pattern-base-class--mixin).
+
+Concrete examples in the current codebase:
+
+- **`claim_fk_lookups`**: declared on `Location` only ([location.py](../../backend/apps/catalog/models/location.py)); read via `getattr(model_class, "claim_fk_lookups", {})` in [resolve/\_helpers.py](../../backend/apps/catalog/resolve/_helpers.py) (two call sites) and [validate_catalog.py](../../backend/apps/catalog/management/commands/validate_catalog.py). Three consumers, none typed; a typo in any of them silently returns `{}`. Belongs on `ClaimControlledModel` as `ClassVar[dict[str, str]] = {}`.
+- **`claims_exempt`**: declared per-model where the model has fields to exempt (e.g. [location.py](../../backend/apps/catalog/models/location.py)); read via `getattr(model_class, "claims_exempt", frozenset())` in [core/models.py](../../backend/apps/core/models.py). Belongs on `ClaimControlledModel` as `ClassVar[frozenset[str]] = frozenset()`.
+- **Wikilink-picker `link_*` attrs** (`link_sort_order`, `link_label`, `link_description`, `link_autocomplete_*`): declared bare on the four ordered linkable types (Title, MachineModel, Manufacturer, Person); read via `getattr(model, "link_*", default)` six times in [catalog/apps.py](../../backend/apps/catalog/apps.py)'s wikilink registration loop. Belong on a new `WikilinkableModel` mixin — see [ModelDrivenWikilinkableMetadata.md](ModelDrivenWikilinkableMetadata.md).
+
+Counter-example showing the right shape: `alias_claim_field` is declared on `AliasBase` in [core/models.py](../../backend/apps/core/models.py) as `ClassVar[str]`, with `__init_subclass__` enforcement in the same file. Consumers in [\_alias_registry.py](../../backend/apps/catalog/_alias_registry.py) read `alias_cls.alias_claim_field` directly — no `getattr` fallback needed because the contract is enforced at the base.
+
+## Rules of thumb
+
+Cross-cutting rules that apply to any work in this space — picking ClassVar shapes, designing registries, choosing where to enforce, writing parity tests. Some are restated in pattern-specific `Rules:` lists above; this section is where the cross-pattern rules live.
+
+- **Semantics over RHS shape.** Pick the collection type that matches the meaning of the attr, not what the literal happens to look like. `soft_delete_*` started as `tuple[str, ...]` because the RHS was a tuple literal; the right type was `frozenset[str]` because order and duplicates are meaningless. Update the literal at the same time as the annotation.
+- **Don't lie about the shape in the annotation.** Consumer-side `getattr(..., default)` defaults must match the annotated type. If the annotation says `frozenset[str]`, the default is `frozenset()`, not `()`. Don't smuggle a mismatched default past the type checker.
+- **Base annotates, subclasses assign.** Annotate the `ClassVar` on the base; concrete subclasses assign values without re-annotating. Canonical examples: `MEDIA_CATEGORIES` on `MediaSupported`, `entity_type` on `LinkableModel`, `alias_claim_field` on `AliasBase`.
+- **Hoist to the smallest base that captures the audience.** A `ClassVar` meaningful for every claim-controlled model belongs on `ClaimControlledModel`, not above or below. Each per-feature doc's "Why this lives on X" section repeats the audience argument.
+- **Blanket inclusion beats opt-in markers** for correctness-critical paths. An opt-in flag like `bust_all_cache_on_save: ClassVar[bool]` would recreate the drift surface a `__subclasses__()` walk is meant to eliminate. Default-on is fail-safe-by-construction.
+- **Parity tests pin derived sets.** When a registry, signal list, or set is derived from a `_meta` walk or `__subclasses__()` walk, the parity test asserts the _expected output_, not `derived == derived`. New models fire the test and get reviewed intentionally.
+- **Enforce at startup, not at first request.** `__init_subclass__` validators or `apps.checks` system checks catch missing or malformed declarations at boot. The check lives where the contract lives.
+- **Document coverage gaps in code, not just PR discussion.** A comment in `signals.py` explains why `MachineModel*` through-rows aren't in the cache-invalidation walk (the claims resolver invalidates directly via `transaction.on_commit`). PR discussion is searchable; code comments are findable.
+- **`Literal[...]` over abstract bases recreates drift.** Considered for `entity_type` and rejected: a base `Literal` union spanning all subclasses must stay in sync with the subclass declarations — exactly the drift surface the model-driven approach eliminates. `__init_subclass__` validation + the registry builder catch typos at import time, which is effectively as early as type-check time for this codebase.
 
 ## Alternatives considered and rejected
 

--- a/docs/plans/model_driven_metadata/ModelDrivenMetadataCleanup.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenMetadataCleanup.md
@@ -1,115 +1,51 @@
 # Model-Driven Metadata Cleanup
 
-Sibling doc to [ModelDrivenMetadata.md](ModelDrivenMetadata.md). The umbrella doc establishes the principle and the canonical Shape 1/2/3 templates. This doc covers the small-but-real gap between those templates and the existing codebase — typing inconsistencies, one fragile convention, and two hand-maintained lists that should be `_meta` walks.
+Companion doc to the umbrella [ModelDrivenMetadata.md](ModelDrivenMetadata.md). The umbrella establishes the [principles](ModelDrivenMetadata.md#principle-the-model-is-the-source-of-truth), [design patterns](ModelDrivenMetadata.md#design-patterns), [antipatterns](ModelDrivenMetadata.md#antipatterns), [smell catalog](ModelDrivenMetadata.md#smells), and [rules of thumb](ModelDrivenMetadata.md#rules-of-thumb).
 
-## Scope
+This doc is the roadmap for bringing the codebase into line with [ModelDrivenMetadata.md](ModelDrivenMetadata.md).
 
-Bring existing model-driven metadata patterns to the canonical conventions in [ModelDrivenMetadata.md](ModelDrivenMetadata.md) before new spec work (`CatalogRelationshipSpec`, `CitationSourceSpec`) starts introducing more. Two motivations:
+## Roadmap
 
-1. **Consistency as a copy-target.** Right now, a new contributor can copy `claim_fk_lookups` (untyped ad-hoc `getattr`) or `MEDIA_CATEGORIES` (`ClassVar`-typed, mixin-discovered) and propagate whichever inconsistency they happened to encounter. After this cleanup, any existing class attr is a valid template.
-2. **Warm-up for the spec work.** The `AliasBase` upgrade and the Cluster 3 `_meta`-walk replacements exercise the same machinery (explicit identity attr, `ready()`-time discovery, parity tests) that `CatalogRelationshipSpec` needs — on a much smaller blast radius.
+Each item has its own per-feature doc with the full design, examples, and step-by-step plan; this table sequences them.
 
-## Shape 2 typing sweep — _landed_
+| #   | Item                                    | Type              | Doc                                                                          | Blast radius       | Depends on |
+| --- | --------------------------------------- | ----------------- | ---------------------------------------------------------------------------- | ------------------ | ---------- |
+| 1   | `claims_exempt` hoist                   | Hoist             | [ModelDrivenClaimsExemptMetadata.md](ModelDrivenClaimsExemptMetadata.md)     | Small              | —          |
+| 2   | `claim_fk_lookups` hoist                | Hoist             | [ModelDrivenClaimFkLookupsMetadata.md](ModelDrivenClaimFkLookupsMetadata.md) | Small              | —          |
+| 3   | Soft-delete attrs hoist                 | Hoist             | [ModelDrivenSoftDeleteMetadata.md](ModelDrivenSoftDeleteMetadata.md)         | Small              | —          |
+| 4   | `immutable_after_create` (new)          | New behavior      | [ModelDrivenImmutableAfterCreate.md](ModelDrivenImmutableAfterCreate.md)     | Small-medium       | —          |
+| 5   | Linkability (LinkableModel + factories) | Steel thread      | [ModelDrivenLinkability.md](ModelDrivenLinkability.md)                       | Large (in flight)  | #4         |
+| 6   | `WikilinkableModel` mixin               | New mixin + hoist | [ModelDrivenWikilinkableMetadata.md](ModelDrivenWikilinkableMetadata.md)     | Medium             | (after #5) |
+| 7   | `NamedModel` base                       | New base          | [ModelDrivenNamedMetadata.md](ModelDrivenNamedMetadata.md)                   | Large (~14 models) | —          |
+| 8   | Resolver signature standardization      | Cleanup           | (inline below)                                                               | Small              | —          |
 
-Existing Shape 2 class attrs that work correctly but lack `ClassVar[...]` typing. Each is a one-line edit.
+**Suggested order:** **1 → 2 → 3** (the three small hoists; same recipe — declare ClassVar on base, drop `getattr` in consumer; confidence-building), then **4** (pre-condition for #5), then **5** (the active steel thread), then **6** (uses Linkability outputs), then **7** (broadest reach, lowest urgency, save for after the patterns and tooling are well-exercised). Item **8** is independent and can land any time.
 
-| Attr                            | Pre-sweep                     | Final                      |
-| ------------------------------- | ----------------------------- | -------------------------- |
-| `claim_fk_lookups`              | untyped, bare `getattr`       | `ClassVar[dict[str, str]]` |
-| `claims_exempt`                 | untyped                       | `ClassVar[frozenset[str]]` |
-| `soft_delete_cascade_relations` | untyped → `tuple[str, ...]`   | `ClassVar[frozenset[str]]` |
-| `soft_delete_usage_blockers`    | untyped → `tuple[str, ...]`   | `ClassVar[frozenset[str]]` |
-| `MEDIA_CATEGORIES`              | already `ClassVar[list[str]]` | unchanged                  |
+### Resolver signature standardization
 
-The `soft_delete_*` attrs went through two commits: a first pass that mirrored the tuple literal on the RHS (`ClassVar[tuple[str, ...]]`), then a second pass that corrected the semantics to `ClassVar[frozenset[str]]` with a `frozenset({...})` RHS. History is preserved in the arrow above as a worked example of the rule below.
+Mechanical prep work without its own per-feature doc:
 
-Rule of thumb for these annotations: pick the collection type that matches the **semantics** of the attr, not just what the RHS literal happens to look like. Order and duplicates are meaningless for `soft_delete_*` (they're unordered sets of relation names — same shape as `claims_exempt`), so `frozenset[str]` is the right annotation even if the RHS was originally written as a tuple literal. Update the RHS to `frozenset({...})` at the same time, and update any consumer `getattr(..., default)` defaults to match the annotated type (`frozenset()` here, not `()`) — don't lie about the shape in the annotation or smuggle a mismatched default past the type checker.
-
-Consumer-side: the bare `getattr(model, "attr", default)` reads stay — they're the canonical Shape 2 access pattern per the umbrella. Only the declarations get typed.
-
-### Declaration inventory (verified)
-
-Confirmed by grep across `backend/apps/` before the sweep landed:
-
-- `claim_fk_lookups` — `catalog/models/location.py` (1 site; `Location` only).
-- `claims_exempt` — `catalog/models/location.py` (1 site; `Location` only).
-- `soft_delete_cascade_relations` — `catalog/models/title.py` (1 site; `Title` only).
-- `soft_delete_usage_blockers` — 5 sites across `catalog/models/`: `theme.py` (`Theme`), `taxonomy.py` (`RewardType`, `Tag`, `CreditRole`), `gameplay_feature.py` (`GameplayFeature`).
-- `MEDIA_CATEGORIES` — base annotation on `MediaSupported` in `core/models.py`; concrete subclasses (`person`, `manufacturer`, `machine_model`, `gameplay_feature`) just assign values without re-annotating. This is the canonical "base annotates, subclasses assign" pattern and is the template `entity_type` should follow.
-
-Every consumer uses `getattr(model_class, "attr", default)` with a default matching the annotated type — no shadowing, no drift risk. No base class declares any of the four opt-in attrs, so subclass declarations are the only source of truth.
-
-### `entity_type` typing — _landed_
-
-`entity_type` and `entity_type_plural` on `LinkableModel` are now `ClassVar[str]` on the base (previously bare instance-level `str` annotations). Aligns with the other Shape 2 attrs on this mixin (`MEDIA_CATEGORIES`, `link_url_pattern`, `alias_claim_field`) so the "base annotates, subclasses assign" template reads the same everywhere. One-liner on the base; no subclass or consumer edits.
-
-**Why not `ClassVar[Literal[...]]`?** Considered and rejected. A base `Literal` union listing all 19 current values would create a parallel canonical list that must stay in sync with subclass declarations — the exact drift surface the model-driven approach is meant to eliminate. Adding a new entity would touch three places (new model + two `Literal` unions) instead of one. The `soft_delete_*` "semantics over RHS shape" rule doesn't transfer here: that rule was about collection type for a single local attr (`frozenset` vs `tuple`); for `entity_type`, the "closed set" spans all subclasses and is already derived by `LinkableModel.__subclasses__()` walks. Typos and duplicates are caught at import time by `__init_subclass__` validation and the registry builder — effectively as early as type-check time for this codebase. No boundary consumer takes `entity_type` as untrusted input, so the stronger type buys nothing the runtime validation doesn't already provide.
-
-### Optional: `MEDIA_CATEGORIES` readiness validator
-
-Not strictly required, but a `ready()`-time validator asserting every concrete `MediaSupported` subclass sets `MEDIA_CATEGORIES` to a non-empty list would catch "forgot to declare" errors at startup instead of first request. Defer if it adds friction; land if it's cheap.
-
-## Shape 3 upgrades
-
-### `AliasBase` — explicit identity attr — _landed_
-
-Previously `_alias_registry.py` derived the claim namespace from `_meta.verbose_name` (`f"{verbose_name.replace(' ', '_')}_alias"`) — the "silver" fragility flagged in the Shape 3 ranking, since changing a model's `verbose_name` would silently shift the claim namespace. The upgrade:
-
-1. `AliasBase` declares `alias_claim_field: ClassVar[str]` (base annotation, no default) and each of the seven concrete subclasses assigns the explicit value (`"theme_alias"`, `"person_alias"`, etc.). Same "base annotates, subclasses assign" pattern as `MEDIA_CATEGORIES`.
-2. `AliasBase.__init_subclass__` enforces the declaration at class-creation time — a forgetful or empty-string subclass raises `TypeError` at import, before any discovery walk runs. `discover_alias_types()` can therefore do direct `cls.alias_claim_field` access and trust the annotation.
-3. `apps.check_models_ready()` runs at the top of `discover_alias_types()` to guard the `lru_cache` against a too-early call (the function walks `__subclasses__()` and reads `_meta`).
-
-Parity test in `test_resolve_dispatch.py` asserts the full `{(parent_model, claim_field)}` set of seven tuples — catches both typos in the claim_field string and right-value-wrong-class misdeclarations. New `AliasBase` subclasses fail the test and force intentional review.
-
-**Grep-audit result (safe).** Beyond `_alias_registry.py`, the derived strings appear as literals in `resolve/_relationships.py` (per-parent `resolve_*_aliases` functions), `management/commands/ingest_pinbase.py`, `api/themes.py`, and tests. Every existing literal matches the derived value 1:1 — the upgrade only makes the derivation explicit; no string values change, and nothing reaches the frontend.
-
-### `core/entity_types.py` — cosmetic alignment
-
-Currently uses a module-level `_ENTITY_TYPE_MAP: dict | None = None` with a `global` statement in `get_linkable_model()`. Already functionally gold. Swap to `@functools.lru_cache(maxsize=1)` on a build function to match the canonical template and `_alias_registry.py`. Purely cosmetic; skip if it reads as churn.
-
-## Cluster 3 — `_meta`-walk replacements
-
-Two hand-maintained lists that are one `_meta` / app-registry walk away from being derived. Both are Shape 1 (no spec, no class attr).
-
-### Cache-invalidation signal list — _landed_
-
-Previously `catalog/signals.py` hand-listed eight models whose saves should bust the `/all/` cache. The upgrade replaced the list with an app-registry walk at `ready()` time: concrete `CatalogModel` subclasses plus three explicit extras (`Location`, `CorporateEntityLocation`, `Credit`). A parity test in `test_api_cache.py` pins the derived 22-model set so new `CatalogModel` additions fire the test and get reviewed intentionally.
-
-Lessons worth retaining for future `_meta`-walk work:
-
-- **Blanket inclusion beats opt-in markers** for correctness-critical paths. An alternative design — add `bust_all_cache_on_save: ClassVar[bool]` and let models opt in — would have recreated the exact drift surface the walk was eliminating. Fail-safe-by-construction is the right default: new entity → automatic freshness, at the cost of some over-invalidation on models that happen not to be embedded in `/all/` payloads (a cache-hit-rate cost, not a correctness cost).
-- **Widening from 8 → 22 was a bug fix, not a behavior regression.** The old list was missing taxonomy models (`Theme`, `Tag`, `GameplayFeature`, `RewardType`, `Series`, `Franchise`, etc.) that _are_ embedded in `/all/` payloads; edits to them via admin or outside the claims pipeline produced stale responses. That's exactly the drift the walk was designed to catch.
-- **The parity test's hardcoded expected set is the point.** It pins the derived output so new models fire the test and force intentional review. Don't collapse the expected set into the same walk as production — that would make the test assert `x == x`.
-- **Document the coverage gaps in code, not just PR discussion.** `MachineModel*` through-rows and `AliasBase` subclasses aren't covered by this signal path because they're populated by the claims resolver (which calls `invalidate_all()` directly via `transaction.on_commit`). A comment in `signals.py` explains this so future maintainers can find the answer to "why isn't `MachineModelTheme` in here?" without having to git-blame.
-
-### `_SOURCE_FIELDS` in `citation/seeding.py`
-
-Currently a hand-sync'd frozenset of scalar column names on `CitationSource`. Upgrade: derive from `CitationSource._meta.get_fields()` minus relations at seed time. Parity test catches drift if a scalar is added to the model but forgotten in seed YAML.
-
-**Defer to `CitationSourceSpec` work.** This cleanup target overlaps the upcoming [ModelDrivenCitationSourceMetadata.md](ModelDrivenCitationSourceMetadata.md) axis, which will very likely subsume or reshape what `_SOURCE_FIELDS` describes. Landing it as a standalone `_meta`-walk now and then revisiting it under `CitationSourceSpec` means touching citation seeding twice. Skip until the citation spec work starts, then fold into that effort.
-
-## Resolver signature standardization
-
-Mechanical prep work for `CatalogRelationshipSpec` that has no dependency on the spec itself and reads cleanly as cleanup. See the "Resolver strategy" section of [ModelDrivenCatalogRelationshipMetadata.md](ModelDrivenCatalogRelationshipMetadata.md) for the full audit; the cleanup items are:
-
-1. Rename `entity_ids` → `subject_ids` on all bespoke resolvers (affects `resolve_all_corporate_entity_locations`, `resolve_media_attachments`, and any others surfaced by the audit). Keep the existing `model_ids` callers working by renaming them too.
+1. Rename `entity_ids` → `subject_ids` on bespoke resolvers (`resolve_all_corporate_entity_locations`, `resolve_media_attachments`, and any others surfaced by the audit). Rename existing `model_ids` callers too.
 2. Drop the unused `dict[str, int]` stats return from `resolve_all_corporate_entity_locations` (no consumer reads it).
 3. Confirm every bespoke resolver conforms to `(subject_ids: set[int] | None = None) -> None` after the above.
 
-This is not _required_ before `CatalogRelationshipSpec` lands — the spec PR could do it — but separating it keeps the spec PR narrowly focused on introducing the spec + generic resolver, and lets the rename land sooner as an independent refactor.
+Originally scoped as prep for `CatalogRelationshipSpec`; lands cleanly as an independent refactor regardless of whether that spec ever revives.
 
-## Sequencing
+## Deferred
 
-### Landed
+Items where the right moment hasn't arrived. Each links to its own status doc.
 
-1. Shape 2 typing sweep (table) — including the `frozenset[str]` follow-up for `soft_delete_*`.
-2. Cache-invalidation signal list `_meta` walk — including parity test and coverage-gap comment.
-3. `AliasBase` explicit-identity-attr upgrade.
-4. `entity_type` / `entity_type_plural` base `ClassVar[str]` typing on `LinkableModel`.
+- **`CatalogRelationshipSpec`** — the typed-spec axis for catalog through-model relationships. Deferred pending a second independent consumer; status in [ModelDrivenCatalogRelationshipMetadata.md](ModelDrivenCatalogRelationshipMetadata.md).
+- **`CitationSourceSpec`** — the typed-spec axis for citation source families. Deferred pending a third structured-parser source family; status in [ModelDrivenCitationSourceMetadata.md](ModelDrivenCitationSourceMetadata.md).
+- **`_SOURCE_FIELDS` in `citation/seeding.py`** — hand-sync'd frozenset of scalar columns on `CitationSource`. Folds into the `CitationSourceSpec` work when that revives; landing it standalone now would mean touching citation seeding twice.
+- **`MEDIA_CATEGORIES` readiness validator** — `ready()`-time check that every concrete `MediaSupported` subclass declares a non-empty `MEDIA_CATEGORIES`. Optional; not blocking anything.
+- **`entity_types.py` cosmetic alignment** — swap module-level `_ENTITY_TYPE_MAP: dict | None = None` + `global` for `@functools.lru_cache(maxsize=1)` on a build function, matching the canonical typed-spec template. Purely cosmetic.
 
-### Remaining
+## Done
 
-1. Resolver signature standardization — independent cleanup; can land any time before `CatalogRelationshipSpec` implementation.
-2. `entity_types.py` cosmetic — optional.
+Shipped work, kept as a record so the lessons stay attached to the worked examples that produced them.
 
-None of these have hard dependencies on the new spec work. They can land before or alongside it; the value is that new-spec contributors have a clean, consistent landscape to copy from.
+- **Shape 2 typing sweep.** Typed `claim_fk_lookups`, `claims_exempt`, `soft_delete_cascade_relations`, `soft_delete_usage_blockers` as proper `ClassVar`s. The `soft_delete_*` attrs went through a tuple-then-frozenset correction that surfaced the "semantics over RHS shape" principle.
+- **`entity_type` / `entity_type_plural` typing.** Promoted to `ClassVar[str]` on `LinkableModel`. `Literal[...]` was considered and rejected — see the "`Literal[...]` over abstract bases recreates drift" principle.
+- **`AliasBase` explicit identity attr.** Replaced the `_meta.verbose_name`-derived claim namespace with an explicit `alias_claim_field: ClassVar[str]` declared per subclass, enforced by `__init_subclass__`, parity-tested. Surfaced the "enforce at startup" and "parity tests pin derived sets" principles.
+- **Cache-invalidation signal list.** Replaced the hand-maintained 8-model list with an app-registry walk at `ready()` time, widening to 22 models and fixing latent staleness for taxonomy edits made outside the claims pipeline. Surfaced the "blanket inclusion beats opt-in markers" principle.

--- a/docs/plans/model_driven_metadata/ModelDrivenNamedMetadata.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenNamedMetadata.md
@@ -1,0 +1,75 @@
+# Named Model
+
+## Context
+
+This work is an instance of the broader pattern in [ModelDrivenMetadata.md](ModelDrivenMetadata.md): encode per-model behavior on the model itself, consume it generically from shared infrastructure.
+
+`NamedModel` is a new abstract Django base for catalog entities that have a human-readable `name` field. Today every catalog model declares `name = models.CharField(...)` per-subclass with subtly varying config (max_length, unique, blank). The convention is universal but enforced only by a `name: str` type annotation on `LinkableModel` — there's no actual base-class field, so the contract isn't visible to Django's introspection or the type checker beyond the bare annotation.
+
+`NamedModel` makes the convention real: a typed Django field on an abstract base, subclassed by every catalog model that participates, with subclasses overriding the field declaration only when their config legitimately differs.
+
+## The contract
+
+```python
+class NamedModel(models.Model):
+    """A catalog entity with a human-readable name.
+
+    Concrete subclasses inherit ``name`` directly with the base's defaults,
+    or override the field declaration when they need different config
+    (max_length, unique, blank, help_text). Abstract field override is a
+    standard Django idiom — see the Django docs on abstract base classes.
+    """
+
+    name = models.CharField(max_length=200, validators=[validate_no_mojibake])
+
+    class Meta:
+        abstract = True
+
+    def __str__(self) -> str:
+        return self.name
+```
+
+Subclasses fall into two groups:
+
+- **Use the base default unchanged**: Person (`max_length=200, validators=[validate_no_mojibake]`).
+- **Override the field declaration** for a different shape:
+  - `max_length=300`: Title, MachineModel, CorporateEntity.
+  - `unique=True`: Manufacturer, System, Series, GameplayFeature, taxonomy models.
+  - `blank=True`: Location (claim-controlled name).
+  - Add `help_text`: CorporateEntity.
+
+Override is verbose (the subclass redeclares the entire field), but Django supports it cleanly on abstract bases, and the cost is bounded — each subclass redeclares its `name` field exactly as it does today.
+
+## Why this is separate from `LinkableModel`
+
+`LinkableModel` answers "what's this model's URL identity?" — `entity_type`, `public_id_field`, `link_url_pattern`. Some models could be linkable without being named (an entity identified only by location-path or a tokenized ID). Some models could be named without being linkable (an internal-only entity that has a label but no public URL).
+
+Today every catalog model that's linkable also has a `name` field — the two concerns coexist in practice — but the umbrella's [one capability per base](ModelDrivenMetadata.md#pattern-base-class--mixin) rule argues for splitting. `LinkableModel`'s `name: str` type annotation is a workaround for the missing base — once `NamedModel` exists, the annotation moves to where the contract actually lives.
+
+## Current state and hoist plan
+
+Today's situation:
+
+- 14+ catalog models declare `name = models.CharField(...)` per-subclass with subtly varying config.
+- `LinkableModel` carries `name: str` as a type annotation only — no Django field on the base.
+- The comment in `core/models.py` explicitly explains why: "different max_length / validators per entity."
+- Every consumer that reads `obj.name` relies on the convention; nothing on the type system or Django introspection enforces it.
+
+Hoist:
+
+1. Add `NamedModel(models.Model)` to `apps/core/models.py` with the typed `name` field, abstract Meta, and `__str__` returning `self.name`.
+2. Make every catalog model that has a `name` field inherit `NamedModel`. Subclasses with the base's default config (Person) drop their field declaration; subclasses with different config keep it as an override.
+3. **Remove the `name: str` type annotation from `LinkableModel`** — the contract now lives on `NamedModel`. Update the surrounding comment in `core/models.py` to reflect the new home.
+4. Mostly no consumer changes — every `obj.name` read continues to work, and the type checker can now see `name` declared on `NamedModel` rather than only as a type hint.
+
+No semantic change. Existing tests covering name-based behavior carry over.
+
+## What stays out of scope
+
+- **`display_name_field` ClassVar override hook.** Considered and rejected — every catalog model uses `name` as the display field, with no exceptions today. Adding a ClassVar to override a convention that nobody overrides is preemptive infrastructure (see the umbrella's [one capability per base](ModelDrivenMetadata.md#pattern-base-class--mixin) rule's "pick the smallest one that fits" guidance). If a future model ever needs a non-`name` display field, declare a `ClassVar[str] = "name"` on `NamedModel` then.
+- **Search behavior, name normalization, slug derivation.** All of these read `obj.name` but live in their own subsystems. `NamedModel` provides the field; downstream consumers stay where they are.
+- **`slug`.** `slug` is a similar per-subclass-declared field with a `slug: str` annotation on `LinkableModel`. A parallel `SluggedModel` could be argued for, but `LinkableModel` already provides the URL identity contract via `public_id_field`, and not every linkable model uses a `slug` field for that (Location uses `location_path`). So `slug` is more conventional than load-bearing — defer until it's a real pain.
+
+## Why this lives in `apps.core.models`
+
+`NamedModel` is generic infrastructure — not catalog-specific, not claim-specific, not soft-delete-specific. Living in `apps/core/models.py` alongside `LinkableModel`, `ClaimControlledModel`, and `EntityStatusMixin` keeps the per-capability mixin family co-located. Catalog models import and inherit from it; nothing about `NamedModel` itself reaches into the catalog layer.

--- a/docs/plans/model_driven_metadata/ModelDrivenSoftDeleteMetadata.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenSoftDeleteMetadata.md
@@ -1,0 +1,63 @@
+# Model-Driven Soft-Delete Metadata
+
+## Context
+
+This work is an instance of the broader pattern in [ModelDrivenMetadata.md](ModelDrivenMetadata.md): encode per-model behavior on the model itself, consume it generically from shared infrastructure.
+
+`EntityStatusMixin` is the base for soft-deletable catalog entities. Its soft-delete behavior has two per-model knobs that today live as bare `ClassVar`s on individual subclasses, read via `getattr` from the soft-delete machinery in [`apps/catalog/api/soft_delete.py`](../../backend/apps/catalog/api/soft_delete.py). This doc covers the hoist of both knobs onto `EntityStatusMixin` in a single step — same shape, same recipe, no reason to split.
+
+## The contracts
+
+`EntityStatusMixin` declares both as typed ClassVars with empty defaults:
+
+```python
+class EntityStatusMixin(models.Model):
+    soft_delete_cascade_relations: ClassVar[frozenset[str]] = frozenset()
+    soft_delete_usage_blockers: ClassVar[frozenset[str]] = frozenset()
+    # ...
+    class Meta:
+        abstract = True
+```
+
+| Attr                            | Default       | Purpose                                                                                                  |
+| ------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------- |
+| `soft_delete_cascade_relations` | `frozenset()` | Reverse-manager names whose related rows should soft-delete alongside the parent.                        |
+| `soft_delete_usage_blockers`    | `frozenset()` | Reverse-manager names whose presence blocks soft-delete (M2M through-rows, self-ref hierarchy children). |
+
+Default empty — every existing subclass without an explicit declaration is unaffected. Subclasses with cascade or block requirements override:
+
+```python
+class Title(ClaimControlledModel, EntityStatusMixin):
+    soft_delete_cascade_relations: ClassVar[frozenset[str]] = frozenset({"machine_models", ...})
+
+class Theme(ClaimControlledModel, EntityStatusMixin):
+    soft_delete_usage_blockers: ClassVar[frozenset[str]] = frozenset({...})
+```
+
+The soft-delete machinery in `apps/catalog/api/soft_delete.py` reads each attr directly from `type(entity)` — no fallback needed because the contract lives on the base.
+
+## Current state and hoist plan
+
+Today both attrs are typed (`ClassVar[frozenset[str]]`, per [ModelDrivenMetadataCleanup.md](ModelDrivenMetadataCleanup.md)) but only declared on subclasses that need them. Consumers in `apps/catalog/api/soft_delete.py` read via:
+
+- `getattr(type(entity), "soft_delete_cascade_relations", frozenset())` (one call site, `soft_delete.py:148`).
+- `getattr(type(entity), "soft_delete_usage_blockers", frozenset())` (one call site, `soft_delete.py:212`).
+
+This is the [field-on-model antipattern](ModelDrivenMetadata.md#antipattern-field-on-model) shape — typed declarations on subclasses, untyped reads on the consumer side.
+
+Declarations today:
+
+- `soft_delete_cascade_relations`: declared on Title only.
+- `soft_delete_usage_blockers`: declared on Theme, GameplayFeature, and three taxonomy models (System, Series, Franchise via the shared taxonomy base).
+
+Hoist:
+
+1. Add both ClassVars to `EntityStatusMixin` in `apps/core/models.py` with `frozenset()` defaults.
+2. Subclass declarations remain — they become typed overrides of the base default rather than ad-hoc additions.
+3. Replace the two `getattr(type(entity), "<attr>", frozenset())` reads in `apps/catalog/api/soft_delete.py` with direct attribute access (`type(entity).<attr>`).
+4. Update the module docstring in `soft_delete.py` (lines 9, 22, 29) to describe the attrs as `EntityStatusMixin` ClassVars rather than "opt-in attributes on the model."
+5. No semantic change. Existing soft-delete cascade and blocker tests carry over.
+
+## Why this lives on `EntityStatusMixin`
+
+Both attrs are meaningful only for models that participate in the soft-delete lifecycle. `EntityStatusMixin` is the smallest base that captures the audience — every soft-deletable entity inherits from it, and nothing else does. Hoisting puts the contract on the class the consumer already knows about, lets the type checker enforce the shape, and brings soft-delete metadata in line with the rest of the model-driven metadata work (see [ModelDrivenClaimsMetadata.md](ModelDrivenClaimsMetadata.md) for the parallel hoists in the claims family).

--- a/docs/plans/model_driven_metadata/ModelDrivenWikilinkableMetadata.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenWikilinkableMetadata.md
@@ -1,0 +1,75 @@
+# Wikilinkable Model
+
+## Context
+
+This work is an instance of the broader pattern in [ModelDrivenMetadata.md](ModelDrivenMetadata.md): encode per-model behavior on the model itself, consume it generically from shared infrastructure. It's adjacent to but separate from [ModelDrivenLinkability.md](ModelDrivenLinkability.md) — see "Why this is separate from `LinkableModel`" below.
+
+`WikilinkableModel` is a new mixin that catalog models opt into to participate in the **wikilink autocomplete picker** — the popup that appears when a user types `[[` in a markdown textarea, letting them choose a type and then autocomplete a target row of that type. The wikilink system itself stays model-agnostic; it consumes a registry of `LinkType` entries built once at app-ready time by walking `WikilinkableModel.__subclasses__()`.
+
+## The contract
+
+```python
+class WikilinkableModel(LinkableModel):
+    """A linkable model that appears in the wikilink autocomplete picker."""
+
+    link_sort_order: ClassVar[int] = 100
+    link_label: ClassVar[str] = ""        # derived in __init_subclass__ if empty
+    link_description: ClassVar[str] = ""  # derived in __init_subclass__ if empty
+    link_autocomplete_search_fields: ClassVar[tuple[str, ...]] = ("name__icontains",)
+    link_autocomplete_ordering: ClassVar[tuple[str, ...]] = ("name",)
+    link_autocomplete_select_related: ClassVar[tuple[str, ...]] = ()
+```
+
+| Attr                               | Default                                   | Purpose                                                                  |
+| ---------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------ |
+| `link_sort_order`                  | `100`                                     | Display order in the wikilink picker (lower = earlier).                  |
+| `link_label`                       | `str(model._meta.verbose_name).title()`   | Human-readable type label in the picker.                                 |
+| `link_description`                 | `f"Link to a {model._meta.verbose_name}"` | One-liner description shown alongside the label.                         |
+| `link_autocomplete_search_fields`  | `("name__icontains",)`                    | Django ORM filter spec for autocomplete queries against the type's rows. |
+| `link_autocomplete_ordering`       | `("name",)`                               | Django ORM ordering for autocomplete results.                            |
+| `link_autocomplete_select_related` | `()`                                      | `select_related()` kwargs for autocomplete queries.                      |
+
+Subclasses declare overrides where needed:
+
+```python
+class Title(ClaimControlledModel, WikilinkableModel):
+    link_sort_order: ClassVar[int] = 10
+```
+
+`link_label` and `link_description` are derived in `__init_subclass__` from `model._meta.verbose_name` when the subclass leaves them empty — the same trick `LinkableModel` uses for `link_url_pattern`. Defaults live in the mixin; the consumer reads attributes directly with no `getattr` fallback.
+
+Discovery is `WikilinkableModel.__subclasses__()`. No hand-maintained list of who participates; mixing in opts the model into the picker, not mixing in keeps it out.
+
+## Why this is separate from `LinkableModel`
+
+`LinkableModel` answers "what's this model's URL identity?" — `entity_type`, `entity_type_plural`, `public_id_field`, `link_url_pattern`. Every model that has URLs declares this.
+
+`WikilinkableModel` answers "should this type appear in the wikilink picker, and how?" — picker label, sort order, autocomplete config. Only types that the editorial UI exposes for wikilinking declare this. A future admin-only or internal-only linkable model would skip `WikilinkableModel` and not appear in the picker.
+
+This matches the umbrella's [one capability per base](ModelDrivenMetadata.md#pattern-base-class--mixin) rule. Linkability and wikilinkability are independent capabilities, even though one depends on the other (you must be linkable to be wikilinkable; the mixin enforces this by inheriting from `LinkableModel`).
+
+It also keeps the wikilink system itself model-agnostic. The wikilink registry doesn't know about Title or Manufacturer; it just walks `WikilinkableModel` subclasses and reads each one's declared ClassVars. Editorial decisions ("Title appears first in the picker") live on the model class as the source of truth — not in a hand-maintained registry inside the wikilink layer.
+
+## Current state and hoist plan
+
+The wikilink registration loop in [`apps/catalog/apps.py`](../../backend/apps/catalog/apps.py) iterates `apps.get_app_config("catalog").get_models()`, filters by `issubclass(model, LinkableModel)`, and reads picker config via `getattr(model, "link_*", default)` for six different attrs — the [field-on-model antipattern](ModelDrivenMetadata.md#antipattern-field-on-model) shape, six call sites, untyped, with consumer-side fallbacks.
+
+Declarations today:
+
+- `link_sort_order = 10/20/30/40` declared bare on Title, MachineModel, Manufacturer, Person.
+- `link_type_name`, `link_label`, `link_description`, `link_autocomplete_*` — zero declarations; every model uses the registry's fallback.
+
+Hoist:
+
+1. Add `WikilinkableModel(LinkableModel)` to `apps/core/models.py` with the six typed ClassVars and the `__init_subclass__` derivation for `link_label` / `link_description`.
+2. **Strip the "Class attributes for link registration (all optional)" block** from `LinkableModel`'s docstring. Today's class body never actually declared those attrs — the docstring just listed them as recognized override hooks. The hooks move to `WikilinkableModel`, so the block becomes misleading and should go away (or be replaced with a one-line pointer to `WikilinkableModel` for picker presentation).
+3. **Drop `link_type_name` entirely.** Zero declarers; the registry can use `model.entity_type` (already on `LinkableModel`) as the registry name. No need for an unused override hook.
+4. Make Title, MachineModel, Manufacturer, Person inherit `WikilinkableModel`. Their existing `link_sort_order` declarations become typed overrides of the base default.
+5. Make every other catalog model that should appear in the wikilink picker inherit `WikilinkableModel` — the same `__subclasses__()` walk that drives discovery requires explicit opt-in. (This is intentional: a model only appears in the picker if it declares it should.)
+6. Replace the registration loop in `catalog/apps.py` with a walk over `WikilinkableModel.__subclasses__()`, using direct attribute access on the mixin's ClassVars. No `getattr` fallbacks, no `issubclass` filter.
+
+No semantic change to the wikilink picker. Existing tests covering the registry and the picker UI carry over; one new test asserts that a `LinkableModel` subclass that doesn't mix in `WikilinkableModel` doesn't appear in the registry.
+
+## Why this lives in `apps.core.models`
+
+`WikilinkableModel` is a catalog-app-aware concept (the picker only lists catalog entity types), but the mixin itself is generic Python infrastructure. Living in `apps/core/models.py` alongside `LinkableModel` keeps the linkability/wikilinkability stack co-located. Catalog models import and inherit from it; the wikilink registration loop in `catalog/apps.py` walks its subclass set.


### PR DESCRIPTION
## Summary
- Split the model-driven metadata plan into focused per-aspect docs: claims, claims-exempt, FK lookups, immutability, linkability, named, soft-delete, wikilinkable.
- Refresh the top-level `ModelDrivenMetadata.md` plan and `ModelDrivenMetadataCleanup.md` notes to reference the new breakdowns.

## Test plan
- [ ] Docs-only change — render the new files on GitHub and confirm links/headings look right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)