### PR TITLE
refactor(provenance): narrow claims chain to type[ClaimControlledModel]

### DIFF
--- a/backend/apps/catalog/_alias_registry.py
+++ b/backend/apps/catalog/_alias_registry.py
@@ -10,13 +10,14 @@ import functools
 from typing import NamedTuple
 
 from django.apps import apps
-from django.db import models
+
+from apps.provenance.models import ClaimControlledModel
 
 
 class AliasType(NamedTuple):
     """A discovered ``AliasBase`` subclass and the claim field that holds its aliases."""
 
-    parent_model: type[models.Model]
+    parent_model: type[ClaimControlledModel]
     claim_field: str
 
 
@@ -51,6 +52,11 @@ def discover_alias_types() -> tuple[AliasType, ...]:
         parent_model = fks[0].related_model
         if parent_model is None or isinstance(parent_model, str):
             raise RuntimeError(f"{alias_cls.__name__} FK has no related model")
+        if not issubclass(parent_model, ClaimControlledModel):
+            raise RuntimeError(
+                f"{alias_cls.__name__} parent {parent_model.__name__} "
+                "is not a ClaimControlledModel subclass"
+            )
         result.append(AliasType(parent_model, alias_cls.alias_claim_field))
 
     return tuple(sorted(result, key=lambda at: at.claim_field))

--- a/backend/apps/catalog/_alias_registry.py
+++ b/backend/apps/catalog/_alias_registry.py
@@ -1,7 +1,7 @@
 """Alias-type discovery from AliasBase subclasses.
 
-Shared module that both ``claims.py`` and ``resolve/`` can import without
-creating circular dependencies — it only touches ``core.models.AliasBase``.
+Catalog-private. Lives in its own module so ``claims.py`` and ``resolve/``
+can both import it without creating a cycle between them.
 """
 
 from __future__ import annotations
@@ -12,6 +12,8 @@ from typing import NamedTuple
 from django.apps import apps
 
 from apps.provenance.models import ClaimControlledModel
+
+from .models import AliasBase
 
 
 class AliasType(NamedTuple):
@@ -34,8 +36,6 @@ def discover_alias_types() -> tuple[AliasType, ...]:
     creation, not here.
     """
     apps.check_models_ready()
-
-    from apps.core.models import AliasBase
 
     result: list[AliasType] = []
     for alias_cls in AliasBase.__subclasses__():

--- a/backend/apps/catalog/api/edit_claims.py
+++ b/backend/apps/catalog/api/edit_claims.py
@@ -27,13 +27,13 @@ from apps.catalog.models import (
     Theme,
     Title,
 )
-from apps.core.models import get_claim_fields
 from apps.provenance.models import (
     ChangeSet,
     ChangeSetAction,
     CitationInstance,
     Claim,
     ClaimControlledModel,
+    get_claim_fields,
 )
 from apps.provenance.schemas import CitationReferenceInputSchema
 from apps.provenance.validation import validate_claim_value

--- a/backend/apps/catalog/api/edit_claims.py
+++ b/backend/apps/catalog/api/edit_claims.py
@@ -153,7 +153,7 @@ def raise_form_error(message: str) -> NoReturn:
 
 
 def plan_scalar_field_claims(
-    model_class: type[db_models.Model],
+    model_class: type[ClaimControlledModel],
     fields: dict[str, Any],
     *,
     entity: db_models.Model | None = None,
@@ -184,7 +184,7 @@ class FieldConstraintSchema(Schema):
 
 
 def get_field_constraints(
-    model_class: type[db_models.Model],
+    model_class: type[ClaimControlledModel],
 ) -> dict[str, FieldConstraintSchema]:
     """Extract min/max/step constraints from numeric claim fields.
 
@@ -228,7 +228,7 @@ def get_field_constraints(
 
 
 def validate_scalar_fields(
-    model_class: type[db_models.Model],
+    model_class: type[ClaimControlledModel],
     fields: dict[str, Any],
     *,
     entity: db_models.Model | None = None,

--- a/backend/apps/catalog/api/entity_create.py
+++ b/backend/apps/catalog/api/entity_create.py
@@ -99,7 +99,7 @@ def _resolve_alias_relation(
     """Return ``(alias_model, parent_fk_name)`` if *model_cls* exposes an
     ``aliases`` reverse manager, else ``None``.
 
-    Catalog alias models inherit from :class:`apps.core.models.AliasBase`
+    Catalog alias models inherit from :class:`apps.catalog.models.AliasBase`
     (value column + ``related_name="aliases"`` on the parent FK). Using
     ``_meta.related_objects`` instead of ``getattr`` on the class keeps
     the lookup robust across model reloads and avoids hardcoding FK

--- a/backend/apps/catalog/claims.py
+++ b/backend/apps/catalog/claims.py
@@ -16,7 +16,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 from apps.core.types import JsonBody
-from apps.provenance.models import IdentityPart, make_claim_key
+from apps.provenance.models import ClaimControlledModel, IdentityPart, make_claim_key
 from apps.provenance.validation import (
     RelationshipSchema,
     ValueKeySpec,
@@ -81,7 +81,7 @@ def register_catalog_relationship_schemas() -> None:
                 fk_target=(CreditRole, "pk"),
             ),
         ),
-        valid_subjects=frozenset({MachineModel, Series}),
+        valid_subjects={MachineModel, Series},
     )
 
     # Gameplay feature M2M on MachineModel — with optional integer count.
@@ -102,7 +102,7 @@ def register_catalog_relationship_schemas() -> None:
                 nullable=True,
             ),
         ),
-        valid_subjects=frozenset({MachineModel}),
+        valid_subjects={MachineModel},
     )
 
     # Simple M2Ms on MachineModel — theme / tag / reward_type.
@@ -117,7 +117,7 @@ def register_catalog_relationship_schemas() -> None:
                 fk_target=(Theme, "pk"),
             ),
         ),
-        valid_subjects=frozenset({MachineModel}),
+        valid_subjects={MachineModel},
     )
     register_relationship_schema(
         namespace="tag",
@@ -130,7 +130,7 @@ def register_catalog_relationship_schemas() -> None:
                 fk_target=(Tag, "pk"),
             ),
         ),
-        valid_subjects=frozenset({MachineModel}),
+        valid_subjects={MachineModel},
     )
     register_relationship_schema(
         namespace="reward_type",
@@ -143,7 +143,7 @@ def register_catalog_relationship_schemas() -> None:
                 fk_target=(RewardType, "pk"),
             ),
         ),
-        valid_subjects=frozenset({MachineModel}),
+        valid_subjects={MachineModel},
     )
 
     # Abbreviation (literal) on Title + MachineModel.
@@ -157,7 +157,7 @@ def register_catalog_relationship_schemas() -> None:
                 identity="value",
             ),
         ),
-        valid_subjects=frozenset({Title, MachineModel}),
+        valid_subjects={Title, MachineModel},
     )
 
     # Location on CorporateEntity.
@@ -172,7 +172,7 @@ def register_catalog_relationship_schemas() -> None:
                 fk_target=(Location, "pk"),
             ),
         ),
-        valid_subjects=frozenset({CorporateEntity}),
+        valid_subjects={CorporateEntity},
     )
 
     # Hierarchy parents (self-referential).
@@ -187,7 +187,7 @@ def register_catalog_relationship_schemas() -> None:
                 fk_target=(Theme, "pk"),
             ),
         ),
-        valid_subjects=frozenset({Theme}),
+        valid_subjects={Theme},
     )
     register_relationship_schema(
         namespace="gameplay_feature_parent",
@@ -200,7 +200,7 @@ def register_catalog_relationship_schemas() -> None:
                 fk_target=(GameplayFeature, "pk"),
             ),
         ),
-        valid_subjects=frozenset({GameplayFeature}),
+        valid_subjects={GameplayFeature},
     )
 
     # Alias namespaces — one schema per AliasBase subclass.
@@ -220,7 +220,7 @@ def register_catalog_relationship_schemas() -> None:
                     required=False,
                 ),
             ),
-            valid_subjects=frozenset({alias_type.parent_model}),
+            valid_subjects={alias_type.parent_model},
         )
 
     # Media attachment — derived at registration by walking all concrete
@@ -229,11 +229,11 @@ def register_catalog_relationship_schemas() -> None:
     # abstract base is ever introduced.
     from django.apps import apps as _apps
 
-    media_subjects = frozenset(
+    media_subjects: set[type[ClaimControlledModel]] = {
         m
         for m in _apps.get_models()
         if issubclass(m, MediaSupported) and not m._meta.abstract
-    )
+    }
     register_relationship_schema(
         namespace="media_attachment",
         value_keys=(

--- a/backend/apps/catalog/ingestion/apply.py
+++ b/backend/apps/catalog/ingestion/apply.py
@@ -256,7 +256,7 @@ def _validate_entity_claim_consistency(plan: IngestPlan) -> None:
     """Every claim-controlled field populated by a PlannedEntityCreate
     (via kwargs or handle_refs) must have a matching PlannedClaimAssert
     targeting the same handle."""
-    from apps.core.models import get_claim_fields
+    from apps.provenance.models import get_claim_fields
 
     asserted_by_handle: dict[str, set[str]] = defaultdict(set)
     for pca in plan.assertions:

--- a/backend/apps/catalog/ingestion/apply.py
+++ b/backend/apps/catalog/ingestion/apply.py
@@ -81,7 +81,7 @@ class PlannedEntityCreate:
     anything they reference — the adapter controls ordering.
     """
 
-    model_class: type[models.Model]
+    model_class: type[ClaimControlledModel]
     # kwargs are spread into ``model_class(**kwargs)`` — schema varies per
     # model class, so the value type is genuinely heterogeneous.
     kwargs: dict[str, Any]
@@ -507,7 +507,7 @@ def _create_entities(
 
     for batch in batches:
         model_class = batch[0].model_class
-        pairs: list[tuple[PlannedEntityCreate, models.Model]] = []
+        pairs: list[tuple[PlannedEntityCreate, ClaimControlledModel]] = []
         for entity in batch:
             # Resolve handle_refs into kwargs before instantiation.
             resolved_kwargs = entity.kwargs.copy()
@@ -516,7 +516,7 @@ def _create_entities(
             pairs.append((entity, model_class(**resolved_kwargs)))
 
         instances = [inst for _, inst in pairs]
-        model_class.objects.bulk_create(instances)
+        model_class._default_manager.bulk_create(instances)
         ct_id = ContentType.objects.get_for_model(model_class).pk
         for entity, instance in pairs:
             handle_map[entity.handle] = EntityKey(ct_id, instance.pk)

--- a/backend/apps/catalog/management/commands/validate_catalog.py
+++ b/backend/apps/catalog/management/commands/validate_catalog.py
@@ -281,7 +281,7 @@ def check_unresolved_fk_claims(result: ValidationResult) -> None:
     This catches cases where ingestion asserted a claim like
     manufacturer=some-slug but no Manufacturer with that slug exists.
     """
-    from apps.core.models import get_claim_fields
+    from apps.provenance.models import get_claim_fields
 
     ct = ContentType.objects.get_for_model(MachineModel)
     claim_fields = get_claim_fields(MachineModel)

--- a/backend/apps/catalog/management/commands/validate_catalog.py
+++ b/backend/apps/catalog/management/commands/validate_catalog.py
@@ -285,7 +285,7 @@ def check_unresolved_fk_claims(result: ValidationResult) -> None:
 
     ct = ContentType.objects.get_for_model(MachineModel)
     claim_fields = get_claim_fields(MachineModel)
-    fk_lookups_map = getattr(MachineModel, "claim_fk_lookups", {})
+    fk_lookups_map = MachineModel.claim_fk_lookups
 
     for field_name in claim_fields:
         field = MachineModel._meta.get_field(field_name)

--- a/backend/apps/catalog/models/__init__.py
+++ b/backend/apps/catalog/models/__init__.py
@@ -4,7 +4,7 @@ The catalog represents the resolved/materialized view of each entity.
 Field values are derived by resolving claims from the provenance layer.
 """
 
-from .base import CatalogModel
+from .base import AliasBase, CatalogModel
 from .gameplay_feature import (
     GameplayFeature,
     GameplayFeatureAlias,

--- a/backend/apps/catalog/models/base.py
+++ b/backend/apps/catalog/models/base.py
@@ -1,13 +1,61 @@
-"""CatalogModel abstract base — marker for top-level catalog entities."""
+"""CatalogModel and AliasBase abstract bases for catalog entities."""
 
 from __future__ import annotations
 
 from typing import ClassVar, Self
 
-from apps.core.models import CatalogManager, EntityStatusMixin, LinkableModel
+from django.db import models
+
+from apps.core.models import (
+    CatalogManager,
+    EntityStatusMixin,
+    LinkableModel,
+    TimeStampedModel,
+)
 from apps.provenance.models import ClaimControlledModel
 
-__all__ = ["CatalogModel"]
+__all__ = ["AliasBase", "CatalogModel"]
+
+
+class AliasBase(TimeStampedModel):
+    """Abstract base for alias lookup models.
+
+    Alias values are stored and compared in lowercase (matching the
+    UniqueConstraint(Lower("value")) that every subclass must define).
+    Claims live on the *parent* object, not on the alias row itself.
+
+    Subclasses must add:
+    - A ForeignKey to the parent model (named after the parent, related_name="aliases")
+    - A UniqueConstraint on Lower("value") with a table-specific name
+    - ``alias_claim_field``: the claim namespace on the parent that carries
+      alias values (e.g. ``"theme_alias"``). Enforced at class creation
+      via ``__init_subclass__``; read by ``discover_alias_types``.
+    """
+
+    alias_claim_field: ClassVar[str]
+
+    value = models.CharField(max_length=200)
+
+    class Meta(TimeStampedModel.Meta):
+        abstract = True
+        ordering = ["value"]
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        # NB: we can't gate on ``cls._meta.abstract`` here — Django's ModelBase
+        # runs ``__init_subclass__`` with ``abstract`` still inherited as True
+        # from the parent, then rewrites it to False for concrete subclasses
+        # later. So this check runs for every AliasBase subclass, concrete or
+        # not. That's fine: any abstract intermediate can just declare
+        # ``alias_claim_field`` for its concrete descendants to inherit.
+        super().__init_subclass__(**kwargs)
+        if not getattr(cls, "alias_claim_field", None):
+            raise TypeError(
+                f"{cls.__name__} must declare a non-empty `alias_claim_field` "
+                'class attr (e.g. `alias_claim_field = "theme_alias"`)'
+            )
+
+    def __str__(self) -> str:
+        return self.value
 
 
 class CatalogModel(LinkableModel, EntityStatusMixin, ClaimControlledModel):

--- a/backend/apps/catalog/models/gameplay_feature.py
+++ b/backend/apps/catalog/models/gameplay_feature.py
@@ -10,7 +10,6 @@ from django.db import models
 from django.db.models.functions import Lower
 
 from apps.core.models import (
-    AliasBase,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -21,7 +20,7 @@ from apps.core.models import (
 from apps.core.validators import validate_no_mojibake
 from apps.media.models import MediaSupported
 
-from .base import CatalogModel
+from .base import AliasBase, CatalogModel
 
 __all__ = ["GameplayFeature", "GameplayFeatureAlias", "MachineModelGameplayFeature"]
 

--- a/backend/apps/catalog/models/location.py
+++ b/backend/apps/catalog/models/location.py
@@ -7,9 +7,11 @@ from typing import ClassVar
 from django.db import models
 from django.db.models.functions import Lower, Now
 
-from apps.core.models import AliasBase, EntityStatusMixin, field_not_blank, status_valid
+from apps.core.models import EntityStatusMixin, field_not_blank, status_valid
 from apps.core.validators import validate_no_mojibake
 from apps.provenance.models import ClaimControlledModel
+
+from .base import AliasBase
 
 __all__ = [
     "CorporateEntityLocation",

--- a/backend/apps/catalog/models/manufacturer.py
+++ b/backend/apps/catalog/models/manufacturer.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.db.models.functions import Lower
 
 from apps.core.models import (
-    AliasBase,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -20,7 +19,7 @@ from apps.core.models import (
 from apps.core.validators import validate_no_mojibake
 from apps.media.models import MediaSupported
 
-from .base import CatalogModel
+from .base import AliasBase, CatalogModel
 
 __all__ = [
     "CorporateEntity",

--- a/backend/apps/catalog/models/person.py
+++ b/backend/apps/catalog/models/person.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.db.models.functions import Lower
 
 from apps.core.models import (
-    AliasBase,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -20,7 +19,7 @@ from apps.core.models import (
 from apps.core.validators import validate_no_mojibake
 from apps.media.models import MediaSupported
 
-from .base import CatalogModel
+from .base import AliasBase, CatalogModel
 
 __all__ = ["Credit", "Person", "PersonAlias"]
 

--- a/backend/apps/catalog/models/taxonomy.py
+++ b/backend/apps/catalog/models/taxonomy.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.db.models.functions import Lower
 
 from apps.core.models import (
-    AliasBase,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -18,7 +17,7 @@ from apps.core.models import (
 )
 from apps.core.validators import validate_no_mojibake
 
-from .base import CatalogModel
+from .base import AliasBase, CatalogModel
 
 if TYPE_CHECKING:
     from .machine_model import MachineModel

--- a/backend/apps/catalog/models/theme.py
+++ b/backend/apps/catalog/models/theme.py
@@ -8,7 +8,6 @@ from django.db import models
 from django.db.models.functions import Lower
 
 from apps.core.models import (
-    AliasBase,
     MarkdownField,
     SluggedModel,
     TimeStampedModel,
@@ -18,7 +17,7 @@ from apps.core.models import (
 )
 from apps.core.validators import validate_no_mojibake
 
-from .base import CatalogModel
+from .base import AliasBase, CatalogModel
 
 __all__ = ["MachineModelTheme", "Theme", "ThemeAlias"]
 

--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -92,7 +92,7 @@ def resolve_model(machine_model: MachineModel) -> MachineModel:
             winners[claim.claim_key] = claim
 
     # Apply field values (shared with bulk path).
-    from apps.core.models import get_claim_fields
+    from apps.provenance.models import get_claim_fields
 
     claim_fields = get_claim_fields(MachineModel)
     field_defaults = get_field_defaults(MachineModel, claim_fields)
@@ -232,7 +232,7 @@ def resolve_machine_models(stdout: OutputWrapper | None = None) -> int:
     resolve_all_title_abbreviations()
 
     # 1. Pre-fetch lookup tables.
-    from apps.core.models import get_claim_fields
+    from apps.provenance.models import get_claim_fields
 
     claim_fields = get_claim_fields(MachineModel)
     field_defaults = get_field_defaults(MachineModel, claim_fields)

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -271,7 +271,7 @@ def resolve_entity[T: ClaimControlledModel](obj: T) -> T:
     ``get_claim_fields``), resolves winners, applies them (including FK
     fields), saves, and syncs markdown references.
     """
-    from apps.core.models import get_claim_fields
+    from apps.provenance.models import get_claim_fields
 
     model_class = type(obj)
     fields = get_claim_fields(model_class)
@@ -321,7 +321,7 @@ def resolve_all_entities(
 
     Discovers claim-controlled fields by introspecting the model.
     """
-    from apps.core.models import get_claim_fields
+    from apps.provenance.models import get_claim_fields
 
     fields = get_claim_fields(model_class)
     return _resolve_bulk(model_class, fields, object_ids=object_ids)

--- a/backend/apps/catalog/resolve/_helpers.py
+++ b/backend/apps/catalog/resolve/_helpers.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any, cast
 from django.db import models
 from django.db.models import QuerySet
 
+from apps.provenance.models import ClaimControlledModel
+
 if TYPE_CHECKING:
     from apps.provenance.models import Claim
 
@@ -56,7 +58,7 @@ class FKInfo:
 
 
 def _resolve_fk_generic(
-    model_class: type[models.Model],
+    model_class: type[ClaimControlledModel],
     field_name: str,
     value: object,
     lookup: dict[str, models.Model] | None = None,
@@ -85,8 +87,7 @@ def _resolve_fk_generic(
             "FK field %s on %s has no related model", field_name, model_class
         )
         return None
-    fk_lookups_map = getattr(model_class, "claim_fk_lookups", {})
-    lookup_key = fk_lookups_map.get(field_name, "slug")
+    lookup_key = model_class.claim_fk_lookups.get(field_name, "slug")
 
     if lookup is not None:
         result = lookup.get(key)
@@ -100,17 +101,16 @@ def _resolve_fk_generic(
 
 
 def build_fk_info(
-    model_class: type[models.Model],
+    model_class: type[ClaimControlledModel],
     claim_fields: dict[str, str],
 ) -> FKInfo:
     """Identify FK fields and pre-build slug-to-instance lookups for bulk resolution."""
     info = FKInfo()
-    fk_lookups_map = getattr(model_class, "claim_fk_lookups", {})
     for attr in claim_fields.values():
         f = model_class._meta.get_field(attr)
         if f.is_relation:
             info.fk_fields.add(attr)
-            lookup_key = fk_lookups_map.get(attr, "slug")
+            lookup_key = model_class.claim_fk_lookups.get(attr, "slug")
             target_model = f.related_model
             if target_model is None:
                 continue

--- a/backend/apps/catalog/tests/test_models.py
+++ b/backend/apps/catalog/tests/test_models.py
@@ -12,9 +12,8 @@ from apps.catalog.models import (
     System,
 )
 from apps.catalog.tests.conftest import make_machine_model
-from apps.core.models import get_claim_fields
 from apps.core.validators import validate_no_mojibake
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Claim, Source, get_claim_fields
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_resolve_bulk.py
+++ b/backend/apps/catalog/tests/test_resolve_bulk.py
@@ -19,8 +19,8 @@ from apps.catalog.resolve import (
     resolve_model,
 )
 from apps.catalog.tests.conftest import make_machine_model
-from apps.core.models import RecordReference, get_claim_fields
-from apps.provenance.models import Claim, Source
+from apps.core.models import RecordReference
+from apps.provenance.models import Claim, Source, get_claim_fields
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_resolve_dispatch.py
+++ b/backend/apps/catalog/tests/test_resolve_dispatch.py
@@ -84,7 +84,7 @@ class TestDiscoverAliasTypes:
         """
         from django.db import models
 
-        from apps.core.models import AliasBase
+        from apps.catalog.models import AliasBase
 
         with pytest.raises(TypeError, match="alias_claim_field"):
 

--- a/backend/apps/catalog/tests/test_resolve_dispatch.py
+++ b/backend/apps/catalog/tests/test_resolve_dispatch.py
@@ -17,7 +17,7 @@ from apps.catalog.models import (
 )
 from apps.catalog.resolve._dispatch import resolve_after_mutation
 from apps.catalog.tests.conftest import make_machine_model
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Claim, ClaimControlledModel, Source
 from apps.provenance.validation import get_relationship_schema
 
 # ---------------------------------------------------------------------------
@@ -65,7 +65,7 @@ class TestDiscoverAliasTypes:
     def test_known_types_present(self):
         # Full (parent_model, claim_field) tuples — catches typos AND
         # misdeclarations like the right claim_field on the wrong class.
-        assert set(discover_alias_types()) == {
+        expected: set[tuple[type[ClaimControlledModel], str]] = {
             (Theme, "theme_alias"),
             (Manufacturer, "manufacturer_alias"),
             (Person, "person_alias"),
@@ -74,6 +74,7 @@ class TestDiscoverAliasTypes:
             (CorporateEntity, "corporate_entity_alias"),
             (Location, "location_alias"),
         }
+        assert set(discover_alias_types()) == expected
 
     def test_subclass_without_alias_claim_field_fails_at_creation(self):
         """AliasBase.__init_subclass__ must fire at class definition, not

--- a/backend/apps/catalog/tests/test_source_enabled.py
+++ b/backend/apps/catalog/tests/test_source_enabled.py
@@ -18,9 +18,8 @@ from apps.catalog.resolve import (
 )
 from apps.catalog.resolve._relationships import resolve_all_credits
 from apps.catalog.tests.conftest import make_machine_model
-from apps.core.models import get_claim_fields
 from apps.provenance.helpers import active_claims
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Claim, Source, get_claim_fields
 
 User = get_user_model()
 

--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -291,47 +291,6 @@ def get_markdown_fields(model: type[models.Model]) -> list[str]:
     return [f.name for f in model._meta.get_fields() if isinstance(f, MarkdownField)]
 
 
-# Infrastructure fields exempt from claims on every model.
-_CLAIMS_EXEMPT_NAMES = frozenset(
-    {"id", "uuid", "created_at", "updated_at", "extra_data"}
-)
-
-
-def get_claim_fields(model_class: type[models.Model]) -> dict[str, str]:
-    """Discover claim-controlled fields by introspecting a Django model.
-
-    Returns ``{field_name: field_name}`` for every concrete field that is
-    claim-controlled.  Fields are excluded if they are:
-
-    * primary keys
-    * in ``_CLAIMS_EXEMPT_NAMES`` (infrastructure fields)
-    * listed in the model's ``claims_exempt`` class attribute
-    * GenericForeignKey helper columns (``content_type``, ``object_id``)
-
-    FK fields are included — the resolver handles slug lookup automatically.
-    """
-    per_model_exempt: frozenset[str] = getattr(
-        model_class, "claims_exempt", frozenset()
-    )
-    fields: dict[str, str] = {}
-    for f in model_class._meta.get_fields():
-        if not isinstance(f, models.Field):
-            continue
-        if not getattr(f, "concrete", False):
-            continue
-        if f.primary_key:
-            continue
-        if f.name in _CLAIMS_EXEMPT_NAMES:
-            continue
-        if f.name in per_model_exempt:
-            continue
-        # Skip GenericForeignKey helper columns (content_type_id, object_id).
-        if f.name in ("content_type", "object_id"):
-            continue
-        fields[f.name] = f.name
-    return fields
-
-
 # ---------------------------------------------------------------------------
 # LinkableModel mixin (link target registration)
 # ---------------------------------------------------------------------------

--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -25,47 +25,6 @@ class TimeStampedModel(models.Model):
         abstract = True
 
 
-class AliasBase(TimeStampedModel):
-    """Abstract base for alias lookup models.
-
-    Alias values are stored and compared in lowercase (matching the
-    UniqueConstraint(Lower("value")) that every subclass must define).
-    Claims live on the *parent* object, not on the alias row itself.
-
-    Subclasses must add:
-    - A ForeignKey to the parent model (named after the parent, related_name="aliases")
-    - A UniqueConstraint on Lower("value") with a table-specific name
-    - ``alias_claim_field``: the claim namespace on the parent that carries
-      alias values (e.g. ``"theme_alias"``). Enforced at class creation
-      via ``__init_subclass__``; read by ``discover_alias_types``.
-    """
-
-    alias_claim_field: ClassVar[str]
-
-    value = models.CharField(max_length=200)
-
-    class Meta(TimeStampedModel.Meta):
-        abstract = True
-        ordering = ["value"]
-
-    def __init_subclass__(cls, **kwargs: object) -> None:
-        # NB: we can't gate on ``cls._meta.abstract`` here — Django's ModelBase
-        # runs ``__init_subclass__`` with ``abstract`` still inherited as True
-        # from the parent, then rewrites it to False for concrete subclasses
-        # later. So this check runs for every AliasBase subclass, concrete or
-        # not. That's fine: any abstract intermediate can just declare
-        # ``alias_claim_field`` for its concrete descendants to inherit.
-        super().__init_subclass__(**kwargs)
-        if not getattr(cls, "alias_claim_field", None):
-            raise TypeError(
-                f"{cls.__name__} must declare a non-empty `alias_claim_field` "
-                'class attr (e.g. `alias_claim_field = "theme_alias"`)'
-            )
-
-    def __str__(self) -> str:
-        return self.value
-
-
 def field_not_blank(field_name: str) -> models.CheckConstraint:
     """CHECK constraint: field != ''. Use in concrete model Meta.constraints."""
     return models.CheckConstraint(

--- a/backend/apps/provenance/models/__init__.py
+++ b/backend/apps/provenance/models/__init__.py
@@ -15,4 +15,5 @@ from .claim import (
     make_claim_key,
 )
 from .ingest_run import IngestRun
+from .introspection import get_claim_fields
 from .source import Source, SourceFieldLicense

--- a/backend/apps/provenance/models/base.py
+++ b/backend/apps/provenance/models/base.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 
@@ -9,7 +11,7 @@ __all__ = ["ClaimControlledModel"]
 
 
 class ClaimControlledModel(models.Model):
-    """Abstract base for entities whose display fields are claim-controlled.
+    """Abstract base for entities with claim-controlled fields.
 
     Declares the reverse-accessor to provenance claims and the typed ``slug``
     / ``name`` shape that claim-resolver helpers read generically.  Does NOT
@@ -37,6 +39,15 @@ class ClaimControlledModel(models.Model):
     # actual CharField / SlugField with their own max_length and validators.
     slug: str
     name: str
+
+    # Field names excluded from claim control on this model.
+    # Default empty so most models are unaffected.
+    # Subclasses override with their own ``frozenset``.
+    claims_exempt: ClassVar[frozenset[str]] = frozenset()
+
+    # Per-FK override of the lookup field for claim writes/resolution.
+    # Default empty; subclasses override (do not mutate) — see Location.
+    claim_fk_lookups: ClassVar[dict[str, str]] = {}
 
     claims = GenericRelation("provenance.Claim")
 

--- a/backend/apps/provenance/models/introspection.py
+++ b/backend/apps/provenance/models/introspection.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from django.db import models
 
+from .base import ClaimControlledModel
+
 __all__ = ["get_claim_fields"]
 
 
@@ -13,7 +15,7 @@ _CLAIMS_EXEMPT_NAMES = frozenset(
 )
 
 
-def get_claim_fields(model_class: type[models.Model]) -> dict[str, str]:
+def get_claim_fields(model_class: type[ClaimControlledModel]) -> dict[str, str]:
     """Discover claim-controlled fields by introspecting a Django model.
 
     Returns ``{field_name: field_name}`` for every concrete field that is
@@ -26,9 +28,7 @@ def get_claim_fields(model_class: type[models.Model]) -> dict[str, str]:
 
     FK fields are included — the resolver handles slug lookup automatically.
     """
-    per_model_exempt: frozenset[str] = getattr(
-        model_class, "claims_exempt", frozenset()
-    )
+    per_model_exempt = model_class.claims_exempt
     fields: dict[str, str] = {}
     for f in model_class._meta.get_fields():
         if not isinstance(f, models.Field):

--- a/backend/apps/provenance/models/introspection.py
+++ b/backend/apps/provenance/models/introspection.py
@@ -1,0 +1,48 @@
+"""Introspection helpers for claim-controlled models."""
+
+from __future__ import annotations
+
+from django.db import models
+
+__all__ = ["get_claim_fields"]
+
+
+# Infrastructure fields exempt from claims on every model.
+_CLAIMS_EXEMPT_NAMES = frozenset(
+    {"id", "uuid", "created_at", "updated_at", "extra_data"}
+)
+
+
+def get_claim_fields(model_class: type[models.Model]) -> dict[str, str]:
+    """Discover claim-controlled fields by introspecting a Django model.
+
+    Returns ``{field_name: field_name}`` for every concrete field that is
+    claim-controlled.  Fields are excluded if they are:
+
+    * primary keys
+    * in ``_CLAIMS_EXEMPT_NAMES`` (infrastructure fields)
+    * listed in the model's ``claims_exempt`` class attribute
+    * GenericForeignKey helper columns (``content_type``, ``object_id``)
+
+    FK fields are included — the resolver handles slug lookup automatically.
+    """
+    per_model_exempt: frozenset[str] = getattr(
+        model_class, "claims_exempt", frozenset()
+    )
+    fields: dict[str, str] = {}
+    for f in model_class._meta.get_fields():
+        if not isinstance(f, models.Field):
+            continue
+        if not getattr(f, "concrete", False):
+            continue
+        if f.primary_key:
+            continue
+        if f.name in _CLAIMS_EXEMPT_NAMES:
+            continue
+        if f.name in per_model_exempt:
+            continue
+        # Skip GenericForeignKey helper columns (content_type_id, object_id).
+        if f.name in ("content_type", "object_id"):
+            continue
+        fields[f.name] = f.name
+    return fields

--- a/backend/apps/provenance/tests/test_validation.py
+++ b/backend/apps/provenance/tests/test_validation.py
@@ -713,6 +713,54 @@ class TestValidateClaimsBatchRelationships:
         assert id(good) in valid_ids
 
 
+@pytest.mark.django_db
+class TestValidateClaimsBatchContentTypeNarrowing:
+    """Claims whose ``content_type`` points at a non-``ClaimControlledModel``
+    are rejected at the ``ContentType.model_class()`` boundary.
+
+    Two-claim shape is load-bearing: it confirms that the rejection path
+    does NOT poison ``model_cache``/``fields_cache`` and short-circuit
+    later iterations as if the ct_id were resolved.
+    """
+
+    def test_rejects_claims_for_non_ccm_content_type(self, caplog):
+        import logging
+
+        from django.contrib.contenttypes.models import ContentType
+
+        from apps.core.models import License
+
+        # License extends TimeStampedModel, not ClaimControlledModel.
+        license_ct = ContentType.objects.get_for_model(License)
+
+        bad_a = Claim(
+            content_type_id=license_ct.pk,
+            object_id=1,
+            field_name="name",
+            claim_key="",
+            value="x",
+        )
+        bad_b = Claim(
+            content_type_id=license_ct.pk,
+            object_id=2,
+            field_name="name",
+            claim_key="",
+            value="y",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="apps.provenance.validation"):
+            valid, rejected_count = validate_claims_batch([bad_a, bad_b])
+
+        assert rejected_count == 2
+        valid_ids = {id(c) for c in valid}
+        assert id(bad_a) not in valid_ids
+        assert id(bad_b) not in valid_ids
+        non_ccm_warnings = [
+            r for r in caplog.records if "non-claim-controlled" in r.getMessage()
+        ]
+        assert len(non_ccm_warnings) == 2
+
+
 # ---------------------------------------------------------------------------
 # validate_single_relationship_claim — shape-rejection rules
 # ---------------------------------------------------------------------------
@@ -994,7 +1042,7 @@ class TestRegisterRelationshipSchemaGuards:
                         identity="x",
                     ),
                 ),
-                valid_subjects=frozenset({Theme}),
+                valid_subjects={Theme},
             )
         # Pin "raise before insert" — a future refactor that inserts and
         # then validates would pass the exception assertion but pollute the
@@ -1023,7 +1071,7 @@ class TestRegisterRelationshipSchemaGuards:
                         identity="x",
                     ),
                 ),
-                valid_subjects=frozenset({Theme}),
+                valid_subjects={Theme},
             )
         # Same "raise before insert" invariant. Compared against any
         # pre-existing entry (there shouldn't be one) to stay robust if a

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -22,6 +23,8 @@ from django.core.exceptions import (
     ValidationError,
 )
 from django.db import models
+
+from apps.provenance.models import ClaimControlledModel, get_claim_fields
 
 if TYPE_CHECKING:
     from apps.provenance.models import Claim
@@ -71,7 +74,7 @@ class RelationshipSchema:
 
     namespace: str
     value_keys: tuple[ValueKeySpec, ...]
-    valid_subjects: frozenset[type[models.Model]]
+    valid_subjects: frozenset[type[ClaimControlledModel]]
 
 
 _relationship_schemas: dict[str, RelationshipSchema] = {}
@@ -88,7 +91,7 @@ _namespaces_cache: frozenset[str] | None = None
 def register_relationship_schema(
     namespace: str,
     value_keys: tuple[ValueKeySpec, ...],
-    valid_subjects: frozenset[type[models.Model]],
+    valid_subjects: Iterable[type[ClaimControlledModel]],
 ) -> None:
     """Register a relationship schema. Idempotent; conflicting re-registration raises.
 
@@ -107,8 +110,6 @@ def register_relationship_schema(
     means this guard does not protect every (namespace, model) pair — only
     those where the namespace is registered for the subject.
     """
-    from apps.provenance.models import get_claim_fields
-
     for spec in value_keys:
         if spec.identity is not None and not spec.required:
             raise ImproperlyConfigured(
@@ -117,7 +118,10 @@ def register_relationship_schema(
                 f"(identity={spec.identity!r}, required=False)"
             )
 
-    for subject_model in valid_subjects:
+    # Lock down the input here so the schema's invariant (immutability) is
+    # an internal guarantee, not something callers must satisfy.
+    frozen_subjects = frozenset(valid_subjects)
+    for subject_model in frozen_subjects:
         if namespace in get_claim_fields(subject_model):
             raise ImproperlyConfigured(
                 f"namespace {namespace!r} collides with a concrete claim field "
@@ -127,7 +131,7 @@ def register_relationship_schema(
     new = RelationshipSchema(
         namespace=namespace,
         value_keys=value_keys,
-        valid_subjects=valid_subjects,
+        valid_subjects=frozen_subjects,
     )
     existing = _relationship_schemas.get(namespace)
     if existing is not None:
@@ -165,14 +169,14 @@ def get_relationship_namespaces() -> frozenset[str]:
 
 
 def is_valid_subject(
-    schema: RelationshipSchema, subject_model: type[models.Model]
+    schema: RelationshipSchema, subject_model: type[ClaimControlledModel]
 ) -> bool:
     """Whether ``subject_model`` is a registered subject for this schema."""
     return subject_model in schema.valid_subjects
 
 
 def classify_claim(
-    model_class: type[models.Model],
+    model_class: type[ClaimControlledModel],
     field_name: str,
     claim_key: str,
     value: Any,  # noqa: ANN401 - signature preserved for call-site stability
@@ -206,8 +210,6 @@ def classify_claim(
     single-claim use in ``assert_claim``).
     """
     if claim_fields is None:
-        from apps.provenance.models import get_claim_fields
-
         claim_fields = get_claim_fields(model_class)
 
     if field_name in claim_fields:
@@ -224,7 +226,7 @@ def classify_claim(
 
 def validate_single_relationship_claim(
     *,
-    subject_model: type[models.Model],
+    subject_model: type[ClaimControlledModel],
     field_name: str,
     claim_key: str,
     value: Any,  # noqa: ANN401 - claim value is arbitrary JSON
@@ -330,14 +332,19 @@ def validate_single_relationship_claim(
         )
 
 
-def _has_extra_data(model_class: type[models.Model]) -> bool:
+def _has_extra_data(model_class: type[ClaimControlledModel]) -> bool:
     """Check whether a model has a concrete ``extra_data`` field.
 
     Uses ``_meta`` field introspection rather than ``hasattr`` to avoid
     matching non-field attributes (properties, methods, etc.).
     """
     try:
-        model_class._meta.get_field("extra_data")
+        # django-stubs validates string-literal field lookups against the
+        # model's declared fields. ``extra_data`` is declared on some
+        # concrete catalog subclasses (e.g. MachineModel), not on the
+        # abstract ``ClaimControlledModel`` we accept here, so the literal
+        # lookup type-fails at the base — runtime semantics are correct.
+        model_class._meta.get_field("extra_data")  # type: ignore[misc]
         return True
     except FieldDoesNotExist:
         return False
@@ -346,7 +353,7 @@ def _has_extra_data(model_class: type[models.Model]) -> bool:
 def validate_claim_value(
     field_name: str,
     value: Any,  # noqa: ANN401 - claim value is arbitrary JSON (scalar/dict/list/null)
-    model_class: type[models.Model],
+    model_class: type[ClaimControlledModel],
 ) -> Any:  # noqa: ANN401 - returns the (possibly coerced) claim value, same shape as input
     """Validate and possibly transform a scalar claim value.
 
@@ -443,14 +450,12 @@ def validate_claims_batch(
     """
     from django.contrib.contenttypes.models import ContentType
 
-    from apps.provenance.models import get_claim_fields
-
     rejected: list[Claim] = []
-    fk_claims: list[tuple[Claim, type[models.Model]]] = []
+    fk_claims: list[tuple[Claim, type[ClaimControlledModel]]] = []
     rel_claims: list[Claim] = []
 
     # Cache model_class and claim_fields per content_type_id.
-    model_cache: dict[int, type[models.Model]] = {}
+    model_cache: dict[int, type[ClaimControlledModel]] = {}
     fields_cache: dict[int, dict[str, str]] = {}
 
     for claim in pending_claims:
@@ -458,13 +463,19 @@ def validate_claims_batch(
 
         if ct_id not in model_cache:
             model_class = ContentType.objects.get_for_id(ct_id).model_class()
-            if model_class is None:
+            if model_class is None or not issubclass(model_class, ClaimControlledModel):
                 logger.warning(
-                    "Rejected claim for unknown content type id %s (object_id=%s)",
+                    "Rejected claim for unknown or non-claim-controlled "
+                    "content type id %s (object_id=%s)",
                     ct_id,
                     claim.object_id,
                 )
                 rejected.append(claim)
+                # NB: we deliberately do not write model_cache[ct_id] /
+                # fields_cache[ct_id] on the rejection path. Subsequent claims
+                # with the same ct_id will re-check and re-reject; that's
+                # correct — we never want a poisoned ct_id to silently
+                # short-circuit later iterations as if it were resolved.
                 continue
             model_cache[ct_id] = model_class
             fields_cache[ct_id] = get_claim_fields(model_cache[ct_id])
@@ -545,7 +556,7 @@ def validate_claims_batch(
 
 
 def validate_fk_claims_batch(
-    fk_claims: list[tuple[Claim, type[models.Model]]],
+    fk_claims: list[tuple[Claim, type[ClaimControlledModel]]],
 ) -> list[Claim]:
     """Batch-validate FK scalar claims. Returns list of rejected claims.
 
@@ -554,7 +565,8 @@ def validate_fk_claims_batch(
     convention from the resolver.
     """
     groups: dict[
-        tuple[type[models.Model], str], list[tuple[Claim, type[models.Model]]]
+        tuple[type[ClaimControlledModel], str],
+        list[tuple[Claim, type[ClaimControlledModel]]],
     ] = defaultdict(list)
     for claim, model_class in fk_claims:
         groups[(model_class, claim.field_name)].append((claim, model_class))
@@ -566,8 +578,7 @@ def validate_fk_claims_batch(
         assert isinstance(target_model, type)
         assert issubclass(target_model, models.Model)
         target_manager = target_model._default_manager
-        fk_lookups_map = getattr(model_class, "claim_fk_lookups", {})
-        lookup_key = fk_lookups_map.get(field_name, "slug")
+        lookup_key = model_class.claim_fk_lookups.get(field_name, "slug")
 
         # Collect all non-empty slug values, keyed by claim identity.
         slug_by_claim: dict[int, str] = {}

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -107,7 +107,7 @@ def register_relationship_schema(
     means this guard does not protect every (namespace, model) pair — only
     those where the namespace is registered for the subject.
     """
-    from apps.core.models import get_claim_fields
+    from apps.provenance.models import get_claim_fields
 
     for spec in value_keys:
         if spec.identity is not None and not spec.required:
@@ -206,7 +206,7 @@ def classify_claim(
     single-claim use in ``assert_claim``).
     """
     if claim_fields is None:
-        from apps.core.models import get_claim_fields
+        from apps.provenance.models import get_claim_fields
 
         claim_fields = get_claim_fields(model_class)
 
@@ -443,7 +443,7 @@ def validate_claims_batch(
     """
     from django.contrib.contenttypes.models import ContentType
 
-    from apps.core.models import get_claim_fields
+    from apps.provenance.models import get_claim_fields
 
     rejected: list[Claim] = []
     fk_claims: list[tuple[Claim, type[models.Model]]] = []

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -183,10 +183,19 @@ def get_field_constraints(
     """Return numeric field constraints derived from model validators."""
     from apps.catalog.api.edit_claims import get_field_constraints as _get
     from apps.core.entity_types import get_linkable_model
+    from apps.provenance.models import ClaimControlledModel
 
     try:
         model_class = get_linkable_model(entity_type)
     except ValueError:
         raise HttpError(404, f"Unknown entity type: {entity_type}") from None
 
+    # All registered linkable models extend ClaimControlledModel via
+    # CatalogModel — surface a misconfigured registry as a server error
+    # rather than disguising it as 404.
+    if not issubclass(model_class, ClaimControlledModel):
+        raise RuntimeError(
+            f"Linkable model for entity_type={entity_type!r} "
+            f"({model_class.__name__}) is not a ClaimControlledModel subclass"
+        )
     return _get(model_class)

--- a/backend/mypy-baseline.txt
+++ b/backend/mypy-baseline.txt
@@ -43,7 +43,6 @@ apps/catalog/ingestion/bulk_utils.py:0: error: Missing type arguments for generi
 apps/catalog/ingestion/bulk_utils.py:0: error: Incompatible types in assignment (expression has type "CorporateEntityAlias", variable has type "ManufacturerAlias")  [assignment]
 apps/catalog/ingestion/bulk_utils.py:0: error: "ManufacturerAlias" has no attribute "corporate_entity"  [attr-defined]
 apps/catalog/ingestion/apply.py:0: error: Invalid index type "str | None" for "dict[str, int]"; expected type "str"  [index]
-apps/catalog/ingestion/apply.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
 apps/catalog/ingestion/apply.py:0: error: Incompatible type for "content_type_id" of "Claim" (got "int | None", expected "Combinable | int | str")  [misc]
 apps/catalog/ingestion/apply.py:0: error: Incompatible type for "object_id" of "Claim" (got "int | None", expected "float | int | str | Combinable")  [misc]
 apps/catalog/tests/test_models.py:0: error: Incompatible type for "manufacturer" of "System" (got "None", expected "Manufacturer | Combinable")  [misc]

--- a/docs/plans/model_driven_metadata/LocationCrud.md
+++ b/docs/plans/model_driven_metadata/LocationCrud.md
@@ -1,0 +1,191 @@
+# Location CRUD
+
+This plan implements Location create, edit, delete, restore, edit-history, sources, and frontend routes. It will be the first full multi-segment `LinkableModel` CRUD surface, and prove out the changes.
+
+## Context
+
+This work should land after [ModelDrivenLinkability.md](ModelDrivenLinkability.md). Linkability establishes the generic URL identity and shared CRUD-factory contracts: `public_id_field`, `public_id`, `:path` route params, page-level edit-history / sources lookup by `(entity_type, public_id)`, and factory support for non-`slug` public IDs.
+
+Location CRUD is the proof that that work actually generalized. Location is the first model that needs a multi-segment `public_id` (`location_path`) and a non-`slug` FK claim lookup (`claim_fk_lookups = {"parent": "location_path"}`). If Location can reach create, restore, edit-history, and sources through the shared factories/endpoints without Location-specific overrides, the Linkability abstraction is doing real work.
+
+The validation criterion:
+
+- Location create uses `register_entity_create` for both top-level countries and child locations.
+- Location restore uses `register_entity_restore`.
+- Location edit-history and sources use the generic `/api/pages/edit-history/{entity_type}/{public_id:path}/` and `/api/pages/sources/{entity_type}/{public_id:path}/` endpoints.
+- Bespoke Location code exists only where hierarchy semantics genuinely differ: PATCH claims, delete-preview subtree analysis, and cascade delete.
+
+## Decisions
+
+- Location inherits `LinkableModel` and declares `entity_type = "location"`, `entity_type_plural = "locations"`, and `public_id_field = "location_path"`.
+- Location declares `immutable_after_create = frozenset({"parent"})`. Re-parenting is not supported because `location_path` encodes ancestry and changing it would require recomputing the whole subtree and every reference.
+- Top-level Location create always creates a `country`.
+- Child Location create derives `location_type` from the country ancestor's `divisions`, using `country.divisions[parent_depth - 1]`.
+- Name and slug uniqueness are sibling-scoped for children; top-level countries collide at the root scope.
+- Location delete is blocked if any row in the subtree has an active `CorporateEntityLocation`.
+- Unblocked Location delete soft-deletes the root and descendants in one `ChangeSet`.
+
+## Backend
+
+### Path and type helpers
+
+Add `backend/apps/catalog/services/location_paths.py`:
+
+```python
+def compute_location_path(parent: Location | None, slug: str) -> str:
+    return slug if parent is None else f"{parent.location_path}/{slug}"
+
+
+def derive_child_location_type(parent: Location) -> str:
+    ...
+```
+
+`derive_child_location_type` walks from `parent.location_path` to the country ancestor, then indexes the country's `divisions` by parent depth. When `parent` is already the country, use `parent.divisions` directly instead of doing another DB fetch. Raise `ValidationError` with a useful message if the country has no divisions or the tree is deeper than the declared divisions.
+
+### Write router
+
+Add `backend/apps/catalog/api/locations_write.py` and register it under `/locations/`.
+
+Top-level create:
+
+- Route: `POST /api/locations/`
+- Factory: `register_entity_create`
+- `public_id_field="location_path"`
+- `body_schema=LocationCreateSchema`
+- Extra claims: `location_type="country"`, `divisions=data.divisions`
+- Extra row kwargs: `location_type`, `divisions`, `location_path=compute_location_path(None, data.slug)`
+
+Child create:
+
+- Route: `POST /api/locations/{parent_public_id:path}/children/`
+- Factory: `register_entity_create` in parented mode
+- `parent_field="parent"`
+- `parent_model=Location`
+- `route_suffix="children"`
+- `scope_filter_builder=lambda parent: Q(parent=parent)`
+- Extra claims: derived `location_type`
+- Extra row kwargs: derived `location_type`, `location_path=compute_location_path(parent, data.slug)`
+
+PATCH claims:
+
+- Route: `PATCH /api/locations/{public_id:path}/claims/`
+- Bespoke for now because there is no shared PATCH-claims factory.
+- Body allows scalar edits for `name`, `description`, `short_name`, `code`, plus aliases, note, and citation.
+- `divisions` is editable only for top-level country rows.
+- Body must not allow `parent`, `slug`, or `location_type`.
+- Use the same primitives as themes: `validate_scalar_fields`, `plan_alias_claims`, and `execute_claims`.
+
+Delete preview:
+
+- Route: `GET /api/locations/{public_id:path}/delete-preview/`
+- Walk the root plus descendants by `location_path`.
+- Return descendant counts by `location_type`, total count, active `CorporateEntityLocation` blockers, and `is_blocked`.
+- Only active referrers block deletion.
+
+Delete:
+
+- Route: `DELETE /api/locations/{public_id:path}/`
+- Recompute delete-preview server-side.
+- Return `409` if blocked.
+- Otherwise write `status=deleted` claims for root and descendants in one transaction and one `ChangeSet` with `action=DELETE`.
+- Cascading delete consumes one delete rate-limit bucket.
+
+Restore:
+
+- Route: `POST /api/locations/{public_id:path}/restore/`
+- Factory: `register_entity_restore`
+- Pass `parent_field="parent"` so restore is rejected while the parent is deleted.
+- Restore affects only the requested row; descendants remain deleted unless restored separately.
+
+### Read API
+
+Extend `LocationDetailSchema` with:
+
+```python
+expected_child_type: str | None
+```
+
+Populate it with `derive_child_location_type(location)`, or `None` if derivation fails because divisions are missing or exhausted. This lets the frontend stop hardcoding country-specific child labels.
+
+## Frontend
+
+Add the missing write routes under `frontend/src/routes/locations/`.
+
+- `/locations/new` creates a top-level country. It asks for name, slug, note, citation, and comma-separated divisions. Redirect target is `/locations/{slug}`.
+- `/locations/[...path]/new` creates a child location. It uses the parent detail's `expected_child_type` for labels such as "New State" or "New Region". It sends only name, slug, note, and citation; the server derives type. If `expected_child_type` is `null`, render an explanatory state instead of a form.
+- `/locations/[...path]/edit` and `/edit/[section]` reuse the shared taxonomy edit base components.
+- `/locations/[...path]/edit-history` uses the generic edit-history loader with `entity_type="location"` and `public_id=path`.
+- `/locations/[...path]/sources` uses the generic sources loader.
+- `/locations/[...path]/delete` uses the shared delete page, adapting descendant counts and blockers into the existing UI contract.
+
+Add Location editor wiring:
+
+- `frontend/src/lib/components/editors/location-edit-sections.ts`
+- `frontend/src/lib/components/editors/LocationEditorSwitch.svelte`
+- `frontend/src/routes/locations/[...path]/save-location-claims.ts`
+
+The edit menu should not offer parent, slug, or location-type edits.
+
+### Child labels
+
+Remove the frontend `EXPECTED_CHILD` fallback. `newChildLabel(profile)` should prefer:
+
+1. The first existing child's `location_type`, when children exist.
+2. `profile.expected_child_type`, when there are no children.
+3. `null`, which suppresses the "+ New ..." action rather than showing a wrong label.
+
+Once Location is fully mapped, remove `locations` from the `UNMAPPED_ROUTE_DIRS` skip list in `catalog-meta.test.ts`.
+
+## Tests
+
+Backend tests:
+
+- `compute_location_path` covers top-level, child, and deeper paths.
+- `derive_child_location_type` covers USA, France, missing divisions, and too-deep trees.
+- Top-level create succeeds, rejects name collisions, rejects `location_path` collisions, and rejects missing divisions.
+- Top-level create rejects extra fields such as a client-supplied `location_type`.
+- Child create succeeds, rejects sibling name/slug collisions, allows same slug under different parents, and writes the parent FK claim using `parent.location_path`.
+- Child create derives country-specific child types.
+- PATCH edits name, description, and aliases.
+- PATCH rejects `parent`, `slug`, and `location_type`.
+- Detail includes `expected_child_type` for valid hierarchies and `null` when it cannot be derived.
+- Delete-preview counts descendants and reports active `CorporateEntityLocation` blockers.
+- DELETE returns `409` when blocked and cascade soft-deletes the subtree when unblocked.
+- Restore reactivates only the requested row and is rejected when the parent is deleted.
+- Generic edit-history and sources endpoints resolve Location by multi-segment public ID.
+
+Frontend tests:
+
+- Location helper tests cover existing-child label, server-supplied `expected_child_type`, and `null` suppression.
+- `saveLocationClaims` sends `public_id`, not `slug`.
+- Delete page renders blocked and unblocked states.
+- Catalog metadata parity no longer skips `locations`.
+
+## Verification
+
+Run the smallest useful set while implementing, then finish with:
+
+```bash
+make api-gen
+make lint
+make test
+```
+
+Manual smoke test against `make dev` with a logged-in superuser:
+
+- `/locations`, `/locations/usa`, and `/locations/usa/il/chicago` still render.
+- Create a new country at `/locations/new`.
+- Create a child from the new country's action menu.
+- Edit name, description, and aliases.
+- Visit edit-history and sources for the new child.
+- Delete the child.
+- Confirm deleting `/locations/usa` is blocked by active corporate-entity location referrers.
+- Confirm existing single-segment entities such as themes and manufacturers still handle edit, edit-history, sources, and delete after the `slug` to `public_id` rename.
+
+## Out of Scope
+
+- Re-parenting Location.
+- Restore UI on deleted-entity pages.
+- Rich divisions editor UI.
+- Undoing a specific past delete `ChangeSet`.
+- Switching generic href consumers to call `entity.get_absolute_url()` directly.

--- a/docs/plans/model_driven_metadata/ModelDrivenLinkability.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenLinkability.md
@@ -103,3 +103,16 @@ This tells the claims layer: "when writing the `parent` FK claim, the value is t
 Strictly speaking `claim_fk_lookups` is a `ClaimControlledModel` ClassVar — it governs claim writes, not linkability. It's documented here because the linkability layer is the consumer that exposes the need: as soon as a related model's `public_id_field` isn't `slug`, the FK claim value must follow.
 
 The shared factories and the claims executor both read this map. Hardcoding `parent.slug` anywhere in the write path is a [field-on-model antipattern](ModelDrivenMetadata.md#antipattern-field-on-model) waiting to happen.
+
+## Follow-up: retype the entity registry as `type[CatalogModel]`
+
+Once Location lands as a `LinkableModel` it also satisfies `CatalogModel` by composition (it already has `EntityStatusMixin + ClaimControlledModel`). At that point the registry walked by `get_linkable_model` is, in fact, a `CatalogModel` registry — every entry is linkable _and_ claim-controlled _and_ status-tracked.
+
+That makes a small typing cleanup possible:
+
+- Walk `CatalogModel.__subclasses__()` rather than `LinkableModel.__subclasses__()`.
+- Return `type[CatalogModel]` and rename to match (`get_entity_model` or `get_catalog_model`).
+- Delete the `issubclass(model_class, ClaimControlledModel)` guard at [`backend/config/api.py:196`](../../../backend/config/api.py#L196) — `type[CatalogModel]` is already a `type[ClaimControlledModel]`.
+- Leave `LinkableModel` as a pure structural contract (no registry, no `__subclasses__()` walk), so a future linkable-but-not-CCM model can still adopt it independently.
+
+Out of scope for this plan — it's a typing/naming cleanup that piggybacks on Location becoming a `CatalogModel`, not part of the contract-widening work. Track as its own small PR after [LocationCrud.md](LocationCrud.md) lands.

--- a/docs/plans/model_driven_metadata/ModelDrivenLinkability.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenLinkability.md
@@ -12,10 +12,12 @@ For all the catalog models that are URL-addressable, we want that capability to 
 
 This doc outlines an architecture that will support a `LinkableModel` that works for ALL URL-addressable models.
 
+The follow-on implementation plan is [LocationCrud.md](LocationCrud.md). It should land after this work and serves as the proof that the abstraction held: Location must be able to use the shared create/restore factories and generic edit-history / sources endpoints while reserving bespoke code only for true hierarchy semantics.
+
 ## The Contracts
 
 - **[`LinkableModel`](#linkablemodel)**: declares URL identity.
-- **[`ClaimControlledModel.immutable_after_create`](ImmutableAfterCreate.md)**: a new capability on `ClaimControlledModel` to block updates on a field. Location neeeds to block re-parenting, since re-parenting would invalidate the materialized `location_path` on the row and every descendant. This gives Location the ability to freeze its `parent` field. This is a pre-condition for this doc; the work lives in [ImmutableAfterCreate.md](ImmutableAfterCreate.md).
+- **[`ClaimControlledModel.immutable_after_create`](ModelDrivenImmutableAfterCreate.md)**: a new capability on `ClaimControlledModel` to block updates on a field. Location needs to block re-parenting, since re-parenting would invalidate the materialized `location_path` on the row and every descendant. This gives Location the ability to freeze its `parent` field. This is a pre-condition for this doc; the work lives in [ModelDrivenImmutableAfterCreate.md](ModelDrivenImmutableAfterCreate.md).
 
 ## LinkableModel
 

--- a/docs/plans/model_driven_metadata/ModelDrivenMetadata.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenMetadata.md
@@ -176,7 +176,7 @@ Concrete examples in the current codebase:
 - **`claims_exempt`**: declared per-model where the model has fields to exempt (e.g. [location.py](../../backend/apps/catalog/models/location.py)); read via `getattr(model_class, "claims_exempt", frozenset())` in [core/models.py](../../backend/apps/core/models.py). Belongs on `ClaimControlledModel` as `ClassVar[frozenset[str]] = frozenset()`.
 - **Wikilink-picker `link_*` attrs** (`link_sort_order`, `link_label`, `link_description`, `link_autocomplete_*`): declared bare on the four ordered linkable types (Title, MachineModel, Manufacturer, Person); read via `getattr(model, "link_*", default)` six times in [catalog/apps.py](../../backend/apps/catalog/apps.py)'s wikilink registration loop. Belong on a new `WikilinkableModel` mixin — see [ModelDrivenWikilinkableMetadata.md](ModelDrivenWikilinkableMetadata.md).
 
-Counter-example showing the right shape: `alias_claim_field` is declared on `AliasBase` in [core/models.py](../../backend/apps/core/models.py) as `ClassVar[str]`, with `__init_subclass__` enforcement in the same file. Consumers in [\_alias_registry.py](../../backend/apps/catalog/_alias_registry.py) read `alias_cls.alias_claim_field` directly — no `getattr` fallback needed because the contract is enforced at the base.
+Counter-example showing the right shape: `alias_claim_field` is declared on `AliasBase` in [catalog/models/base.py](../../backend/apps/catalog/models/base.py) as `ClassVar[str]`, with `__init_subclass__` enforcement in the same file. Consumers in [\_alias_registry.py](../../backend/apps/catalog/_alias_registry.py) read `alias_cls.alias_claim_field` directly — no `getattr` fallback needed because the contract is enforced at the base.
 
 ## Rules of thumb
 

--- a/docs/plans/model_driven_metadata/ModelDrivenMetadataCleanup.md
+++ b/docs/plans/model_driven_metadata/ModelDrivenMetadataCleanup.md
@@ -15,11 +15,12 @@ Each item has its own per-feature doc with the full design, examples, and step-b
 | 3   | Soft-delete attrs hoist                 | Hoist             | [ModelDrivenSoftDeleteMetadata.md](ModelDrivenSoftDeleteMetadata.md)         | Small              | —          |
 | 4   | `immutable_after_create` (new)          | New behavior      | [ModelDrivenImmutableAfterCreate.md](ModelDrivenImmutableAfterCreate.md)     | Small-medium       | —          |
 | 5   | Linkability (LinkableModel + factories) | Steel thread      | [ModelDrivenLinkability.md](ModelDrivenLinkability.md)                       | Large (in flight)  | #4         |
-| 6   | `WikilinkableModel` mixin               | New mixin + hoist | [ModelDrivenWikilinkableMetadata.md](ModelDrivenWikilinkableMetadata.md)     | Medium             | (after #5) |
-| 7   | `NamedModel` base                       | New base          | [ModelDrivenNamedMetadata.md](ModelDrivenNamedMetadata.md)                   | Large (~14 models) | —          |
-| 8   | Resolver signature standardization      | Cleanup           | (inline below)                                                               | Small              | —          |
+| 6   | Location CRUD validation                | Steel thread      | [LocationCrud.md](LocationCrud.md)                                           | Large              | #5         |
+| 7   | `WikilinkableModel` mixin               | New mixin + hoist | [ModelDrivenWikilinkableMetadata.md](ModelDrivenWikilinkableMetadata.md)     | Medium             | (after #5) |
+| 8   | `NamedModel` base                       | New base          | [ModelDrivenNamedMetadata.md](ModelDrivenNamedMetadata.md)                   | Large (~14 models) | —          |
+| 9   | Resolver signature standardization      | Cleanup           | (inline below)                                                               | Small              | —          |
 
-**Suggested order:** **1 → 2 → 3** (the three small hoists; same recipe — declare ClassVar on base, drop `getattr` in consumer; confidence-building), then **4** (pre-condition for #5), then **5** (the active steel thread), then **6** (uses Linkability outputs), then **7** (broadest reach, lowest urgency, save for after the patterns and tooling are well-exercised). Item **8** is independent and can land any time.
+**Suggested order:** **1 → 2 → 3** (the three small hoists; same recipe — declare ClassVar on base, drop `getattr` in consumer; confidence-building), then **4** (pre-condition for #5), then **5** (the active steel thread), then **6** (proves #5 against Location's multi-segment public ID), then **7** (uses Linkability outputs), then **8** (broadest reach, lowest urgency, save for after the patterns and tooling are well-exercised). Item **9** is independent and can land any time.
 
 ### Resolver signature standardization
 


### PR DESCRIPTION
## Summary

- Move `get_claim_fields` from `apps.core` to a new `apps.provenance.models.introspection` module so the claims-introspection API lives in the provenance domain (and unblocks tightening its parameter type without violating app-boundary rules).
- Hoist `claims_exempt` and `claim_fk_lookups` onto `ClaimControlledModel` as documented ClassVars (defaulted to empty), replacing the implicit `getattr`-with-default contract that was scattered across the codebase.
- Narrow `type[Model]` → `type[ClaimControlledModel]` across the entire claims chain: `validation.py` (RelationshipSchema, classify_claim, validate_claim_value, validate_claims_batch, validate_fk_claims_batch), `introspection.get_claim_fields`, FK resolve helpers, and the edit-claims / ingest-apply layers. `ContentType.model_class()` is narrowed once with an explicit `issubclass` check + warning; the model_cache is deliberately not poisoned on rejection (regression test added).
- Relocate `AliasBase` from `apps.core` to `apps.catalog.models.base` alongside `CatalogModel`. AliasBase is only used by catalog code, and living in core blocked typing its `parent_model` ClassVar as `type[ClaimControlledModel]` without inverting layers.
- `register_relationship_schema` now accepts `Iterable[type[ClaimControlledModel]]` and freezes internally — eliminates 11+ verbose annotations at call sites that frozenset's invariance was forcing.
- Two runtime `issubclass` guards remain (`_alias_registry.py` parent-FK introspection, `config/api.py` linkable-registry boundary) where the type system can't see invariants the code relies on. Both are documented follow-ups in the plan.

## Test plan

- [ ] `make test` (backend pytest + frontend vitest)
- [ ] `make lint` (ruff + eslint/prettier + mypy)
- [ ] Spot-check ingest pipeline still applies FK claims (`make ingest` on a small sample)
- [ ] Verify edit-claims API still resolves and validates FK claims end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)