### PR TITLE
refactor(licensing): split claim-aware resolution out of apps.core

### DIFF
--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -9,9 +9,7 @@ from django.db.models import Model, Prefetch
 
 from apps.core.licensing import (
     UNKNOWN_LICENSE_RANK,
-    build_source_field_license_map,
     get_minimum_display_rank,
-    resolve_effective_license,
 )
 from apps.core.markdown import render_markdown_field
 from apps.core.markdown_links import convert_storage_to_authoring
@@ -19,6 +17,10 @@ from apps.core.types import JsonData
 from apps.media.models import EntityMedia
 from apps.media.schemas import MediaRenditionsSchema, UploadedMediaSchema
 from apps.media.storage import build_public_url, build_storage_key
+from apps.provenance.licensing import (
+    build_source_field_license_map,
+    resolve_effective_license,
+)
 from apps.provenance.models import Claim
 from apps.provenance.schemas import (
     AttributionSchema,

--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -13,13 +13,12 @@ from typing import Any
 from django.core.management.base import OutputWrapper
 from django.utils import timezone
 
-from apps.core.licensing import (
-    IMAGE_FIELDS,
+from apps.core.types import JsonBody
+from apps.provenance.licensing import (
     SourceFieldLicenseMap,
     build_source_field_license_map,
     resolve_effective_license,
 )
-from apps.core.types import JsonBody
 from apps.provenance.models import Claim, ClaimControlledModel
 
 from ..claims import get_relationship_namespaces
@@ -68,6 +67,11 @@ from ._relationships import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Claim field_names whose values are images. License metadata for these
+# fields gets denormalized into extra_data so the API can filter by
+# permissiveness_rank without joining back through claims.
+IMAGE_FIELDS = frozenset({"opdb.images", "ipdb.image_urls", "image_urls"})
 
 
 def resolve_model(machine_model: MachineModel) -> MachineModel:

--- a/backend/apps/catalog/signals.py
+++ b/backend/apps/catalog/signals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from constance.signals import config_updated
 from django.db import models
 from django.db.models.signals import post_delete, post_save
 
@@ -15,6 +16,20 @@ def _invalidate_cache(
     **kwargs: Any,  # noqa: ANN401 - Django signal kwargs are framework-owned
 ) -> None:
     invalidate_all()
+
+
+# Constance's config_updated signal passes arbitrary value types (whatever the
+# changed setting holds — str, int, bool, etc.) and reserves the right to add
+# keyword arguments, so this is a framework-owned callback surface.
+def _invalidate_cache_on_policy_change(
+    sender: Any,  # noqa: ANN401 — constance signal sender
+    key: str,
+    old_value: Any,  # noqa: ANN401 — constance setting value, arbitrary type
+    new_value: Any,  # noqa: ANN401 — constance setting value, arbitrary type
+    **kwargs: Any,  # noqa: ANN401 — Django signal framework passthrough
+) -> None:
+    if key == "CONTENT_DISPLAY_POLICY":
+        invalidate_all()
 
 
 def _cache_invalidating_models() -> list[type[models.Model]]:
@@ -53,3 +68,7 @@ def connect() -> None:
         post_delete.connect(
             _invalidate_cache, sender=model, dispatch_uid=f"{uid}_delete"
         )
+    config_updated.connect(
+        _invalidate_cache_on_policy_change,
+        dispatch_uid="invalidate_cache_on_content_display_policy",
+    )

--- a/backend/apps/catalog/tests/test_api_cache.py
+++ b/backend/apps/catalog/tests/test_api_cache.py
@@ -1,4 +1,5 @@
 import pytest
+from constance.signals import config_updated
 from django.core.cache import cache
 
 from apps.catalog.cache import MODELS_ALL_KEY, TITLES_ALL_KEY
@@ -122,6 +123,41 @@ class TestCacheInvalidatingModelsParity:
             Title,
         }
         assert set(_cache_invalidating_models()) == expected
+
+
+class TestPolicyChangeInvalidation:
+    """Changing CONTENT_DISPLAY_POLICY busts cached /all/ payloads, since the
+    rendered content depends on the active display threshold."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        cache.clear()
+        yield
+        cache.clear()
+
+    def test_policy_change_invalidates_cache(self, client, machine_model):
+        client.get("/api/models/all/")
+        assert cache.get(MODELS_ALL_KEY) is not None
+
+        config_updated.send(
+            sender=None,
+            key="CONTENT_DISPLAY_POLICY",
+            old_value="licensed-only",
+            new_value="show-all",
+        )
+        assert cache.get(MODELS_ALL_KEY) is None
+
+    def test_unrelated_key_change_does_not_invalidate(self, client, machine_model):
+        client.get("/api/models/all/")
+        assert cache.get(MODELS_ALL_KEY) is not None
+
+        config_updated.send(
+            sender=None,
+            key="SOME_OTHER_KEY",
+            old_value="a",
+            new_value="b",
+        )
+        assert cache.get(MODELS_ALL_KEY) is not None
 
 
 class TestConditionalGet:

--- a/backend/apps/catalog/tests/test_image_licensing.py
+++ b/backend/apps/catalog/tests/test_image_licensing.py
@@ -6,8 +6,8 @@ from apps.catalog.api.helpers import _extract_image_urls
 from apps.catalog.models import Title
 from apps.catalog.resolve import resolve_model
 from apps.catalog.tests.conftest import make_machine_model
-from apps.core.licensing import resolve_effective_license
 from apps.core.models import License
+from apps.provenance.licensing import resolve_effective_license
 from apps.provenance.models import Claim, Source, SourceFieldLicense
 
 
@@ -79,7 +79,7 @@ class TestEffectiveLicenseResolution:
         claim = Claim.objects.assert_claim(title, "description", "text", source=opdb)
         claim.source = opdb
 
-        from apps.core.licensing import build_source_field_license_map
+        from apps.provenance.licensing import build_source_field_license_map
 
         sfl_map = build_source_field_license_map()
         lic = resolve_effective_license(claim, sfl_map)

--- a/backend/apps/core/apps.py
+++ b/backend/apps/core/apps.py
@@ -1,30 +1,6 @@
-from typing import Any
-
 from django.apps import AppConfig
 
 
 class CoreConfig(AppConfig):
     name = "apps.core"
     verbose_name = "Core"
-
-    def ready(self) -> None:
-        from constance.signals import config_updated
-
-        config_updated.connect(_on_constance_updated)
-
-
-# Constance's config_updated signal passes arbitrary value types (whatever the
-# changed setting holds — str, int, bool, etc.) and reserves the right to add
-# keyword arguments, so this is a framework-owned callback surface.
-def _on_constance_updated(
-    sender: Any,  # noqa: ANN401 — constance signal sender
-    key: str,
-    old_value: Any,  # noqa: ANN401 — constance setting value, arbitrary type
-    new_value: Any,  # noqa: ANN401 — constance setting value, arbitrary type
-    **kwargs: Any,  # noqa: ANN401 — Django signal framework passthrough
-) -> None:
-    """Invalidate API caches when Constance settings change."""
-    if key == "CONTENT_DISPLAY_POLICY":
-        from apps.catalog.cache import invalidate_all
-
-        invalidate_all()

--- a/backend/apps/core/licensing.py
+++ b/backend/apps/core/licensing.py
@@ -1,18 +1,10 @@
-"""Licensing helpers for display threshold and effective license resolution."""
+"""License policy helpers: display threshold, rank lookup, canonical seeding."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TypedDict
 
-if TYPE_CHECKING:
-    from apps.core.models import License
-    from apps.provenance.models import Claim
-
-
-# Prefetched (source_id, field_name) → license lookup, built once per request
-# by build_source_field_license_map() to avoid N+1 queries when resolving
-# effective licenses for many claims.
-type SourceFieldLicenseMap = dict[tuple[int, str], License | None]
+from apps.core.models import License
 
 
 class _LicenseSeed(TypedDict):
@@ -59,27 +51,8 @@ def is_displayable(license_obj: License | None) -> bool:
     return effective_rank(license_obj) >= get_minimum_display_rank()
 
 
-# Image field names that get license metadata denormalized into extra_data.
-IMAGE_FIELDS = frozenset({"opdb.images", "ipdb.image_urls", "image_urls"})
-
-
-def build_source_field_license_map() -> SourceFieldLicenseMap:
-    """Prefetch all SourceFieldLicense rows into a lookup dict.
-
-    Returns {(source_id, field_name): license_obj}.
-    """
-    from apps.provenance.models import SourceFieldLicense
-
-    return {
-        (sfl.source_id, sfl.field_name): sfl.license
-        for sfl in SourceFieldLicense.objects.select_related("license").all()
-    }
-
-
 def ensure_licenses() -> int:
     """Create canonical license records if they don't exist. Returns count created."""
-    from apps.core.models import License
-
     created = 0
     for data in _CANONICAL_LICENSES:
         _, was_created = License.objects.get_or_create(slug=data["slug"], defaults=data)
@@ -382,26 +355,3 @@ _CANONICAL_LICENSES: list[_LicenseSeed] = [
         "permissiveness_rank": 0,
     },
 ]
-
-
-def resolve_effective_license(
-    claim: Claim,
-    sfl_map: SourceFieldLicenseMap | None = None,
-) -> License | None:
-    """Resolve the effective license for a claim.
-
-    Resolution order:
-    1. claim.license (per-claim override)
-    2. SourceFieldLicense for (claim.source, claim.field_name)
-    3. claim.source.default_license (source-wide default)
-    4. None (unknown)
-    """
-    if claim.license_id:
-        return claim.license
-    if claim.source_id:
-        if sfl_map is not None:
-            sfl_license = sfl_map.get((claim.source_id, claim.field_name))
-            if sfl_license:
-                return sfl_license
-        return claim.source.default_license if claim.source else None
-    return None

--- a/backend/apps/core/markdown.py
+++ b/backend/apps/core/markdown.py
@@ -13,6 +13,9 @@ from django.db import models
 from django.utils.safestring import mark_safe
 from markdown_it import MarkdownIt
 
+from apps.core.markdown_links import render_all_links
+from apps.core.models import get_markdown_fields
+
 # CommonMark-compliant markdown parser.
 # - linkify: auto-link bare URLs during parsing (structure-aware, won't
 #   linkify inside code blocks or existing links)
@@ -153,8 +156,6 @@ def render_markdown_html(
     if not text:
         return ""
     # Convert [[type:ref]] links to markdown links (before markdown processing)
-    from apps.core.markdown_links import render_all_links
-
     text = render_all_links(text, metadata_out=metadata_out)
     # Convert markdown to HTML (bare URLs are auto-linked during parsing)
     html = _md.render(text)
@@ -203,8 +204,6 @@ def render_markdown_fields(
             **render_markdown_fields(obj),
         }
     """
-    from apps.core.models import get_markdown_fields
-
     result: dict[str, str | list[dict[str, Any]]] = {}
     for field_name in get_markdown_fields(type(obj)):
         citations: list[dict[str, Any]] = []

--- a/backend/apps/core/markdown_links.py
+++ b/backend/apps/core/markdown_links.py
@@ -30,6 +30,7 @@ from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import Q
 
+from apps.core.models import RecordReference, get_markdown_fields
 from apps.core.schemas import LinkTargetSchema
 
 
@@ -505,8 +506,6 @@ def sync_references(source: models.Model, content: str) -> None:
     """
     from django.contrib.contenttypes.models import ContentType
 
-    from apps.core.models import RecordReference
-
     content = content or ""
 
     # Parse all link IDs from content using registered patterns
@@ -604,8 +603,6 @@ def prepare_markdown_claim_value(
     Raises :exc:`~django.core.exceptions.ValidationError` if any linked
     targets don't exist.
     """
-    from apps.core.models import get_markdown_fields
-
     if (
         isinstance(value, str)
         and value

--- a/backend/apps/provenance/licensing.py
+++ b/backend/apps/provenance/licensing.py
@@ -1,0 +1,45 @@
+"""Claim- and source-aware license resolution."""
+
+from __future__ import annotations
+
+from apps.core.models import License
+from apps.provenance.models import Claim, SourceFieldLicense
+
+# Prefetched (source_id, field_name) → license lookup, built once per request
+# by build_source_field_license_map() to avoid N+1 queries when resolving
+# effective licenses for many claims.
+type SourceFieldLicenseMap = dict[tuple[int, str], License | None]
+
+
+def build_source_field_license_map() -> SourceFieldLicenseMap:
+    """Prefetch all SourceFieldLicense rows into a lookup dict.
+
+    Returns {(source_id, field_name): license_obj}.
+    """
+    return {
+        (sfl.source_id, sfl.field_name): sfl.license
+        for sfl in SourceFieldLicense.objects.select_related("license").all()
+    }
+
+
+def resolve_effective_license(
+    claim: Claim,
+    sfl_map: SourceFieldLicenseMap | None = None,
+) -> License | None:
+    """Resolve the effective license for a claim.
+
+    Resolution order:
+    1. claim.license (per-claim override)
+    2. SourceFieldLicense for (claim.source, claim.field_name)
+    3. claim.source.default_license (source-wide default)
+    4. None (unknown)
+    """
+    if claim.license_id:
+        return claim.license
+    if claim.source_id:
+        if sfl_map is not None:
+            sfl_license = sfl_map.get((claim.source_id, claim.field_name))
+            if sfl_license:
+                return sfl_license
+        return claim.source.default_license if claim.source else None
+    return None


### PR DESCRIPTION
## Summary

- `apps.core.licensing` previously mixed pure license policy with claim/source license resolution, requiring a `TYPE_CHECKING` import of `Claim` and a runtime lazy import of `SourceFieldLicense` to break a core→provenance cycle.
- Moves `SourceFieldLicenseMap`, `build_source_field_license_map`, and `resolve_effective_license` to a new `apps.provenance.licensing` module. `IMAGE_FIELDS` (catalog/ingest-specific) moves into `apps.catalog.resolve`. Core retains rank helpers, display threshold, canonical license seeding.
- Moves the `CONTENT_DISPLAY_POLICY` Constance cache-invalidation listener from `CoreConfig.ready()` into `apps.catalog.signals` — the cache being invalidated belongs to catalog. Adds tests for the moved listener (matching key busts cache, unrelated key does not).
- While in the area: drops now-unnecessary `TYPE_CHECKING` blocks and function-body lazy imports across `apps.core` (`licensing`, `markdown`, `markdown_links`, `apps`).

After this change, `apps.core` has **zero outbound `apps.*` imports** outside tests and migrations.

## Test plan

- [x] `uv run pytest` — 2266 passed, 1 skipped (pre-existing)
- [x] `uv run ruff check apps/` — clean
- [x] `uv run ruff format --check apps/` — 285 files already formatted
- [x] `uv run mypy apps/` — 160 errors, identical to baseline (no new regressions)
- [x] New test coverage: `TestPolicyChangeInvalidation` in `apps/catalog/tests/test_api_cache.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)