### PR TITLE
refactor(catalog): split api/helpers.py into images and rich_text modules

### DIFF
--- a/backend/apps/catalog/api/corporate_entities.py
+++ b/backend/apps/catalog/api/corporate_entities.py
@@ -33,11 +33,11 @@ from .edit_claims import (
 )
 from .entity_crud import register_entity_create, register_entity_delete_restore
 from .helpers import (
-    _build_rich_text,
-    _collect_titles,
-    _serialize_locations,
+    collect_titles,
+    serialize_locations,
 )
 from .manufacturers import manufacturers_router
+from .rich_text import build_rich_text
 from .schemas import (
     CorporateEntityClaimPatchSchema,
     CorporateEntityLocationSchema,
@@ -106,13 +106,13 @@ def _serialize_detail(ce: CorporateEntity) -> CorporateEntityDetailSchema:
     return CorporateEntityDetailSchema(
         name=ce.name,
         slug=ce.slug,
-        description=_build_rich_text(ce, "description", active_claims(ce)),
+        description=build_rich_text(ce, "description", active_claims(ce)),
         manufacturer=EntityRef(name=ce.manufacturer.name, slug=ce.manufacturer.slug),
         year_start=ce.year_start,
         year_end=ce.year_end,
         aliases=[a.value for a in ce.aliases.all()],
-        locations=_serialize_locations(ce),
-        titles=_collect_titles(ce.models.all()),
+        locations=serialize_locations(ce),
+        titles=collect_titles(ce.models.all()),
     )
 
 
@@ -157,7 +157,7 @@ def list_corporate_entities(
             year_start=ce.year_start,
             year_end=ce.year_end,
             model_count=cast(HasModelCount, ce).model_count,
-            locations=_serialize_locations(ce),
+            locations=serialize_locations(ce),
         )
         for ce in qs
     ]

--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -22,10 +22,8 @@ from ..models import Franchise, MachineModel, Title
 from ._typing import HasTitleCount
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
-from .helpers import (
-    _build_rich_text,
-    _serialize_title_ref,
-)
+from .helpers import serialize_title_ref
+from .rich_text import build_rich_text
 from .schemas import ClaimPatchSchema, TitleRef
 
 # ---------------------------------------------------------------------------
@@ -106,11 +104,9 @@ def _serialize_franchise_detail(franchise: Franchise) -> FranchiseDetailSchema:
     return FranchiseDetailSchema(
         name=franchise.name,
         slug=franchise.slug,
-        description=_build_rich_text(
-            franchise, "description", active_claims(franchise)
-        ),
+        description=build_rich_text(franchise, "description", active_claims(franchise)),
         titles=[
-            _serialize_title_ref(t, min_rank=min_rank) for t in franchise.titles.all()
+            serialize_title_ref(t, min_rank=min_rank) for t in franchise.titles.all()
         ],
     )
 

--- a/backend/apps/catalog/api/gameplay_features.py
+++ b/backend/apps/catalog/api/gameplay_features.py
@@ -26,11 +26,8 @@ from .edit_claims import (
     validate_scalar_fields,
 )
 from .entity_crud import register_entity_create, register_entity_delete_restore
-from .helpers import (
-    _build_rich_text,
-    _media_prefetch,
-    _serialize_uploaded_media,
-)
+from .images import media_prefetch, serialize_uploaded_media
+from .rich_text import build_rich_text
 from .schemas import (
     EntityRef,
     HierarchyClaimPatchSchema,
@@ -70,7 +67,7 @@ def _detail_qs() -> QuerySet[GameplayFeature]:
         Prefetch("children", queryset=GameplayFeature.objects.active()),
         "aliases",
         claims_prefetch(),
-        _media_prefetch(),
+        media_prefetch(),
     )
 
 
@@ -78,14 +75,14 @@ def _serialize_detail(feature: GameplayFeature) -> GameplayFeatureDetailSchema:
     return GameplayFeatureDetailSchema(
         name=feature.name,
         slug=feature.slug,
-        description=_build_rich_text(feature, "description", active_claims(feature)),
+        description=build_rich_text(feature, "description", active_claims(feature)),
         aliases=[a.value for a in feature.aliases.all()],
         parents=[EntityRef(name=p.name, slug=p.slug) for p in feature.parents.all()],
         children=[
             EntityRef(name=c.name, slug=c.slug)
             for c in feature.children.order_by("name")
         ],
-        uploaded_media=_serialize_uploaded_media(all_media(feature)),
+        uploaded_media=serialize_uploaded_media(all_media(feature)),
     )
 
 

--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -2,31 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
-from typing import Any
+from collections.abc import Iterable
 
-from django.db.models import Model, Prefetch
+from django.db.models import Model
 
-from apps.core.licensing import (
-    UNKNOWN_LICENSE_RANK,
-    get_minimum_display_rank,
-)
-from apps.core.markdown import render_markdown_field
-from apps.core.markdown_links import convert_storage_to_authoring
+from apps.core.licensing import get_minimum_display_rank
 from apps.core.types import JsonData
-from apps.media.models import EntityMedia
-from apps.media.schemas import MediaRenditionsSchema, UploadedMediaSchema
-from apps.media.storage import build_public_url, build_storage_key
-from apps.provenance.licensing import (
-    build_source_field_license_map,
-    resolve_effective_license,
-)
-from apps.provenance.models import Claim
-from apps.provenance.schemas import (
-    AttributionSchema,
-    InlineCitationSchema,
-    RichTextSchema,
-)
 
 from ..models import (
     CorporateEntity,
@@ -36,6 +17,7 @@ from ..models import (
     MachineModel,
     Title,
 )
+from .images import extract_image_urls
 from .schemas import (
     CorporateEntityLocationAncestorRef,
     CorporateEntityLocationSchema,
@@ -52,7 +34,7 @@ from .schemas import (
 # ---------------------------------------------------------------------------
 
 
-def _serialize_credit(credit: Credit) -> CreditSchema:
+def serialize_credit(credit: Credit) -> CreditSchema:
     """Serialize a Credit row into a CreditSchema."""
     return CreditSchema(
         person=EntityRef(name=credit.person.name, slug=credit.person.slug),
@@ -60,19 +42,6 @@ def _serialize_credit(credit: Credit) -> CreditSchema:
         role_display=credit.role.name,
         role_sort_order=credit.role.display_order,
     )
-
-
-def _first_thumbnail(
-    entities_with_models: Iterable[CorporateEntity], *, min_rank: int
-) -> str | None:
-    """Return the first non-None thumbnail URL from nested entity→model prefetches."""
-    for entity in entities_with_models:
-        for model in entity.models.all():
-            if model.extra_data:
-                thumb, _ = _extract_image_urls(model.extra_data, min_rank=min_rank)
-                if thumb:
-                    return thumb
-    return None
 
 
 def _intersect_facet_sets(
@@ -96,7 +65,7 @@ def _intersect_facet_sets(
     return [EntityRef(slug=s, name=n) for s, n in sorted(common)] if common else []
 
 
-def _serialize_title_ref(title: Title, *, min_rank: int | None = None) -> TitleRef:
+def serialize_title_ref(title: Title, *, min_rank: int | None = None) -> TitleRef:
     """Serialize a Title for use in franchise/series listing context.
 
     Expects *title* to have prefetched ``machine_models`` (with
@@ -108,9 +77,7 @@ def _serialize_title_ref(title: Title, *, min_rank: int | None = None) -> TitleR
     year = None
     first = next(iter(title.machine_models.all()), None)
     if first is not None:
-        thumbnail_url, _ = _extract_image_urls(
-            first.extra_data or {}, min_rank=min_rank
-        )
+        thumbnail_url, _ = extract_image_urls(first.extra_data or {}, min_rank=min_rank)
         manufacturer_name = (
             first.corporate_entity.manufacturer.name
             if first.corporate_entity and first.corporate_entity.manufacturer
@@ -129,231 +96,7 @@ def _serialize_title_ref(title: Title, *, min_rank: int | None = None) -> TitleR
     )
 
 
-# ---------------------------------------------------------------------------
-# Media helpers
-# ---------------------------------------------------------------------------
-
-
-# Slot 2 is Any because prefetch_related has a single _PrefetchedQuerySetT
-# TypeVar it must unify across all heterogeneous Prefetch args at the call
-# site; any concrete queryset type here breaks that unification. The Any
-# is an artifact of django-stubs' API design, not lost information.
-def _media_prefetch() -> Prefetch[str, Any, str]:
-    """Return a Prefetch for ready EntityMedia with assets."""
-    return Prefetch(
-        "entity_media",
-        queryset=EntityMedia.objects.filter(
-            asset__status="ready",
-        ).select_related("asset", "asset__uploaded_by"),
-        to_attr="all_media",
-    )
-
-
-def _serialize_uploaded_media(
-    all_media: Iterable[EntityMedia],
-) -> list[UploadedMediaSchema]:
-    """Serialize EntityMedia rows into the uploaded_media response list."""
-    return [
-        UploadedMediaSchema(
-            asset_uuid=str(em.asset.uuid),
-            category=em.category,
-            is_primary=em.is_primary,
-            uploaded_by_username=(
-                em.asset.uploaded_by.username if em.asset.uploaded_by else None
-            ),
-            renditions=MediaRenditionsSchema(
-                thumb=build_public_url(build_storage_key(em.asset.uuid, "thumb")),
-                display=build_public_url(build_storage_key(em.asset.uuid, "display")),
-            ),
-        )
-        for em in all_media
-    ]
-
-
-def _uploaded_image_urls(
-    primary_media: Sequence[EntityMedia] | None,
-) -> tuple[str | None, str | None]:
-    """Return (thumbnail_url, hero_image_url) from prefetched EntityMedia.
-
-    Prefers ``backglass`` category, then falls back to any primary.
-    Returns ``(None, None)`` when no uploaded media is available.
-    """
-    if not primary_media:
-        return None, None
-
-    # Prefer backglass, fall back to first available primary.
-    chosen = None
-    for em in primary_media:
-        if em.category == "backglass":
-            chosen = em
-            break
-    if chosen is None:
-        chosen = primary_media[0]
-
-    asset_uuid = chosen.asset.uuid
-    thumb = build_public_url(build_storage_key(asset_uuid, "thumb"))
-    hero = build_public_url(build_storage_key(asset_uuid, "display"))
-    return thumb, hero
-
-
-def _extract_image_urls(
-    extra_data: JsonData,
-    primary_media: Sequence[EntityMedia] | None = None,
-    *,
-    min_rank: int | None = None,
-) -> tuple[str | None, str | None]:
-    """Return (thumbnail_url, hero_image_url).
-
-    When *primary_media* (prefetched ``EntityMedia`` rows) contains uploaded
-    images, those are used unconditionally (no license gating — Pinbase owns
-    them).  Otherwise falls back to third-party images in *extra_data*,
-    respecting the global Constance display threshold.
-
-    Pass *min_rank* to avoid repeated Constance DB lookups in tight loops.
-    """
-    # Uploaded media always wins — no license gating.
-    thumb, hero = _uploaded_image_urls(primary_media)
-    if thumb or hero:
-        return thumb, hero
-
-    if min_rank is None:
-        min_rank = get_minimum_display_rank()
-
-    def _rank_ok(key: str) -> bool:
-        rank = extra_data.get(f"{key}.__permissiveness_rank")
-        effective = rank if isinstance(rank, int) else UNKNOWN_LICENSE_RANK
-        return effective >= min_rank
-
-    def _abs(url: str | None) -> str | None:
-        """Return *url* only if it's an absolute HTTP(S) URL, else None."""
-        if url and (url.startswith("http://") or url.startswith("https://")):
-            return url
-        return None
-
-    # Try OPDB structured images first (have size variants).
-    images = extra_data.get("opdb.images")
-    if images and isinstance(images, list) and _rank_ok("opdb.images"):
-        img = None
-        for candidate in images:
-            if isinstance(candidate, dict) and candidate.get("primary"):
-                img = candidate
-                break
-        if img is None:
-            img = images[0] if images else None
-        if isinstance(img, dict):
-            urls = img.get("urls") or {}
-            thumbnail = _abs(urls.get("medium") or urls.get("small"))
-            hero = _abs(urls.get("large") or urls.get("medium"))
-            if thumbnail or hero:
-                return thumbnail, hero
-
-    # Fall back to flat URL list (IPDB-sourced or scraped).
-    for key in ("ipdb.image_urls", "image_urls"):
-        image_urls = extra_data.get(key)
-        if image_urls and isinstance(image_urls, list) and _rank_ok(key):
-            first = image_urls[0]
-            if isinstance(first, str) and _abs(first):
-                return first, first
-
-    return None, None
-
-
-def _extract_image_attribution(
-    extra_data: JsonData,
-    primary_media: Sequence[EntityMedia] | None = None,
-) -> AttributionSchema | None:
-    """Return AttributionSchema for the displayed image, or None.
-
-    When uploaded media is being used (determined by *primary_media*), returns
-    ``None`` — no third-party license to cite.  Otherwise checks each external
-    image source in priority order and returns info for the first source that
-    passes the display threshold.
-    """
-    # Uploaded media has no third-party attribution.
-    if primary_media:
-        return None
-
-    min_rank = get_minimum_display_rank()
-
-    for key in ("opdb.images", "ipdb.image_urls", "image_urls"):
-        data = extra_data.get(key)
-        if not data:
-            continue
-        rank_raw = extra_data.get(f"{key}.__permissiveness_rank")
-        rank = rank_raw if isinstance(rank_raw, int) else None
-        effective = rank if rank is not None else UNKNOWN_LICENSE_RANK
-        if effective >= min_rank:
-            license_slug_raw = extra_data.get(f"{key}.__license_slug")
-            license_slug = (
-                license_slug_raw if isinstance(license_slug_raw, str) else None
-            )
-            return AttributionSchema(
-                license_slug=license_slug,
-                permissiveness_rank=rank,
-            )
-
-    return None
-
-
-def _extract_description_attribution(
-    active_claims: Iterable[Claim],
-) -> AttributionSchema | None:
-    """Return AttributionSchema for the winning description claim, or None.
-
-    Expects active_claims to be ordered by claim_key, -priority, -created_at
-    (the standard prefetch ordering).
-    """
-    sfl_map = None
-    for claim in active_claims:
-        if claim.field_name == "description":
-            if sfl_map is None:
-                sfl_map = build_source_field_license_map()
-            lic = resolve_effective_license(claim, sfl_map)
-            return AttributionSchema(
-                license_slug=lic.slug if lic else None,
-                license_name=lic.short_name if lic else None,
-                license_url=lic.url if lic else None,
-                permissiveness_rank=lic.permissiveness_rank if lic else None,
-                requires_attribution=lic.requires_attribution if lic else False,
-                source_name=claim.source.name if claim.source else None,
-                source_url=claim.source.url if claim.source else None,
-                attribution_text=claim.citation or None,
-            )
-    return None
-
-
-def _build_rich_text(
-    obj: Model,
-    field_name: str,
-    active_claims: Iterable[Claim] | None = None,
-) -> RichTextSchema:
-    """Build a RichTextSchema for a text field with attribution.
-
-    Reads the raw text from obj.{field_name}, renders HTML via
-    render_markdown_field, and extracts attribution from the winning claim.
-
-    The ``text`` value is returned in authoring format (``[[type:slug]]``)
-    so edit forms show human-readable link references.  The ``html`` value
-    is rendered from the storage format and is display-ready.
-    """
-    raw_text = getattr(obj, field_name, "") or ""
-    text = convert_storage_to_authoring(raw_text) if raw_text else raw_text
-    rendered = render_markdown_field(obj, field_name)
-    citations = [InlineCitationSchema.model_validate(c) for c in rendered.citations]
-
-    attribution = None
-    if active_claims is not None:
-        attribution = _extract_description_attribution(active_claims)
-
-    return RichTextSchema(
-        text=text,
-        html=rendered.html,
-        citations=citations,
-        attribution=attribution,
-    )
-
-
-def _collect_titles(
+def collect_titles(
     models: Iterable[MachineModel], *, include_manufacturer: bool = False
 ) -> list[RelatedTitleSchema]:
     """Group models by title into a deduplicated title list."""
@@ -364,9 +107,7 @@ def _collect_titles(
             continue
         key = m.title.slug
         if key not in titles:
-            thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[
-                0
-            ]
+            thumbnail_url = extract_image_urls(m.extra_data or {}, min_rank=min_rank)[0]
             manufacturer_name = None
             if include_manufacturer:
                 mfr = (
@@ -383,9 +124,7 @@ def _collect_titles(
                 manufacturer_name=manufacturer_name,
             )
         elif titles[key].thumbnail_url is None:
-            thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[
-                0
-            ]
+            thumbnail_url = extract_image_urls(m.extra_data or {}, min_rank=min_rank)[0]
             if thumbnail_url:
                 titles[key].thumbnail_url = thumbnail_url
     return sorted(titles.values(), key=lambda t: (t.year is None, -(t.year or 0)))
@@ -406,7 +145,7 @@ def _location_ancestors(loc: Location) -> list[CorporateEntityLocationAncestorRe
     return ancestors
 
 
-def _serialize_locations(
+def serialize_locations(
     entity: CorporateEntity,
 ) -> list[CorporateEntityLocationSchema]:
     """Serialize CorporateEntityLocation rows with ancestor chains."""
@@ -454,14 +193,14 @@ def _get_feature_descendant_slugs(slug: str) -> set[str]:
     return result
 
 
-def _serialize_title_machine(
+def serialize_title_machine(
     pm: MachineModel, *, min_rank: int | None = None
 ) -> TitleModelSchema:
     """Serialize a MachineModel for use in title/theme/system machine lists."""
     if min_rank is None:
         min_rank = get_minimum_display_rank()
 
-    thumbnail_url, _ = _extract_image_urls(pm.extra_data or {}, min_rank=min_rank)
+    thumbnail_url, _ = extract_image_urls(pm.extra_data or {}, min_rank=min_rank)
 
     # Include variants only when prefetched to avoid N+1 queries.
     variant_qs = (
@@ -474,7 +213,7 @@ def _serialize_title_machine(
             name=v.name,
             slug=v.slug,
             year=v.year,
-            thumbnail_url=_extract_image_urls(v.extra_data or {}, min_rank=min_rank)[0],
+            thumbnail_url=extract_image_urls(v.extra_data or {}, min_rank=min_rank)[0],
         )
         for v in variant_qs
     ]

--- a/backend/apps/catalog/api/images.py
+++ b/backend/apps/catalog/api/images.py
@@ -1,0 +1,202 @@
+"""Image and uploaded-media helpers for catalog API endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from django.db.models import Prefetch
+
+from apps.core.licensing import (
+    UNKNOWN_LICENSE_RANK,
+    get_minimum_display_rank,
+)
+from apps.core.types import JsonData
+from apps.media.models import EntityMedia
+from apps.media.schemas import MediaRenditionsSchema, UploadedMediaSchema
+from apps.media.storage import build_public_url, build_storage_key
+from apps.provenance.schemas import AttributionSchema
+
+from ..models import CorporateEntity
+
+__all__ = [
+    "extract_image_attribution",
+    "extract_image_urls",
+    "first_thumbnail",
+    "media_prefetch",
+    "serialize_uploaded_media",
+]
+
+
+# Slot 2 is Any because prefetch_related has a single _PrefetchedQuerySetT
+# TypeVar it must unify across all heterogeneous Prefetch args at the call
+# site; any concrete queryset type here breaks that unification. The Any
+# is an artifact of django-stubs' API design, not lost information.
+def media_prefetch() -> Prefetch[str, Any, str]:
+    """Return a Prefetch for ready EntityMedia with assets."""
+    return Prefetch(
+        "entity_media",
+        queryset=EntityMedia.objects.filter(
+            asset__status="ready",
+        ).select_related("asset", "asset__uploaded_by"),
+        to_attr="all_media",
+    )
+
+
+def serialize_uploaded_media(
+    all_media: Iterable[EntityMedia],
+) -> list[UploadedMediaSchema]:
+    """Serialize EntityMedia rows into the uploaded_media response list."""
+    return [
+        UploadedMediaSchema(
+            asset_uuid=str(em.asset.uuid),
+            category=em.category,
+            is_primary=em.is_primary,
+            uploaded_by_username=(
+                em.asset.uploaded_by.username if em.asset.uploaded_by else None
+            ),
+            renditions=MediaRenditionsSchema(
+                thumb=build_public_url(build_storage_key(em.asset.uuid, "thumb")),
+                display=build_public_url(build_storage_key(em.asset.uuid, "display")),
+            ),
+        )
+        for em in all_media
+    ]
+
+
+def _uploaded_image_urls(
+    primary_media: Sequence[EntityMedia] | None,
+) -> tuple[str | None, str | None]:
+    """Return (thumbnail_url, hero_image_url) from prefetched EntityMedia.
+
+    Prefers ``backglass`` category, then falls back to any primary.
+    Returns ``(None, None)`` when no uploaded media is available.
+    """
+    if not primary_media:
+        return None, None
+
+    # Prefer backglass, fall back to first available primary.
+    chosen = None
+    for em in primary_media:
+        if em.category == "backglass":
+            chosen = em
+            break
+    if chosen is None:
+        chosen = primary_media[0]
+
+    asset_uuid = chosen.asset.uuid
+    thumb = build_public_url(build_storage_key(asset_uuid, "thumb"))
+    hero = build_public_url(build_storage_key(asset_uuid, "display"))
+    return thumb, hero
+
+
+def extract_image_urls(
+    extra_data: JsonData,
+    primary_media: Sequence[EntityMedia] | None = None,
+    *,
+    min_rank: int | None = None,
+) -> tuple[str | None, str | None]:
+    """Return (thumbnail_url, hero_image_url).
+
+    When *primary_media* (prefetched ``EntityMedia`` rows) contains uploaded
+    images, those are used unconditionally (no license gating — Pinbase owns
+    them).  Otherwise falls back to third-party images in *extra_data*,
+    respecting the global Constance display threshold.
+
+    Pass *min_rank* to avoid repeated Constance DB lookups in tight loops.
+    """
+    # Uploaded media always wins — no license gating.
+    thumb, hero = _uploaded_image_urls(primary_media)
+    if thumb or hero:
+        return thumb, hero
+
+    if min_rank is None:
+        min_rank = get_minimum_display_rank()
+
+    def _rank_ok(key: str) -> bool:
+        rank = extra_data.get(f"{key}.__permissiveness_rank")
+        effective = rank if isinstance(rank, int) else UNKNOWN_LICENSE_RANK
+        return effective >= min_rank
+
+    def _abs(url: str | None) -> str | None:
+        """Return *url* only if it's an absolute HTTP(S) URL, else None."""
+        if url and (url.startswith("http://") or url.startswith("https://")):
+            return url
+        return None
+
+    # Try OPDB structured images first (have size variants).
+    images = extra_data.get("opdb.images")
+    if images and isinstance(images, list) and _rank_ok("opdb.images"):
+        img = None
+        for candidate in images:
+            if isinstance(candidate, dict) and candidate.get("primary"):
+                img = candidate
+                break
+        if img is None:
+            img = images[0] if images else None
+        if isinstance(img, dict):
+            urls = img.get("urls") or {}
+            thumbnail = _abs(urls.get("medium") or urls.get("small"))
+            hero = _abs(urls.get("large") or urls.get("medium"))
+            if thumbnail or hero:
+                return thumbnail, hero
+
+    # Fall back to flat URL list (IPDB-sourced or scraped).
+    for key in ("ipdb.image_urls", "image_urls"):
+        image_urls = extra_data.get(key)
+        if image_urls and isinstance(image_urls, list) and _rank_ok(key):
+            first = image_urls[0]
+            if isinstance(first, str) and _abs(first):
+                return first, first
+
+    return None, None
+
+
+def extract_image_attribution(
+    extra_data: JsonData,
+    primary_media: Sequence[EntityMedia] | None = None,
+) -> AttributionSchema | None:
+    """Return AttributionSchema for the displayed image, or None.
+
+    When uploaded media is being used (determined by *primary_media*), returns
+    ``None`` — no third-party license to cite.  Otherwise checks each external
+    image source in priority order and returns info for the first source that
+    passes the display threshold.
+    """
+    # Uploaded media has no third-party attribution.
+    if primary_media:
+        return None
+
+    min_rank = get_minimum_display_rank()
+
+    for key in ("opdb.images", "ipdb.image_urls", "image_urls"):
+        data = extra_data.get(key)
+        if not data:
+            continue
+        rank_raw = extra_data.get(f"{key}.__permissiveness_rank")
+        rank = rank_raw if isinstance(rank_raw, int) else None
+        effective = rank if rank is not None else UNKNOWN_LICENSE_RANK
+        if effective >= min_rank:
+            license_slug_raw = extra_data.get(f"{key}.__license_slug")
+            license_slug = (
+                license_slug_raw if isinstance(license_slug_raw, str) else None
+            )
+            return AttributionSchema(
+                license_slug=license_slug,
+                permissiveness_rank=rank,
+            )
+
+    return None
+
+
+def first_thumbnail(
+    entities_with_models: Iterable[CorporateEntity], *, min_rank: int
+) -> str | None:
+    """Return the first non-None thumbnail URL from nested entity→model prefetches."""
+    for entity in entities_with_models:
+        for model in entity.models.all():
+            if model.extra_data:
+                thumb, _ = extract_image_urls(model.extra_data, min_rank=min_rank)
+                if thumb:
+                    return thumb
+    return None

--- a/backend/apps/catalog/api/locations.py
+++ b/backend/apps/catalog/api/locations.py
@@ -30,7 +30,8 @@ from ..models import (
 )
 from ..services.location_paths import lookup_child_division
 from ._typing import HasModelCount
-from .helpers import _build_rich_text, _first_thumbnail
+from .images import first_thumbnail
+from .rich_text import build_rich_text
 
 # ---------------------------------------------------------------------------
 # Schemas
@@ -99,7 +100,7 @@ class _LocationNode:
     aliases: tuple[str, ...]
     # Pre-rendered at cache-build time so public detail reads stay
     # zero-query. Description rendering has no rank dependency
-    # (``_build_rich_text`` only consults claims for attribution; rank
+    # (``build_rich_text`` only consults claims for attribution; rank
     # gating in this module is image-only and runs per-request via
     # ``_get_manufacturers_for_pks``), so caching the rendered schema
     # is safe.
@@ -128,7 +129,7 @@ def _get_location_tree() -> _LocationTree:
         return cast(_LocationTree, result)
 
     # Load all locations with parent chains (up to 4 levels deep).
-    # ``aliases`` + ``claims_prefetch()`` feed ``_build_rich_text`` so
+    # ``aliases`` + ``claims_prefetch()`` feed ``build_rich_text`` so
     # the rendered description can be cached per node.
     all_locs = list(
         Location.objects.active()
@@ -170,7 +171,7 @@ def _get_location_tree() -> _LocationTree:
             short_name=loc.short_name,
             code=loc.code,
             aliases=tuple(a.value for a in loc.aliases.all()),
-            description=_build_rich_text(loc, "description", active_claims(loc)),
+            description=build_rich_text(loc, "description", active_claims(loc)),
             divisions=tuple(loc.divisions or ()),
         )
         children_index.setdefault(parent_path, []).append(loc.location_path)
@@ -253,7 +254,7 @@ def _get_manufacturers_for_pks(pks: Iterable[int]) -> list[LocationManufacturerS
             name=mfr.name,
             slug=mfr.slug,
             model_count=cast(HasModelCount, mfr).model_count,
-            thumbnail_url=_first_thumbnail(mfr.entities.all(), min_rank=min_rank),
+            thumbnail_url=first_thumbnail(mfr.entities.all(), min_rank=min_rank),
         )
         for mfr in qs
     ]

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -78,16 +78,18 @@ from .edit_claims import (
     raise_form_error,
 )
 from .helpers import (
-    _build_rich_text,
-    _extract_image_attribution,
-    _extract_image_urls,
     _extract_variant_features,
     _get_feature_descendant_slugs,
-    _media_prefetch,
-    _serialize_credit,
-    _serialize_title_machine,
-    _serialize_uploaded_media,
+    serialize_credit,
+    serialize_title_machine,
 )
+from .images import (
+    extract_image_attribution,
+    extract_image_urls,
+    media_prefetch,
+    serialize_uploaded_media,
+)
+from .rich_text import build_rich_text
 from .schemas import (
     AlreadyDeletedSchema,
     CreditSchema,
@@ -302,7 +304,7 @@ def _build_model_list_qs(
 def _serialize_model_list(
     pm: MachineModel, *, min_rank: int | None = None
 ) -> dict[str, Any]:
-    thumbnail_url, _ = _extract_image_urls(
+    thumbnail_url, _ = extract_image_urls(
         pm.extra_data or {}, primary_media(pm), min_rank=min_rank
     )
     mfr = (
@@ -347,18 +349,18 @@ def _serialize_model_detail(pm: MachineModel) -> ModelDetailSchema:
     """
     min_rank = get_minimum_display_rank()
 
-    credits = [_serialize_credit(c) for c in pm.credits.all()]
+    credits = [serialize_credit(c) for c in pm.credits.all()]
 
     claims = active_claims(pm)
 
     media = all_media(pm)
     primary = [em for em in media if em.is_primary]
-    thumbnail_url, hero_image_url = _extract_image_urls(
+    thumbnail_url, hero_image_url = extract_image_urls(
         pm.extra_data or {}, primary or None, min_rank=min_rank
     )
-    image_attribution = _extract_image_attribution(pm.extra_data or {}, primary or None)
-    uploaded_media = _serialize_uploaded_media(media)
-    description = _build_rich_text(pm, "description", claims)
+    image_attribution = extract_image_attribution(pm.extra_data or {}, primary or None)
+    uploaded_media = serialize_uploaded_media(media)
+    description = build_rich_text(pm, "description", claims)
     variant_features = _extract_variant_features(pm.extra_data or {})
 
     variants = [
@@ -525,7 +527,7 @@ def _serialize_model_detail(pm: MachineModel) -> ModelDetailSchema:
             else None
         ),
         title_models=[
-            _serialize_title_machine(sibling, min_rank=min_rank)
+            serialize_title_machine(sibling, min_rank=min_rank)
             for sibling in (pm.title.machine_models.all() if pm.title else [])
             if sibling.variant_of_id is None
         ],
@@ -585,7 +587,7 @@ def _model_detail_qs() -> QuerySet[MachineModel]:
                 ),
             ),
             claims_prefetch(),
-            _media_prefetch(),
+            media_prefetch(),
         )
     )
 
@@ -709,7 +711,7 @@ def list_recent_models(request: HttpRequest) -> list[ModelRecentSchema]:
         if title_id in seen_titles:
             continue
         seen_titles.add(title_id)
-        thumbnail_url, _ = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)
+        thumbnail_url, _ = extract_image_urls(m.extra_data or {}, min_rank=min_rank)
         results.append(
             ModelRecentSchema(
                 name=m.name,
@@ -851,7 +853,7 @@ def list_all_models(
     result: list[dict[str, Any]] = []
     for r in rows:
         mid = r.id
-        thumbnail_url, _ = _extract_image_urls(r.extra_data or {}, min_rank=min_rank)
+        thumbnail_url, _ = extract_image_urls(r.extra_data or {}, min_rank=min_rank)
 
         # Build search_text from bulk maps
         parts: list[str] = []

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -42,13 +42,11 @@ from .constants import DEFAULT_PAGE_SIZE
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
 from .helpers import (
-    _build_rich_text,
-    _collect_titles,
-    _extract_image_urls,
-    _media_prefetch,
-    _serialize_locations,
-    _serialize_uploaded_media,
+    collect_titles,
+    serialize_locations,
 )
+from .images import extract_image_urls, media_prefetch, serialize_uploaded_media
+from .rich_text import build_rich_text
 from .schemas import (
     ClaimPatchSchema,
     CorporateEntityLocationSchema,
@@ -168,7 +166,7 @@ def _serialize_manufacturer_detail(mfr: Manufacturer) -> ManufacturerDetailSchem
     return ManufacturerDetailSchema(
         name=mfr.name,
         slug=mfr.slug,
-        description=_build_rich_text(mfr, "description", active_claims(mfr)),
+        description=build_rich_text(mfr, "description", active_claims(mfr)),
         year_start=min(year_starts) if year_starts else None,
         year_end=max(year_ends) if year_ends else None,
         logo_url=mfr.logo_url,
@@ -179,17 +177,17 @@ def _serialize_manufacturer_detail(mfr: Manufacturer) -> ManufacturerDetailSchem
                 slug=e.slug,
                 year_start=e.year_start,
                 year_end=e.year_end,
-                locations=_serialize_locations(e),
+                locations=serialize_locations(e),
             )
             for e in mfr.entities.all()
         ],
-        titles=_collect_titles(m for e in mfr.entities.all() for m in e.models.all()),
+        titles=collect_titles(m for e in mfr.entities.all() for m in e.models.all()),
         systems=[
             ManufacturerSystemSchema(name=s.name, slug=s.slug)
             for s in mfr.systems.all()
         ],
         persons=persons,
-        uploaded_media=_serialize_uploaded_media(all_media(mfr)),
+        uploaded_media=serialize_uploaded_media(all_media(mfr)),
     )
 
 
@@ -218,7 +216,7 @@ def _manufacturer_qs() -> QuerySet[Manufacturer]:
         ),
         Prefetch("systems", queryset=System.objects.active().order_by("name")),
         claims_prefetch(),
-        _media_prefetch(),
+        media_prefetch(),
     )
 
 
@@ -456,7 +454,7 @@ def list_all_manufacturers(
         tm_id = mfr_thumb_model.get(mfr_id)
         tm = thumb_models.get(tm_id) if tm_id else None
         if tm and tm.extra_data:
-            thumb, _ = _extract_image_urls(tm.extra_data, min_rank=min_rank)
+            thumb, _ = extract_image_urls(tm.extra_data, min_rank=min_rank)
 
         loc_refs_map = mfr_location_refs.get(mfr_id, {})
         locations = [

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -49,12 +49,8 @@ from .entity_create import (
     validate_name,
     validate_slug_format,
 )
-from .helpers import (
-    _build_rich_text,
-    _extract_image_urls,
-    _media_prefetch,
-    _serialize_uploaded_media,
-)
+from .images import extract_image_urls, media_prefetch, serialize_uploaded_media
+from .rich_text import build_rich_text
 from .schemas import (
     AlreadyDeletedSchema,
     ClaimPatchSchema,
@@ -142,9 +138,9 @@ def _serialize_person_detail(person: Person) -> PersonDetailSchema:
             continue
         title = c.model.title
         key = title.slug
-        thumbnail_url = _extract_image_urls(
-            c.model.extra_data or {}, min_rank=min_rank
-        )[0]
+        thumbnail_url = extract_image_urls(c.model.extra_data or {}, min_rank=min_rank)[
+            0
+        ]
         if key not in accum:
             accum[key] = _PersonTitleAccum(
                 name=title.name,
@@ -177,7 +173,7 @@ def _serialize_person_detail(person: Person) -> PersonDetailSchema:
     return PersonDetailSchema(
         name=person.name,
         slug=person.slug,
-        description=_build_rich_text(person, "description", active_claims(person)),
+        description=build_rich_text(person, "description", active_claims(person)),
         birth_year=person.birth_year,
         birth_month=person.birth_month,
         birth_day=person.birth_day,
@@ -188,7 +184,7 @@ def _serialize_person_detail(person: Person) -> PersonDetailSchema:
         nationality=person.nationality,
         photo_url=person.photo_url,
         titles=titles,
-        uploaded_media=_serialize_uploaded_media(all_media(person)),
+        uploaded_media=serialize_uploaded_media(all_media(person)),
     )
 
 
@@ -203,7 +199,7 @@ def _person_qs() -> QuerySet[Person]:
             .order_by(F("model__year").desc(nulls_last=True), "model__name"),
         ),
         claims_prefetch(),
-        _media_prefetch(),
+        media_prefetch(),
     )
 
 
@@ -282,7 +278,7 @@ def list_all_people(
         tm_id = person_thumb_model.get(person_id)
         tm = thumb_models.get(tm_id) if tm_id else None
         if tm and tm.extra_data:
-            t, _ = _extract_image_urls(tm.extra_data, min_rank=min_rank)
+            t, _ = extract_image_urls(tm.extra_data, min_rank=min_rank)
             if t:
                 thumb = t
         result.append(

--- a/backend/apps/catalog/api/rich_text.py
+++ b/backend/apps/catalog/api/rich_text.py
@@ -1,0 +1,80 @@
+"""Rich-text rendering helpers for catalog API endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from django.db.models import Model
+
+from apps.core.markdown import render_markdown_field
+from apps.core.markdown_links import convert_storage_to_authoring
+from apps.provenance.licensing import (
+    build_source_field_license_map,
+    resolve_effective_license,
+)
+from apps.provenance.models import Claim
+from apps.provenance.schemas import (
+    AttributionSchema,
+    InlineCitationSchema,
+    RichTextSchema,
+)
+
+__all__ = ["build_rich_text"]
+
+
+def _extract_description_attribution(
+    active_claims: Iterable[Claim],
+) -> AttributionSchema | None:
+    """Return AttributionSchema for the winning description claim, or None.
+
+    Expects active_claims to be ordered by claim_key, -priority, -created_at
+    (the standard prefetch ordering).
+    """
+    sfl_map = None
+    for claim in active_claims:
+        if claim.field_name == "description":
+            if sfl_map is None:
+                sfl_map = build_source_field_license_map()
+            lic = resolve_effective_license(claim, sfl_map)
+            return AttributionSchema(
+                license_slug=lic.slug if lic else None,
+                license_name=lic.short_name if lic else None,
+                license_url=lic.url if lic else None,
+                permissiveness_rank=lic.permissiveness_rank if lic else None,
+                requires_attribution=lic.requires_attribution if lic else False,
+                source_name=claim.source.name if claim.source else None,
+                source_url=claim.source.url if claim.source else None,
+                attribution_text=claim.citation or None,
+            )
+    return None
+
+
+def build_rich_text(
+    obj: Model,
+    field_name: str,
+    active_claims: Iterable[Claim] | None = None,
+) -> RichTextSchema:
+    """Build a RichTextSchema for a text field with attribution.
+
+    Reads the raw text from obj.{field_name}, renders HTML via
+    render_markdown_field, and extracts attribution from the winning claim.
+
+    The ``text`` value is returned in authoring format (``[[type:slug]]``)
+    so edit forms show human-readable link references.  The ``html`` value
+    is rendered from the storage format and is display-ready.
+    """
+    raw_text = getattr(obj, field_name, "") or ""
+    text = convert_storage_to_authoring(raw_text) if raw_text else raw_text
+    rendered = render_markdown_field(obj, field_name)
+    citations = [InlineCitationSchema.model_validate(c) for c in rendered.citations]
+
+    attribution = None
+    if active_claims is not None:
+        attribution = _extract_description_attribution(active_claims)
+
+    return RichTextSchema(
+        text=text,
+        html=rendered.html,
+        citations=citations,
+        attribution=attribution,
+    )

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -23,11 +23,11 @@ from ._typing import HasTitleCount
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
 from .helpers import (
-    _build_rich_text,
-    _extract_image_urls,
-    _serialize_credit,
-    _serialize_title_ref,
+    serialize_credit,
+    serialize_title_ref,
 )
+from .images import extract_image_urls
+from .rich_text import build_rich_text
 from .schemas import (
     ClaimPatchSchema,
     CreditSchema,
@@ -100,11 +100,9 @@ def _serialize_series_detail(series: Series) -> SeriesDetailSchema:
     return SeriesDetailSchema(
         name=series.name,
         slug=series.slug,
-        description=_build_rich_text(series, "description", active_claims(series)),
-        titles=[
-            _serialize_title_ref(t, min_rank=min_rank) for t in series.titles.all()
-        ],
-        credits=[_serialize_credit(c) for c in series.credits.all()],
+        description=build_rich_text(series, "description", active_claims(series)),
+        titles=[serialize_title_ref(t, min_rank=min_rank) for t in series.titles.all()],
+        credits=[serialize_credit(c) for c in series.credits.all()],
     )
 
 
@@ -140,7 +138,7 @@ def list_series(request: HttpRequest) -> list[SeriesListItemSchema]:
         thumb = None
         for title in s.titles.all():
             for pm in title.machine_models.all():
-                t, _ = _extract_image_urls(pm.extra_data or {}, min_rank=min_rank)
+                t, _ = extract_image_urls(pm.extra_data or {}, min_rank=min_rank)
                 if t:
                     thumb = t
                     break
@@ -150,7 +148,7 @@ def list_series(request: HttpRequest) -> list[SeriesListItemSchema]:
             SeriesListItemSchema(
                 name=s.name,
                 slug=s.slug,
-                description=_build_rich_text(s, "description"),
+                description=build_rich_text(s, "description"),
                 title_count=cast(HasTitleCount, s).title_count,
                 thumbnail_url=thumb,
             )

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -39,10 +39,8 @@ from .entity_create import (
     validate_slug_format,
 )
 from .entity_crud import register_entity_delete_restore
-from .helpers import (
-    _build_rich_text,
-    _extract_image_urls,
-)
+from .images import extract_image_urls
+from .rich_text import build_rich_text
 from .schemas import (
     ClaimPatchSchema,
     EntityCreateInputSchema,
@@ -114,7 +112,7 @@ def _serialize_system_detail(system: System) -> SystemDetailSchema:
         if m.title is None:
             continue
         key = m.title.slug
-        thumbnail_url = _extract_image_urls(m.extra_data or {}, min_rank=min_rank)[0]
+        thumbnail_url = extract_image_urls(m.extra_data or {}, min_rank=min_rank)[0]
         if key not in accum:
             mfr = (
                 m.corporate_entity.manufacturer
@@ -156,7 +154,7 @@ def _serialize_system_detail(system: System) -> SystemDetailSchema:
     return SystemDetailSchema(
         name=system.name,
         slug=system.slug,
-        description=_build_rich_text(system, "description", active_claims(system)),
+        description=build_rich_text(system, "description", active_claims(system)),
         manufacturer=(
             EntityRef(name=system.manufacturer.name, slug=system.manufacturer.slug)
             if system.manufacturer

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -40,8 +40,10 @@ from .entity_crud import (
     register_entity_create,
     register_entity_delete_restore,
 )
-from .helpers import _build_rich_text, _extract_image_urls, _serialize_title_machine
+from .helpers import serialize_title_machine
+from .images import extract_image_urls
 from .people import PersonGridItemSchema
+from .rich_text import build_rich_text
 from .schemas import (
     ClaimPatchSchema,
     TitleModelSchema,
@@ -120,14 +122,14 @@ def _serialize_taxonomy(
         aliases = [a.value for a in obj.aliases.all()]
     # Dual-use serializer: called from list endpoints (no claims prefetch)
     # and detail endpoints (claims_prefetch applied). `getattr` with None
-    # lets _build_rich_text skip attribution for list callers; detail
+    # lets build_rich_text skip attribution for list callers; detail
     # callers get full attribution. Don't replace with active_claims() —
     # it would raise on the list path.
     return TaxonomySchema(
         name=obj.name,
         slug=obj.slug,
         display_order=obj.display_order,
-        description=_build_rich_text(
+        description=build_rich_text(
             obj, "description", getattr(obj, "active_claims", None)
         ),
         aliases=aliases,
@@ -507,7 +509,7 @@ def _serialize_reward_type_detail(rt: RewardType) -> RewardTypeDetailSchema:
     return RewardTypeDetailSchema(
         **_serialize_taxonomy(rt).model_dump(),
         machines=[
-            _serialize_title_machine(pm, min_rank=min_rank)
+            serialize_title_machine(pm, min_rank=min_rank)
             for pm in rt.machine_models.all()
         ],
     )
@@ -649,7 +651,7 @@ def _credit_role_people(cr: CreditRole) -> list[PersonGridItemSchema]:
         tm_id = person_thumb_model.get(pid)
         tm = thumb_models.get(tm_id) if tm_id else None
         if tm and tm.extra_data:
-            t, _ = _extract_image_urls(tm.extra_data, min_rank=min_rank)
+            t, _ = extract_image_urls(tm.extra_data, min_rank=min_rank)
             if t:
                 thumbnail = t
         out.append(

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -25,10 +25,8 @@ from .edit_claims import (
     validate_scalar_fields,
 )
 from .entity_crud import register_entity_create, register_entity_delete_restore
-from .helpers import (
-    _build_rich_text,
-    _serialize_title_machine,
-)
+from .helpers import serialize_title_machine
+from .rich_text import build_rich_text
 from .schemas import (
     EntityRef,
     HierarchyClaimPatchSchema,
@@ -84,14 +82,14 @@ def _serialize_detail(theme: Theme) -> ThemeDetailSchema:
     return ThemeDetailSchema(
         name=theme.name,
         slug=theme.slug,
-        description=_build_rich_text(theme, "description", active_claims(theme)),
+        description=build_rich_text(theme, "description", active_claims(theme)),
         aliases=[a.value for a in theme.aliases.all()],
         parents=[EntityRef(name=t.name, slug=t.slug) for t in theme.parents.all()],
         children=[
             EntityRef(name=t.name, slug=t.slug) for t in theme.children.order_by("name")
         ],
         machines=[
-            _serialize_title_machine(pm, min_rank=min_rank)
+            serialize_title_machine(pm, min_rank=min_rank)
             for pm in theme.machine_models.all()
         ],
     )

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -78,18 +78,17 @@ from .entity_create import (
     validate_slug_format,
 )
 from .helpers import (
-    _build_rich_text,
-    _extract_image_urls,
     _intersect_facet_sets,
-    _media_prefetch,
-    _serialize_credit,
-    _serialize_title_machine,
+    serialize_credit,
+    serialize_title_machine,
 )
+from .images import extract_image_urls, media_prefetch
 from .machine_models import (
     ModelDetailSchema,
     _model_detail_qs,
     _serialize_model_detail,
 )
+from .rich_text import build_rich_text
 from .schemas import (
     AlreadyDeletedSchema,
     CreditSchema,
@@ -305,7 +304,7 @@ def _serialize_title_list(
             ratings.append(float(m.ipdb_rating))
 
     if machines:
-        thumbnail_url, _ = _extract_image_urls(
+        thumbnail_url, _ = extract_image_urls(
             machines[0].extra_data or {}, min_rank=min_rank
         )
         first = machines[0]
@@ -536,7 +535,7 @@ def _select_title_hero_image_url(
     if not models:
         return None
 
-    _, hero_image_url = _extract_image_urls(
+    _, hero_image_url = extract_image_urls(
         models[0].extra_data or {}, min_rank=min_rank
     )
     return hero_image_url
@@ -545,7 +544,7 @@ def _select_title_hero_image_url(
 def _serialize_title_detail(title: Title) -> TitleDetailSchema:
     min_rank = get_minimum_display_rank()
     model_objs = list(title.machine_models.all())
-    machines = [_serialize_title_machine(pm, min_rank=min_rank) for pm in model_objs]
+    machines = [serialize_title_machine(pm, min_rank=min_rank) for pm in model_objs]
     series = (
         EntityRef(name=title.series.name, slug=title.series.slug)
         if title.series
@@ -563,7 +562,7 @@ def _serialize_title_detail(title: Title) -> TitleDetailSchema:
         for c in pm.credits.all():
             key = CreditKey(c.person.slug, c.role.slug)
             model_keys.add(key)
-            credit_data.setdefault(key, _serialize_credit(c))
+            credit_data.setdefault(key, serialize_credit(c))
         credit_sets.append(model_keys)
 
     if credit_sets:
@@ -589,7 +588,7 @@ def _serialize_title_detail(title: Title) -> TitleDetailSchema:
         pm = _model_detail_qs().get(slug=machines[0].slug)
         model_detail = _serialize_model_detail(pm)
 
-    description = _build_rich_text(title, "description", active_claims(title))
+    description = build_rich_text(title, "description", active_claims(title))
 
     return TitleDetailSchema(
         name=title.name,
@@ -648,7 +647,7 @@ def _title_models_prefetch() -> Prefetch[str, Any, str]:
             "credits__person",
             "credits__role",
             "variants",
-            _media_prefetch(),
+            media_prefetch(),
         )
         .order_by("year", "name"),
     )
@@ -795,7 +794,7 @@ def list_all_titles(request: HttpRequest) -> HttpResponse:
         id__in=primary_model_ids
     ).values_list("id", "extra_data"):
         if extra_data:
-            thumb, _ = _extract_image_urls(extra_data, min_rank=min_rank)
+            thumb, _ = extract_image_urls(extra_data, min_rank=min_rank)
             thumb_data[mid] = thumb
         else:
             thumb_data[mid] = None

--- a/backend/apps/catalog/tests/test_image_licensing.py
+++ b/backend/apps/catalog/tests/test_image_licensing.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from apps.catalog.api.helpers import _extract_image_urls
+from apps.catalog.api.images import extract_image_urls
 from apps.catalog.models import Title
 from apps.catalog.resolve import resolve_model
 from apps.catalog.tests.conftest import make_machine_model
@@ -185,7 +185,7 @@ class TestExtractImageUrlsWithThreshold:
             "opdb.images.__license_slug": "not-allowed",
             "opdb.images.__permissiveness_rank": 0,
         }
-        thumb, hero = _extract_image_urls(extra_data)
+        thumb, hero = extract_image_urls(extra_data)
         assert thumb is None
         assert hero is None
 
@@ -205,7 +205,7 @@ class TestExtractImageUrlsWithThreshold:
             "ipdb.image_urls": ["https://ipdb.org/ipdb.jpg"],
             "ipdb.image_urls.__permissiveness_rank": 85,  # above threshold
         }
-        thumb, _ = _extract_image_urls(extra_data)
+        thumb, _ = extract_image_urls(extra_data)
         assert thumb == "https://ipdb.org/ipdb.jpg"
 
     def test_null_rank_uses_unknown_rank(self):
@@ -223,7 +223,7 @@ class TestExtractImageUrlsWithThreshold:
             "opdb.images.__permissiveness_rank": None,  # unknown
         }
         # With "licensed-only" (min_rank=38), unknown (rank 5) should be hidden.
-        thumb, hero = _extract_image_urls(extra_data)
+        thumb, hero = extract_image_urls(extra_data)
         assert thumb is None
         assert hero is None
 
@@ -244,7 +244,7 @@ class TestExtractImageUrlsWithThreshold:
             "opdb.images.__permissiveness_rank": 0,
         }
         with override_config(CONTENT_DISPLAY_POLICY="show-all"):
-            thumb, _ = _extract_image_urls(extra_data)
+            thumb, _ = extract_image_urls(extra_data)
         assert thumb == "https://img.opdb.org/m.jpg"
 
     def test_include_unknown_shows_null_rank(self):
@@ -264,5 +264,5 @@ class TestExtractImageUrlsWithThreshold:
             "opdb.images.__permissiveness_rank": None,
         }
         with override_config(CONTENT_DISPLAY_POLICY="include-unknown"):
-            thumb, _ = _extract_image_urls(extra_data)
+            thumb, _ = extract_image_urls(extra_data)
         assert thumb == "https://img.opdb.org/m.jpg"

--- a/backend/apps/media/helpers.py
+++ b/backend/apps/media/helpers.py
@@ -13,12 +13,12 @@ def all_media(entity: models.Model) -> list[EntityMedia]:
     """Return all ready EntityMedia rows prefetched onto *entity*.
 
     Raises AssertionError if the queryset wasn't set up with
-    ``_media_prefetch()`` (to_attr="all_media").
+    ``media_prefetch()`` (to_attr="all_media").
     """
     media = getattr(entity, "all_media", None)
     if media is None:
         raise AssertionError(
-            f"{type(entity).__name__} was not loaded with _media_prefetch()"
+            f"{type(entity).__name__} was not loaded with media_prefetch()"
         )
     return cast(list[EntityMedia], media)
 

--- a/backend/apps/media/tests/test_api_response.py
+++ b/backend/apps/media/tests/test_api_response.py
@@ -7,7 +7,7 @@ from constance.test import override_config
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 
-from apps.catalog.api.helpers import _extract_image_attribution, _extract_image_urls
+from apps.catalog.api.images import extract_image_attribution, extract_image_urls
 from apps.catalog.models import MachineModel
 from apps.catalog.tests.conftest import make_machine_model
 from apps.media.models import EntityMedia, MediaAsset
@@ -100,7 +100,7 @@ OPDB_EXTRA_DATA = {
 
 
 # ---------------------------------------------------------------------------
-# _extract_image_urls — uploaded-first fallback
+# extract_image_urls — uploaded-first fallback
 # ---------------------------------------------------------------------------
 
 
@@ -109,7 +109,7 @@ class TestUploadedFirstFallback:
         em = _attach(ct_mm, machine_model, asset, category="backglass")
         primary_media = [em]
 
-        thumb, hero = _extract_image_urls({}, primary_media)
+        thumb, hero = extract_image_urls({}, primary_media)
 
         assert thumb == _expected_thumb(asset)
         assert hero == _expected_hero(asset)
@@ -119,7 +119,7 @@ class TestUploadedFirstFallback:
         em = _attach(ct_mm, machine_model, asset, category="playfield")
         primary_media = [em]
 
-        thumb, hero = _extract_image_urls({}, primary_media)
+        thumb, hero = extract_image_urls({}, primary_media)
 
         assert thumb == _expected_thumb(asset)
         assert hero == _expected_hero(asset)
@@ -141,7 +141,7 @@ class TestUploadedFirstFallback:
         # Playfield listed first to test preference logic.
         primary_media = [em_playfield, em_backglass]
 
-        thumb, hero = _extract_image_urls({}, primary_media)
+        thumb, hero = extract_image_urls({}, primary_media)
 
         assert thumb == _expected_thumb(asset)
         assert hero == _expected_hero(asset)
@@ -151,7 +151,7 @@ class TestUploadedFirstFallback:
         em = _attach(ct_mm, machine_model, asset, category="backglass")
         primary_media = [em]
 
-        thumb, hero = _extract_image_urls(OPDB_EXTRA_DATA, primary_media)
+        thumb, hero = extract_image_urls(OPDB_EXTRA_DATA, primary_media)
 
         assert thumb == _expected_thumb(asset)
         assert hero == _expected_hero(asset)
@@ -161,20 +161,20 @@ class TestUploadedFirstFallback:
         is empty and we fall through to external."""
         # In the real queryset, failed assets are filtered out by
         # asset__status="ready". Here we simulate that by passing an empty list.
-        thumb, hero = _extract_image_urls(OPDB_EXTRA_DATA, primary_media=[])
+        thumb, hero = extract_image_urls(OPDB_EXTRA_DATA, primary_media=[])
 
         assert thumb == "https://img.opdb.org/m.jpg"
         assert hero == "https://img.opdb.org/l.jpg"
 
     def test_no_uploaded_no_external(self):
-        thumb, hero = _extract_image_urls({}, primary_media=[])
+        thumb, hero = extract_image_urls({}, primary_media=[])
 
         assert thumb is None
         assert hero is None
 
     def test_no_primary_media_param_uses_external(self):
         """When primary_media is not passed (None), falls through to external."""
-        thumb, hero = _extract_image_urls(OPDB_EXTRA_DATA)
+        thumb, hero = extract_image_urls(OPDB_EXTRA_DATA)
 
         assert thumb == "https://img.opdb.org/m.jpg"
         assert hero == "https://img.opdb.org/l.jpg"
@@ -190,14 +190,14 @@ class TestUploadedFirstFallback:
             ],
             "opdb.images.__permissiveness_rank": 50,
         }
-        thumb, hero = _extract_image_urls(extra_data, primary_media=[])
+        thumb, hero = extract_image_urls(extra_data, primary_media=[])
 
         assert thumb is None
         assert hero is None
 
 
 # ---------------------------------------------------------------------------
-# _extract_image_attribution — uploaded vs external
+# extract_image_attribution — uploaded vs external
 # ---------------------------------------------------------------------------
 
 
@@ -206,19 +206,19 @@ class TestImageAttribution:
         em = _attach(ct_mm, machine_model, asset, category="backglass")
         primary_media = [em]
 
-        attr = _extract_image_attribution(OPDB_EXTRA_DATA, primary_media)
+        attr = extract_image_attribution(OPDB_EXTRA_DATA, primary_media)
 
         assert attr is None
 
     def test_external_media_returns_attribution(self):
-        attr = _extract_image_attribution(OPDB_EXTRA_DATA, primary_media=[])
+        attr = extract_image_attribution(OPDB_EXTRA_DATA, primary_media=[])
 
         assert attr is not None
         assert attr.license_slug == "cc-by-sa-4-0"
         assert attr.permissiveness_rank == 50
 
     def test_no_media_returns_none(self):
-        attr = _extract_image_attribution({}, primary_media=[])
+        attr = extract_image_attribution({}, primary_media=[])
 
         assert attr is None
 
@@ -235,7 +235,7 @@ class TestLicenseGating:
         primary_media = [em]
 
         with override_config(CONTENT_DISPLAY_POLICY="licensed-only"):
-            thumb, hero = _extract_image_urls({}, primary_media)
+            thumb, hero = extract_image_urls({}, primary_media)
 
         assert thumb == _expected_thumb(asset)
         assert hero == _expected_hero(asset)
@@ -255,7 +255,7 @@ class TestLicenseGating:
             "opdb.images.__permissiveness_rank": 0,
         }
         with override_config(CONTENT_DISPLAY_POLICY="licensed-only"):
-            thumb, hero = _extract_image_urls(extra_data, primary_media=[])
+            thumb, hero = extract_image_urls(extra_data, primary_media=[])
 
         assert thumb is None
         assert hero is None

--- a/backend/apps/media/tests/test_helpers.py
+++ b/backend/apps/media/tests/test_helpers.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.django_db
 class TestAllMedia:
     def test_returns_list_when_prefetched(self):
         pm = make_machine_model(name="X", slug="x")
-        # simulate _media_prefetch() attaching the attr — it lives on
+        # simulate media_prefetch() attaching the attr — it lives on
         # prefetched querysets, not on bare model instances, so we don't
         # type it at the class level. setattr (vs direct attribute
         # assignment) silences mypy's attr-defined error.
@@ -24,7 +24,7 @@ class TestAllMedia:
     def test_raises_when_not_prefetched(self):
         pm = make_machine_model(name="X", slug="x")
 
-        with pytest.raises(AssertionError, match="_media_prefetch"):
+        with pytest.raises(AssertionError, match="media_prefetch"):
             all_media(pm)
 
 


### PR DESCRIPTION
## Summary

- Move image/media extraction helpers (`extract_image_urls`, `extract_image_attribution`, `first_thumbnail`, `media_prefetch`, `serialize_uploaded_media`) into new `apps/catalog/api/images.py`
- Move `build_rich_text` into new `apps/catalog/api/rich_text.py`
- Drop lying underscores from helpers shared across sibling modules: `serialize_credit`, `serialize_title_ref`, `serialize_title_machine`, `collect_titles`, `serialize_locations`
- `helpers.py` shrinks 497 → 236 lines; remaining underscore helpers (`_intersect_facet_sets`, `_extract_variant_features`, `_get_feature_descendant_slugs`, `_location_ancestors`) stay put — moving them is pure churn for one-call-site helpers
- New modules declare `__all__` so the public surface is explicit
- Also fixes stale `_media_prefetch` references in `apps/media/helpers.py` docstring/error message and matching test

Behavior-preserving: no schema changes (verified via `make api-gen`), no response shape changes.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (2355 backend + 999 frontend)
- [x] `make api-gen` produces no schema diff
- [ ] Spot-check entity detail pages in browser (Title, Manufacturer, Location) to confirm thumbnails, rich-text descriptions, and uploaded media still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)