### PR TITLE
rename: light pass swapping Pinbase → Flipcommons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,16 +16,16 @@ DJANGO_SUPERUSER_PASSWORD=change-me
 #
 # SECRET_KEY            Required. Generate with: python -c "import secrets; print(secrets.token_urlsafe(50))"
 # DEBUG                 Required. Set to "false"
-# ALLOWED_HOSTS         Required. Your Railway domain, e.g. "pinbase-production.up.railway.app"
-# CSRF_TRUSTED_ORIGINS  Required. Full origin, e.g. "https://pinbase-production.up.railway.app"
-# SITE_ORIGIN           Required. Public origin for prerendered meta tags, e.g. "https://pinbase.org"
+# ALLOWED_HOSTS         Required. Comma-separated hosts, e.g. "flipcommons.org,www.flipcommons.org"
+# CSRF_TRUSTED_ORIGINS  Required. Full origins, e.g. "https://flipcommons.org,https://www.flipcommons.org"
+# SITE_ORIGIN           Required. Public origin for prerendered meta tags, e.g. "https://flipcommons.org"
 # DATABASE_URL          Auto-set by Railway Postgres plugin
 # PORT                  Auto-set by Railway
 
 # ── SvelteKit ─────────────────────────────────────────────────────
 # SITE_ORIGIN is used at build time for prerendered page meta tags
 # (canonical URLs, OG tags). Defaults to http://localhost:5173 in dev.
-# SITE_ORIGIN=https://pinbase.org
+# SITE_ORIGIN=https://flipcommons.org
 
 # ── WorkOS AuthKit ────────────────────────────────────────────────
 # Required for SSO login. Get these from your WorkOS dashboard.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,14 +47,14 @@ Prefer the factories over `ChangeSet.objects.create` in new code:
 
 ## Project Overview
 
-Django + SvelteKit monorepo. Django owns the data model, APIs (Django Ninja), and admin UI. SvelteKit handles the user-facing frontend with Node SSR for public pages and CSR for authenticated app pages.
+Flipcommons is a Django + SvelteKit monorepo. Django owns the data model, APIs (Django Ninja), and admin UI. SvelteKit handles the user-facing frontend with Node SSR for public pages and CSR for authenticated app pages.
 
 Catalog data and the DuckDB exploration database live in separate repos:
 
 - **[pindata](https://github.com/deanmoses/pindata)** — canonical catalog records (markdown files + JSON schemas)
 - **[pinexplore](https://github.com/deanmoses/pinexplore)** — DuckDB exploration/validation database
 
-Both publish to Cloudflare R2. Pinbase pulls catalog JSON exports from R2 via `make pull-ingest`.
+Both publish to Cloudflare R2. This project pulls catalog JSON exports from R2 via `make pull-ingest`.
 
 See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,14 +47,14 @@ Prefer the factories over `ChangeSet.objects.create` in new code:
 
 ## Project Overview
 
-Django + SvelteKit monorepo. Django owns the data model, APIs (Django Ninja), and admin UI. SvelteKit handles the user-facing frontend with Node SSR for public pages and CSR for authenticated app pages.
+Flipcommons is a Django + SvelteKit monorepo. Django owns the data model, APIs (Django Ninja), and admin UI. SvelteKit handles the user-facing frontend with Node SSR for public pages and CSR for authenticated app pages.
 
 Catalog data and the DuckDB exploration database live in separate repos:
 
 - **[pindata](https://github.com/deanmoses/pindata)** — canonical catalog records (markdown files + JSON schemas)
 - **[pinexplore](https://github.com/deanmoses/pinexplore)** — DuckDB exploration/validation database
 
-Both publish to Cloudflare R2. Pinbase pulls catalog JSON exports from R2 via `make pull-ingest`.
+Both publish to Cloudflare R2. This project pulls catalog JSON exports from R2 via `make pull-ingest`.
 
 See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# Pinbase
+# Flipcommons
 
-An interactive, collaborative database of pinball knowledge.
+This is the source code for https://flipcommons.org/, an interactive, collaborative database of pinball knowledge.
+
+It's sponsored and hosted by The Flip, Chicago's playable pinball museum.
 
 ## Architecture
 
-Django + SvelteKit monorepo. Django owns the data model, APIs, and admin UI. SvelteKit handles the user-facing frontend.
+This is a Django + SvelteKit monorepo. SvelteKit handles the user-facing frontend. Django owns the backend: the database data model, APIs, and it also serves Django's admin UI.
 
 - **Backend**: Django + Django Ninja API at `/api/`, admin at `/admin/`
 - **Frontend**: SvelteKit with Node SSR for public routes and CSR-only authenticated app routes
@@ -12,7 +14,7 @@ Django + SvelteKit monorepo. Django owns the data model, APIs, and admin UI. Sve
 - **Dev proxy**: Vite proxies `/api/`, `/admin/`, `/media/`, and `/static/` to Django
 - **Production routing**: Caddy fronts SvelteKit SSR and Django inside one Railway service
 
-## Quickstart
+## Getting started
 
 **Requirements**: Python 3.14+, Node 24+, [uv](https://docs.astral.sh/uv/), [pnpm](https://pnpm.io/) (or enable via `corepack enable`)
 

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -13,7 +13,7 @@ from apps.catalog.api.edit_claims import (
 from apps.provenance.rate_limits import RateLimitExceededError
 
 api = NinjaAPI(
-    title="Pinbase API",
+    title="API",
     urls_namespace="api",
 )
 
@@ -122,7 +122,7 @@ def _handle_pydantic_validation_error(
     for err in exc.errors:
         loc = err.get("loc") or ()
         msg = err.get("msg", "Invalid value.")
-        # Use the last loc segment as the field key. Pinbase's per-field
+        # Use the last loc segment as the field key. The per-field
         # error renderer keys on bare names ("year", "slug") — matching
         # what application-thrown StructuredValidationError uses. Loc
         # paths from Pydantic include request source + nesting

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -58,14 +58,14 @@ Prefer the factories over `ChangeSet.objects.create` in new code:
 
 ## Project Overview
 
-Django + SvelteKit monorepo. Django owns the data model, APIs (Django Ninja), and admin UI. SvelteKit handles the user-facing frontend with Node SSR for public pages and CSR for authenticated app pages.
+Flipcommons is a Django + SvelteKit monorepo. Django owns the data model, APIs (Django Ninja), and admin UI. SvelteKit handles the user-facing frontend with Node SSR for public pages and CSR for authenticated app pages.
 
 Catalog data and the DuckDB exploration database live in separate repos:
 
 - **[pindata](https://github.com/deanmoses/pindata)** — canonical catalog records (markdown files + JSON schemas)
 - **[pinexplore](https://github.com/deanmoses/pinexplore)** — DuckDB exploration/validation database
 
-Both publish to Cloudflare R2. Pinbase pulls catalog JSON exports from R2 via `make pull-ingest`.
+Both publish to Cloudflare R2. This project pulls catalog JSON exports from R2 via `make pull-ingest`.
 
 See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -4,7 +4,7 @@ This documents the project's system architecture.
 
 ## High-Level Shape
 
-Pinbase is a Django + SvelteKit monorepo with a small number of clear subsystems.
+This project is a Django + SvelteKit monorepo with a small number of clear subsystems.
 
 - Django owns the backend: data model, provenance/claims logic, ingest pipeline, API, and admin UI.
 - SvelteKit owns the frontend.

--- a/docs/Hosting.md
+++ b/docs/Hosting.md
@@ -1,6 +1,6 @@
 # Deployment on Railway
 
-Pinbase runs as a **single [Railway](https://railway.com/) service**: one Docker container running Caddy, SvelteKit Node SSR, and Django/Gunicorn.
+This site runs as a **single [Railway](https://railway.com/) service**: one Docker container running Caddy, SvelteKit Node SSR, and Django/Gunicorn.
 
 This document is the operator-facing reference for production deployment, runtime processes, ports, and troubleshooting.
 
@@ -89,8 +89,8 @@ In the Railway service dashboard:
 | ----------------------- | ----------------------------------------------------------------------------- |
 | `SECRET_KEY`            | Random string: `python -c "import secrets; print(secrets.token_urlsafe(50))"` |
 | `DEBUG`                 | `false`                                                                       |
-| `ALLOWED_HOSTS`         | Your Railway domain, e.g. `pinbase-production.up.railway.app`                 |
-| `CSRF_TRUSTED_ORIGINS`  | Full origin, e.g. `https://pinbase-production.up.railway.app`                 |
+| `ALLOWED_HOSTS`         | Comma-separated hosts, e.g. `flipcommons.org,www.flipcommons.org`             |
+| `CSRF_TRUSTED_ORIGINS`  | Full origins, e.g. `https://flipcommons.org,https://www.flipcommons.org`      |
 | `INTERNAL_API_BASE_URL` | `http://127.0.0.1:8000`                                                       |
 
 `DATABASE_URL` and `PORT` are set automatically by Railway.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -41,7 +41,7 @@ As a nonprofit and a dedicated proponent of open source, The Flip wants to estab
 
 Most databases collapse every question down to a single stored answer. That makes the data easy to display, but it hides where the answer came from, makes disagreements hard to inspect, and makes later correction or comparison much harder.
 
-Pinbase treats [provenance](Provenance.md) as part of the product, not just as backend bookkeeping.
+This project treats [provenance](Provenance.md) as part of the product, not just as backend bookkeeping.
 
 - every important fact can carry attribution: who said it, where it came from, and when it entered the system
 - conflicting claims from different sources can coexist instead of forcing the system to pretend there was never a dispute
@@ -53,7 +53,7 @@ This matters for pinball because the subject is full of messy history, conflicti
 
 ## Why Openness Is A Differentiator
 
-Pinbase is being built as an open system, not a walled garden.
+This project is being built as an open system, not a walled garden.
 
 - the codebase is open source
 - the project is intended to make pinball knowledge easier to inspect, reuse, and build on
@@ -61,13 +61,13 @@ Pinbase is being built as an open system, not a walled garden.
 - APIs and exports make the data more useful to museums, researchers, hobbyists, and downstream tools
 - provenance and licensing make it easier to understand what can be reused, under what terms, and where it came from
 
-This does not mean every piece of information in Pinbase is automatically public domain or free of constraints. Some data originates from outside sources with their own licensing limits, and the project is still working through what the most permissive responsible approach can be in each area.
+This does not mean every piece of information in the project is automatically public domain or free of constraints. Some data originates from outside sources with their own licensing limits, and the project is still working through what the most permissive responsible approach can be in each area.
 
-But openness is still a core differentiator. The goal is for Pinbase to make pinball knowledge more available, more legible, and more reusable than systems where the data is difficult to access, difficult to verify, or effectively locked away.
+But openness is still a core differentiator. The goal is to make pinball knowledge more available, more legible, and more reusable than systems where the data is difficult to access, difficult to verify, or effectively locked away.
 
 ## Why The Domain Model Is A Differentiator
 
-Pinbase treats the structure of pinball knowledge as the most critical part of the product, via a rich [domain model](DomainModel.md),
+This project treats the structure of pinball knowledge as the most critical part of the product, via a rich [domain model](DomainModel.md),
 
 - games are modeled at multiple levels, including Titles, Models, variants, remakes, and conversions
 - makers are not treated as one flat name field; brands, manufacturers, corporate entities, and hardware systems can each be represented precisely
@@ -76,7 +76,7 @@ Pinbase treats the structure of pinball knowledge as the most critical part of t
 
 Most pinball sites are built by and for collectors and are oriented around the concept of a model. That works for learning all about that model, but it tends to flatten the domain and leave important distinctions implicit, inconsistent, or missing entirely.
 
-This is important because the public usually thinks in terms of titles, not specific moels within a title, while researchers and serious enthusiasts often need much more precision than a simple model lists can provide. By modeling the pinball world with more care, Pinbase can be easier to browse, more flexible to explore, and more accurate than systems that rely more heavily on free-form or flattened data.
+This is important because the public usually thinks in terms of titles, not specific moels within a title, while researchers and serious enthusiasts often need much more precision than a simple model lists can provide. By modeling the pinball world with more care, the site can be easier to browse, more flexible to explore, and more accurate than systems that rely more heavily on free-form or flattened data.
 
 ## Read Next
 


### PR DESCRIPTION
## Summary

- Swap user-facing **Pinbase** → **Flipcommons** in README, top-level docs, API title, and `.env.example`
- Most prose now uses "this project" / "this site" rather than baking the name in (per project preference)
- Regenerated `CLAUDE.md` / `AGENTS.md` from updated `docs/AGENTS.src.md`

## Out of scope (intentionally not touched)

- `docs/plans/**` — plan documents
- Backend code beyond the API title string + one stray comment
- Tests
- The ingest source named `pinbase` (its `Source.slug`, `ingest_pinbase` command, `data/ingest_sources/pinbase/`, `test_ingest_pinbase_*.py`, scripts) — needs a separate decision on the new identifier and a DB reset
- Sibling repos (`pindata`, `pinexplore`) keep their names
- R2 buckets unchanged
- Example Railway hostnames in `docs/Hosting.md` updated to real production hosts (`flipcommons.org`, `www.flipcommons.org`)

## Test plan

- [ ] CI passes
- [ ] Visual sanity check on rendered docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)