### PR TITLE
rename: pass 2 — drop "Pinbase" from prose and outbound user-agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,66 +4,11 @@
 
 # Development Guide
 
-This file provides guidance to AI programming agents when working with code in this repository.
-
-## Python Style — Non-Negotiable
-
-`except ExcType1, ExcType2:` is **valid Python 3** and is ruff-format's preferred style.
-Do NOT add parentheses. `except (ExcType1, ExcType2):` will be reverted by ruff-format every time. Stop trying to fix it.
-
-## Svelte, HTML, CSSS
-
-### You MUST use Svelte 5 — Non-Negotiable
-
-The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). Do NOT use legacy Svelte 4 patterns:
-
-- `export let` → use `let { } = $props()`
-- `$:` reactive declarations → use `$derived` / `$derived.by()` / `$effect()`
-- `on:click` directive syntax → use `onclick` attribute
-- `createEventDispatcher` → use callback props
-- `<slot>` → use `{@render children()}` snippets
-- `$$props` / `$$restProps` → use `$props()` with rest syntax
-
-### CSS — Non-Negotiable
-
-NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.
-
-## ALL User-Inputted Catalog Fields MUST be Claims-Based — Non-Negotiable
-
-**Every user-inputted catalog field MUST be claims-based**: scalars, FKs, M2M, slugs, parents, aliases. This includes ingested data that goes into fields that users can input.
-
-**System-generated fields aren't claims-based**: `id`/`uuid`, timestamps, derived fields like `Location.location_path = f"{parent.location_path}/{slug}"`.
-
-The test is "could a user input this field?" If yes, claim it. If no, it's system-generated. There is no third category. See [docs/Provenance.md](Provenance.md) for the architecture.
-
-### Writing ChangeSets — `action` Is Required On User ChangeSets
-
-Every `ChangeSet` attributed to a user must carry an `action` value (`create`, `edit`, `delete`, or `revert`). Ingest ChangeSets never do — they're identified by the `ingest_run` FK. The DB enforces this via the `provenance_changeset_action_iff_user` check constraint, so forgetting means an `IntegrityError`, not a code-review catch.
-
-Prefer the factories over `ChangeSet.objects.create` in new code:
-
-- Application code: call `execute_claims(entity, specs, user=..., action=ChangeSetAction.EDIT)` — the action kwarg is required at the type level for readability, even though `EDIT` is the default. Revert writes use `ChangeSetAction.REVERT`. Create flows use `ChangeSetAction.CREATE`.
-- Test fixtures: use `from apps.provenance.test_factories import user_changeset, ingest_changeset` instead of constructing `ChangeSet` rows directly. The factories encode the constraint invariants so mistakes fail at call time, not at DB time.
+This file provides guidance to AI programming agents when working with the Flipcommons project, an interactive, collaborative database of pinball knowledge.
 
 ## Project Overview
 
 Flipcommons is a Django + SvelteKit monorepo. Django owns the data model, APIs (Django Ninja), and admin UI. SvelteKit handles the user-facing frontend with Node SSR for public pages and CSR for authenticated app pages.
-
-Catalog data and the DuckDB exploration database live in separate repos:
-
-- **[pindata](https://github.com/deanmoses/pindata)** — canonical catalog records (markdown files + JSON schemas)
-- **[pinexplore](https://github.com/deanmoses/pinexplore)** — DuckDB exploration/validation database
-
-Both publish to Cloudflare R2. This project pulls catalog JSON exports from R2 via `make pull-ingest`.
-
-See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
-
-**Key architectural decisions:**
-
-- Session-based auth via same-origin proxy/reverse proxy (no JWT, no CORS)
-- Auth gating in the SPA is UX-only; the backend is the source of truth for access control
-- OpenAPI types generated from Django Ninja schema (not committed, derived from backend)
-- Single domain: `/api/`, `/admin/`, `/media/`, and `/static/` route to Django, everything else to SvelteKit
 
 ## Requirements
 
@@ -116,6 +61,7 @@ docs/             Documentation source files
 ## Key Conventions
 
 - Backend dependencies managed with `uv`, frontend with `pnpm`
+- Session cookies for auth (no JWT, no CORS); SPA auth gates are UX-only — the backend is the source of truth for access control
 - CSRF: Django sets `csrftoken` cookie; the frontend `client.ts` reads it and sends `X-CSRFToken` on mutating requests
 - Vite dev server proxies `/api/`, `/admin/`, `/media/`, and `/static/` to Django at `127.0.0.1:8000`
 - For SSR route conventions, see [Svelte.md](Svelte.md). For API design — both endpoint shape (page-oriented vs resource) and schema design heuristics (when to consolidate, when to keep separate, inheritance smells) — see [ApiDesign.md](ApiDesign.md)
@@ -141,6 +87,53 @@ SvelteKit's `resolve()` from `$app/paths` is strongly typed and only accepts kno
 ```
 
 The `svelte/no-navigation-without-resolve` ESLint rule is disabled project-wide because it doesn't recognize the wrapper.
+
+## Critical Rules — Non-Negotiable
+
+These rules exist because agents have repeatedly gotten them wrong. Read them before writing code.
+
+### Python: `except A, B:` is correct
+
+`except ExcType1, ExcType2:` is **valid Python 3** and is ruff-format's preferred style.
+Do NOT add parentheses. `except (ExcType1, ExcType2):` will be reverted by ruff-format every time. Stop trying to fix it.
+
+### Svelte 5 runes mode only
+
+The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). Do NOT use legacy Svelte 4 patterns:
+
+- `export let` → use `let { } = $props()`
+- `$:` reactive declarations → use `$derived` / `$derived.by()` / `$effect()`
+- `on:click` directive syntax → use `onclick` attribute
+- `createEventDispatcher` → use callback props
+- `<slot>` → use `{@render children()}` snippets
+- `$$props` / `$$restProps` → use `$props()` with rest syntax
+
+### No `:global` in Svelte styles
+
+NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.
+
+### All user-inputted catalog fields MUST be claims-based
+
+**Every user-inputted catalog field MUST be claims-based**: scalars, FKs, M2M, slugs, parents, aliases. This includes ingested data that goes into fields that users can input.
+
+**System-generated fields aren't claims-based**: `id`/`uuid`, timestamps, derived fields like `Location.location_path = f"{parent.location_path}/{slug}"`.
+
+The test is "could a user input this field?" If yes, claim it. If no, it's system-generated. There is no third category. See [docs/Provenance.md](Provenance.md) for the architecture.
+
+#### Writing ChangeSets — `action` is required on user ChangeSets
+
+Every `ChangeSet` attributed to a user must carry an `action` value (`create`, `edit`, `delete`, or `revert`). Ingest ChangeSets never do — they're identified by the `ingest_run` FK. The DB enforces this via the `provenance_changeset_action_iff_user` check constraint, so forgetting means an `IntegrityError`, not a code-review catch.
+
+Prefer the factories over `ChangeSet.objects.create` in new code:
+
+- Application code: call `execute_claims(entity, specs, user=..., action=ChangeSetAction.EDIT)` — the action kwarg is required at the type level for readability, even though `EDIT` is the default. Revert writes use `ChangeSetAction.REVERT`. Create flows use `ChangeSetAction.CREATE`.
+- Test fixtures: use `from apps.provenance.test_factories import user_changeset, ingest_changeset` instead of constructing `ChangeSet` rows directly. The factories encode the constraint invariants so mistakes fail at call time, not at DB time.
+
+### General rules
+
+- Don't silence linter warnings — fix the underlying issue
+- Never hardcode secrets — use environment variables via `.env`
+- Describe your approach before implementing non-trivial changes
 
 ## Environment Setup (Codex Cloud)
 
@@ -195,6 +188,8 @@ For new behavior, include tests. Consider writing the test first, though sometim
 
 ## Data Modeling
 
+See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
+
 See [docs/DataModeling.md](DataModeling.md) for modeling principles, Django pitfalls, and constraint testing patterns. Key rules:
 
 - **Validate strictly** — start with the tightest constraint you can defend. Relaxing is a one-line migration; tightening requires auditing every row.
@@ -205,8 +200,14 @@ See [docs/DataModeling.md](DataModeling.md) for modeling principles, Django pitf
 
 When reviewing code or a PR, read [docs/Reviewing.md](Reviewing.md) first and follow its checklist.
 
-## Rules
+## Related Repos
 
-- Don't silence linter warnings — fix the underlying issue
-- Never hardcode secrets — use environment variables via `.env`
-- Describe your approach before implementing non-trivial changes
+This project has two sister projects:
+
+### Catalog seed records
+
+**[pindata](https://github.com/deanmoses/pindata)**: pre-launch seed canonical catalog records (markdown files + JSON schemas). It publishes the catalog as JSON to Cloudflare R2 and this project pulls it down from R2 via `make pull-ingest`.
+
+### Analytics DB over pinball data
+
+**[pinexplore](https://github.com/deanmoses/pinexplore)**: DuckDB exploration/validation database for exploring the Pindata data as well as other sources of pinball knowledge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,66 +4,11 @@
 
 # Development Guide
 
-This file provides guidance to AI programming agents when working with code in this repository.
-
-## Python Style — Non-Negotiable
-
-`except ExcType1, ExcType2:` is **valid Python 3** and is ruff-format's preferred style.
-Do NOT add parentheses. `except (ExcType1, ExcType2):` will be reverted by ruff-format every time. Stop trying to fix it.
-
-## Svelte, HTML, CSSS
-
-### You MUST use Svelte 5 — Non-Negotiable
-
-The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). Do NOT use legacy Svelte 4 patterns:
-
-- `export let` → use `let { } = $props()`
-- `$:` reactive declarations → use `$derived` / `$derived.by()` / `$effect()`
-- `on:click` directive syntax → use `onclick` attribute
-- `createEventDispatcher` → use callback props
-- `<slot>` → use `{@render children()}` snippets
-- `$$props` / `$$restProps` → use `$props()` with rest syntax
-
-### CSS — Non-Negotiable
-
-NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.
-
-## ALL User-Inputted Catalog Fields MUST be Claims-Based — Non-Negotiable
-
-**Every user-inputted catalog field MUST be claims-based**: scalars, FKs, M2M, slugs, parents, aliases. This includes ingested data that goes into fields that users can input.
-
-**System-generated fields aren't claims-based**: `id`/`uuid`, timestamps, derived fields like `Location.location_path = f"{parent.location_path}/{slug}"`.
-
-The test is "could a user input this field?" If yes, claim it. If no, it's system-generated. There is no third category. See [docs/Provenance.md](Provenance.md) for the architecture.
-
-### Writing ChangeSets — `action` Is Required On User ChangeSets
-
-Every `ChangeSet` attributed to a user must carry an `action` value (`create`, `edit`, `delete`, or `revert`). Ingest ChangeSets never do — they're identified by the `ingest_run` FK. The DB enforces this via the `provenance_changeset_action_iff_user` check constraint, so forgetting means an `IntegrityError`, not a code-review catch.
-
-Prefer the factories over `ChangeSet.objects.create` in new code:
-
-- Application code: call `execute_claims(entity, specs, user=..., action=ChangeSetAction.EDIT)` — the action kwarg is required at the type level for readability, even though `EDIT` is the default. Revert writes use `ChangeSetAction.REVERT`. Create flows use `ChangeSetAction.CREATE`.
-- Test fixtures: use `from apps.provenance.test_factories import user_changeset, ingest_changeset` instead of constructing `ChangeSet` rows directly. The factories encode the constraint invariants so mistakes fail at call time, not at DB time.
+This file provides guidance to AI programming agents when working with the Flipcommons project, an interactive, collaborative database of pinball knowledge.
 
 ## Project Overview
 
 Flipcommons is a Django + SvelteKit monorepo. Django owns the data model, APIs (Django Ninja), and admin UI. SvelteKit handles the user-facing frontend with Node SSR for public pages and CSR for authenticated app pages.
-
-Catalog data and the DuckDB exploration database live in separate repos:
-
-- **[pindata](https://github.com/deanmoses/pindata)** — canonical catalog records (markdown files + JSON schemas)
-- **[pinexplore](https://github.com/deanmoses/pinexplore)** — DuckDB exploration/validation database
-
-Both publish to Cloudflare R2. This project pulls catalog JSON exports from R2 via `make pull-ingest`.
-
-See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
-
-**Key architectural decisions:**
-
-- Session-based auth via same-origin proxy/reverse proxy (no JWT, no CORS)
-- Auth gating in the SPA is UX-only; the backend is the source of truth for access control
-- OpenAPI types generated from Django Ninja schema (not committed, derived from backend)
-- Single domain: `/api/`, `/admin/`, `/media/`, and `/static/` route to Django, everything else to SvelteKit
 
 ## Requirements
 
@@ -116,6 +61,7 @@ docs/             Documentation source files
 ## Key Conventions
 
 - Backend dependencies managed with `uv`, frontend with `pnpm`
+- Session cookies for auth (no JWT, no CORS); SPA auth gates are UX-only — the backend is the source of truth for access control
 - CSRF: Django sets `csrftoken` cookie; the frontend `client.ts` reads it and sends `X-CSRFToken` on mutating requests
 - Vite dev server proxies `/api/`, `/admin/`, `/media/`, and `/static/` to Django at `127.0.0.1:8000`
 - For SSR route conventions, see [Svelte.md](Svelte.md). For API design — both endpoint shape (page-oriented vs resource) and schema design heuristics (when to consolidate, when to keep separate, inheritance smells) — see [ApiDesign.md](ApiDesign.md)
@@ -141,6 +87,53 @@ SvelteKit's `resolve()` from `$app/paths` is strongly typed and only accepts kno
 ```
 
 The `svelte/no-navigation-without-resolve` ESLint rule is disabled project-wide because it doesn't recognize the wrapper.
+
+## Critical Rules — Non-Negotiable
+
+These rules exist because agents have repeatedly gotten them wrong. Read them before writing code.
+
+### Python: `except A, B:` is correct
+
+`except ExcType1, ExcType2:` is **valid Python 3** and is ruff-format's preferred style.
+Do NOT add parentheses. `except (ExcType1, ExcType2):` will be reverted by ruff-format every time. Stop trying to fix it.
+
+### Svelte 5 runes mode only
+
+The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). Do NOT use legacy Svelte 4 patterns:
+
+- `export let` → use `let { } = $props()`
+- `$:` reactive declarations → use `$derived` / `$derived.by()` / `$effect()`
+- `on:click` directive syntax → use `onclick` attribute
+- `createEventDispatcher` → use callback props
+- `<slot>` → use `{@render children()}` snippets
+- `$$props` / `$$restProps` → use `$props()` with rest syntax
+
+### No `:global` in Svelte styles
+
+NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.
+
+### All user-inputted catalog fields MUST be claims-based
+
+**Every user-inputted catalog field MUST be claims-based**: scalars, FKs, M2M, slugs, parents, aliases. This includes ingested data that goes into fields that users can input.
+
+**System-generated fields aren't claims-based**: `id`/`uuid`, timestamps, derived fields like `Location.location_path = f"{parent.location_path}/{slug}"`.
+
+The test is "could a user input this field?" If yes, claim it. If no, it's system-generated. There is no third category. See [docs/Provenance.md](Provenance.md) for the architecture.
+
+#### Writing ChangeSets — `action` is required on user ChangeSets
+
+Every `ChangeSet` attributed to a user must carry an `action` value (`create`, `edit`, `delete`, or `revert`). Ingest ChangeSets never do — they're identified by the `ingest_run` FK. The DB enforces this via the `provenance_changeset_action_iff_user` check constraint, so forgetting means an `IntegrityError`, not a code-review catch.
+
+Prefer the factories over `ChangeSet.objects.create` in new code:
+
+- Application code: call `execute_claims(entity, specs, user=..., action=ChangeSetAction.EDIT)` — the action kwarg is required at the type level for readability, even though `EDIT` is the default. Revert writes use `ChangeSetAction.REVERT`. Create flows use `ChangeSetAction.CREATE`.
+- Test fixtures: use `from apps.provenance.test_factories import user_changeset, ingest_changeset` instead of constructing `ChangeSet` rows directly. The factories encode the constraint invariants so mistakes fail at call time, not at DB time.
+
+### General rules
+
+- Don't silence linter warnings — fix the underlying issue
+- Never hardcode secrets — use environment variables via `.env`
+- Describe your approach before implementing non-trivial changes
 
 ## Tool Usage
 
@@ -189,6 +182,8 @@ For new behavior, include tests. Consider writing the test first, though sometim
 
 ## Data Modeling
 
+See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
+
 See [docs/DataModeling.md](DataModeling.md) for modeling principles, Django pitfalls, and constraint testing patterns. Key rules:
 
 - **Validate strictly** — start with the tightest constraint you can defend. Relaxing is a one-line migration; tightening requires auditing every row.
@@ -199,8 +194,14 @@ See [docs/DataModeling.md](DataModeling.md) for modeling principles, Django pitf
 
 When reviewing code or a PR, read [docs/Reviewing.md](Reviewing.md) first and follow its checklist.
 
-## Rules
+## Related Repos
 
-- Don't silence linter warnings — fix the underlying issue
-- Never hardcode secrets — use environment variables via `.env`
-- Describe your approach before implementing non-trivial changes
+This project has two sister projects:
+
+### Catalog seed records
+
+**[pindata](https://github.com/deanmoses/pindata)**: pre-launch seed canonical catalog records (markdown files + JSON schemas). It publishes the catalog as JSON to Cloudflare R2 and this project pulls it down from R2 via `make pull-ingest`.
+
+### Analytics DB over pinball data
+
+**[pinexplore](https://github.com/deanmoses/pinexplore)**: DuckDB exploration/validation database for exploring the Pindata data as well as other sources of pinball knowledge.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Flipcommons
 
-This is the source code for https://flipcommons.org/, an interactive, collaborative database of pinball knowledge.
+This is the source code for [Flipcommons](https://flipcommons.org/), an interactive, collaborative database of pinball knowledge.
 
-It's sponsored and hosted by The Flip, Chicago's playable pinball museum.
+It's sponsored and hosted by [The Flip](https://www.theflip.museum/), Chicago's playable pinball museum.
 
 ## Architecture
 

--- a/backend/apps/catalog/api/images.py
+++ b/backend/apps/catalog/api/images.py
@@ -99,7 +99,7 @@ def extract_image_urls(
     """Return (thumbnail_url, hero_image_url).
 
     When *primary_media* (prefetched ``EntityMedia`` rows) contains uploaded
-    images, those are used unconditionally (no license gating — Pinbase owns
+    images, those are used unconditionally (no license gating — this project owns
     them).  Otherwise falls back to third-party images in *extra_data*,
     respecting the global Constance display threshold.
 

--- a/backend/apps/catalog/ingestion/fandom_wiki.py
+++ b/backend/apps/catalog/ingestion/fandom_wiki.py
@@ -51,7 +51,7 @@ import requests
 
 FANDOM_API = "https://pinball.fandom.com/api.php"
 FANDOM_WIKI_BASE = "https://pinball.fandom.com/wiki"
-USER_AGENT = "Pinbase/1.0 (Project of The Flip pinball museum; contact via github.com/deanmoses/pinbase)"
+USER_AGENT = "Flipcommons/1.0 (Project of The Flip pinball museum; contact via github.com/The-Flip/flipcommons)"
 
 # Map of bold-label text in the infobox designer field → Credit.role value.
 # Keys are lowercase for case-insensitive matching.

--- a/backend/apps/catalog/ingestion/ipdb/adapter.py
+++ b/backend/apps/catalog/ingestion/ipdb/adapter.py
@@ -164,7 +164,7 @@ def build_ipdb_plan(
     bad = validate_narrative_slugs(all_vocab_slugs)
     if bad:
         raise CommandError(
-            f"Narrative feature pattern slug(s) not found in pinbase vocabulary: "
+            f"Narrative feature pattern slug(s) not found in catalog vocabulary: "
             f"{', '.join(bad)}\n"
             "Update _NARRATIVE_FEATURE_PATTERNS to use valid slugs."
         )
@@ -369,7 +369,7 @@ def build_ipdb_plan(
     if unknown_mpu_strings:
         lines = "\n".join(f"  {s}" for s in sorted(unknown_mpu_strings))
         raise CommandError(
-            f"Unknown MPU strings not in pinbase systems:\n{lines}\n"
+            f"Unknown MPU strings not in catalog systems:\n{lines}\n"
             "Add mpu_strings entries to data/pinbase/systems/ and re-export before re-ingesting."
         )
 
@@ -592,7 +592,7 @@ def _process_corporate_entity(
             if not ce_paths:
                 raise CommandError(
                     f"IPDB mfr {mfr_id} ({ce.slug!r}): has location data but "
-                    f"this CE has no pinbase-curated location. "
+                    f"this CE has no curated location. "
                     f"Curate this CE in pindata first."
                 )
             compatible = any(
@@ -604,7 +604,7 @@ def _process_corporate_entity(
             if not compatible:
                 raise CommandError(
                     f"IPDB mfr {mfr_id}: location mismatch — "
-                    f"pinbase={ce_paths!r}, ipdb={resolved_path!r}. "
+                    f"curated={ce_paths!r}, ipdb={resolved_path!r}. "
                     f"Fix in pindata or add an IPDB override in parsers.py."
                 )
     else:
@@ -619,7 +619,7 @@ def _process_corporate_entity(
             raise CommandError(
                 f"IPDB mfr {mfr_id}: cannot resolve manufacturer brand for "
                 f"company={company!r}, trade={trade!r}. "
-                f"All manufacturers must pre-exist in pinbase."
+                f"All manufacturers must pre-exist in the catalog."
             )
         mfr = resolver.get_by_slug(slug)
         if mfr is None:

--- a/backend/apps/catalog/ingestion/opdb/adapter.py
+++ b/backend/apps/catalog/ingestion/opdb/adapter.py
@@ -264,7 +264,7 @@ def compute_fingerprint(opdb_path: str) -> str:
 
 
 def _manufacturer_diagnostics(machines: list[OpdbRecord]) -> list[str]:
-    """Return warnings for OPDB manufacturers not represented in pinbase."""
+    """Return warnings for OPDB manufacturers not represented in the catalog."""
     pinbase_opdb_mfr_ids = set(
         Manufacturer.objects.filter(
             opdb_manufacturer_id__isnull=False,
@@ -282,7 +282,7 @@ def _manufacturer_diagnostics(machines: list[OpdbRecord]) -> list[str]:
         return []
     names = [f"{opdb_mfr_by_id[mid]} (opdb_id={mid})" for mid in sorted(missing_ids)]
     return [
-        f"{len(missing_ids)} OPDB manufacturer(s) not in pinbase: " + ", ".join(names)
+        f"{len(missing_ids)} OPDB manufacturer(s) not in catalog: " + ", ".join(names)
     ]
 
 

--- a/backend/apps/catalog/ingestion/wikidata_sparql.py
+++ b/backend/apps/catalog/ingestion/wikidata_sparql.py
@@ -47,7 +47,7 @@ from typing import NamedTuple
 import requests
 
 SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
-USER_AGENT = "Pinbase/1.0 (Project of The Flip pinball museum; contact via github.com/deanmoses/pinbase)"
+USER_AGENT = "Flipcommons/1.0 (Project of The Flip pinball museum; contact via github.com/The-Flip/flipcommons)"
 
 # Wikidata property → Credit.role mapping.
 # Only properties that link humans to pinball machines and have meaningful

--- a/backend/apps/catalog/management/commands/ingest_all.py
+++ b/backend/apps/catalog/management/commands/ingest_all.py
@@ -1,6 +1,6 @@
 """Orchestrate the full ingestion pipeline.
 
-Pinbase curated data is ingested first so it bootstraps the entities that
+Curated catalog data is ingested first so it bootstraps the entities that
 external sources (IPDB, OPDB) will match against and enrich:
 
 Runs: ingest_pinbase → ingest_ipdb → ingest_opdb →
@@ -28,7 +28,7 @@ from apps.catalog.management.commands.ingest_pinbase import (
 )
 
 STEPS = [
-    # Phase 1: Pinbase curated data — bootstrap entities.
+    # Phase 1: Curated catalog data — bootstrap entities.
     "ingest_pinbase",
     # Phase 2: External sources — match existing records, assert claims.
     "ingest_ipdb",
@@ -40,7 +40,7 @@ STEPS = [
 
 
 class Command(BaseCommand):
-    help = "Run the full ingestion pipeline: Pinbase, IPDB, OPDB, resolve."
+    help = "Run the full ingestion pipeline: curated, IPDB, OPDB, resolve."
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -56,7 +56,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--export-dir",
             default=DEFAULT_EXPORT_DIR,
-            help="Path to exported Pinbase JSON directory.",
+            help="Path to exported curated catalog JSON directory.",
         )
         parser.add_argument(
             "--write",

--- a/backend/apps/catalog/naming.py
+++ b/backend/apps/catalog/naming.py
@@ -24,7 +24,7 @@ Known limitation: NFKC compatibility decomposition expands some decorative
 codepoints into letters, so e.g. "Godzilla™" normalizes to "godzillatm"
 rather than "godzilla". This is an acceptable trade for the benefit of
 folding full-width and composed forms to their ASCII equivalents, which is
-the more common case in pinbase's catalog. Revisit if real titles surface
+the more common case in this project's catalog. Revisit if real titles surface
 with decorative marks.
 """
 

--- a/backend/apps/catalog/tests/conftest.py
+++ b/backend/apps/catalog/tests/conftest.py
@@ -242,9 +242,9 @@ _IPDB_NARRATIVE_FEATURE_SLUGS = [
 
 @pytest.fixture
 def ipdb_locations(db):
-    """Create Location records and pinbase-curated CE+CEL rows for the IPDB fixture.
+    """Create Location records and curated CE+CEL rows for the IPDB fixture.
 
-    IPDB validation requires CEs to already have pinbase-curated locations.
+    IPDB validation requires CEs to already have curated locations.
     The fixture covers the three manufacturers in ipdb_sample.json:
     Gottlieb (93) and Williams (351) in Chicago, Bally/Midway (349) in Franklin Park.
     """

--- a/backend/apps/catalog/tests/test_ingest_ipdb.py
+++ b/backend/apps/catalog/tests/test_ingest_ipdb.py
@@ -274,7 +274,7 @@ class TestIngestIpdbUnknownMpu:
 # IpdbIds are noted for traceability.
 # ---------------------------------------------------------------------------
 
-# Feature map drawn from the actual pinbase gameplay_feature vocabulary
+# Feature map drawn from the actual gameplay_feature vocabulary
 # (ref_feature_gameplay view in pinexplore).  Includes every term needed
 # by the test cases below.
 _FM = {

--- a/backend/apps/catalog/tests/test_ingest_opdb.py
+++ b/backend/apps/catalog/tests/test_ingest_opdb.py
@@ -130,14 +130,14 @@ class TestIngestOpdb:
         ).exists()
 
     def test_no_title_claims(self):
-        """OPDB no longer asserts title claims — Pinbase owns title grouping."""
+        """OPDB no longer asserts title claims — curated catalog owns title grouping."""
         source = Source.objects.get(slug="opdb")
         assert not Claim.objects.filter(
             source=source, field_name="title", is_active=True
         ).exists()
 
     def test_no_variant_of_claims(self):
-        """OPDB no longer asserts variant_of claims — Pinbase owns relationships."""
+        """OPDB no longer asserts variant_of claims — curated catalog owns relationships."""
         source = Source.objects.get(slug="opdb")
         assert not Claim.objects.filter(
             source=source, field_name="variant_of", is_active=True

--- a/backend/apps/citation/extraction.py
+++ b/backend/apps/citation/extraction.py
@@ -89,7 +89,7 @@ def classify_input(raw: str) -> tuple[str, str] | None:
 _OL_TIMEOUT = 4  # seconds for edition request
 _WALL_CLOCK = 5  # total budget for all requests
 _CACHE_TTL = 60 * 60 * 24 * 7  # 7 days
-_USER_AGENT = "Pinbase/1.0 (citation metadata lookup)"
+_USER_AGENT = "Flipcommons/1.0 (citation metadata lookup)"
 
 
 def _parse_year(publish_date: str) -> int | None:

--- a/backend/apps/citation/safe_fetch.py
+++ b/backend/apps/citation/safe_fetch.py
@@ -51,7 +51,7 @@ class _FetchOneResult(NamedTuple):
 # ---------------------------------------------------------------------------
 
 _MAX_REDIRECTS = 5
-_USER_AGENT = "Pinbase/1.0 (citation metadata lookup)"
+_USER_AGENT = "Flipcommons/1.0 (citation metadata lookup)"
 
 
 def _is_blocked(addr: str) -> bool:

--- a/backend/apps/core/tests/test_markdown.py
+++ b/backend/apps/core/tests/test_markdown.py
@@ -244,8 +244,8 @@ class TestRenderAllLinks:
 
     def test_render_with_base_url(self, manufacturer):
         text = f"See [[manufacturer:id:{manufacturer.pk}]]"
-        result = render_all_links(text, base_url="https://pinbase.app")
-        assert "https://pinbase.app/manufacturers/williams" in result
+        result = render_all_links(text, base_url="https://flipcommons.org")
+        assert "https://flipcommons.org/manufacturers/williams" in result
 
     def test_render_multiple_links(self, manufacturer, system):
         text = (

--- a/backend/apps/media/models/asset.py
+++ b/backend/apps/media/models/asset.py
@@ -1,4 +1,4 @@
-"""MediaAsset: one logical Pinbase-owned uploaded media item."""
+"""MediaAsset: one logical first-party uploaded media item."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class MediaAsset(TimeStampedModel):
-    """One logical Pinbase-owned uploaded media item (infrastructure)."""
+    """One logical first-party uploaded media item (infrastructure)."""
 
     renditions: models.Manager[MediaRendition]
 

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -15,66 +15,11 @@ Markers:
 
 END_IGNORE
 
-This file provides guidance to AI programming agents when working with code in this repository.
-
-## Python Style — Non-Negotiable
-
-`except ExcType1, ExcType2:` is **valid Python 3** and is ruff-format's preferred style.
-Do NOT add parentheses. `except (ExcType1, ExcType2):` will be reverted by ruff-format every time. Stop trying to fix it.
-
-## Svelte, HTML, CSSS
-
-### You MUST use Svelte 5 — Non-Negotiable
-
-The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). Do NOT use legacy Svelte 4 patterns:
-
-- `export let` → use `let { } = $props()`
-- `$:` reactive declarations → use `$derived` / `$derived.by()` / `$effect()`
-- `on:click` directive syntax → use `onclick` attribute
-- `createEventDispatcher` → use callback props
-- `<slot>` → use `{@render children()}` snippets
-- `$$props` / `$$restProps` → use `$props()` with rest syntax
-
-### CSS — Non-Negotiable
-
-NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.
-
-## ALL User-Inputted Catalog Fields MUST be Claims-Based — Non-Negotiable
-
-**Every user-inputted catalog field MUST be claims-based**: scalars, FKs, M2M, slugs, parents, aliases. This includes ingested data that goes into fields that users can input.
-
-**System-generated fields aren't claims-based**: `id`/`uuid`, timestamps, derived fields like `Location.location_path = f"{parent.location_path}/{slug}"`.
-
-The test is "could a user input this field?" If yes, claim it. If no, it's system-generated. There is no third category. See [docs/Provenance.md](Provenance.md) for the architecture.
-
-### Writing ChangeSets — `action` Is Required On User ChangeSets
-
-Every `ChangeSet` attributed to a user must carry an `action` value (`create`, `edit`, `delete`, or `revert`). Ingest ChangeSets never do — they're identified by the `ingest_run` FK. The DB enforces this via the `provenance_changeset_action_iff_user` check constraint, so forgetting means an `IntegrityError`, not a code-review catch.
-
-Prefer the factories over `ChangeSet.objects.create` in new code:
-
-- Application code: call `execute_claims(entity, specs, user=..., action=ChangeSetAction.EDIT)` — the action kwarg is required at the type level for readability, even though `EDIT` is the default. Revert writes use `ChangeSetAction.REVERT`. Create flows use `ChangeSetAction.CREATE`.
-- Test fixtures: use `from apps.provenance.test_factories import user_changeset, ingest_changeset` instead of constructing `ChangeSet` rows directly. The factories encode the constraint invariants so mistakes fail at call time, not at DB time.
+This file provides guidance to AI programming agents when working with the Flipcommons project, an interactive, collaborative database of pinball knowledge.
 
 ## Project Overview
 
 Flipcommons is a Django + SvelteKit monorepo. Django owns the data model, APIs (Django Ninja), and admin UI. SvelteKit handles the user-facing frontend with Node SSR for public pages and CSR for authenticated app pages.
-
-Catalog data and the DuckDB exploration database live in separate repos:
-
-- **[pindata](https://github.com/deanmoses/pindata)** — canonical catalog records (markdown files + JSON schemas)
-- **[pinexplore](https://github.com/deanmoses/pinexplore)** — DuckDB exploration/validation database
-
-Both publish to Cloudflare R2. This project pulls catalog JSON exports from R2 via `make pull-ingest`.
-
-See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
-
-**Key architectural decisions:**
-
-- Session-based auth via same-origin proxy/reverse proxy (no JWT, no CORS)
-- Auth gating in the SPA is UX-only; the backend is the source of truth for access control
-- OpenAPI types generated from Django Ninja schema (not committed, derived from backend)
-- Single domain: `/api/`, `/admin/`, `/media/`, and `/static/` route to Django, everything else to SvelteKit
 
 ## Requirements
 
@@ -127,6 +72,7 @@ docs/             Documentation source files
 ## Key Conventions
 
 - Backend dependencies managed with `uv`, frontend with `pnpm`
+- Session cookies for auth (no JWT, no CORS); SPA auth gates are UX-only — the backend is the source of truth for access control
 - CSRF: Django sets `csrftoken` cookie; the frontend `client.ts` reads it and sends `X-CSRFToken` on mutating requests
 - Vite dev server proxies `/api/`, `/admin/`, `/media/`, and `/static/` to Django at `127.0.0.1:8000`
 - For SSR route conventions, see [Svelte.md](Svelte.md). For API design — both endpoint shape (page-oriented vs resource) and schema design heuristics (when to consolidate, when to keep separate, inheritance smells) — see [ApiDesign.md](ApiDesign.md)
@@ -152,6 +98,53 @@ SvelteKit's `resolve()` from `$app/paths` is strongly typed and only accepts kno
 ```
 
 The `svelte/no-navigation-without-resolve` ESLint rule is disabled project-wide because it doesn't recognize the wrapper.
+
+## Critical Rules — Non-Negotiable
+
+These rules exist because agents have repeatedly gotten them wrong. Read them before writing code.
+
+### Python: `except A, B:` is correct
+
+`except ExcType1, ExcType2:` is **valid Python 3** and is ruff-format's preferred style.
+Do NOT add parentheses. `except (ExcType1, ExcType2):` will be reverted by ruff-format every time. Stop trying to fix it.
+
+### Svelte 5 runes mode only
+
+The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). Do NOT use legacy Svelte 4 patterns:
+
+- `export let` → use `let { } = $props()`
+- `$:` reactive declarations → use `$derived` / `$derived.by()` / `$effect()`
+- `on:click` directive syntax → use `onclick` attribute
+- `createEventDispatcher` → use callback props
+- `<slot>` → use `{@render children()}` snippets
+- `$$props` / `$$restProps` → use `$props()` with rest syntax
+
+### No `:global` in Svelte styles
+
+NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.
+
+### All user-inputted catalog fields MUST be claims-based
+
+**Every user-inputted catalog field MUST be claims-based**: scalars, FKs, M2M, slugs, parents, aliases. This includes ingested data that goes into fields that users can input.
+
+**System-generated fields aren't claims-based**: `id`/`uuid`, timestamps, derived fields like `Location.location_path = f"{parent.location_path}/{slug}"`.
+
+The test is "could a user input this field?" If yes, claim it. If no, it's system-generated. There is no third category. See [docs/Provenance.md](Provenance.md) for the architecture.
+
+#### Writing ChangeSets — `action` is required on user ChangeSets
+
+Every `ChangeSet` attributed to a user must carry an `action` value (`create`, `edit`, `delete`, or `revert`). Ingest ChangeSets never do — they're identified by the `ingest_run` FK. The DB enforces this via the `provenance_changeset_action_iff_user` check constraint, so forgetting means an `IntegrityError`, not a code-review catch.
+
+Prefer the factories over `ChangeSet.objects.create` in new code:
+
+- Application code: call `execute_claims(entity, specs, user=..., action=ChangeSetAction.EDIT)` — the action kwarg is required at the type level for readability, even though `EDIT` is the default. Revert writes use `ChangeSetAction.REVERT`. Create flows use `ChangeSetAction.CREATE`.
+- Test fixtures: use `from apps.provenance.test_factories import user_changeset, ingest_changeset` instead of constructing `ChangeSet` rows directly. The factories encode the constraint invariants so mistakes fail at call time, not at DB time.
+
+### General rules
+
+- Don't silence linter warnings — fix the underlying issue
+- Never hardcode secrets — use environment variables via `.env`
+- Describe your approach before implementing non-trivial changes
 
 START_CLAUDE
 
@@ -228,6 +221,8 @@ For new behavior, include tests. Consider writing the test first, though sometim
 
 ## Data Modeling
 
+See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
+
 See [docs/DataModeling.md](DataModeling.md) for modeling principles, Django pitfalls, and constraint testing patterns. Key rules:
 
 - **Validate strictly** — start with the tightest constraint you can defend. Relaxing is a one-line migration; tightening requires auditing every row.
@@ -238,8 +233,14 @@ See [docs/DataModeling.md](DataModeling.md) for modeling principles, Django pitf
 
 When reviewing code or a PR, read [docs/Reviewing.md](Reviewing.md) first and follow its checklist.
 
-## Rules
+## Related Repos
 
-- Don't silence linter warnings — fix the underlying issue
-- Never hardcode secrets — use environment variables via `.env`
-- Describe your approach before implementing non-trivial changes
+This project has two sister projects:
+
+### Catalog seed records
+
+**[pindata](https://github.com/deanmoses/pindata)**: pre-launch seed canonical catalog records (markdown files + JSON schemas). It publishes the catalog as JSON to Cloudflare R2 and this project pulls it down from R2 via `make pull-ingest`.
+
+### Analytics DB over pinball data
+
+**[pinexplore](https://github.com/deanmoses/pinexplore)**: DuckDB exploration/validation database for exploring the Pindata data as well as other sources of pinball knowledge.

--- a/docs/AppBoundaries.md
+++ b/docs/AppBoundaries.md
@@ -1,6 +1,6 @@
 # Django App Boundaries
 
-This document defines the dependency rules and responsibilities of Pinbase's Django apps.
+This document defines the dependency rules and responsibilities of this project's Django apps.
 
 ## Apps
 

--- a/docs/DataModeling.md
+++ b/docs/DataModeling.md
@@ -1,6 +1,6 @@
 # Data Modeling
 
-Principles and conventions for Django models in Pinbase.
+Principles and conventions for Django models in this project.
 
 ## Principles
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -1,6 +1,6 @@
 # Development
 
-This document is the contributor-facing hub for working on the Pinbase codebase.
+This document is the contributor-facing hub for working on this project's codebase.
 
 It does not try to restate every project rule. Instead, it points to the more specific docs that define how work in this repository should be approached.
 
@@ -73,7 +73,7 @@ The important rule is: solve integration by designing a boundary, not by punchin
 
 As a contributor, keep these distinctions clear:
 
-- product and domain docs explain what Pinbase is modeling
+- product and domain docs explain what this project is modeling
 - architecture docs explain how the system is organized
 - development docs explain how to work safely in the codebase
 - plan docs in [plans/README.md](plans/README.md) are historical reference, not canonical current documentation

--- a/docs/EntityNaming.md
+++ b/docs/EntityNaming.md
@@ -1,6 +1,6 @@
 # Entity Naming
 
-Pinbase's linkable entities (titles, models, manufacturers, people, etc.) share one canonical name that spans the backend data model, API URLs, and frontend route segments. This doc is the single place that rule lives.
+This project's linkable entities (titles, models, manufacturers, people, etc.) share one canonical name that spans the backend data model, API URLs, and frontend route segments. This doc is the single place that rule lives.
 
 ## The rule
 

--- a/docs/Ingest.md
+++ b/docs/Ingest.md
@@ -1,6 +1,6 @@
 # Data Ingestion
 
-Pinbase is populated via Django management commands. The main pipeline
+This project is populated via Django management commands. The main pipeline
 (`ingest_all`) seeds internal data then imports external sources. Optional
 enrichment commands (Fandom, Wikidata) run separately.
 
@@ -8,7 +8,7 @@ enrichment commands (Fandom, Wikidata) run separately.
 
 Catalog data and external source files are maintained in the
 [pindata](https://github.com/deanmoses/pindata) repo and published to
-Cloudflare R2. Pinbase pulls them locally before running the ingest pipeline:
+Cloudflare R2. This project pulls them locally before running the ingest pipeline:
 
 ```bash
 make pull-ingest   # download R2 → local data/ingest_sources/
@@ -141,7 +141,7 @@ uv run python manage.py pull_and_ingest --dest ../data/ingest_sources
 ### 1. Pull data and run ingest
 
 ```bash
-railway ssh --service pinbase
+railway ssh --service flip-commons
 .venv/bin/python manage.py pull_and_ingest
 ```
 

--- a/docs/Media.md
+++ b/docs/Media.md
@@ -1,12 +1,12 @@
 # Media System
 
-Pinbase hosts user-uploaded images in S3-compatible storage (Cloudflare R2). Uploads go through Django, which generates renditions synchronously and stores them directly in R2. The browser loads images straight from storage — Django is never in the serving path.
+This project hosts user-uploaded images in S3-compatible storage (Cloudflare R2). Uploads go through Django, which generates renditions synchronously and stores them directly in R2. The browser loads images straight from storage — Django is never in the serving path.
 
 ## Ownership Boundary
 
-The media system only handles media that Pinbase has a clear license to display: images uploaded by users (who grant Pinbase a license) or owned by The Flip Museum.
+The media system only handles media that this project has a clear license to display: images uploaded by users (who grant this project a license) or owned by The Flip Museum.
 
-Third-party media (OPDB, IPDB, Fandom, Wikidata) stays outside. Pinbase does not download, transcode, re-host, or proxy third-party files — there are legal issues with doing so. Third-party image references remain in `extra_data` where they came from.
+Third-party media (OPDB, IPDB, Fandom, Wikidata) stays outside. This project does not download, transcode, re-host, or proxy third-party files — there are legal issues with doing so. Third-party image references remain in `extra_data` where they came from.
 
 The API prefers uploaded media first, then falls back to third-party references when no uploads exist for a given entity.
 

--- a/docs/SSRConversion.md
+++ b/docs/SSRConversion.md
@@ -1,6 +1,6 @@
 # SSR Conversion
 
-This document is the implementation checklist for converting an existing SvelteKit route subtree from CSR to SSR in Pinbase.
+This document is the implementation checklist for converting an existing SvelteKit route subtree from CSR to SSR in this project.
 
 For SSR philosophy and API design rules, read [Svelte.md](Svelte.md) and [ApiDesign.md](ApiDesign.md).
 

--- a/docs/Svelte.md
+++ b/docs/Svelte.md
@@ -1,6 +1,6 @@
 # Svelte
 
-This document defines how to think about and develop SvelteKit pages in Pinbase.
+This document defines how to think about and develop SvelteKit pages in this project.
 
 ## Authoring Conventions
 

--- a/docs/WebArchitecture.md
+++ b/docs/WebArchitecture.md
@@ -1,6 +1,6 @@
 # Web Architecture
 
-This document describes how Pinbase's web application behaves at runtime: how browser requests flow through the stack, how same-origin is preserved, and how SSR and CSR are split between routes.
+This document describes how this project's web application behaves at runtime: how browser requests flow through the stack, how same-origin is preserved, and how SSR and CSR are split between routes.
 
 For the top-level system map, see [Architecture.md](Architecture.md). For deployment and operator details, see [Hosting.md](Hosting.md).
 
@@ -31,7 +31,7 @@ The frontend does not own business truth. It renders and edits data through Djan
 
 ## Same-Origin Model
 
-Pinbase uses a same-origin model in both development and production.
+This project uses a same-origin model in both development and production.
 
 ### Why
 
@@ -81,7 +81,7 @@ See [Hosting.md](Hosting.md) for the production serving details.
 
 ## Rendering Model
 
-Pinbase uses both SSR and CSR, but not for the same kinds of routes.
+This project uses both SSR and CSR, but not for the same kinds of routes.
 
 - Public content-heavy routes should usually render meaningful HTML on the server.
 - Internal or highly interactive application routes may deliberately opt out with `ssr = false`.


### PR DESCRIPTION
## Summary

Second pass of the Pinbase → Flipcommons rename.

- Narrative "Pinbase" → "this project" / "this site" in 9 top-level docs and backend comments, docstrings, and error messages
- Outbound User-Agents (Fandom, Wikidata, citation fetch) updated to `Flipcommons/1.0` and `github.com/The-Flip/flipcommons`
- Railway service reference in [docs/Ingest.md](docs/Ingest.md) updated to `flip-commons`
- Includes the in-progress restructuring of [docs/AGENTS.src.md](docs/AGENTS.src.md) and [README.md](README.md)

## Out of scope (deferred)

- Filenames (`ingest_pinbase.py` and 5 test files)
- Django management command names (`ingest_pinbase`, `ingest_pinbase_taxonomy`, etc.) and the `slug="pinbase"` `Source` record — needs a coordinated rename + data migration
- Python identifiers like `pinbase_source`, `pinbase_opdb_mfr_ids` — coupled to the above
- R2 bucket names, `media.pinbase.app`, internal R2 User-Agent — Cloudflare/R2 not yet cut over
- `docs/plans/` historical docs

## Test plan

- [x] `ruff check` passes on touched files
- [x] `pytest apps/core/tests/test_markdown.py apps/catalog/tests/test_ingest_opdb.py` passes
- [x] Pre-commit hooks pass (regenerated `CLAUDE.md` / `AGENTS.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)