### PR TITLE
rename: pinbase/ ingest paths → pindata/; merge pinbase + editorial Source rows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,13 +36,13 @@ WORKOS_REDIRECT_URI=http://localhost:5173/api/auth/callback/
 
 # ── Cloudflare R2 (ingest source storage) ────────────────────────────
 # Public read URL (no auth needed — used by pull_ingest_sources):
-R2_PUBLIC_URL=https://pub-8f33ea1ac628450298edd0d3243ecf5a.r2.dev
+R2_PUBLIC_URL=https://pub-8a5220445534421c879b6ff9ede350f1.r2.dev
 
 # ── Media storage (S3-compatible provider) ──────────────────────────
 # Leave blank for local filesystem storage (FileSystemStorage).
 # Set all five to enable S3-compatible storage in production.
 # Works with any S3-compatible provider (Cloudflare R2, AWS S3, Backblaze B2, etc.)
-# MEDIA_STORAGE_BUCKET=pinbase-media
+# MEDIA_STORAGE_BUCKET=flipcommons-media
 # MEDIA_STORAGE_ENDPOINT=https://<account_id>.r2.cloudflarestorage.com
 # MEDIA_STORAGE_REGION=auto
 # MEDIA_STORAGE_ACCESS_KEY=

--- a/backend/apps/catalog/ingestion/constants.py
+++ b/backend/apps/catalog/ingestion/constants.py
@@ -5,4 +5,4 @@ IPDB_SKIP_MANUFACTURER_IDS: frozenset[int] = frozenset({0, 328})
 # Default paths for external data dumps (relative to backend/).
 DEFAULT_IPDB_PATH = "../data/ingest_sources/ipdb_xantari.json"
 DEFAULT_OPDB_PATH = "../data/ingest_sources/opdb_export_machines.json"
-DEFAULT_EXPORT_DIR = "../data/ingest_sources/pinbase/"
+DEFAULT_EXPORT_DIR = "../data/ingest_sources/pindata/"

--- a/backend/apps/catalog/ingestion/ipdb/adapter.py
+++ b/backend/apps/catalog/ingestion/ipdb/adapter.py
@@ -370,7 +370,7 @@ def build_ipdb_plan(
         lines = "\n".join(f"  {s}" for s in sorted(unknown_mpu_strings))
         raise CommandError(
             f"Unknown MPU strings not in catalog systems:\n{lines}\n"
-            "Add mpu_strings entries to data/pinbase/systems/ and re-export before re-ingesting."
+            "Add mpu_strings entries to pindata's catalog/systems/*.md and re-export before re-ingesting."
         )
 
     # ── Step 8: Warnings ─────────────────────────────────────────

--- a/backend/apps/catalog/management/commands/ingest_pinbase.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase.py
@@ -76,7 +76,7 @@ from apps.provenance.models import Claim, Source
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_EXPORT_DIR = Path(__file__).parents[5] / "data" / "explore" / "pinbase"
+DEFAULT_EXPORT_DIR = Path(__file__).parents[5] / "data" / "ingest_sources" / "pindata"
 
 
 def _parent_path(location_path: str) -> str | None:
@@ -255,10 +255,14 @@ class Command(BaseCommand):
         # independently via is_enabled in admin.
         self._ai_desc_sources: dict[type[CatalogModel], Source] = {}
         for model_class, slug_suffix in _ai_desc_source_registry():
-            src, _ = Source.objects.get_or_create(
-                slug=f"pinbase-ai-desc-{slug_suffix}",
+            plural = str(
+                model_class._meta.verbose_name_plural or model_class.__name__
+            ).title()
+            src, _ = Source.objects.update_or_create(
+                slug=f"flipcommons-ai-desc-{slug_suffix}",
                 defaults={
-                    "name": f"Pinbase AI Descriptions ({model_class.__name__})",
+                    "name": f"Flipcommons AI Descriptions ({model_class.__name__})",
+                    "description": f"Flipcommons AI-generated descriptions for {plural}",
                     "source_type": Source.SourceType.EDITORIAL,
                     "priority": 300,
                 },

--- a/backend/apps/catalog/management/commands/ingest_pinbase.py
+++ b/backend/apps/catalog/management/commands/ingest_pinbase.py
@@ -233,19 +233,11 @@ class Command(BaseCommand):
         self.export_dir = Path(options["export_dir"])
 
         # Create sources used across phases.
-        self.pinbase_source, _ = Source.objects.get_or_create(
-            slug="pinbase",
+        self.flipcommons_source, _ = Source.objects.update_or_create(
+            slug="flipcommons-catalog",
             defaults={
-                "name": "Pinbase",
-                "source_type": Source.SourceType.EDITORIAL,
-                "priority": 300,
-                "description": "Pinbase curated data.",
-            },
-        )
-        self.editorial_source, _ = Source.objects.update_or_create(
-            slug="editorial",
-            defaults={
-                "name": "Editorial",
+                "name": "Flipcommons Catalog",
+                "description": "Flipcommons-curated pinball catalog data.",
                 "source_type": Source.SourceType.EDITORIAL,
                 "priority": 300,
             },
@@ -313,7 +305,7 @@ class Command(BaseCommand):
     ) -> dict[str, int]:
         """Assert claims, deferring description claims for later.
 
-        Non-description claims go to self.pinbase_source immediately.
+        Non-description claims go to self.flipcommons_source immediately.
         Description claims are stashed in ``_deferred_desc_claims`` and
         flushed at the end of the pipeline (after all entities exist)
         so that wikilink validation can resolve cross-references.
@@ -331,7 +323,7 @@ class Command(BaseCommand):
 
         if other_claims:
             s = Claim.objects.bulk_assert_claims(
-                self.pinbase_source, other_claims, **kwargs
+                self.flipcommons_source, other_claims, **kwargs
             )
             for k in stats:
                 stats[k] += s[k]
@@ -356,7 +348,7 @@ class Command(BaseCommand):
         for model_class, claims in by_model.items():
             ai_source = self._ai_desc_sources.get(model_class)
             if ai_source is None:
-                ai_source = self.pinbase_source
+                ai_source = self.flipcommons_source
             s = Claim.objects.bulk_assert_claims(ai_source, claims)
             total_created += s["created"]
             total_unchanged += s["unchanged"]
@@ -428,7 +420,7 @@ class Command(BaseCommand):
         if not entries:
             return
 
-        source = self.pinbase_source
+        source = self.flipcommons_source
         ct = ContentType.objects.get_for_model(Location)
 
         # Sort by depth (path segments) so parents always precede children.
@@ -660,7 +652,7 @@ class Command(BaseCommand):
         if not entries:
             return
 
-        source = self.pinbase_source
+        source = self.flipcommons_source
         ct = ContentType.objects.get_for_model(Theme)
 
         # --- Entity upsert ---
@@ -776,7 +768,7 @@ class Command(BaseCommand):
         if not entries:
             return
 
-        source = self.pinbase_source
+        source = self.flipcommons_source
         ct = ContentType.objects.get_for_model(GameplayFeature)
 
         # --- Entity upsert ---
@@ -895,7 +887,7 @@ class Command(BaseCommand):
         if not rt_entries:
             return
 
-        source = self.pinbase_source
+        source = self.flipcommons_source
         rt_by_slug = {r.slug: r for r in RewardType.objects.all()}
         rt_ct_id = ContentType.objects.get_for_model(RewardType).pk
         rt_aliases_by_pk: dict[int, list[str]] = {}
@@ -924,7 +916,7 @@ class Command(BaseCommand):
         if not entries:
             return
 
-        source = self.editorial_source
+        source = self.flipcommons_source
         existing_slugs = set(Manufacturer.objects.values_list("slug", flat=True))
 
         objs = [
@@ -1007,7 +999,7 @@ class Command(BaseCommand):
         if not entries:
             return
 
-        source = self.editorial_source
+        source = self.flipcommons_source
         ct_id = ContentType.objects.get_for_model(CorporateEntity).pk
         mfr_by_slug = {m.slug: m for m in Manufacturer.objects.all()}
         existing_slugs = set(CorporateEntity.objects.values_list("slug", flat=True))
@@ -1285,7 +1277,7 @@ class Command(BaseCommand):
         if not entries:
             return
 
-        source = self.pinbase_source
+        source = self.flipcommons_source
         ct_id = ContentType.objects.get_for_model(Person).pk
         existing_slugs = set(Person.objects.values_list("slug", flat=True))
 
@@ -1706,7 +1698,7 @@ class Command(BaseCommand):
         if not entries:
             return
 
-        source = self.pinbase_source
+        source = self.flipcommons_source
         ct_id = ContentType.objects.get_for_model(MachineModel).pk
 
         by_opdb_id: dict[str, MachineModel] = {

--- a/backend/apps/catalog/management/commands/pull_and_ingest.py
+++ b/backend/apps/catalog/management/commands/pull_and_ingest.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         kwargs: dict[str, str | bool] = {
             "ipdb": f"{dest}/ipdb_xantari.json",
             "opdb": f"{dest}/opdb_export_machines.json",
-            "export_dir": f"{dest}/pinbase/",
+            "export_dir": f"{dest}/pindata/",
         }
         if write:
             kwargs["write"] = True

--- a/backend/apps/catalog/management/commands/pull_ingest_sources.py
+++ b/backend/apps/catalog/management/commands/pull_ingest_sources.py
@@ -5,7 +5,7 @@ Uses only stdlib (urllib.request) so it works on Railway's slim Python image.
 The R2 bucket has two manifests:
   - manifest.json          — root-level ingest sources (IPDB, OPDB, etc.),
                              published by pinexplore.
-  - pinbase/manifest.json  — catalog export files, published by pindata.
+  - pindata/manifest.json  — catalog export files, published by pindata.
 
 This command fetches both and downloads the files the ingest pipeline needs.
 
@@ -72,10 +72,10 @@ _NEEDED_FILES = {
 
 # Manifests to fetch: (url_path, local_prefix)
 # - Root manifest entries are stored as-is under dest.
-# - pinbase/ manifest entries are stored under pinbase/ locally.
+# - pindata/ manifest entries are stored under pindata/ locally.
 _MANIFESTS = [
     ("manifest.json", ""),
-    ("pinbase/manifest.json", "pinbase/"),
+    ("pindata/manifest.json", "pindata/"),
 ]
 
 
@@ -100,7 +100,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--url",
             default=os.environ.get(
-                "R2_PUBLIC_URL", "https://pub-8f33ea1ac628450298edd0d3243ecf5a.r2.dev"
+                "R2_PUBLIC_URL", "https://pub-8a5220445534421c879b6ff9ede350f1.r2.dev"
             ),
             help="Base URL of the R2 public bucket (default: R2_PUBLIC_URL env var).",
         )
@@ -132,7 +132,7 @@ class Command(BaseCommand):
                 continue
 
             # Determine the base URL for files in this manifest.
-            # pinbase/manifest.json lists files relative to pinbase/.
+            # pindata/manifest.json lists files relative to pindata/.
             manifest_base = base_url
             if "/" in manifest_path:
                 manifest_base = f"{base_url}/{manifest_path.rsplit('/', 1)[0]}"

--- a/backend/apps/catalog/management/commands/validate_catalog.py
+++ b/backend/apps/catalog/management/commands/validate_catalog.py
@@ -441,18 +441,18 @@ def check_credits_without_matching_claims(result: ValidationResult) -> None:
 
 
 def check_uncurated_themes(result: ValidationResult) -> None:
-    """Themes that were auto-created during ingestion (no pinbase source claim)."""
+    """Themes that were auto-created during ingestion (no flipcommons-catalog source claim)."""
     from apps.provenance.models import Source
 
-    pinbase = Source.objects.filter(slug="pinbase").first()
-    if not pinbase:
+    flipcommons_catalog = Source.objects.filter(slug="flipcommons-catalog").first()
+    if not flipcommons_catalog:
         return
 
     ct = ContentType.objects.get_for_model(Theme)
     curated_theme_ids = set(
         Claim.objects.filter(
             content_type=ct,
-            source=pinbase,
+            source=flipcommons_catalog,
             field_name="name",
             is_active=True,
         ).values_list("object_id", flat=True)
@@ -461,7 +461,9 @@ def check_uncurated_themes(result: ValidationResult) -> None:
     uncurated = Theme.objects.exclude(pk__in=curated_theme_ids)
     count = uncurated.count()
     if count:
-        result.note(f"{count} theme(s) were auto-created (no pinbase name claim)")
+        result.note(
+            f"{count} theme(s) were auto-created (no flipcommons-catalog name claim)"
+        )
         for t in uncurated.order_by("name")[:10]:
             result.note(f"  {t.slug!r} ({t.name})")
         if count > 10:

--- a/backend/apps/catalog/tests/test_ingest_pinbase_locations.py
+++ b/backend/apps/catalog/tests/test_ingest_pinbase_locations.py
@@ -15,14 +15,14 @@ from django.core.management import call_command
 from apps.catalog.models import Location, LocationAlias
 from apps.provenance.models import Source
 
-PINBASE_SOURCE_SLUG = "pinbase"
+PINBASE_SOURCE_SLUG = "flipcommons-catalog"
 
 
 @pytest.fixture
 def pinbase_source(db):
     return Source.objects.create(
         slug=PINBASE_SOURCE_SLUG,
-        name="Pinbase",
+        name="Flipcommons Catalog",
         source_type="editorial",
         priority=300,
     )

--- a/backend/apps/catalog/tests/test_ingest_pinbase_models.py
+++ b/backend/apps/catalog/tests/test_ingest_pinbase_models.py
@@ -144,7 +144,7 @@ class TestIngestPinbaseModels:
 
         call_command("ingest_pinbase", export_dir=export_dir)
 
-        source = Source.objects.get(slug="pinbase-ai-desc-model")
+        source = Source.objects.get(slug="flipcommons-ai-desc-model")
         claim = mm.claims.get(source=source, field_name="description", is_active=True)
         assert claim.value == "A test description"
 

--- a/backend/apps/catalog/tests/test_ingest_pinbase_models.py
+++ b/backend/apps/catalog/tests/test_ingest_pinbase_models.py
@@ -88,7 +88,7 @@ class TestIngestPinbaseModels:
 
         call_command("ingest_pinbase", export_dir=export_dir)
 
-        source = Source.objects.get(slug="pinbase")
+        source = Source.objects.get(slug="flipcommons-catalog")
         claim = mm.claims.get(source=source, field_name="name", is_active=True)
         assert claim.value == "Foo (Limited Edition)"
 
@@ -124,7 +124,7 @@ class TestIngestPinbaseModels:
         call_command("ingest_pinbase", export_dir=export_dir)
         call_command("ingest_pinbase", export_dir=export_dir)
 
-        source = Source.objects.get(slug="pinbase")
+        source = Source.objects.get(slug="flipcommons-catalog")
         assert (
             mm.claims.filter(source=source, field_name="name", is_active=True).count()
             == 1
@@ -162,7 +162,7 @@ class TestIngestPinbaseModels:
 
         call_command("ingest_pinbase", export_dir=export_dir)
 
-        source = Source.objects.get(slug="pinbase")
+        source = Source.objects.get(slug="flipcommons-catalog")
         claim = mm.claims.get(source=source, field_name="display_type", is_active=True)
         assert claim.value == "alphanumeric"
 
@@ -187,7 +187,7 @@ class TestIngestPinbaseModels:
 
         call_command("ingest_pinbase", export_dir=export_dir)
 
-        source = Source.objects.get(slug="pinbase")
+        source = Source.objects.get(slug="flipcommons-catalog")
         claim = child.claims.get(source=source, field_name="variant_of", is_active=True)
         assert claim.value == "parent-model"
 
@@ -317,7 +317,7 @@ class TestIngestPinbaseModels:
 
         call_command("ingest_pinbase", export_dir=export_dir)
 
-        source = Source.objects.get(slug="pinbase")
+        source = Source.objects.get(slug="flipcommons-catalog")
         claim = conv_mm.claims.get(
             source=source, field_name="converted_from", is_active=True
         )
@@ -367,7 +367,7 @@ class TestIngestPinbaseModels:
 
         call_command("ingest_pinbase", export_dir=export_dir)
 
-        source = Source.objects.get(slug="pinbase")
+        source = Source.objects.get(slug="flipcommons-catalog")
         claim = mm.claims.get(source=source, field_name="title", is_active=True)
         assert claim.value == "test-title"
 

--- a/backend/apps/catalog/tests/test_validate_catalog.py
+++ b/backend/apps/catalog/tests/test_validate_catalog.py
@@ -54,9 +54,12 @@ def ipdb(db):
 
 
 @pytest.fixture
-def pinbase_source(db):
+def flipcommons_source(db):
     return Source.objects.create(
-        name="Pinbase", slug="pinbase", source_type="editorial", priority=300
+        name="Flipcommons Catalog",
+        slug="flipcommons-catalog",
+        source_type="editorial",
+        priority=300,
     )
 
 
@@ -201,8 +204,8 @@ class TestUnresolvedCreditClaims:
 
 
 class TestUncuratedThemes:
-    def test_auto_created_themes_noted(self, db, ipdb, pinbase_source, capsys):
-        # Curated theme — has a pinbase name claim.
+    def test_auto_created_themes_noted(self, db, ipdb, flipcommons_source, capsys):
+        # Curated theme — has a flipcommons-catalog name claim.
         curated = Theme.objects.create(name="Sports", slug="sports")
         from django.contrib.contenttypes.models import ContentType
 
@@ -210,13 +213,13 @@ class TestUncuratedThemes:
         Claim.objects.create(
             content_type=ct,
             object_id=curated.pk,
-            source=pinbase_source,
+            source=flipcommons_source,
             field_name="name",
             claim_key="name",
             value="Sports",
         )
 
-        # Uncurated theme — no pinbase claim.
+        # Uncurated theme — no flipcommons-catalog claim.
         Theme.objects.create(name="Basebal", slug="basebal")
 
         call_command("validate_catalog")


### PR DESCRIPTION
## Summary

Two coordinated commits as part of the Pinbase → Flipcommons rename cutover:

1. **rename**: `pinbase/` ingest paths → `pindata/`; AI Source slugs `pinbase-ai-desc-{x}` → `flipcommons-ai-desc-{x}`. Includes IPDB MPU-strings error message fix (was already pointing at a wrong path pre-rename) and unification of `ingest_pinbase`'s `DEFAULT_EXPORT_DIR` with `constants.py`'s.
2. **merge**: collapse the two semantically-redundant `Source` rows used by `ingest_pinbase` (slug=`pinbase`, slug=`editorial`) into one `slug=flipcommons-catalog` row. Both were `source_type=editorial`, `priority=300`; the split was by entity type and only used inside `ingest_pinbase` itself.

Coordinated with sister changes:
- pindata: R2 prefix `pinbase/` → `pindata/` (PR open).
- pinexplore: skip-list now excludes `pindata/`; default URL points at the new bucket (committed direct to main).

No Django migration needed — `Source` rows are data, not schema. Old rows die with the dev/staging DB wipe that follows the R2 cutover; production will be re-ingested fresh from the new bucket.

## Test plan

- [x] `make test` (2379 backend + 999 frontend) passes against the still-populated old DB.
- [x] After local DB wipe + `make pull-ingest` + `make ingest`: full test suite green; admin shows 1 × `flipcommons-catalog`, 20 × `flipcommons-ai-desc-*`, zero pinbase/editorial rows.
- [x] Pre-commit hooks pass (ruff, mypy, secrets, backend-test). Hooks ran for the first time this session after fixing a stranded `core.hooksPath` from the on-disk repo rename.
- [ ] Production deploy to Railway with new bucket env vars (`MEDIA_STORAGE_BUCKET`, `R2_PUBLIC_URL`, `MEDIA_PUBLIC_BASE_URL`).

## Out of scope

Filename renames (`ingest_pinbase.py`), variable names (`pinbase_opdb_mfr_ids`), and the outbound `User-Agent: pinbase/1.0` are intentionally left for a future cosmetic pass — they're not coupled to the R2 layout or DB state and renaming them does not affect ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)