### PR TITLE
Switch media hosting to iDrive e2 + Bunny CDN

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -47,6 +47,43 @@ test(api): add health endpoint integration test
 3. Write a concise description (under 72 characters)
 4. Add body only if the "why" isn't obvious from the description
 
+## Verifying the commit actually happened
+
+Pre-commit hooks fail often in this repo (ruff, mypy/dmypy, prettier, markdownlint, detect-secrets, frontend lint+check+test, backend pytest, agent-docs-regen). A failed commit does NOT advance HEAD — but the failure is easy to miss if you only skim `git commit` output.
+
+After every `git commit`, run this in the same shell call so the result is unambiguous:
+
+```sh
+git commit -m "..." ; echo "EXIT=$?" ; git rev-parse --short HEAD
+```
+
+The commit succeeded only if **all three** hold:
+
+- `EXIT=0`
+- HEAD moved (compare to the short SHA before the commit)
+- `git status` is clean afterward
+
+If any of those fail, the commit did not happen. Read the hook output to classify the failure and recover.
+
+### The autofix trap
+
+Several hooks rewrite files and then fail the commit, leaving the fixes unstaged in the working tree:
+
+- `ruff check --fix` and `ruff format` (backend Python)
+- `prettier --write` (markdown)
+- `end-of-file-fixer`, `trailing-whitespace`, `mixed-line-ending`
+- `agent-docs-regen` (rewrites `CLAUDE.md` / `AGENTS.md` and runs `git add` on them)
+
+Look for `"files were modified by this hook"` or `"Failed"` in the output. Recovery: `git add` the modified paths and create a NEW commit (never `--amend` after a hook failure — the prior commit didn't happen, so amend would rewrite the wrong commit).
+
+### Other common failures
+
+- **mypy daemon out of sync** — symptom: errors that don't match the code. Fix: `make mypy-restart`, then retry.
+- **frontend tests / backend pytest fail** — fix the test or the code; do not skip with `--no-verify`.
+- **`no-commit-to-branch`** — you're on `main`. Switch to a feature branch.
+- **`check-added-large-files`** — a file exceeds 1000 KB. Don't commit it; reconsider whether it belongs in git.
+- **`agent-docs-no-direct-edit`** — you edited `CLAUDE.md` or `AGENTS.md` directly. Edit `docs/AGENTS.src.md` instead.
+
 ## Project-specific notes
 
 - Do NOT stage `frontend/src/lib/api/schema.d.ts` — it is gitignored and should never be committed.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -47,6 +47,43 @@ test(api): add health endpoint integration test
 3. Write a concise description (under 72 characters)
 4. Add body only if the "why" isn't obvious from the description
 
+## Verifying the commit actually happened
+
+Pre-commit hooks fail often in this repo (ruff, mypy/dmypy, prettier, markdownlint, detect-secrets, frontend lint+check+test, backend pytest, agent-docs-regen). A failed commit does NOT advance HEAD — but the failure is easy to miss if you only skim `git commit` output.
+
+After every `git commit`, run this in the same Bash call so the result is unambiguous:
+
+```sh
+git commit -m "..." ; echo "EXIT=$?" ; git rev-parse --short HEAD
+```
+
+The commit succeeded only if **all three** hold:
+
+- `EXIT=0`
+- HEAD moved (compare to the short SHA before the commit)
+- `git status` is clean afterward
+
+If any of those fail, the commit did not happen. Read the hook output to classify the failure and recover.
+
+### The autofix trap
+
+Several hooks rewrite files and then fail the commit, leaving the fixes unstaged in the working tree:
+
+- `ruff check --fix` and `ruff format` (backend Python)
+- `prettier --write` (markdown)
+- `end-of-file-fixer`, `trailing-whitespace`, `mixed-line-ending`
+- `agent-docs-regen` (rewrites `CLAUDE.md` / `AGENTS.md` and runs `git add` on them)
+
+Look for `"files were modified by this hook"` or `"Failed"` in the output. Recovery: `git add` the modified paths and create a NEW commit (never `--amend` after a hook failure — the prior commit didn't happen, so amend would rewrite the wrong commit).
+
+### Other common failures
+
+- **mypy daemon out of sync** — symptom: errors that don't match the code. Fix: `make mypy-restart`, then retry.
+- **frontend tests / backend pytest fail** — fix the test or the code; do not skip with `--no-verify`.
+- **`no-commit-to-branch`** — you're on `main`. Switch to a feature branch.
+- **`check-added-large-files`** — a file exceeds 1000 KB. Don't commit it; reconsider whether it belongs in git.
+- **`agent-docs-no-direct-edit`** — you edited `CLAUDE.md` or `AGENTS.md` directly. Edit `docs/AGENTS.src.md` instead.
+
 ## Project-specific notes
 
 - Do NOT stage `frontend/src/lib/api/schema.d.ts` — it is gitignored and should never be committed.

--- a/.env.example
+++ b/.env.example
@@ -41,10 +41,10 @@ R2_PUBLIC_URL=https://pub-8a5220445534421c879b6ff9ede350f1.r2.dev
 # ── Media storage (S3-compatible provider) ──────────────────────────
 # Leave blank for local filesystem storage (FileSystemStorage).
 # Set all five to enable S3-compatible storage in production.
-# Works with any S3-compatible provider (Cloudflare R2, AWS S3, Backblaze B2, etc.)
+# Production uses iDrive e2 (Chicago region) fronted by Bunny CDN at media.flipcommons.org.
 # MEDIA_STORAGE_BUCKET=flipcommons-media
-# MEDIA_STORAGE_ENDPOINT=https://<account_id>.r2.cloudflarestorage.com
-# MEDIA_STORAGE_REGION=auto
+# MEDIA_STORAGE_ENDPOINT=https://s3.us-midwest-1.idrivee2.com
+# MEDIA_STORAGE_REGION=us-midwest-1
 # MEDIA_STORAGE_ACCESS_KEY=
 # MEDIA_STORAGE_SECRET_KEY=
-# MEDIA_PUBLIC_BASE_URL=https://media.example.com/
+# MEDIA_PUBLIC_BASE_URL=https://media.flipcommons.org/

--- a/backend/apps/media/storage.py
+++ b/backend/apps/media/storage.py
@@ -26,8 +26,8 @@ def build_storage_key(asset_uuid: UUID, rendition_type: str) -> str:
     """Derive the storage key for a rendition.
 
     Keys are deterministic from asset UUID + rendition type alone.
-    Content-Type is stored as object metadata by S3/R2, not encoded
-    in the key.
+    Content-Type is stored as object metadata by the storage backend,
+    not encoded in the key.
     """
     if rendition_type not in _VALID_RENDITION_TYPES:
         msg = f"Invalid rendition_type: {rendition_type!r}"

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -140,6 +140,12 @@ if os.environ.get("MEDIA_STORAGE_BUCKET"):
     AWS_S3_ENDPOINT_URL = os.environ["MEDIA_STORAGE_ENDPOINT"].strip()
     AWS_ACCESS_KEY_ID = os.environ["MEDIA_STORAGE_ACCESS_KEY"].strip()
     AWS_SECRET_ACCESS_KEY = os.environ["MEDIA_STORAGE_SECRET_KEY"].strip()
+    # Storage keys are UUID-derived and write-once, so renditions are
+    # immutable once written. `immutable` tells browsers to skip
+    # revalidation entirely, not just honor max-age.
+    AWS_S3_OBJECT_PARAMETERS = {
+        "CacheControl": "public, max-age=31536000, immutable",
+    }
 else:
     STORAGES["default"] = {
         "BACKEND": "django.core.files.storage.FileSystemStorage",

--- a/docs/Hosting.md
+++ b/docs/Hosting.md
@@ -15,8 +15,9 @@ Browser ──→ Railway (single Caddy service)
               ├─ /_app/*                → SvelteKit Node SSR
               ├─ /api/*                 → Django Ninja API
               ├─ /admin/*               → Django Admin
-              ├─ /media/*               → Django/media storage
               └─ /static/*              → Django staticfiles / WhiteNoise
+
+Browser ──→ media.flipcommons.org       → Bunny CDN → iDrive e2 private bucket
 ```
 
 ### Runtime flow
@@ -26,15 +27,18 @@ Browser ──→ Railway (single Caddy service)
    Svelte runtime, Django, and Caddy in one container.
 
 2. **Caddy reverse proxy**: Caddy listens on Railway's public `PORT` and
-   routes `/api/`, `/admin/`, `/media/`, and `/static/` to Django on
-   `127.0.0.1:8000`. All other requests are forwarded to SvelteKit SSR on
-   `127.0.0.1:3000`.
+   routes `/api/`, `/admin/`, and `/static/` to Django on `127.0.0.1:8000`.
+   All other requests are forwarded to SvelteKit SSR on `127.0.0.1:3000`.
 
 3. **WhiteNoise static files**: Django still serves collected static files
-   for admin assets through `/static/`. Uploaded media continues to flow
-   through Django storage settings.
+   for admin assets through `/static/`.
 
-4. **Migrations on deploy**: Railway's `preDeployCommand` runs
+4. **Uploaded media serving**: Django writes uploaded media to the configured
+   S3-compatible storage backend. In production, public media URLs point at
+   Bunny CDN on `media.flipcommons.org`, which pulls from the private iDrive e2
+   bucket. Django is not in the production media-serving path.
+
+5. **Migrations on deploy**: Railway's `preDeployCommand` runs
    `manage.py migrate` before the new container accepts traffic. If the
    migration fails, the old container keeps serving.
 

--- a/docs/Media.md
+++ b/docs/Media.md
@@ -1,6 +1,8 @@
 # Media System
 
-This project hosts user-uploaded images in S3-compatible storage (Cloudflare R2). Uploads go through Django, which generates renditions synchronously and stores them directly in R2. The browser loads images straight from storage — Django is never in the serving path.
+This project hosts user-uploaded images in **iDrive e2** (S3-compatible object storage, Chicago region `us-midwest-1`, bucket `flipcommons-media`) with **Bunny CDN** in front at `media.flipcommons.org`. Uploads go through Django, which generates renditions synchronously and writes them to the iDrive bucket. The browser loads images through Bunny — Django is never in the serving path. Bunny authenticates to the iDrive bucket via S3 signature, so the bucket itself stays private.
+
+Storage and CDN are wired through provider-neutral env vars (`MEDIA_STORAGE_*`, `MEDIA_PUBLIC_BASE_URL`); nothing in the application code or storage keys names a vendor, so swapping to another S3-compatible backend is an env-var change plus a one-time bucket copy.
 
 ## Ownership Boundary
 
@@ -56,14 +58,6 @@ Infrastructure:
 - Frontend polling pattern activation in `media-upload.ts`.
 - `VideoPlayer.svelte` component with transcode state handling (adapted from flipfix's video player patterns).
 - HLS adaptive streaming only if demand justifies operational cost.
-
-### Follow-Up: CDN
-
-Put a CDN in front of the image serving. This requires no code changes.
-
-- Point a custom domain (e.g. `media.pinbase.app`) through Cloudflare DNS — this automatically enables Cloudflare's CDN in front of R2 (free tier, zero additional cost).
-- Switch `MEDIA_PUBLIC_BASE_URL` to the custom domain.
-- Configure cache headers and optional purge hooks.
 
 ### Follow-Up: Dedupe
 

--- a/docs/WebArchitecture.md
+++ b/docs/WebArchitecture.md
@@ -61,9 +61,12 @@ In production, one Railway service handles:
 
 - `/api/` via Django Ninja
 - `/admin/` via Django admin
-- `/media/` via Django storage/media handling
 - `/static/` via Django/WhiteNoise
 - frontend routes via SvelteKit Node SSR
+
+Uploaded media is served outside the Railway request path: API payloads return
+URLs on `media.flipcommons.org`, where Bunny CDN pulls from the private iDrive
+e2 bucket.
 
 At a high level:
 
@@ -72,9 +75,13 @@ Browser
   -> Caddy
      -> /api/* handled by Django/Gunicorn
      -> /admin/* handled by Django admin
-     -> /media/* handled by Django/media storage
      -> /static/* handled by Django/WhiteNoise
      -> frontend routes handled by SvelteKit Node SSR
+
+Browser
+  -> media.flipcommons.org
+     -> Bunny CDN
+        -> iDrive e2 private bucket
 ```
 
 See [Hosting.md](Hosting.md) for the production serving details.

--- a/docs/plans/media/Media.md
+++ b/docs/plans/media/Media.md
@@ -1,7 +1,5 @@
 # Media Support Plan
 
-Plan date: 2026-03-31
-
 This document outlines photo and video upload and storage support for Pinbase. Decisions are informed by reviewing the Flipfix sister project's production media system (which AIs are encouraged to inspect at ~/dev/flipfix/) and adapting its patterns to Pinbase's claims-based architecture. The database will be reset; no migration/backfill is needed.
 
 ## Goals
@@ -265,57 +263,42 @@ These can be tuned after seeing real usage.
 
 ## Storage
 
-### Cloudflare R2 via django-storages
+### S3-compatible object storage + CDN
 
-Use **Cloudflare R2** as the storage backend, accessed through `django-storages` with the S3-compatible API. R2 is the recommended provider because:
+Use S3-compatible object storage as the backend, accessed through `django-storages`. Production uses **iDrive e2** for the bucket, with **Bunny CDN** in front at `media.flipcommons.org`.
 
-- **We already have it** — Pinbase pulls ingest sources from an R2 bucket today. Same Cloudflare account, new bucket (or same bucket, different prefix).
-- **Zero egress fees** — for a media-heavy catalog site, this matters. Every thumbnail in a grid view, every hero image on a detail page — free to serve.
-- **Hosting-independent** — R2 is durable storage decoupled from Railway. If we change hosting providers, media doesn't move.
-- **Integrated CDN path** — Cloudflare's CDN (free tier) sits natively in front of R2. No cross-provider wiring needed. When CDN time comes, it's a DNS change, not an architecture change.
+Architecture:
 
-Using django-storages with R2's S3-compatible API also gives us:
-
-- Same file locations whether uploaded through Django or later via presigned URLs. No migration needed when switching upload path.
-- Swappable to any other S3-compatible service if needed (AWS S3, Backblaze B2, etc.).
+- **Private origin.** The media bucket is private. The CDN authenticates to the origin with S3 access key + secret. Nothing in the bucket is publicly readable directly; clients must come through the CDN.
+- **Custom domain serving.** Public URLs are `https://media.flipcommons.org/<storage-key>`. Django is not in the serving path.
+- **US-Central origin proximity.** The bucket lives in iDrive's Chicago datacenter, close to the museum's location and the CDN's Chicago PoP. This location was chosen so that cold reads to Chicago users are fast.
+- **Provider-neutral wiring.** `MEDIA_STORAGE_BUCKET`, `MEDIA_STORAGE_ENDPOINT`, `MEDIA_STORAGE_REGION`, `MEDIA_STORAGE_ACCESS_KEY`, `MEDIA_STORAGE_SECRET_KEY`, `MEDIA_PUBLIC_BASE_URL`. Swapping to another S3-compatible vendor (Wasabi, Backblaze B2, etc.) is an env-var change plus a one-time bucket copy. Nothing in the application code or storage keys names a vendor.
+- **Hosting-independent.** Object storage is durable and decoupled from Railway. If we change app hosting, media doesn't move.
 
 ### Cost Expectations
 
-Rough order-of-magnitude estimate, using Cloudflare R2 Standard pricing as of 2026-04-02. Check the current [Cloudflare R2 pricing page](https://developers.cloudflare.com/r2/pricing/) before relying on these numbers — pricing and free-tier limits can change.
+Rough order-of-magnitude estimate at near-term scale. Pricing varies by provider; verify current numbers before relying on these.
 
-Assumptions for a near-term Pinbase scenario:
+Assumptions:
 
 - `5,000` uploaded images.
 - Each upload creates `3` stored objects: `original`, `thumb`, `display`.
-- `60` image reads per hour on average, with little or no useful CDN cache hit rate.
-- Storage dominates cost; request volume at this scale does not.
+- `60` image reads per hour on average.
+- Storage dominates cost; request volume and egress at this scale do not.
 
-R2 price points that matter here:
+Estimated monthly storage cost at `5,000` uploaded images, assuming pay-per-GB pricing in the $0.004–$0.015/GB-month range typical of low-cost S3-compatible providers:
 
-- Storage: first `10 GB` free, then `$0.015 / GB-month`.
-- Class A operations (writes, deletes, list): first `1,000,000 / month` free, then `$4.50 / million`.
-- Class B operations (reads): first `10,000,000 / month` free, then `$0.36 / million`.
-- Egress: `$0`.
-
-Traffic math:
-
-- `60` reads/hour is about `43,200` reads/month.
-- That is far below the free `10,000,000` monthly Class B limit, so read cost is effectively `$0` even if Cloudflare CDN caching is poor.
-- `5,000` uploads means about `15,000` object writes for the initial import or early growth phase, also far below the free Class A limit.
-
-Estimated monthly storage cost at `5,000` uploaded images:
-
-| Average stored size per uploaded image set (`original` + `thumb` + `display`) | Total stored | Estimated monthly R2 cost |
-| ----------------------------------------------------------------------------- | ------------ | ------------------------- |
-| `1.4 MB`                                                                      | `~7.0 GB`    | `$0.00`                   |
-| `3.4 MB`                                                                      | `~16.8 GB`   | `~$0.10`                  |
-| `5.4 MB`                                                                      | `~26.5 GB`   | `~$0.26`                  |
-| `10.4 MB`                                                                     | `~50.9 GB`   | `~$0.61`                  |
+| Average stored size per uploaded image set (`original` + `thumb` + `display`) | Total stored | Estimated monthly cost |
+| ----------------------------------------------------------------------------- | ------------ | ---------------------- |
+| `1.4 MB`                                                                      | `~7.0 GB`    | `~$0.05`               |
+| `3.4 MB`                                                                      | `~16.8 GB`   | `~$0.10`               |
+| `5.4 MB`                                                                      | `~26.5 GB`   | `~$0.20`               |
+| `10.4 MB`                                                                     | `~50.9 GB`   | `~$0.40`               |
 
 Practical takeaway:
 
-- For the first few thousand images, R2 cost is likely to be negligible.
-- Even without strong cache hit rates, read traffic has to grow by orders of magnitude before request charges matter.
+- For the first few thousand images, total monthly cost is well under a dollar.
+- Read traffic at this scale is negligible against typical free tiers and per-request pricing.
 - The real long-term cost driver is total stored bytes, especially large originals or future video assets, not image serving.
 
 ### Key Generation
@@ -351,8 +334,7 @@ Future video rendition types (follow-up):
 
 - Storage keys are computed at runtime by `build_storage_key()` — nothing stored in the database.
 - Public URL = `settings.MEDIA_PUBLIC_BASE_URL + build_storage_key(...)`.
-- Today: `MEDIA_PUBLIC_BASE_URL` points at the storage provider's public origin.
-- Later: point a custom domain (e.g. `media.pinbase.app`) through Cloudflare DNS, which automatically enables the CDN. Change one env var, no database rewrite.
+- `MEDIA_PUBLIC_BASE_URL` points at `media.flipcommons.org`, which the CDN serves from the private bucket.
 
 ### Local Development
 
@@ -514,7 +496,7 @@ Types for media API responses come from the existing OpenAPI-generated `schema.d
 MEDIA_PUBLIC_BASE_URL = os.environ.get("MEDIA_PUBLIC_BASE_URL", "/media/")
 
 if os.environ.get("MEDIA_STORAGE_BUCKET"):
-    # Production: S3-compatible provider (Cloudflare R2, AWS S3, Backblaze B2, etc.)
+    # Production: S3-compatible provider (configured via env vars)
     STORAGES["default"] = {
         "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
     }
@@ -642,12 +624,6 @@ Infrastructure:
 - Normalize third-party media reference shapes across OPDB/IPDB/Fandom/Wikidata.
 - Centralize "uploaded first, external fallback second" media selection in one helper.
 
-### Follow-Up: CDN Cutover
-
-- Point a custom domain (e.g. `media.pinbase.app`) through Cloudflare DNS — this automatically enables Cloudflare's CDN in front of R2 (free tier, zero additional cost).
-- Switch `MEDIA_PUBLIC_BASE_URL` to the custom domain.
-- Configure cache headers and optional purge hooks.
-
 ### Follow-Up: User Roles and Permissions
 
 - Design a cross-cutting user-role/permission model that applies to all claim types (not just media).
@@ -672,7 +648,7 @@ Infrastructure:
 | sha256 dedupe         | Deferred (far future)                     | Adds complexity without clear near-term value.                                                                                                     |
 | Task queue            | Deferred (video follow-up)                | No async work needed. Evaluate options when video lands.                                                                                           |
 | Rendition format      | WebP                                      | Good compression, universal browser support. AVIF deferred.                                                                                        |
-| Storage provider      | Cloudflare R2                             | Already in use for ingest sources. Zero egress, hosting-independent, integrated CDN path (free).                                                   |
+| Storage + CDN         | S3-compatible private bucket + CDN        | Bucket private; CDN authenticates via S3 keys. Public URLs at `media.flipcommons.org`. Provider-neutral env vars.                                  |
 | Third-party media     | Stays in `extra_data`                     | Not temporary — permanent fallback layer. API reads both uploaded and external.                                                                    |
 | Category vocabulary   | Per-entity-type registry                  | Not a global enum. `MachineModel` gets `backglass`/`playfield`/`cabinet`/`other`.                                                                  |
 | Frontend architecture | Logic in TypeScript, thin Svelte wrappers | Testable without DOM. Follows flipfix's interaction patterns in Svelte 5 runes.                                                                    |

--- a/docs/plans/media/MediaHostingProviderOptions.md
+++ b/docs/plans/media/MediaHostingProviderOptions.md
@@ -1,0 +1,211 @@
+# Media Hosting Provider Options
+
+This doc evaluates specific storage and CDN providers against the requirements in [MediaHostingProviderRequirements.md](MediaHostingProviderRequirements.md). Requirements are referenced below by name (e.g. "the production-grade serving requirement", "the managed-TLS requirement") rather than by number, since the requirement order may change.
+
+Storage and CDN are evaluated separately. Unbundling them is the industry norm past the smallest scale; combining them at the recommendation step is the reader's job. The recommendation at the end picks one of each.
+
+Cloudflare and AWS options are excluded by the avoid-Cloudflare and avoid-AWS preferences and are not evaluated here.
+
+## File Storage Options
+
+All assume `django-storages` with the S3-compatible backend. `MEDIA_STORAGE_BUCKET`, `MEDIA_STORAGE_ENDPOINT`, etc. are already wired up in [backend/config/settings.py](../../../backend/config/settings.py).
+
+### Backblaze B2
+
+- **S3 API**: GA, mature, very well-trodden in `django-storages` setups.
+- **US-East**: Yes — Reston, Virginia (`us-east-005`) added in 2024. Verify GA status before committing.
+- **Cost**: $0.006/GB-month. No minimum charge — pure per-GB. At launch volume: pennies/month. Egress: 3× free egress per month relative to storage volume, then $0.01/GB. Bandwidth Alliance partnership has historically given free egress to Bunny CDN (verify current terms).
+- **Cold-read perf**: HDD-backed tier for cost. Cold-read TTFB is the slowest of the candidates here — public benchmarks have shown 100–200ms higher first-byte than Wasabi for similar workloads. With CDN tiered caching in front this matters less for steady-state, but at low launch traffic where many images won't be cache-hot, it's perceptible.
+- **Operational simplicity**: clean self-serve dashboard, application keys with bucket-scoped permissions. **Largest developer community of any candidate** — most tutorials, most Stack Overflow answers, deepest third-party docs.
+- **Private origin**: yes — buckets can be private; CDN authenticates with application keys.
+- **Viability**: publicly traded (NASDAQ: BLZE), founded 2007, ~$130M annual revenue. Audited financials. Strongest viability of the simple-vendor storage candidates.
+- **Verdict**: best community/docs and strongest public-co viability, but slowest cold reads. Right pick if community size matters more than cold-read latency.
+
+### DigitalOcean Spaces
+
+- **S3 API**: GA, mature.
+- **US-East**: `nyc3` (New York). ✓
+- **Cost**: $5/month flat — includes 250 GB storage and 1 TB transfer. Floor is high relative to actual usage at launch.
+- **Cold-read perf**: SSD-backed. Competitive with S3 for TTFB.
+- **Operational simplicity**: friendliest self-serve UX of any candidate. Sign up, click Create Space, get keys.
+- **Private origin**: yes — buckets can be private; access keys for CDN.
+- **Note on Spaces CDN**: their bundled CDN is **not** considered here. Spaces CDN fails the managed-TLS requirement when DNS isn't hosted at DigitalOcean. As pure storage behind a different CDN, that issue doesn't apply.
+- **Viability**: publicly traded (NYSE: DOCN), ~$700M annual revenue, profitable, founded 2011. Solid.
+- **Verdict**: solid storage candidate, especially for operational simplicity. $5/month floor is the only real downside.
+
+### Wasabi
+
+- **S3 API**: GA, well-trodden. Multiple production `django-storages` users.
+- **US-East**: `us-east-1` (Virginia) and `us-east-2` (Virginia). ✓
+- **Cost**: $0.007/GB-month effective ($6.99/TB/month). **1 TB minimum charge** — pay ~$7/month even when storing a few GB. Egress free under "fair use" (egress ≤ monthly storage volume).
+- **Cold-read perf**: SSD-forward architecture. Wasabi explicitly markets fast read latency as a differentiator and has independent benchmarks supporting it. Fast cold reads relative to B2 (~50–100ms TTFB in typical conditions).
+- **Operational simplicity**: clean dashboard, standard S3-style access keys. Account signup is heavier than B2 (asks for more business info upfront). Smaller developer community than B2.
+- **Private origin**: yes.
+- **Quirks**: 90-day minimum retention — files deleted within 90 days still bill for the full 90 days. Not relevant for our access pattern.
+- **Viability**: privately held, founded 2017 by David Friend (co-founder of Carbonite). $250M+ raised, claims profitability. No public financials. Established storage business; smaller brand presence in the developer sphere than B2.
+- **Verdict**: fast cold reads, simple operations, well-known in the production storage space. Trade-off vs. B2: faster perf, smaller community, private vs. public.
+
+### iDrive e2
+
+- **S3 API**: GA.
+- **Chicago**: There's a Chicago data center!
+- **US-East**: Multiple regions including Virginia and Maryland. ✓
+- **Cost**: ~$0.004/GB-month — cheapest in the field. No minimum on pay-as-you-go pricing. Egress: 3× storage free, then $0.01/GB.
+- **Cold-read perf**: marketed as performance-oriented and reportedly comparable to Wasabi. Less independent benchmarking than B2 or Wasabi.
+- **Operational simplicity**: reasonable self-serve dashboard, standard S3-style access keys. **Smallest developer community** of the three S3-clone candidates — fewer tutorials and SO answers when stuck.
+- **Private origin**: yes.
+- **Viability**: privately held by iDrive Inc. (originally Pro Softnet), founded 1995. 30+ years operating. Long-running consumer-backup business; less brand recognition in the object-storage developer space than Wasabi or B2.
+- **Verdict**: cheapest at scale, perf in the same class as Wasabi. Smallest developer community of the candidates. Good choice if cost matters; Wasabi is similar with better community presence.
+
+### Akamai Object Storage
+
+- **S3 API**: GA (formerly Linode Object Storage; Linode acquired by Akamai in 2022).
+- **US-East**: Newark and Washington DC. ✓
+- **Cost**: ~$5/month for 250 GB storage + 1 TB transfer. Similar shape to DO Spaces.
+- **Cold-read perf**: competitive with DO Spaces and Wasabi. SSD-backed.
+- **Operational simplicity**: the Linode-origin storage dashboard is self-serve and reasonable. Complexity arrives if paired with Akamai CDN (Property Manager) — see CDN section.
+- **Private origin**: yes.
+- **Note on built-in custom-domain feature**: Akamai Object Storage's own custom-domain UI requires BYO TLS cert (manual upload, manual renewal). That fails the managed-TLS requirement. Pairing this storage with a different CDN (Bunny, Fastly) avoids the issue — the CDN handles TLS instead.
+- **Viability**: publicly traded (NASDAQ: AKAM), ~$4B revenue, founded 1998. **Strongest viability of any candidate.**
+- **Verdict**: solid storage with the strongest viability story. Pair with a non-Akamai CDN to dodge Property Manager.
+
+### Fastly Object Storage
+
+- **S3 API**: announced 2024; **verify current GA status and regional availability before committing**. My information here is less certain than for the other options.
+- **US-East**: NY and Virginia (verify which regions are GA for Object Storage specifically).
+- **Cost**: verify current pricing. Free egress to Fastly CDN within the Fastly ecosystem.
+- **Cold-read perf**: well-positioned given Fastly's edge infrastructure and the free internal egress to their CDN.
+- **Operational simplicity**: Fastly's services/origins concepts apply to storage too.
+- **Private origin**: yes.
+- **Viability**: publicly traded (NYSE: FSLY), ~$500M revenue, founded 2011. Solid.
+- **Verdict**: potentially compelling if GA — especially paired with Fastly CDN. GA-status verification required before treating as a real candidate.
+
+### Bunny Edge Storage
+
+- **Status**: **Fails the S3-compatible API requirement.** As of 2026-04-30, Bunny's S3-compatible API is invite-only preview. Their GA API is a proprietary HTTP interface, not S3-compatible.
+- **Verdict**: out for the launch decision. Reopen if/when their S3 API hits GA — at that point Bunny all-in (storage + CDN + Optimizer + Stream) becomes the strongest single-vendor candidate for our future capabilities.
+
+## CDN Options
+
+All CDN options assume the storage provider exposes an S3-compatible HTTPS origin and the CDN is configured as a pull zone with that origin.
+
+### Bunny CDN
+
+- **PoPs**: ~120+ globally. Chicago PoP: yes. Strong in EU/Asia, good in US.
+- **Managed TLS**: free Let's Encrypt for custom hostnames via ACME HTTP-01 against the CDN endpoint. No DNS-on-Bunny required. Automatic renewal. ✓
+- **Operational simplicity**: **the simplest of the three.** Create pull zone, set origin, attach custom hostname, click issue cert. ~15 minutes from zero for a volunteer with no Bunny background.
+- **Cache features**: tiered caching free and on by default — edge miss falls to a regional cache before going to origin. **Perma-Cache** is a paid add-on that keeps long-tail content cached in Bunny's permanent storage even after edge eviction; useful for low-traffic sites where the long tail is mostly cold.
+- **Cost**: ~$0.005–$0.01/GB egress depending on region. No minimum.
+- **Viability**: privately held (BunnyWay d.o.o., Slovenia), founded 2015. Self-described profitable, ~70 employees, 100K+ customers. Smallest of the CDN candidates by a meaningful margin, but the CDN is swappable so the risk is bounded.
+- **Verdict**: best operational simplicity. Right CDN for a volunteer-run setup unless viability concerns dominate.
+
+### Fastly CDN
+
+- **PoPs**: ~70, each typically very large. Chicago PoP: very strong. Performance benchmarks consistently rank Fastly among the fastest globally.
+- **Managed TLS**: Fastly TLS service issues and renews managed certs via ACME, DNS-host-agnostic. ✓
+- **Operational simplicity**: well-designed but more concepts to learn — services, origins, backends, optional VCL/rule snippets, configuration versions, activations. Volunteer onboarding requires real reading.
+- **Cost**: free tier covers most launch traffic; past that, ~$0.12/GB egress (closer to AWS than Bunny). Wasabi has an explicit Fastly partnership — Wasabi → Fastly origin egress is free under their alliance.
+- **Viability**: publicly traded (NYSE: FSLY), ~$500M revenue, founded 2011. Solid.
+- **Verdict**: best raw perf (slightly), best public-company CDN viability, but operationally heavier than Bunny — cost is paid every time anyone touches the config.
+
+### Akamai CDN (Property Manager)
+
+- **PoPs**: ~4000+, the largest CDN network in the world. Chicago PoP: strong. Best for global reach to underserved regions.
+- **Managed TLS**: Default DV certs, ACME-provisioned, DNS-host-agnostic via `_acme-challenge` CNAME. ✓
+- **Operational simplicity**: **the heaviest of the three.** Property Manager is the enterprise CDN configuration apparatus: properties, behaviors, rule trees, CP codes, configuration versions and activations to staging and production networks. Same family of complexity as AWS CloudFront — well-designed but requires real expertise to configure.
+- **Cost**: bundled with Akamai Object Storage's basic tier; larger Akamai-CDN-only contracts are enterprise-quoted.
+- **Viability**: publicly traded (NASDAQ: AKAM), ~$4B revenue. Strongest viability of any CDN candidate.
+- **Verdict**: best CDN reach and viability, worst operational simplicity. Right pick only if someone is willing to learn Property Manager.
+
+## Decision
+
+**Storage: iDrive e2 (US-East).**
+**CDN: Bunny CDN.**
+
+Decided 2026-05-01. `media.flipcommons.org` is live and serving a test file through Bunny CDN with iDrive e2 as the origin.
+
+### Why iDrive e2 for storage
+
+#### Chicago data center
+
+Fastest for cold reads in the Chicago area
+
+#### Performance
+
+IDrive e2 is consistently faster than Backblaze B2 and Wasabi in terms of Time to First Byte (TTFB). It uses SSDs, avoids B2's HDD-tier latency.
+
+#### Operational simplicity
+
+I got it running very quicly. Clean self-serve dashboard, standard S3-style access keys.
+
+#### No "90-Day Deletion" Trap
+
+This is the biggest advantage over Wasabi.
+
+    The Wasabi Problem: If you upload a 1GB video and delete it 5 minutes later, Wasabi charges you for that 1GB for the next 89 days.
+
+    The IDrive Win: If a volunteer makes a mistake and deletes/replaces a file, the charge stops immediately. It’s much more forgiving for a dev environment.
+
+#### Predictable "Flat" Pricing
+
+    IDrive e2 costs $0.004 per GB/month.
+
+##### No egress fees
+
+    Unlike AWS S3, there are no egress fees (bandwidth costs) from IDrive. Since you’ve connected it to Bunny.net, IDrive won't charge you a penny for the data moving from their bucket to your CDN. You only pay for what you store.
+
+##### No 1 TB minimum
+
+No $5/month floor like DO Spaces. Costs scale to actual usage.
+
+#### Modern "Virtual Hosted" Support
+
+Supports modern Virtual Hosted-Style URLs. This makes it 100% compatible with boto3 and Bunny.net’s security signatures. It’s built on a newer architecture than some of the older "Legacy" S3 clones.
+
+#### Team Management
+
+IDrive’s "Users" dashboard is much simpler for a volunteer board to understand than AWS IAM.
+
+    You can invite other museum board members as Admins.
+
+    They get their own logins.
+
+    No one has to share a "Master Password."
+
+#### Viability
+
+iDrive is a privately held but established since 1995, long-running consumer-backup business.
+
+#### Trade-off accepted: smaller developer community
+
+Smaller developer community than B2 or Wasabi.
+
+### Why Bunny for CDN
+
+#### CDN Operational simplicity
+
+I tried it out and it was dead simple to set up.
+
+#### Managed TLS
+
+Managed TLS\*\* via free Let's Encrypt — no DNS migration needed.
+
+#### CDN Performance
+
+Perf is good for our type of content (immutable images served to mostly-US viewers).
+
+#### Chicago PoP
+
+Bunny has Chicago presence, which matters for museum-adjacent cold/warm reads.
+
+#### Supports S3 Private Origin
+
+Bunny supports S3-style origin authentication fields, so it can pull from private S3-compatible buckets depending on the storage provider. Confirmed it works with iDrive E2.
+
+#### Cache features
+
+- Tiered cache free and on by default.
+
+#### Cold cache features
+
+- Perma-Cache available if cold-cache prevalence becomes a problem at low launch traffic, to keep long-tail files warm if normal edge cache eviction causes too many cold origin reads.

--- a/docs/plans/media/MediaHostingProviderOptions.md
+++ b/docs/plans/media/MediaHostingProviderOptions.md
@@ -15,10 +15,10 @@ All assume `django-storages` with the S3-compatible backend. `MEDIA_STORAGE_BUCK
 - **S3 API**: GA, mature, very well-trodden in `django-storages` setups.
 - **US-East**: Yes — Reston, Virginia (`us-east-005`) added in 2024. Verify GA status before committing.
 - **Cost**: $0.006/GB-month. No minimum charge — pure per-GB. At launch volume: pennies/month. Egress: 3× free egress per month relative to storage volume, then $0.01/GB. Bandwidth Alliance partnership has historically given free egress to Bunny CDN (verify current terms).
-- **Cold-read perf**: HDD-backed tier for cost. Cold-read TTFB is the slowest of the candidates here — public benchmarks have shown 100–200ms higher first-byte than Wasabi for similar workloads. With CDN tiered caching in front this matters less for steady-state, but at low launch traffic where many images won't be cache-hot, it's perceptible.
+- **Cold-read perf**: HDD-backed tier for cost. Cold-read TTFB is the slowest of the candidates here — public benchmarks have shown 100–200ms higher first-byte than Wasabi for similar workloads. With a CDN/cache layer in front this matters less for steady-state, but at low launch traffic where many images won't be cache-hot, it's perceptible.
 - **Operational simplicity**: clean self-serve dashboard, application keys with bucket-scoped permissions. **Largest developer community of any candidate** — most tutorials, most Stack Overflow answers, deepest third-party docs.
 - **Private origin**: yes — buckets can be private; CDN authenticates with application keys.
-- **Viability**: publicly traded (NASDAQ: BLZE), founded 2007, ~$130M annual revenue. Audited financials. Strongest viability of the simple-vendor storage candidates.
+- **Viability**: publicly traded (NASDAQ: BLZE), founded 2007, ~$146M 2025 revenue. Audited financials. Strongest viability of the simple-vendor storage candidates.
 - **Verdict**: best community/docs and strongest public-co viability, but slowest cold reads. Right pick if community size matters more than cold-read latency.
 
 ### DigitalOcean Spaces
@@ -30,7 +30,7 @@ All assume `django-storages` with the S3-compatible backend. `MEDIA_STORAGE_BUCK
 - **Operational simplicity**: friendliest self-serve UX of any candidate. Sign up, click Create Space, get keys.
 - **Private origin**: yes — buckets can be private; access keys for CDN.
 - **Note on Spaces CDN**: their bundled CDN is **not** considered here. Spaces CDN fails the managed-TLS requirement when DNS isn't hosted at DigitalOcean. As pure storage behind a different CDN, that issue doesn't apply.
-- **Viability**: publicly traded (NYSE: DOCN), ~$700M annual revenue, profitable, founded 2011. Solid.
+- **Viability**: publicly traded (NYSE: DOCN), ~$901M 2025 revenue, profitable, founded 2011. Solid.
 - **Verdict**: solid storage candidate, especially for operational simplicity. $5/month floor is the only real downside.
 
 ### Wasabi
@@ -41,7 +41,7 @@ All assume `django-storages` with the S3-compatible backend. `MEDIA_STORAGE_BUCK
 - **Cold-read perf**: SSD-forward architecture. Wasabi explicitly markets fast read latency as a differentiator and has independent benchmarks supporting it. Fast cold reads relative to B2 (~50–100ms TTFB in typical conditions).
 - **Operational simplicity**: clean dashboard, standard S3-style access keys. Account signup is heavier than B2 (asks for more business info upfront). Smaller developer community than B2.
 - **Private origin**: yes.
-- **Quirks**: 90-day minimum retention — files deleted within 90 days still bill for the full 90 days. Not relevant for our access pattern.
+- **Quirks**: 90-day minimum retention — files deleted within 90 days still bill for the full 90 days. Annoying for us if we test large file uploads and then delete.
 - **Viability**: privately held, founded 2017 by David Friend (co-founder of Carbonite). $250M+ raised, claims profitability. No public financials. Established storage business; smaller brand presence in the developer sphere than B2.
 - **Verdict**: fast cold reads, simple operations, well-known in the production storage space. Trade-off vs. B2: faster perf, smaller community, private vs. public.
 
@@ -49,8 +49,8 @@ All assume `django-storages` with the S3-compatible backend. `MEDIA_STORAGE_BUCK
 
 - **S3 API**: GA.
 - **Chicago**: There's a Chicago data center!
-- **US-East**: Multiple regions including Virginia and Maryland. ✓
-- **Cost**: ~$0.004/GB-month — cheapest in the field. No minimum on pay-as-you-go pricing. Egress: 3× storage free, then $0.01/GB.
+- **US-East**: Virginia (`us-east-1`). ✓
+- **Cost**: $0.005/GB-month ($5/TB) on pay-as-you-go, with a **1 TB minimum** ($5/month floor — same shape as Wasabi, just at $5 vs. $7). Egress: 3× active storage free, then $0.01/GB.
 - **Cold-read perf**: marketed as performance-oriented and reportedly comparable to Wasabi. Less independent benchmarking than B2 or Wasabi.
 - **Operational simplicity**: reasonable self-serve dashboard, standard S3-style access keys. **Smallest developer community** of the three S3-clone candidates — fewer tutorials and SO answers when stuck.
 - **Private origin**: yes.
@@ -65,22 +65,22 @@ All assume `django-storages` with the S3-compatible backend. `MEDIA_STORAGE_BUCK
 - **Cold-read perf**: competitive with DO Spaces and Wasabi. SSD-backed.
 - **Operational simplicity**: the Linode-origin storage dashboard is self-serve and reasonable. Complexity arrives if paired with Akamai CDN (Property Manager) — see CDN section.
 - **Private origin**: yes.
-- **Note on built-in custom-domain feature**: Akamai Object Storage's own custom-domain UI requires BYO TLS cert (manual upload, manual renewal). That fails the managed-TLS requirement. Pairing this storage with a different CDN (Bunny, Fastly) avoids the issue — the CDN handles TLS instead.
-- **Viability**: publicly traded (NASDAQ: AKAM), ~$4B revenue, founded 1998. **Strongest viability of any candidate.**
+- **Note on built-in custom-domain feature**: Akamai Object Storage's own custom-domain TLS feature is only available for E0/E1 endpoint buckets and requires BYO TLS cert (manual upload, manual renewal). That fails the managed-TLS requirement. Pairing this storage with a different CDN (Bunny, Fastly) avoids the issue — the CDN handles TLS instead.
+- **Viability**: publicly traded (NASDAQ: AKAM), ~$4.2B 2025 revenue, founded 1998. **Strongest viability of any candidate.**
 - **Verdict**: solid storage with the strongest viability story. Pair with a non-Akamai CDN to dodge Property Manager.
 
 ### Fastly Object Storage
 
-- **S3 API**: announced 2024; **verify current GA status and regional availability before committing**. My information here is less certain than for the other options.
-- **US-East**: NY and Virginia (verify which regions are GA for Object Storage specifically).
-- **Cost**: verify current pricing. Free egress to Fastly CDN within the Fastly ecosystem.
+- **S3 API**: GA, S3-compatible, intended to work with Fastly Deliver and Compute services.
+- **US-East**: `us-east` regional endpoint. Also supports `us-west` and `eu-central`.
+- **Cost**: 5 GB free, then $0.02/GB-month up to 50 TB, with request charges after free operation quotas. Zero egress fees within the Fastly ecosystem.
 - **Cold-read perf**: well-positioned given Fastly's edge infrastructure and the free internal egress to their CDN.
-- **Operational simplicity**: Fastly's services/origins concepts apply to storage too.
-- **Private origin**: yes.
-- **Viability**: publicly traded (NYSE: FSLY), ~$500M revenue, founded 2011. Solid.
-- **Verdict**: potentially compelling if GA — especially paired with Fastly CDN. GA-status verification required before treating as a real candidate.
+- **Operational simplicity**: Fastly's services/origins concepts apply to storage too. Bucket access keys are account-level by default unless managed through the API.
+- **Private origin**: yes within the Fastly ecosystem; third-party CDN origin compatibility would need explicit verification because public bucket access is not supported.
+- **Viability**: publicly traded (NYSE: FSLY), ~$624M 2025 revenue, founded 2011. Solid.
+- **Verdict**: real product now, but most compelling when paired with Fastly CDN. Less attractive for a Bunny CDN launch because third-party private-origin behavior needs verification and the storage price is higher than the simpler S3-compatible candidates.
 
-### Bunny Edge Storage
+### ❌ Bunny Edge Storage
 
 - **Status**: **Fails the S3-compatible API requirement.** As of 2026-04-30, Bunny's S3-compatible API is invite-only preview. Their GA API is a proprietary HTTP interface, not S3-compatible.
 - **Verdict**: out for the launch decision. Reopen if/when their S3 API hits GA — at that point Bunny all-in (storage + CDN + Optimizer + Stream) becomes the strongest single-vendor candidate for our future capabilities.
@@ -94,8 +94,8 @@ All CDN options assume the storage provider exposes an S3-compatible HTTPS origi
 - **PoPs**: ~120+ globally. Chicago PoP: yes. Strong in EU/Asia, good in US.
 - **Managed TLS**: free Let's Encrypt for custom hostnames via ACME HTTP-01 against the CDN endpoint. No DNS-on-Bunny required. Automatic renewal. ✓
 - **Operational simplicity**: **the simplest of the three.** Create pull zone, set origin, attach custom hostname, click issue cert. ~15 minutes from zero for a volunteer with no Bunny background.
-- **Cache features**: tiered caching free and on by default — edge miss falls to a regional cache before going to origin. **Perma-Cache** is a paid add-on that keeps long-tail content cached in Bunny's permanent storage even after edge eviction; useful for low-traffic sites where the long tail is mostly cold.
-- **Cost**: ~$0.005–$0.01/GB egress depending on region. No minimum.
+- **Cache features**: normal edge caching is built in. **Origin Shield** is an optional free secondary cache layer that consolidates origin misses through one shield region. **Perma-Cache** is optional and uses a Bunny Storage zone to keep long-tail content available from Bunny infrastructure even after edge eviction; useful for low-traffic sites where the long tail is mostly cold.
+- **Cost**: Standard network is $0.01/GB for Europe and North America, higher in other regions. Volume network starts at $0.005/GB but uses a smaller 10-PoP network. Bunny has a $1 monthly minimum.
 - **Viability**: privately held (BunnyWay d.o.o., Slovenia), founded 2015. Self-described profitable, ~70 employees, 100K+ customers. Smallest of the CDN candidates by a meaningful margin, but the CDN is swappable so the risk is bounded.
 - **Verdict**: best operational simplicity. Right CDN for a volunteer-run setup unless viability concerns dominate.
 
@@ -105,7 +105,7 @@ All CDN options assume the storage provider exposes an S3-compatible HTTPS origi
 - **Managed TLS**: Fastly TLS service issues and renews managed certs via ACME, DNS-host-agnostic. ✓
 - **Operational simplicity**: well-designed but more concepts to learn — services, origins, backends, optional VCL/rule snippets, configuration versions, activations. Volunteer onboarding requires real reading.
 - **Cost**: free tier covers most launch traffic; past that, ~$0.12/GB egress (closer to AWS than Bunny). Wasabi has an explicit Fastly partnership — Wasabi → Fastly origin egress is free under their alliance.
-- **Viability**: publicly traded (NYSE: FSLY), ~$500M revenue, founded 2011. Solid.
+- **Viability**: publicly traded (NYSE: FSLY), ~$624M 2025 revenue, founded 2011. Solid.
 - **Verdict**: best raw perf (slightly), best public-company CDN viability, but operationally heavier than Bunny — cost is paid every time anyone touches the config.
 
 ### Akamai CDN (Property Manager)
@@ -113,22 +113,20 @@ All CDN options assume the storage provider exposes an S3-compatible HTTPS origi
 - **PoPs**: ~4000+, the largest CDN network in the world. Chicago PoP: strong. Best for global reach to underserved regions.
 - **Managed TLS**: Default DV certs, ACME-provisioned, DNS-host-agnostic via `_acme-challenge` CNAME. ✓
 - **Operational simplicity**: **the heaviest of the three.** Property Manager is the enterprise CDN configuration apparatus: properties, behaviors, rule trees, CP codes, configuration versions and activations to staging and production networks. Same family of complexity as AWS CloudFront — well-designed but requires real expertise to configure.
-- **Cost**: bundled with Akamai Object Storage's basic tier; larger Akamai-CDN-only contracts are enterprise-quoted.
-- **Viability**: publicly traded (NASDAQ: AKAM), ~$4B revenue. Strongest viability of any CDN candidate.
+- **Cost**: Akamai Object Storage's $5/month tier includes storage and a network transfer allowance, but not a self-serve Property Manager CDN product. Akamai CDN pricing is generally separate and quote-oriented.
+- **Viability**: publicly traded (NASDAQ: AKAM), ~$4.2B 2025 revenue. Strongest viability of any CDN candidate.
 - **Verdict**: best CDN reach and viability, worst operational simplicity. Right pick only if someone is willing to learn Property Manager.
 
 ## Decision
 
-**Storage: iDrive e2 (US-East).**
+**Storage: iDrive e2.**
 **CDN: Bunny CDN.**
-
-Decided 2026-05-01. `media.flipcommons.org` is live and serving a test file through Bunny CDN with iDrive e2 as the origin.
 
 ### Why iDrive e2 for storage
 
 #### Chicago data center
 
-Fastest for cold reads in the Chicago area
+Fastest for CDN misses aka cold reads in the Chicago area
 
 #### Performance
 
@@ -148,15 +146,11 @@ This is the biggest advantage over Wasabi.
 
 #### Predictable "Flat" Pricing
 
-    IDrive e2 costs $0.004 per GB/month.
+    IDrive e2 costs $0.005 per GB/month ($5/TB), with a 1 TB minimum on pay-as-you-go (so a $5/month floor until storage exceeds 1 TB).
 
-##### No egress fees
+##### Generous egress allowance
 
-    Unlike AWS S3, there are no egress fees (bandwidth costs) from IDrive. Since you’ve connected it to Bunny.net, IDrive won't charge you a penny for the data moving from their bucket to your CDN. You only pay for what you store.
-
-##### No 1 TB minimum
-
-No $5/month floor like DO Spaces. Costs scale to actual usage.
+    Unlike AWS S3, IDrive e2's free egress policy covers downloads up to 3× your active stored volume per month. Since traffic from the bucket to Bunny is bounded by what we store, in practice we expect to stay well within the free tier. Beyond 3× storage, overage egress is $0.01/GB.
 
 #### Modern "Virtual Hosted" Support
 
@@ -204,7 +198,7 @@ Bunny supports S3-style origin authentication fields, so it can pull from privat
 
 #### Cache features
 
-- Tiered cache free and on by default.
+- Edge caching is built in. Origin Shield is free but must be enabled/configured.
 
 #### Cold cache features
 

--- a/docs/plans/media/MediaHostingProviderRequirements.md
+++ b/docs/plans/media/MediaHostingProviderRequirements.md
@@ -1,0 +1,69 @@
+# Media Hosting & CDN Provider Requirements
+
+## Background
+
+The media plan in [Media.md](Media.md) selected Cloudflare R2 partly on the assumption that we could put Cloudflare's CDN in front of an R2 bucket via a custom domain on `flipcommons.org`. **That assumption is wrong.** Cloudflare requires the custom domain's DNS to be hosted on Cloudflare to serve a public R2 bucket through it, and we are not moving `flipcommons.org` DNS to Cloudflare.
+
+This doc captures the requirements we use to evaluate replacement storage + CDN providers. The evaluation itself, with options compared and a recommendation, lives in [MediaHostingProviderOptions.md](MediaHostingProviderOptions.md).
+
+## Requirements
+
+1. **No DNS hosting dependency.** DNS stays hosted where it is today. I'm assuming we have to do CNAME validation.
+2. **S3-compatible API.** `django-storages` with the S3 backend is already wired up in [backend/config/settings.py](../../../backend/config/settings.py) using the boto3 library; provider-neutral env vars (`MEDIA_STORAGE_BUCKET`, `MEDIA_STORAGE_ENDPOINT`, etc.) are already in place.
+3. **Custom `media.flipcommons.org` subdomain for serving.** Public URLs go in API responses and we don't want them pointing at a vendor hostname.
+4. **Operational simplicity.** Setup, ongoing config, and troubleshooting should be navigable by a volunteer dev without specialized training. No enterprise IAM-style permission systems to debug, no vendor-specific concepts (VCL, edge runtimes, complex service hierarchies) to learn just to operate a media bucket. Friendly self-serve UX matters more than feature breadth.
+5. **Managed TLS without certificate handling.** `media.flipcommons.org` must get HTTPS through provider-managed certificate issuance and renewal. No manually generated certificates, no uploaded private keys, no recurring certificate-renewal chores, and no requirement to move DNS hosting to the media provider just to get managed TLS.
+6. **Production-grade serving.** No "dev only / rate-limited / no SLA" public URLs in front of real users.
+7. **Viability.** Preferably with a vendor we know won't go out of business.
+8. **Storage location.** We'd prefer file storage close to Chicago, to optimize for perf of cold reads near the museum. Second choice would be US-East.
+   1. Justification: the museum's in Chicago, a lot of the reads will happen there, we'll have a CDN POP in Chicago, and I want cold image serving to be fast to Chicago specifically Especially at first, when the site isn't used much, I expect lots of images won't be hit every day. Dunno how long files stay in CDN cache...
+   2. If we were optimizing for writes we'd put it near the Railway-hosted website in US-East (Virginia), but writes are much less frequent and future presigned uploads could remove app-region write latency.
+9. **Inexpensive.** Under around $10/month at launch, including custom domain if they charge for it, with no unbounded egress risk. Stays cheap as the catalog grows. Egress is the historical blowup.
+10. After doing a comparison, they all seem to be under $10/month. Cost doesn't seem to be a big decision point between them.
+11. **Hosting-independent.** If media is stored at the same provider as Railway, the decision to leave Railway for app hosting and the decision to leave for media hosting must remain independent.
+12. **API URLs do not have to be stable** across a future migration.
+13. **Storage keys stay vendor-neutral.** Already true: `catalog-media/{uuid}/...`.
+
+## CDN
+
+We will be hooking up a CDN to file-serving at the same time.
+
+### CDN facts
+
+- **UUID filenames**. The media filenames are all UUIDs.
+- **Immutable contents**. The media file contents are immutable, so cache forever.
+
+### CDN requirements
+
+- **Chicago-area POP.** A CDN with a POP near Chicago specifically, where the museum is located.
+- **Global POPs.** A CDN with POPs globally, not one that just focuses on a region (like mainly US or mainly Europe)
+- **Same provider as file storage... or not?** I thought I'd like to have the same provider for both CDN and file storage, for operational simplicity, but it sounds like it might be better to get separate file and CDN providers, both best-in-breed and both focusing on simplicity for non-devops users.
+- **Private origin**. I'd prefer the connection between the CDN and the origin to be private. This is not a hard requirement, because the media filenames are all UUIDs, meaning as long as the bucket doesn't list its contents, we could live with a public origin, though I'd RATHER a private connection between the CDN and the bucket
+
+## Perf might be the tie-breaker
+
+As long as the biggest requirements are satisfied -- things like cost, operational simplicity, auto-cert-rotation, DNS hosting, viability -- then maybe let's decide on perf.
+
+Cold image serving should fast. To Chicago specifically, if not everywhere. Especially at first, when the site isn't used much, I expect lots of images won't be hit every day.
+
+## Providers to avoid in possible
+
+1. **Avoid Cloudflare if possible.** I'm feeling a bit burned on Cloudflare's insistence on hosting the DNS, and we have some moral objections to Cloudflare. We'd like a path that lets us leave Cloudflare entirely, including for ingest. No Cloudflare file storage, no Cloudflare CDN.
+2. **Avoid AWS if possible.** AWS is too operationally complex for non-devops volunteer devs (IAM config, Cloudfront config billing surface). We don't use it for anything today, it doesn't feel like the moment to start if we can find something more simple but equally as robust.
+
+## Capabilities of interest (not requirements)
+
+These don't drive the launch decision but are worth knowing because they affect future work:
+
+- **Image transformation on the fly** (`?w=400&format=webp`-style URL params): strong interest. We'd plausibly replace our server-side Pillow rendition pipeline with this in a future PR. Not in the initial cutover — one thing at a time.
+- **Video transcoding pipeline** (upload source → HLS renditions + poster). Interest, not commitment. Affects [Media.md:633-635](Media.md#L633-L635) (the future video transcoding worker).
+- **Adaptive bitrate streaming** (HLS/DASH delivery). Same — interest, not commitment.
+
+## Non-requirements
+
+- Video support is not yet needed.
+- Direct creator upload widgets, signed URLs for gated content.
+
+## Next
+
+See [MediaHostingProviderOptions.md](MediaHostingProviderOptions.md) for the evaluation of specific providers against these requirements, including a recommendation.

--- a/docs/plans/media/Renditions.md
+++ b/docs/plans/media/Renditions.md
@@ -1,5 +1,7 @@
 # Image Renditions Plan
 
+> **⚠️ Outdated.** This plan predates the move to iDrive e2 + Bunny CDN and needs to be updated before it drives any work. The high-level idea (canonical originals + on-demand resizing at the CDN edge) is still directionally right, but the vendor specifics and several mechanics need a refresh.
+
 Plan date: 2026-04-03
 
 This document describes the product and architecture direction for Pinbase-owned image delivery after the initial media support work. It focuses on uploaded images that Pinbase has the right to store and display. Third-party image references remain external.

--- a/docs/plans/media/Video.md
+++ b/docs/plans/media/Video.md
@@ -1,5 +1,7 @@
 # Video Plan
 
+> **⚠️ Outdated.** This plan predates the move to iDrive e2 + Bunny CDN and needs to be updated before it drives any work. The transcoding/playback vendor referenced below should be revisited; the rest of the architecture (claims, ownership boundary, separation of catalog truth from delivery infrastructure) still applies.
+
 Plan date: 2026-04-03
 
 This document describes the product and architecture direction for user-uploaded video in Pinbase. It covers Pinbase-owned video uploads only. Third-party videos remain external.


### PR DESCRIPTION
## Summary
- Switch media architecture from Cloudflare R2 to iDrive e2 (Chicago `us-midwest-1`) fronted by Bunny CDN at `media.flipcommons.org`. Bucket stays private; Bunny pulls via S3 signature.
- Add `MediaHostingProviderRequirements.md` and `MediaHostingProviderOptions.md` capturing the constraints that drove the choice (museum vetoes Cloudflare; AWS too heavy for volunteer ops) and the providers considered.
- Stamp `Cache-Control: public, max-age=31536000, immutable` on every S3 upload via `AWS_S3_OBJECT_PARAMETERS`. Storage keys are UUID-derived and write-once, so the bytes at each key never change — `immutable` lets browsers skip revalidation entirely and lets Bunny treat objects as cacheable indefinitely. Matters more here than under R2 because iDrive bills egress.
- Update `commit` skill with pre-commit failure detection guidance (autofix trap, recovery steps).

Ingest sources stay on Cloudflare R2 for now — only user-uploaded media moves.

## Test plan
- [ ] Set the five `MEDIA_STORAGE_*` env vars + `MEDIA_PUBLIC_BASE_URL` in Railway, point at the iDrive bucket
- [ ] Upload an image through the app, confirm it appears via `media.flipcommons.org`
- [ ] `aws s3api head-object` on the new rendition and confirm `CacheControl: public, max-age=31536000, immutable`
- [ ] `curl -I` through Bunny and confirm the header is forwarded to the browser
- [ ] Confirm Bunny pull-zone is configured to respect origin Cache-Control (follow-up dashboard config, not in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)