### PR TITLE
Editors can change image category

### DIFF
--- a/backend/apps/media/api.py
+++ b/backend/apps/media/api.py
@@ -45,6 +45,7 @@ from apps.media.processing import (
 from apps.media.schemas import (
     AttachmentMetaSchema,
     MediaAssetInputSchema,
+    MediaSetCategoryInputSchema,
     RenditionUrlsSchema,
     UploadSchema,
 )
@@ -382,6 +383,65 @@ def set_primary(request: HttpRequest, body: MediaAssetInputSchema) -> Status[Non
             category=em.category,
             is_primary=True,
         )
+        Claim.objects.assert_claim(
+            entity,
+            "media_attachment",
+            claim_value,
+            user=user,
+            claim_key=claim_key,
+        )
+        resolve_media_attachments(
+            content_type_id=ct.id,
+            subject_ids={entity.pk},
+        )
+
+    return Status(204, None)
+
+
+@media_router.post(
+    "/set-category/",
+    response={
+        204: None,
+        400: ErrorDetailSchema,
+        404: ErrorDetailSchema,
+        422: ValidationErrorSchema,
+    },
+    auth=django_auth,
+)
+def set_category(
+    request: HttpRequest, body: MediaSetCategoryInputSchema
+) -> Status[None]:
+    """Change the category of a media asset already attached to an entity."""
+    user = authed_user(request)
+    ct, entity = _resolve_entity(body.entity_type, body.public_id)
+
+    try:
+        asset = MediaAsset.objects.get(uuid=body.asset_uuid)
+    except MediaAsset.DoesNotExist, ValidationError:
+        raise HttpError(404, "Media asset not found.") from None
+
+    em = EntityMedia.objects.filter(
+        content_type=ct,
+        object_id=entity.pk,
+        asset=asset,
+    ).first()
+    if em is None:
+        raise HttpError(404, "This asset is not attached to the specified entity.")
+
+    if em.category == body.category:
+        return Status(204, None)
+
+    with transaction.atomic():
+        try:
+            claim_key, claim_value = build_media_attachment_claim(
+                entity,
+                asset.pk,
+                category=body.category,
+                is_primary=False,
+            )
+        except ValueError as exc:
+            raise HttpError(400, str(exc)) from exc
+
         Claim.objects.assert_claim(
             entity,
             "media_attachment",

--- a/backend/apps/media/schemas.py
+++ b/backend/apps/media/schemas.py
@@ -50,3 +50,7 @@ class MediaAssetInputSchema(Schema):
     entity_type: str
     public_id: str
     asset_uuid: str
+
+
+class MediaSetCategoryInputSchema(MediaAssetInputSchema):
+    category: str

--- a/backend/apps/media/tests/test_set_category.py
+++ b/backend/apps/media/tests/test_set_category.py
@@ -1,0 +1,251 @@
+"""Tests for media set-category endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import Client
+
+from apps.catalog.claims import build_media_attachment_claim
+from apps.catalog.resolve import resolve_media_attachments
+from apps.catalog.tests.conftest import make_machine_model
+from apps.media.models import EntityMedia, MediaAsset
+from apps.provenance.models import Claim
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user("editor")
+
+
+@pytest.fixture
+def machine_model(db):
+    return make_machine_model(name="Test Machine", slug="test-machine")
+
+
+def _make_asset(user, filename="photo.jpg"):
+    return MediaAsset.objects.create(
+        kind=MediaAsset.Kind.IMAGE,
+        status=MediaAsset.Status.READY,
+        original_filename=filename,
+        mime_type="image/jpeg",
+        byte_size=1024,
+        width=800,
+        height=600,
+        uploaded_by=user,
+    )
+
+
+def _attach_via_claims(entity, asset, user, category="backglass", is_primary=False):
+    claim_key, claim_value = build_media_attachment_claim(
+        entity, asset.pk, category=category, is_primary=is_primary
+    )
+    Claim.objects.assert_claim(
+        entity,
+        "media_attachment",
+        claim_value,
+        user=user,
+        claim_key=claim_key,
+    )
+    ct = ContentType.objects.get_for_model(type(entity))
+    resolve_media_attachments(content_type_id=ct.id, subject_ids={entity.pk})
+
+
+@pytest.fixture
+def auth_client(user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+@pytest.fixture
+def anon_client():
+    return Client()
+
+
+class TestSetCategoryEndpoint:
+    def test_change_category(self, auth_client, machine_model, user):
+        asset = _make_asset(user)
+        _attach_via_claims(
+            machine_model, asset, user, category="backglass", is_primary=True
+        )
+
+        resp = auth_client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+                "category": "playfield",
+            },
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 204
+        em = EntityMedia.objects.get(asset=asset)
+        assert em.category == "playfield"
+
+    def test_lone_attachment_auto_promotes_after_move(
+        self, auth_client, machine_model, user
+    ):
+        """A moved attachment that is alone in its new category auto-promotes."""
+        asset = _make_asset(user)
+        _attach_via_claims(
+            machine_model, asset, user, category="backglass", is_primary=True
+        )
+
+        resp = auth_client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+                "category": "playfield",
+            },
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 204
+        em = EntityMedia.objects.get(asset=asset)
+        assert em.is_primary is True
+
+    def test_does_not_demote_existing_primary_in_new_category(
+        self, auth_client, machine_model, user
+    ):
+        """Recategorizing a primary asset must not demote the new category's primary."""
+        moved = _make_asset(user, "moved.jpg")
+        existing_primary = _make_asset(user, "existing.jpg")
+        _attach_via_claims(
+            machine_model, moved, user, category="backglass", is_primary=True
+        )
+        _attach_via_claims(
+            machine_model,
+            existing_primary,
+            user,
+            category="playfield",
+            is_primary=True,
+        )
+
+        resp = auth_client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(moved.uuid),
+                "category": "playfield",
+            },
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 204
+        assert EntityMedia.objects.get(asset=existing_primary).is_primary is True
+        assert EntityMedia.objects.get(asset=moved).is_primary is False
+
+    def test_same_category_is_noop(self, auth_client, machine_model, user):
+        asset = _make_asset(user)
+        _attach_via_claims(
+            machine_model, asset, user, category="backglass", is_primary=True
+        )
+
+        resp = auth_client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+                "category": "backglass",
+            },
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 204
+        assert EntityMedia.objects.get(asset=asset).category == "backglass"
+
+    def test_invalid_category(self, auth_client, machine_model, user):
+        asset = _make_asset(user)
+        _attach_via_claims(
+            machine_model, asset, user, category="backglass", is_primary=True
+        )
+
+        resp = auth_client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+                "category": "not-a-real-category",
+            },
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 400
+        assert EntityMedia.objects.get(asset=asset).category == "backglass"
+
+    def test_auth_required(self, anon_client, machine_model, user):
+        asset = _make_asset(user)
+        _attach_via_claims(
+            machine_model, asset, user, category="backglass", is_primary=True
+        )
+
+        resp = anon_client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+                "category": "playfield",
+            },
+            content_type="application/json",
+        )
+
+        assert resp.status_code in (401, 403)
+        assert EntityMedia.objects.get(asset=asset).category == "backglass"
+
+    def test_asset_not_attached(self, auth_client, machine_model, user):
+        asset = _make_asset(user)
+
+        resp = auth_client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+                "category": "playfield",
+            },
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 404
+
+    def test_unknown_asset_uuid(self, auth_client, machine_model):
+        resp = auth_client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": "00000000-0000-0000-0000-000000000000",
+                "category": "playfield",
+            },
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 404
+
+    def test_malformed_asset_uuid(self, auth_client, machine_model):
+        resp = auth_client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": "not-a-uuid",
+                "category": "playfield",
+            },
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 404

--- a/frontend/src/lib/api/media-api.ts
+++ b/frontend/src/lib/api/media-api.ts
@@ -123,3 +123,22 @@ export function detachMedia(
 export function setPrimary(entityType: string, publicId: string, assetUuid: string): Promise<void> {
   return mediaAction('/api/media/set-primary/', entityType, publicId, assetUuid);
 }
+
+export async function setCategory(
+  entityType: string,
+  publicId: string,
+  assetUuid: string,
+  category: string,
+): Promise<void> {
+  const { error, response } = await client.POST('/api/media/set-category/', {
+    body: {
+      entity_type: entityType,
+      public_id: publicId,
+      asset_uuid: assetUuid,
+      category,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(error ? parseApiError(error).message : `Request failed (${response.status})`);
+  }
+}

--- a/frontend/src/lib/components/ActionMenu.dom.test.ts
+++ b/frontend/src/lib/components/ActionMenu.dom.test.ts
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import ActionMenuFixture from './ActionMenu.fixture.svelte';
+import ActionMenuListboxFixture from './ActionMenu.listbox.fixture.svelte';
 
 describe('ActionMenu', () => {
   function renderMenu() {
@@ -118,5 +119,69 @@ describe('ActionMenu', () => {
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  describe('pill variant + listbox role', () => {
+    it('renders listbox semantics by default for variant="pill"', async () => {
+      const user = userEvent.setup();
+      render(ActionMenuListboxFixture);
+
+      const trigger = screen.getByRole('button', { name: 'Image category: playfield' });
+      expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+
+      await user.click(trigger);
+
+      const listbox = screen.getByRole('listbox');
+      expect(listbox).toBeInTheDocument();
+      expect(listbox).toHaveClass('opens-up');
+
+      const options = screen.getAllByRole('option');
+      expect(options.map((o) => o.textContent?.trim())).toEqual([
+        'playfield',
+        'backglass',
+        'cabinet',
+      ]);
+
+      const current = screen.getByRole('option', { name: 'playfield' });
+      expect(current).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('option', { name: 'backglass' })).toHaveAttribute(
+        'aria-selected',
+        'false',
+      );
+    });
+
+    it('arrow keys move focus across options and Escape closes', async () => {
+      const user = userEvent.setup();
+      render(ActionMenuListboxFixture);
+
+      const trigger = screen.getByRole('button', { name: 'Image category: playfield' });
+      trigger.focus();
+      await user.keyboard('{ArrowDown}');
+
+      expect(screen.getByRole('option', { name: 'playfield' })).toHaveFocus();
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('option', { name: 'backglass' })).toHaveFocus();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('option', { name: 'cabinet' })).toHaveFocus();
+
+      await user.keyboard('{Escape}');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+
+    it('clicking an option closes the listbox and restores focus to the trigger', async () => {
+      const user = userEvent.setup();
+      const onselect = vi.fn();
+      render(ActionMenuListboxFixture, { onselect });
+
+      const trigger = screen.getByRole('button', { name: 'Image category: playfield' });
+      await user.click(trigger);
+      await user.click(screen.getByRole('option', { name: 'backglass' }));
+
+      expect(onselect).toHaveBeenCalledWith('backglass');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      // Trigger label re-renders with the new selection.
+      expect(screen.getByRole('button', { name: 'Image category: backglass' })).toHaveFocus();
+    });
   });
 });

--- a/frontend/src/lib/components/ActionMenu.listbox.fixture.svelte
+++ b/frontend/src/lib/components/ActionMenu.listbox.fixture.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import ActionMenu from './ActionMenu.svelte';
+  import MenuItem from './MenuItem.svelte';
+
+  let {
+    selected = $bindable<string>('playfield'),
+    onselect,
+  }: {
+    selected?: string;
+    onselect?: (value: string) => void;
+  } = $props();
+
+  const options = ['playfield', 'backglass', 'cabinet'];
+
+  function pick(value: string) {
+    selected = value;
+    onselect?.(value);
+  }
+</script>
+
+<ActionMenu variant="pill" label={selected} ariaLabel={`Image category: ${selected}`}>
+  {#each options as opt (opt)}
+    <MenuItem current={opt === selected} onclick={() => pick(opt)}>{opt}</MenuItem>
+  {/each}
+</ActionMenu>

--- a/frontend/src/lib/components/ActionMenu.svelte
+++ b/frontend/src/lib/components/ActionMenu.svelte
@@ -1,14 +1,31 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte';
+  import { setContext, untrack, type Snippet } from 'svelte';
 
   type Props = {
     label: string;
     disabled?: boolean;
-    variant?: 'default' | 'heading';
+    variant?: 'default' | 'heading' | 'pill';
+    role?: 'menu' | 'listbox';
+    ariaLabel?: string;
     children: Snippet;
   };
 
-  let { label, disabled = false, variant = 'default', children }: Props = $props();
+  let {
+    label,
+    disabled = false,
+    variant = 'default',
+    role: roleProp,
+    ariaLabel,
+    children,
+  }: Props = $props();
+
+  const role: 'menu' | 'listbox' = $derived(roleProp ?? (variant === 'pill' ? 'listbox' : 'menu'));
+  // Context captures the role at construction time and is read once by descendants;
+  // role is stable for the lifetime of the component for all current call sites.
+  setContext<'menu' | 'listbox'>(
+    'action-menu-role',
+    untrack(() => role),
+  );
 
   let open = $state(false);
   let triggerEl: HTMLButtonElement | undefined = $state();
@@ -18,7 +35,9 @@
   const menuId = `${uid}-menu`;
 
   function getMenuItems() {
-    return Array.from(menuEl?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? []);
+    return Array.from(
+      menuEl?.querySelectorAll<HTMLElement>('[role="menuitem"], [role="option"]') ?? [],
+    );
   }
 
   function focusMenuItem(index: number) {
@@ -116,7 +135,13 @@
   function handleMenuClick(event: MouseEvent) {
     const target = event.target;
     if (!(target instanceof Element)) return;
-    if (target.closest('[role="menuitem"]')) closeMenu();
+    if (target.closest('[role="menuitem"], [role="option"]')) {
+      // For listbox semantics restore focus to trigger after selection (matches
+      // native <select> and ARIA Authoring Practices). Action menus typically
+      // hand focus off to whatever the action opens, so keep the existing
+      // behavior there.
+      closeMenu({ restoreFocus: role === 'listbox' });
+    }
   }
 
   $effect(() => {
@@ -182,10 +207,12 @@
     type="button"
     class="trigger"
     class:heading={variant === 'heading'}
+    class:pill={variant === 'pill'}
     {disabled}
-    aria-haspopup="menu"
+    aria-haspopup={role === 'listbox' ? 'listbox' : 'menu'}
     aria-expanded={open}
     aria-controls={open ? menuId : undefined}
+    aria-label={ariaLabel}
     onclick={toggleMenu}
     onkeydown={handleTriggerKeydown}
   >
@@ -196,10 +223,11 @@
       bind:this={menuEl}
       id={menuId}
       class="menu"
-      class:align-start={variant === 'heading'}
-      role="menu"
+      class:align-start={variant === 'heading' || variant === 'pill'}
+      class:opens-up={variant === 'pill'}
+      {role}
       tabindex="-1"
-      aria-label={label}
+      aria-label={ariaLabel ?? label}
       onkeydown={handleMenuKeydown}
       onclick={handleMenuClick}
     >
@@ -233,6 +261,20 @@
     font-size: inherit;
     font-weight: inherit;
     color: inherit;
+  }
+
+  .trigger.pill {
+    background: rgba(0, 0, 0, 0.65);
+    color: #fff;
+    font-size: var(--font-size-0);
+    padding: 0.1em 0.4em;
+    border-radius: var(--radius-1);
+  }
+
+  .trigger.pill:hover,
+  .trigger.pill[aria-expanded='true'] {
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
   }
 
   .trigger:hover,
@@ -270,5 +312,10 @@
   .menu.align-start {
     right: auto;
     left: 0;
+  }
+
+  .menu.opens-up {
+    top: auto;
+    bottom: calc(100% + 4px);
   }
 </style>

--- a/frontend/src/lib/components/MenuItem.svelte
+++ b/frontend/src/lib/components/MenuItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte';
+  import { getContext, type Snippet } from 'svelte';
 
   let {
     href = undefined,
@@ -14,18 +14,37 @@
     current?: boolean;
     children: Snippet;
   } = $props();
+
+  const parentRole = getContext<'menu' | 'listbox'>('action-menu-role') ?? 'menu';
+  const itemRole = parentRole === 'listbox' ? 'option' : 'menuitem';
+  const ariaSelected = $derived(parentRole === 'listbox' ? current : undefined);
 </script>
 
 {#if disabled}
-  <span class:current class="menu-item disabled" role="menuitem" aria-disabled="true" tabindex="-1">
+  <span
+    class:current
+    class="menu-item disabled"
+    role={itemRole}
+    aria-disabled="true"
+    aria-selected={ariaSelected}
+    tabindex="-1"
+  >
     {@render children()}
   </span>
 {:else if href}
-  <a class="menu-item" {href} role="menuitem" tabindex="-1">
+  <a class="menu-item" {href} role={itemRole} aria-selected={ariaSelected} tabindex="-1">
     {@render children()}
   </a>
 {:else}
-  <button class:current class="menu-item" type="button" role="menuitem" tabindex="-1" {onclick}>
+  <button
+    class:current
+    class="menu-item"
+    type="button"
+    role={itemRole}
+    aria-selected={ariaSelected}
+    tabindex="-1"
+    {onclick}
+  >
     {@render children()}
   </button>
 {/if}

--- a/frontend/src/lib/components/PillSelect.dom.test.ts
+++ b/frontend/src/lib/components/PillSelect.dom.test.ts
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import PillSelectFixture from './PillSelect.fixture.svelte';
+
+describe('PillSelect', () => {
+  it('shows the current option label on the trigger', () => {
+    render(PillSelectFixture, { value: 'backglass' });
+    expect(screen.getByRole('button', { name: 'Image category: backglass' })).toHaveTextContent(
+      'backglass',
+    );
+  });
+
+  it('shows the placeholder and "none" in the accessible name when value is null', () => {
+    render(PillSelectFixture, { value: null });
+    const trigger = screen.getByRole('button', { name: 'Image category: none' });
+    expect(trigger).toHaveTextContent('—');
+  });
+
+  it('opens to a listbox of all options with the current one selected', async () => {
+    const user = userEvent.setup();
+    render(PillSelectFixture, { value: 'playfield' });
+
+    const trigger = screen.getByRole('button', { name: 'Image category: playfield' });
+    await user.click(trigger);
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const options = screen.getAllByRole('option');
+    expect(options.map((o) => o.textContent?.trim())).toEqual([
+      'playfield',
+      'backglass',
+      'cabinet',
+    ]);
+    expect(screen.getByRole('option', { name: 'playfield' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  it('fires onchange when a different option is picked', async () => {
+    const user = userEvent.setup();
+    const onchange = vi.fn();
+    render(PillSelectFixture, { value: 'playfield', onchange });
+
+    await user.click(screen.getByRole('button', { name: 'Image category: playfield' }));
+    await user.click(screen.getByRole('option', { name: 'cabinet' }));
+
+    expect(onchange).toHaveBeenCalledTimes(1);
+    expect(onchange).toHaveBeenCalledWith('cabinet');
+  });
+
+  it('does NOT fire onchange when the current option is re-selected', async () => {
+    const user = userEvent.setup();
+    const onchange = vi.fn();
+    render(PillSelectFixture, { value: 'playfield', onchange });
+
+    await user.click(screen.getByRole('button', { name: 'Image category: playfield' }));
+    await user.click(screen.getByRole('option', { name: 'playfield' }));
+
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('blocks opening when disabled', async () => {
+    const user = userEvent.setup();
+    render(PillSelectFixture, { disabled: true });
+
+    const trigger = screen.getByRole('button', { name: 'Image category: playfield' });
+    expect(trigger).toBeDisabled();
+
+    await user.click(trigger);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/components/PillSelect.fixture.svelte
+++ b/frontend/src/lib/components/PillSelect.fixture.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import PillSelect from './PillSelect.svelte';
+
+  let {
+    value = $bindable<string | null>('playfield'),
+    options = [
+      { value: 'playfield', label: 'playfield' },
+      { value: 'backglass', label: 'backglass' },
+      { value: 'cabinet', label: 'cabinet' },
+    ],
+    purpose = 'Image category',
+    disabled = false,
+    onchange,
+  }: {
+    value?: string | null;
+    options?: { value: string; label: string }[];
+    purpose?: string;
+    disabled?: boolean;
+    onchange?: (value: string) => void;
+  } = $props();
+
+  function handleChange(next: string) {
+    value = next;
+    onchange?.(next);
+  }
+</script>
+
+<PillSelect {value} {options} {purpose} {disabled} onchange={handleChange} />

--- a/frontend/src/lib/components/PillSelect.svelte
+++ b/frontend/src/lib/components/PillSelect.svelte
@@ -1,0 +1,44 @@
+<script lang="ts" generics="T extends string">
+  import ActionMenu from './ActionMenu.svelte';
+  import MenuItem from './MenuItem.svelte';
+
+  type Option = { value: T; label: string };
+
+  let {
+    value,
+    options,
+    purpose,
+    placeholder = '—',
+    emptyValueLabel = 'none',
+    disabled = false,
+    onchange,
+  }: {
+    value: T | null | undefined;
+    options: Option[];
+    /**
+     * Describes what is being selected, e.g. "Image category". Combined with the
+     * current value to form the trigger's accessible name (e.g. "Image category: playfield").
+     */
+    purpose: string;
+    placeholder?: string;
+    emptyValueLabel?: string;
+    disabled?: boolean;
+    onchange: (value: T) => void;
+  } = $props();
+
+  const currentLabel = $derived(options.find((o) => o.value === value)?.label ?? placeholder);
+  const accessibleName = $derived(`${purpose}: ${value == null ? emptyValueLabel : currentLabel}`);
+
+  function handleSelect(next: T) {
+    if (next === value) return;
+    onchange(next);
+  }
+</script>
+
+<ActionMenu variant="pill" label={currentLabel} ariaLabel={accessibleName} {disabled}>
+  {#each options as opt (opt.value)}
+    <MenuItem current={opt.value === value} onclick={() => handleSelect(opt.value)}>
+      {opt.label}
+    </MenuItem>
+  {/each}
+</ActionMenu>

--- a/frontend/src/lib/components/editors/MediaEditor.svelte
+++ b/frontend/src/lib/components/editors/MediaEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { invalidateAll } from '$app/navigation';
-  import { detachMedia, setPrimary } from '$lib/api/media-api';
+  import { detachMedia, setCategory, setPrimary } from '$lib/api/media-api';
   import { MEDIA_CATEGORIES } from '$lib/api/catalog-meta';
   import type { UploadedMediaSchema } from '$lib/api/schema';
   import MediaUploadZone from '$lib/components/media/MediaUploadZone.svelte';
@@ -49,9 +49,16 @@
     }
   }
 
-  function handleCategoryChange(assetUuid: string, category: string) {
+  async function handleCategoryChange(assetUuid: string, category: string) {
+    actionError = '';
     const previous = media.find((m) => m.asset_uuid === assetUuid)?.category ?? 'none';
-    toast.success(`Image category changed from ${previous} to ${category}.`);
+    try {
+      await setCategory(entityType, slug, assetUuid, category);
+      await invalidateAll();
+      toast.success(`Image category changed from ${previous} to ${category}.`);
+    } catch (err) {
+      actionError = err instanceof Error ? err.message : 'Failed to change image category.';
+    }
   }
 </script>
 

--- a/frontend/src/lib/components/editors/MediaEditor.svelte
+++ b/frontend/src/lib/components/editors/MediaEditor.svelte
@@ -47,6 +47,10 @@
       actionError = err instanceof Error ? err.message : 'Failed to set primary image.';
     }
   }
+
+  function handleCategoryChange(_assetUuid: string, _category: string) {
+    actionError = 'Category changes are not yet implemented.';
+  }
 </script>
 
 <div class="media-editor">
@@ -64,6 +68,7 @@
         canEdit={true}
         ondelete={handleDelete}
         onsetprimary={handleSetPrimary}
+        oncategorychange={handleCategoryChange}
       />
     </div>
   {/if}

--- a/frontend/src/lib/components/editors/MediaEditor.svelte
+++ b/frontend/src/lib/components/editors/MediaEditor.svelte
@@ -29,24 +29,37 @@
     await invalidateAll();
   }
 
+  async function refreshAfterWrite() {
+    try {
+      await invalidateAll();
+    } catch {
+      // Best-effort refresh; the write already succeeded and the next
+      // navigation will pick up the new state.
+    }
+  }
+
   async function handleDelete(assetUuid: string) {
     actionError = '';
     try {
       await detachMedia(entityType, slug, assetUuid);
-      await invalidateAll();
     } catch (err) {
       actionError = err instanceof Error ? err.message : 'Failed to remove image.';
+      return;
     }
+    toast.success('Image removed.');
+    await refreshAfterWrite();
   }
 
   async function handleSetPrimary(assetUuid: string) {
     actionError = '';
     try {
       await setPrimary(entityType, slug, assetUuid);
-      await invalidateAll();
     } catch (err) {
       actionError = err instanceof Error ? err.message : 'Failed to set primary image.';
+      return;
     }
+    toast.success('Set as primary image.');
+    await refreshAfterWrite();
   }
 
   async function handleCategoryChange(assetUuid: string, category: string) {
@@ -54,11 +67,12 @@
     const previous = media.find((m) => m.asset_uuid === assetUuid)?.category ?? 'none';
     try {
       await setCategory(entityType, slug, assetUuid, category);
-      await invalidateAll();
-      toast.success(`Image category changed from ${previous} to ${category}.`);
     } catch (err) {
       actionError = err instanceof Error ? err.message : 'Failed to change image category.';
+      return;
     }
+    toast.success(`Image category changed from ${previous} to ${category}.`);
+    await refreshAfterWrite();
   }
 </script>
 

--- a/frontend/src/lib/components/editors/MediaEditor.svelte
+++ b/frontend/src/lib/components/editors/MediaEditor.svelte
@@ -5,6 +5,7 @@
   import type { UploadedMediaSchema } from '$lib/api/schema';
   import MediaUploadZone from '$lib/components/media/MediaUploadZone.svelte';
   import MediaGrid from '$lib/components/media/MediaGrid.svelte';
+  import { toast } from '$lib/toast/toast.svelte';
 
   type UploadedMedia = UploadedMediaSchema;
   type MediaEntityKey = keyof typeof MEDIA_CATEGORIES;
@@ -48,8 +49,9 @@
     }
   }
 
-  function handleCategoryChange(_assetUuid: string, _category: string) {
-    actionError = 'Category changes are not yet implemented.';
+  function handleCategoryChange(assetUuid: string, category: string) {
+    const previous = media.find((m) => m.asset_uuid === assetUuid)?.category ?? 'none';
+    toast.success(`Image category changed from ${previous} to ${category}.`);
   }
 </script>
 

--- a/frontend/src/lib/components/media/MediaCard.dom.test.ts
+++ b/frontend/src/lib/components/media/MediaCard.dom.test.ts
@@ -7,9 +7,11 @@ import { makeMedia } from './media-test-fixtures';
 function renderCard(
   props: Partial<{
     canEdit: boolean;
+    categories: string[];
     onclick: (assetUuid: string) => void;
     ondelete: (assetUuid: string) => void;
     onsetprimary: (assetUuid: string) => void;
+    oncategorychange: (assetUuid: string, category: string) => void;
   }> = {},
 ) {
   return render(MediaCard, {
@@ -65,5 +67,77 @@ describe('MediaCard', () => {
     expect(window.confirm).toHaveBeenCalledWith('Remove this image from this machine?');
     expect(ondelete).toHaveBeenCalledWith('asset-1');
     expect(onclick).not.toHaveBeenCalled();
+  });
+
+  describe('category pill', () => {
+    const categories = ['Playfield', 'Backglass', 'Cabinet'];
+
+    it('renders the static badge when no categories are provided', () => {
+      renderCard();
+      expect(screen.queryByRole('button', { name: /image category/i })).not.toBeInTheDocument();
+      // Visible category text still appears (as the static badge).
+      expect(screen.getByText('Backglass')).toBeInTheDocument();
+    });
+
+    it('replaces the static badge with a PillSelect when categories are provided', () => {
+      renderCard({ categories });
+      expect(screen.getByRole('button', { name: 'Image category: Backglass' })).toBeInTheDocument();
+    });
+
+    it('fires oncategorychange with (assetUuid, category) when a different option is picked', async () => {
+      const user = userEvent.setup();
+      const onclick = vi.fn();
+      const oncategorychange = vi.fn();
+      renderCard({ categories, onclick, oncategorychange });
+
+      await user.click(screen.getByRole('button', { name: 'Image category: Backglass' }));
+      await user.click(screen.getByRole('option', { name: 'Playfield' }));
+
+      expect(oncategorychange).toHaveBeenCalledWith('asset-1', 'Playfield');
+      expect(onclick).not.toHaveBeenCalled();
+    });
+
+    it('clicking the pill does NOT open the lightbox', async () => {
+      const user = userEvent.setup();
+      const onclick = vi.fn();
+      renderCard({ categories, onclick });
+
+      await user.click(screen.getByRole('button', { name: 'Image category: Backglass' }));
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      expect(onclick).not.toHaveBeenCalled();
+    });
+
+    it('Enter on the pill opens the listbox without firing the card onclick', async () => {
+      const user = userEvent.setup();
+      const onclick = vi.fn();
+      renderCard({ categories, onclick });
+
+      const trigger = screen.getByRole('button', { name: 'Image category: Backglass' });
+      trigger.focus();
+      await user.keyboard('{Enter}');
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      expect(onclick).not.toHaveBeenCalled();
+    });
+
+    it('Space on the pill opens the listbox without firing the card onclick', async () => {
+      const user = userEvent.setup();
+      const onclick = vi.fn();
+      renderCard({ categories, onclick });
+
+      const trigger = screen.getByRole('button', { name: 'Image category: Backglass' });
+      trigger.focus();
+      await user.keyboard(' ');
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      expect(onclick).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the static badge when canEdit is false even if categories are provided', () => {
+      renderCard({ categories, canEdit: false });
+      expect(screen.queryByRole('button', { name: /image category/i })).not.toBeInTheDocument();
+      expect(screen.getByText('Backglass')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/lib/components/media/MediaCard.dom.test.ts
+++ b/frontend/src/lib/components/media/MediaCard.dom.test.ts
@@ -15,7 +15,7 @@ function renderCard(
   }> = {},
 ) {
   return render(MediaCard, {
-    asset: makeMedia(1, { category: 'Backglass', is_primary: false }),
+    asset: makeMedia(1, { category: 'backglass', is_primary: false }),
     canEdit: true,
     onclick: vi.fn(),
     ondelete: vi.fn(),
@@ -70,18 +70,18 @@ describe('MediaCard', () => {
   });
 
   describe('category pill', () => {
-    const categories = ['Playfield', 'Backglass', 'Cabinet'];
+    const categories = ['playfield', 'backglass', 'cabinet'];
 
     it('renders the static badge when no categories are provided', () => {
       renderCard();
       expect(screen.queryByRole('button', { name: /image category/i })).not.toBeInTheDocument();
       // Visible category text still appears (as the static badge).
-      expect(screen.getByText('Backglass')).toBeInTheDocument();
+      expect(screen.getByText('backglass')).toBeInTheDocument();
     });
 
     it('replaces the static badge with a PillSelect when categories are provided', () => {
       renderCard({ categories });
-      expect(screen.getByRole('button', { name: 'Image category: Backglass' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Image category: backglass' })).toBeInTheDocument();
     });
 
     it('fires oncategorychange with (assetUuid, category) when a different option is picked', async () => {
@@ -90,10 +90,10 @@ describe('MediaCard', () => {
       const oncategorychange = vi.fn();
       renderCard({ categories, onclick, oncategorychange });
 
-      await user.click(screen.getByRole('button', { name: 'Image category: Backglass' }));
-      await user.click(screen.getByRole('option', { name: 'Playfield' }));
+      await user.click(screen.getByRole('button', { name: 'Image category: backglass' }));
+      await user.click(screen.getByRole('option', { name: 'playfield' }));
 
-      expect(oncategorychange).toHaveBeenCalledWith('asset-1', 'Playfield');
+      expect(oncategorychange).toHaveBeenCalledWith('asset-1', 'playfield');
       expect(onclick).not.toHaveBeenCalled();
     });
 
@@ -102,7 +102,7 @@ describe('MediaCard', () => {
       const onclick = vi.fn();
       renderCard({ categories, onclick });
 
-      await user.click(screen.getByRole('button', { name: 'Image category: Backglass' }));
+      await user.click(screen.getByRole('button', { name: 'Image category: backglass' }));
 
       expect(screen.getByRole('listbox')).toBeInTheDocument();
       expect(onclick).not.toHaveBeenCalled();
@@ -113,7 +113,7 @@ describe('MediaCard', () => {
       const onclick = vi.fn();
       renderCard({ categories, onclick });
 
-      const trigger = screen.getByRole('button', { name: 'Image category: Backglass' });
+      const trigger = screen.getByRole('button', { name: 'Image category: backglass' });
       trigger.focus();
       await user.keyboard('{Enter}');
 
@@ -126,7 +126,7 @@ describe('MediaCard', () => {
       const onclick = vi.fn();
       renderCard({ categories, onclick });
 
-      const trigger = screen.getByRole('button', { name: 'Image category: Backglass' });
+      const trigger = screen.getByRole('button', { name: 'Image category: backglass' });
       trigger.focus();
       await user.keyboard(' ');
 
@@ -137,7 +137,7 @@ describe('MediaCard', () => {
     it('falls back to the static badge when canEdit is false even if categories are provided', () => {
       renderCard({ categories, canEdit: false });
       expect(screen.queryByRole('button', { name: /image category/i })).not.toBeInTheDocument();
-      expect(screen.getByText('Backglass')).toBeInTheDocument();
+      expect(screen.getByText('backglass')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/lib/components/media/MediaCard.svelte
+++ b/frontend/src/lib/components/media/MediaCard.svelte
@@ -1,21 +1,33 @@
 <script lang="ts">
   import type { UploadedMediaSchema } from '$lib/api/schema';
+  import PillSelect from '$lib/components/PillSelect.svelte';
 
   type UploadedMedia = UploadedMediaSchema;
 
   let {
     asset,
     canEdit = false,
+    categories = [],
     ondelete,
     onsetprimary,
+    oncategorychange,
     onclick,
   }: {
     asset: UploadedMedia;
     canEdit?: boolean;
+    categories?: string[];
     ondelete?: (assetUuid: string) => void;
     onsetprimary?: (assetUuid: string) => void;
+    oncategorychange?: (assetUuid: string, category: string) => void;
     onclick?: (assetUuid: string) => void;
   } = $props();
+
+  const categoryOptions = $derived(categories.map((c) => ({ value: c, label: c })));
+  const showPill = $derived(canEdit && categoryOptions.length > 0);
+
+  function stopCardKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+  }
 
   function handleDelete(e: MouseEvent) {
     e.stopPropagation();
@@ -51,7 +63,20 @@
 >
   <div class="thumb-wrapper">
     <img src={asset.renditions.thumb} alt="" class="thumb" loading="lazy" />
-    {#if asset.category}
+    {#if showPill}
+      <!-- The wrapper exists to position the pill and to keep click/keydown
+           events from bubbling to the card's lightbox handler. The interactive
+           element is the <button> inside PillSelect, not this div. -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div class="category-pill" onclick={(e) => e.stopPropagation()} onkeydown={stopCardKeydown}>
+        <PillSelect
+          value={asset.category}
+          options={categoryOptions}
+          purpose="Image category"
+          onchange={(c) => oncategorychange?.(asset.asset_uuid, c)}
+        />
+      </div>
+    {:else if asset.category}
       <span class="badge">{asset.category}</span>
     {/if}
     {#if asset.is_primary}
@@ -115,6 +140,13 @@
     font-size: var(--font-size-0);
     padding: 0.1em 0.4em;
     border-radius: var(--radius-1);
+  }
+
+  .category-pill {
+    position: absolute;
+    bottom: var(--size-1);
+    left: var(--size-1);
+    z-index: 1;
   }
 
   .primary-badge {

--- a/frontend/src/lib/components/media/MediaGrid.dom.test.ts
+++ b/frontend/src/lib/components/media/MediaGrid.dom.test.ts
@@ -37,18 +37,18 @@ describe('MediaGrid', () => {
     const user = userEvent.setup();
     render(MediaGrid, {
       media: MEDIA_ITEMS,
-      categories: ['Cabinet', 'Backglass', 'Playfield'],
+      categories: ['cabinet', 'backglass', 'playfield'],
     });
 
     await user.click(screen.getByRole('button', { name: /playfield \(0\)/i }));
-    expect(screen.getByText('No Playfield images yet.')).toBeInTheDocument();
+    expect(screen.getByText('No playfield images yet.')).toBeInTheDocument();
   });
 
   it('opens the lightbox from the filtered media set', async () => {
     const user = userEvent.setup();
     render(MediaGrid, {
       media: MEDIA_ITEMS,
-      categories: ['Cabinet', 'Backglass'],
+      categories: ['cabinet', 'backglass'],
     });
 
     await user.click(screen.getByRole('button', { name: /backglass \(1\)/i }));
@@ -62,7 +62,7 @@ describe('MediaGrid', () => {
     const media = Array.from({ length: 101 }, (_, index) => makeMedia(index + 1));
     render(MediaGrid, {
       media,
-      categories: ['Cabinet'],
+      categories: ['cabinet'],
     });
 
     expect(screen.getAllByRole('button', { name: /^open( .+)? image$/i })).toHaveLength(100);

--- a/frontend/src/lib/components/media/MediaGrid.svelte
+++ b/frontend/src/lib/components/media/MediaGrid.svelte
@@ -13,12 +13,14 @@
     canEdit = false,
     ondelete,
     onsetprimary,
+    oncategorychange,
   }: {
     media: UploadedMedia[];
     categories?: string[];
     canEdit?: boolean;
     ondelete?: (assetUuid: string) => void;
     onsetprimary?: (assetUuid: string) => void;
+    oncategorychange?: (assetUuid: string, category: string) => void;
   } = $props();
 
   let activeCategory = $state<string | null>(null);
@@ -105,7 +107,15 @@
   {:else}
     <div class="grid">
       {#each visibleMedia as asset (asset.asset_uuid)}
-        <MediaCard {asset} {canEdit} {ondelete} {onsetprimary} onclick={openLightbox} />
+        <MediaCard
+          {asset}
+          {canEdit}
+          {categories}
+          {ondelete}
+          {onsetprimary}
+          {oncategorychange}
+          onclick={openLightbox}
+        />
       {/each}
     </div>
 

--- a/frontend/src/lib/components/media/media-test-fixtures.ts
+++ b/frontend/src/lib/components/media/media-test-fixtures.ts
@@ -5,7 +5,7 @@ type UploadedMedia = UploadedMediaSchema;
 export function makeMedia(index: number, overrides: Partial<UploadedMedia> = {}): UploadedMedia {
   return {
     asset_uuid: `asset-${index}`,
-    category: 'Cabinet',
+    category: 'cabinet',
     is_primary: index === 1,
     uploaded_by_username: 'moses',
     renditions: {
@@ -17,7 +17,7 @@ export function makeMedia(index: number, overrides: Partial<UploadedMedia> = {})
 }
 
 export const MEDIA_ITEMS = [
-  makeMedia(1, { category: 'Cabinet', is_primary: true }),
-  makeMedia(2, { category: 'Backglass', uploaded_by_username: 'jane' }),
-  makeMedia(3, { category: 'Cabinet', uploaded_by_username: null as never }),
+  makeMedia(1, { category: 'cabinet', is_primary: true }),
+  makeMedia(2, { category: 'backglass', uploaded_by_username: 'jane' }),
+  makeMedia(3, { category: 'cabinet', uploaded_by_username: null as never }),
 ];

--- a/frontend/src/routes/manufacturers/[slug]/manufacturer-detail.test.ts
+++ b/frontend/src/routes/manufacturers/[slug]/manufacturer-detail.test.ts
@@ -61,7 +61,7 @@ const MOCK_MANUFACTURER = {
   uploaded_media: [
     {
       asset_uuid: 'asset-1',
-      category: 'Cabinet',
+      category: 'cabinet',
       is_primary: true,
       renditions: {
         thumb: 'https://example.com/thumb.jpg',


### PR DESCRIPTION
## Summary
- Adds a `set-category` endpoint on the media API and wires it through the media editor UI
- New `PillSelect` dropdown component (built on `ActionMenu`) used for the category picker on `MediaCard` / `MediaEditor`
- Editor surfaces success/error toasts; write and refresh error states are scoped separately so a failed refresh doesn't mask a successful write

## Test plan
- [ ] `make test` (backend pytest + frontend vitest)
- [ ] Manually change an image's category in the media editor and confirm the toast + persisted value
- [ ] Verify error toast appears when the backend rejects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)