### PR TITLE
media: show uploaded backglass on title cards across the site

### DIFF
--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -23,6 +23,7 @@ from ._typing import HasTitleCount
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
 from .helpers import serialize_title_ref
+from .images import fetch_title_media_map
 from .rich_text import build_rich_text
 from .schemas import ClaimPatchSchema, TitleRef
 
@@ -101,12 +102,15 @@ def _franchise_detail_qs() -> QuerySet[Franchise]:
 
 def _serialize_franchise_detail(franchise: Franchise) -> FranchiseDetailSchema:
     min_rank = get_minimum_display_rank()
+    titles_list = list(franchise.titles.all())
+    media_by_model = fetch_title_media_map(titles_list)
     return FranchiseDetailSchema(
         name=franchise.name,
         slug=franchise.slug,
         description=build_rich_text(franchise, "description", active_claims(franchise)),
         titles=[
-            serialize_title_ref(t, min_rank=min_rank) for t in franchise.titles.all()
+            serialize_title_ref(t, min_rank=min_rank, media_by_model=media_by_model)
+            for t in titles_list
         ],
     )
 

--- a/backend/apps/catalog/api/helpers.py
+++ b/backend/apps/catalog/api/helpers.py
@@ -8,6 +8,7 @@ from django.db.models import Model
 
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.types import JsonData
+from apps.media.models import EntityMedia
 
 from ..models import (
     CorporateEntity,
@@ -65,7 +66,12 @@ def _intersect_facet_sets(
     return [EntityRef(slug=s, name=n) for s, n in sorted(common)] if common else []
 
 
-def serialize_title_ref(title: Title, *, min_rank: int | None = None) -> TitleRef:
+def serialize_title_ref(
+    title: Title,
+    *,
+    min_rank: int | None = None,
+    media_by_model: dict[int, list[EntityMedia]] | None = None,
+) -> TitleRef:
     """Serialize a Title for use in franchise/series listing context.
 
     Expects *title* to have prefetched ``machine_models`` (with
@@ -77,7 +83,10 @@ def serialize_title_ref(title: Title, *, min_rank: int | None = None) -> TitleRe
     year = None
     first = next(iter(title.machine_models.all()), None)
     if first is not None:
-        thumbnail_url, _ = extract_image_urls(first.extra_data or {}, min_rank=min_rank)
+        media = media_by_model.get(first.pk) if media_by_model else None
+        thumbnail_url, _ = extract_image_urls(
+            first.extra_data or {}, media, min_rank=min_rank
+        )
         manufacturer_name = (
             first.corporate_entity.manufacturer.name
             if first.corporate_entity and first.corporate_entity.manufacturer
@@ -97,17 +106,28 @@ def serialize_title_ref(title: Title, *, min_rank: int | None = None) -> TitleRe
 
 
 def collect_titles(
-    models: Iterable[MachineModel], *, include_manufacturer: bool = False
+    models: Iterable[MachineModel],
+    *,
+    include_manufacturer: bool = False,
+    media_by_model: dict[int, list[EntityMedia]] | None = None,
 ) -> list[RelatedTitleSchema]:
-    """Group models by title into a deduplicated title list."""
+    """Group models by title into a deduplicated title list.
+
+    Pass ``media_by_model`` (built by :func:`fetch_model_media_map`) so card
+    thumbnails reflect uploaded backglass; omit it to fall back to
+    ``extra_data`` only.
+    """
     min_rank = get_minimum_display_rank()
     titles: dict[str, RelatedTitleSchema] = {}
     for m in models:
         if m.title is None:
             continue
+        media = media_by_model.get(m.pk) if media_by_model else None
         key = m.title.slug
         if key not in titles:
-            thumbnail_url = extract_image_urls(m.extra_data or {}, min_rank=min_rank)[0]
+            thumbnail_url = extract_image_urls(
+                m.extra_data or {}, media, min_rank=min_rank
+            )[0]
             manufacturer_name = None
             if include_manufacturer:
                 mfr = (
@@ -124,7 +144,9 @@ def collect_titles(
                 manufacturer_name=manufacturer_name,
             )
         elif titles[key].thumbnail_url is None:
-            thumbnail_url = extract_image_urls(m.extra_data or {}, min_rank=min_rank)[0]
+            thumbnail_url = extract_image_urls(
+                m.extra_data or {}, media, min_rank=min_rank
+            )[0]
             if thumbnail_url:
                 titles[key].thumbnail_url = thumbnail_url
     return sorted(titles.values(), key=lambda t: (t.year is None, -(t.year or 0)))
@@ -194,13 +216,19 @@ def _get_feature_descendant_slugs(slug: str) -> set[str]:
 
 
 def serialize_title_machine(
-    pm: MachineModel, *, min_rank: int | None = None
+    pm: MachineModel,
+    *,
+    min_rank: int | None = None,
+    media_by_model: dict[int, list[EntityMedia]] | None = None,
 ) -> TitleModelSchema:
     """Serialize a MachineModel for use in title/theme/system machine lists."""
     if min_rank is None:
         min_rank = get_minimum_display_rank()
 
-    thumbnail_url, _ = extract_image_urls(pm.extra_data or {}, min_rank=min_rank)
+    pm_media = media_by_model.get(pm.pk) if media_by_model else None
+    thumbnail_url, _ = extract_image_urls(
+        pm.extra_data or {}, pm_media, min_rank=min_rank
+    )
 
     # Include variants only when prefetched to avoid N+1 queries.
     variant_qs = (
@@ -213,7 +241,11 @@ def serialize_title_machine(
             name=v.name,
             slug=v.slug,
             year=v.year,
-            thumbnail_url=extract_image_urls(v.extra_data or {}, min_rank=min_rank)[0],
+            thumbnail_url=extract_image_urls(
+                v.extra_data or {},
+                media_by_model.get(v.pk) if media_by_model else None,
+                min_rank=min_rank,
+            )[0],
         )
         for v in variant_qs
     ]

--- a/backend/apps/catalog/api/images.py
+++ b/backend/apps/catalog/api/images.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from typing import Any
 
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import Prefetch
 
 from apps.core.licensing import (
@@ -17,15 +19,57 @@ from apps.media.schemas import MediaRenditionsSchema, UploadedMediaSchema
 from apps.media.storage import build_public_url, build_storage_key
 from apps.provenance.schemas import AttributionSchema
 
-from ..models import CorporateEntity
+from ..models import CorporateEntity, MachineModel, Title
 
 __all__ = [
     "extract_image_attribution",
     "extract_image_urls",
+    "fetch_model_media_map",
+    "fetch_title_media_map",
     "first_thumbnail",
     "media_prefetch",
     "serialize_uploaded_media",
 ]
+
+
+def fetch_model_media_map(
+    model_ids: Iterable[int],
+) -> dict[int, list[EntityMedia]]:
+    """Return ``{model_id: [primary EntityMedia rows]}`` for the given
+    MachineModel ids.
+
+    Filters to ``is_primary=True`` and ``asset__status="ready"`` — matches
+    the input shape ``extract_image_urls`` expects via its ``primary_media``
+    parameter.  One indexed query joined to ``MediaAsset`` for the uuid.
+    """
+    ids = list(model_ids)
+    if not ids:
+        return {}
+    ct = ContentType.objects.get_for_model(MachineModel)
+    grouped: dict[int, list[EntityMedia]] = defaultdict(list)
+    for em in (
+        EntityMedia.objects.filter(
+            content_type=ct,
+            object_id__in=ids,
+            is_primary=True,
+            asset__status="ready",
+        )
+        .select_related("asset")
+        .order_by("created_at")
+    ):
+        grouped[em.object_id].append(em)
+    return grouped
+
+
+def fetch_title_media_map(
+    titles: Iterable[Title],
+) -> dict[int, list[EntityMedia]]:
+    """Build the model media map for every MachineModel under *titles*.
+
+    Requires ``machine_models`` to be prefetched on each title — otherwise
+    walking ``title.machine_models.all()`` triggers one query per title.
+    """
+    return fetch_model_media_map(pm.pk for t in titles for pm in t.machine_models.all())
 
 
 # Slot 2 is Any because prefetch_related has a single _PrefetchedQuerySetT
@@ -92,7 +136,7 @@ def _uploaded_image_urls(
 
 def extract_image_urls(
     extra_data: JsonData,
-    primary_media: Sequence[EntityMedia] | None = None,
+    primary_media: Sequence[EntityMedia] | None,
     *,
     min_rank: int | None = None,
 ) -> tuple[str | None, str | None]:
@@ -102,6 +146,11 @@ def extract_image_urls(
     images, those are used unconditionally (no license gating — this project owns
     them).  Otherwise falls back to third-party images in *extra_data*,
     respecting the global Constance display threshold.
+
+    *primary_media* is required-positional: callers must pass either a list of
+    rows or ``None`` to opt out.  This forces every site to make the
+    media-vs-extra_data choice deliberately rather than silently defaulting to
+    extra_data only.
 
     Pass *min_rank* to avoid repeated Constance DB lookups in tight loops.
     """
@@ -154,7 +203,7 @@ def extract_image_urls(
 
 def extract_image_attribution(
     extra_data: JsonData,
-    primary_media: Sequence[EntityMedia] | None = None,
+    primary_media: Sequence[EntityMedia] | None,
 ) -> AttributionSchema | None:
     """Return AttributionSchema for the displayed image, or None.
 
@@ -192,11 +241,17 @@ def extract_image_attribution(
 def first_thumbnail(
     entities_with_models: Iterable[CorporateEntity], *, min_rank: int
 ) -> str | None:
-    """Return the first non-None thumbnail URL from nested entity→model prefetches."""
+    """Return the first non-None thumbnail URL from nested entity→model prefetches.
+
+    Note: this currently checks only ``extra_data`` — uploaded media on these
+    nested models is not considered.  Acceptable today (the locations endpoint
+    is the only caller and uploads aren't expected on entity→models there);
+    revisit when locations cards need uploaded backglass support.
+    """
     for entity in entities_with_models:
         for model in entity.models.all():
             if model.extra_data:
-                thumb, _ = extract_image_urls(model.extra_data, min_rank=min_rank)
+                thumb, _ = extract_image_urls(model.extra_data, None, min_rank=min_rank)
                 if thumb:
                     return thumb
     return None

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -86,6 +86,7 @@ from .helpers import (
 from .images import (
     extract_image_attribution,
     extract_image_urls,
+    fetch_model_media_map,
     media_prefetch,
     serialize_uploaded_media,
 )
@@ -526,12 +527,23 @@ def _serialize_model_detail(pm: MachineModel) -> ModelDetailSchema:
             if pm.title and pm.title.series
             else None
         ),
-        title_models=[
-            serialize_title_machine(sibling, min_rank=min_rank)
-            for sibling in (pm.title.machine_models.all() if pm.title else [])
-            if sibling.variant_of_id is None
-        ],
+        title_models=_serialize_title_models(pm, min_rank=min_rank),
     )
+
+
+def _serialize_title_models(
+    pm: MachineModel, *, min_rank: int
+) -> list[TitleModelSchema]:
+    if pm.title is None:
+        return []
+    siblings = [s for s in pm.title.machine_models.all() if s.variant_of_id is None]
+    media_by_model = fetch_model_media_map(s.pk for s in siblings)
+    return [
+        serialize_title_machine(
+            sibling, min_rank=min_rank, media_by_model=media_by_model
+        )
+        for sibling in siblings
+    ]
 
 
 def _model_detail_qs() -> QuerySet[MachineModel]:
@@ -704,14 +716,18 @@ def list_recent_models(request: HttpRequest) -> list[ModelRecentSchema]:
         )[:20]  # generous LIMIT — we only need 3 unique titles
     )
     min_rank = get_minimum_display_rank()
+    candidates = list(qs)
+    media_by_model = fetch_model_media_map(m.pk for m in candidates)
     results: list[ModelRecentSchema] = []
     seen_titles: set[int | None] = set()
-    for m in qs:
+    for m in candidates:
         title_id = m.title_id
         if title_id in seen_titles:
             continue
         seen_titles.add(title_id)
-        thumbnail_url, _ = extract_image_urls(m.extra_data or {}, min_rank=min_rank)
+        thumbnail_url, _ = extract_image_urls(
+            m.extra_data or {}, media_by_model.get(m.pk), min_rank=min_rank
+        )
         results.append(
             ModelRecentSchema(
                 name=m.name,
@@ -781,6 +797,7 @@ def list_all_models(
         .order_by("name")
     )
     model_ids = {r.id for r in rows}
+    media_by_model = fetch_model_media_map(model_ids)
 
     # --- Bulk M2M queries for search_text ---
     model_themes: dict[int, list[str]] = defaultdict(list)
@@ -853,7 +870,9 @@ def list_all_models(
     result: list[dict[str, Any]] = []
     for r in rows:
         mid = r.id
-        thumbnail_url, _ = extract_image_urls(r.extra_data or {}, min_rank=min_rank)
+        thumbnail_url, _ = extract_image_urls(
+            r.extra_data or {}, media_by_model.get(mid), min_rank=min_rank
+        )
 
         # Build search_text from bulk maps
         parts: list[str] = []

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -45,7 +45,12 @@ from .helpers import (
     collect_titles,
     serialize_locations,
 )
-from .images import extract_image_urls, media_prefetch, serialize_uploaded_media
+from .images import (
+    extract_image_urls,
+    fetch_model_media_map,
+    media_prefetch,
+    serialize_uploaded_media,
+)
 from .rich_text import build_rich_text
 from .schemas import (
     ClaimPatchSchema,
@@ -163,6 +168,9 @@ def _serialize_manufacturer_detail(mfr: Manufacturer) -> ManufacturerDetailSchem
         key=lambda p: p.name,
     )
 
+    all_models = [m for e in mfr.entities.all() for m in e.models.all()]
+    media_by_model = fetch_model_media_map(m.pk for m in all_models)
+
     return ManufacturerDetailSchema(
         name=mfr.name,
         slug=mfr.slug,
@@ -181,7 +189,7 @@ def _serialize_manufacturer_detail(mfr: Manufacturer) -> ManufacturerDetailSchem
             )
             for e in mfr.entities.all()
         ],
-        titles=collect_titles(m for e in mfr.entities.all() for m in e.models.all()),
+        titles=collect_titles(all_models, media_by_model=media_by_model),
         systems=[
             ManufacturerSystemSchema(name=s.name, slug=s.slug)
             for s in mfr.systems.all()
@@ -328,6 +336,7 @@ def list_all_manufacturers(
             "id", "extra_data"
         )
     }
+    thumb_media = fetch_model_media_map(mfr_thumb_model.values())
 
     # --- Bulk search text + facet data per manufacturer ---
     mfr_ids = {m.pk for m in manufacturers}
@@ -453,8 +462,12 @@ def list_all_manufacturers(
         thumb = None
         tm_id = mfr_thumb_model.get(mfr_id)
         tm = thumb_models.get(tm_id) if tm_id else None
-        if tm and tm.extra_data:
-            thumb, _ = extract_image_urls(tm.extra_data, min_rank=min_rank)
+        if tm:
+            thumb, _ = extract_image_urls(
+                tm.extra_data or {},
+                thumb_media.get(tm.pk),
+                min_rank=min_rank,
+            )
 
         loc_refs_map = mfr_location_refs.get(mfr_id, {})
         locations = [

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -49,7 +49,12 @@ from .entity_create import (
     validate_name,
     validate_slug_format,
 )
-from .images import extract_image_urls, media_prefetch, serialize_uploaded_media
+from .images import (
+    extract_image_urls,
+    fetch_model_media_map,
+    media_prefetch,
+    serialize_uploaded_media,
+)
 from .rich_text import build_rich_text
 from .schemas import (
     AlreadyDeletedSchema,
@@ -132,15 +137,21 @@ def _serialize_person_detail(person: Person) -> PersonDetailSchema:
     (to_attr="active_claims").
     """
     min_rank = get_minimum_display_rank()
+    credits = list(person.credits.all())
+    media_by_model = fetch_model_media_map(
+        c.model_id for c in credits if c.model_id is not None
+    )
     accum: dict[str, _PersonTitleAccum] = {}
-    for c in person.credits.all():
+    for c in credits:
         if c.model is None or c.model.title is None:
             continue
         title = c.model.title
         key = title.slug
-        thumbnail_url = extract_image_urls(c.model.extra_data or {}, min_rank=min_rank)[
-            0
-        ]
+        thumbnail_url = extract_image_urls(
+            c.model.extra_data or {},
+            media_by_model.get(c.model.pk),
+            min_rank=min_rank,
+        )[0]
         if key not in accum:
             accum[key] = _PersonTitleAccum(
                 name=title.name,
@@ -270,6 +281,7 @@ def list_all_people(
             id__in=set(person_thumb_model.values())
         ).only("id", "extra_data")
     }
+    thumb_media = fetch_model_media_map(person_thumb_model.values())
 
     result: list[dict[str, Any]] = []
     for p in people:
@@ -277,8 +289,12 @@ def list_all_people(
         person_id = p.pk
         tm_id = person_thumb_model.get(person_id)
         tm = thumb_models.get(tm_id) if tm_id else None
-        if tm and tm.extra_data:
-            t, _ = extract_image_urls(tm.extra_data, min_rank=min_rank)
+        if tm:
+            t, _ = extract_image_urls(
+                tm.extra_data or {},
+                thumb_media.get(tm.pk),
+                min_rank=min_rank,
+            )
             if t:
                 thumb = t
         result.append(

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -26,7 +26,7 @@ from .helpers import (
     serialize_credit,
     serialize_title_ref,
 )
-from .images import extract_image_urls
+from .images import extract_image_urls, fetch_title_media_map
 from .rich_text import build_rich_text
 from .schemas import (
     ClaimPatchSchema,
@@ -97,11 +97,16 @@ def _series_detail_qs() -> QuerySet[Series]:
 
 def _serialize_series_detail(series: Series) -> SeriesDetailSchema:
     min_rank = get_minimum_display_rank()
+    titles_list = list(series.titles.all())
+    media_by_model = fetch_title_media_map(titles_list)
     return SeriesDetailSchema(
         name=series.name,
         slug=series.slug,
         description=build_rich_text(series, "description", active_claims(series)),
-        titles=[serialize_title_ref(t, min_rank=min_rank) for t in series.titles.all()],
+        titles=[
+            serialize_title_ref(t, min_rank=min_rank, media_by_model=media_by_model)
+            for t in titles_list
+        ],
         credits=[serialize_credit(c) for c in series.credits.all()],
     )
 
@@ -133,12 +138,18 @@ def list_series(request: HttpRequest) -> list[SeriesListItemSchema]:
         )
     )
     min_rank = get_minimum_display_rank()
+    series_list = list(qs)
+    media_by_model = fetch_title_media_map(
+        title for s in series_list for title in s.titles.all()
+    )
     result: list[SeriesListItemSchema] = []
-    for s in qs:
+    for s in series_list:
         thumb = None
         for title in s.titles.all():
             for pm in title.machine_models.all():
-                t, _ = extract_image_urls(pm.extra_data or {}, min_rank=min_rank)
+                t, _ = extract_image_urls(
+                    pm.extra_data or {}, media_by_model.get(pm.pk), min_rank=min_rank
+                )
                 if t:
                     thumb = t
                     break

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -39,7 +39,7 @@ from .entity_create import (
     validate_slug_format,
 )
 from .entity_crud import register_entity_delete_restore
-from .images import extract_image_urls
+from .images import extract_image_urls, fetch_model_media_map
 from .rich_text import build_rich_text
 from .schemas import (
     ClaimPatchSchema,
@@ -107,12 +107,16 @@ class _RelatedTitleAccum:
 
 def _serialize_system_detail(system: System) -> SystemDetailSchema:
     min_rank = get_minimum_display_rank()
+    models_list = list(system.machine_models.all())
+    media_by_model = fetch_model_media_map(m.pk for m in models_list)
     accum: dict[str, _RelatedTitleAccum] = {}
-    for m in system.machine_models.all():
+    for m in models_list:
         if m.title is None:
             continue
         key = m.title.slug
-        thumbnail_url = extract_image_urls(m.extra_data or {}, min_rank=min_rank)[0]
+        thumbnail_url = extract_image_urls(
+            m.extra_data or {}, media_by_model.get(m.pk), min_rank=min_rank
+        )[0]
         if key not in accum:
             mfr = (
                 m.corporate_entity.manufacturer

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -41,7 +41,7 @@ from .entity_crud import (
     register_entity_delete_restore,
 )
 from .helpers import serialize_title_machine
-from .images import extract_image_urls
+from .images import extract_image_urls, fetch_model_media_map
 from .people import PersonGridItemSchema
 from .rich_text import build_rich_text
 from .schemas import (
@@ -506,11 +506,15 @@ def _reward_type_detail_qs() -> QuerySet[RewardType]:
 
 def _serialize_reward_type_detail(rt: RewardType) -> RewardTypeDetailSchema:
     min_rank = get_minimum_display_rank()
+    machines_list = list(rt.machine_models.all())
+    media_by_model = fetch_model_media_map(pm.pk for pm in machines_list)
     return RewardTypeDetailSchema(
         **_serialize_taxonomy(rt).model_dump(),
         machines=[
-            serialize_title_machine(pm, min_rank=min_rank)
-            for pm in rt.machine_models.all()
+            serialize_title_machine(
+                pm, min_rank=min_rank, media_by_model=media_by_model
+            )
+            for pm in machines_list
         ],
     )
 
@@ -640,6 +644,7 @@ def _credit_role_people(cr: CreditRole) -> list[PersonGridItemSchema]:
             id__in=set(person_thumb_model.values())
         ).only("id", "extra_data")
     }
+    thumb_media = fetch_model_media_map(person_thumb_model.values())
 
     min_rank = get_minimum_display_rank()
     out: list[PersonGridItemSchema] = []
@@ -650,8 +655,10 @@ def _credit_role_people(cr: CreditRole) -> list[PersonGridItemSchema]:
         thumbnail: str | None = None
         tm_id = person_thumb_model.get(pid)
         tm = thumb_models.get(tm_id) if tm_id else None
-        if tm and tm.extra_data:
-            t, _ = extract_image_urls(tm.extra_data, min_rank=min_rank)
+        if tm:
+            t, _ = extract_image_urls(
+                tm.extra_data or {}, thumb_media.get(tm.pk), min_rank=min_rank
+            )
             if t:
                 thumbnail = t
         out.append(

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -26,6 +26,7 @@ from .edit_claims import (
 )
 from .entity_crud import register_entity_create, register_entity_delete_restore
 from .helpers import serialize_title_machine
+from .images import fetch_model_media_map
 from .rich_text import build_rich_text
 from .schemas import (
     EntityRef,
@@ -79,6 +80,8 @@ def _detail_qs() -> QuerySet[Theme]:
 
 def _serialize_detail(theme: Theme) -> ThemeDetailSchema:
     min_rank = get_minimum_display_rank()
+    machines_list = list(theme.machine_models.all())
+    media_by_model = fetch_model_media_map(pm.pk for pm in machines_list)
     return ThemeDetailSchema(
         name=theme.name,
         slug=theme.slug,
@@ -89,8 +92,10 @@ def _serialize_detail(theme: Theme) -> ThemeDetailSchema:
             EntityRef(name=t.name, slug=t.slug) for t in theme.children.order_by("name")
         ],
         machines=[
-            serialize_title_machine(pm, min_rank=min_rank)
-            for pm in theme.machine_models.all()
+            serialize_title_machine(
+                pm, min_rank=min_rank, media_by_model=media_by_model
+            )
+            for pm in machines_list
         ],
     )
 

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -38,6 +38,7 @@ from apps.core.schemas import (
     ValidationErrorSchema,
 )
 from apps.media.helpers import all_media
+from apps.media.models import EntityMedia
 from apps.media.schemas import MediaRenditionsSchema
 from apps.media.storage import build_public_url, build_storage_key
 from apps.provenance.helpers import active_claims, claims_prefetch
@@ -82,7 +83,7 @@ from .helpers import (
     serialize_credit,
     serialize_title_machine,
 )
-from .images import extract_image_urls, media_prefetch
+from .images import extract_image_urls, fetch_model_media_map, media_prefetch
 from .machine_models import (
     ModelDetailSchema,
     _model_detail_qs,
@@ -260,7 +261,10 @@ def _dedup_facet_dicts(
 
 
 def _serialize_title_list(
-    title: Title, *, min_rank: int | None = None
+    title: Title,
+    *,
+    min_rank: int | None = None,
+    media_by_model: dict[int, list[EntityMedia]] | None = None,
 ) -> TitleListItemSchema:
     thumbnail_url: str | None = None
     manufacturer: EntityRef | None = None
@@ -304,10 +308,11 @@ def _serialize_title_list(
             ratings.append(float(m.ipdb_rating))
 
     if machines:
-        thumbnail_url, _ = extract_image_urls(
-            machines[0].extra_data or {}, min_rank=min_rank
-        )
         first = machines[0]
+        media = media_by_model.get(first.pk) if media_by_model else None
+        thumbnail_url, _ = extract_image_urls(
+            first.extra_data or {}, media, min_rank=min_rank
+        )
         mfr = (
             first.corporate_entity.manufacturer
             if first.corporate_entity and first.corporate_entity.manufacturer
@@ -520,23 +525,28 @@ def _collect_aggregated_media(
 def _select_title_hero_image_url(
     models: Sequence[MachineModel], *, min_rank: int
 ) -> str | None:
-    """Return the title hero from the earliest model with uploaded backglass media.
-
-    Falls back to the earliest model's existing image-selection logic when no
-    uploaded backglass exists on any model.
-    """
+    """Return the title hero — uploaded backglass on any model wins, else
+    the earliest model's third-party image."""
     for model in models:
-        backglass_media = [em for em in all_media(model) if em.category == "backglass"]
-        if backglass_media:
-            primary_backglass = [em for em in backglass_media if em.is_primary]
-            chosen = primary_backglass[0] if primary_backglass else backglass_media[0]
-            return build_public_url(build_storage_key(chosen.asset.uuid, "display"))
+        backglass = [
+            em
+            for em in all_media(model)
+            if em.category == "backglass" and em.is_primary
+        ]
+        if backglass:
+            _, hero = extract_image_urls(
+                model.extra_data or {}, backglass, min_rank=min_rank
+            )
+            if hero:
+                return hero
 
     if not models:
         return None
 
+    # No uploaded primary backglass on any model — fall through to the
+    # earliest model's third-party image.
     _, hero_image_url = extract_image_urls(
-        models[0].extra_data or {}, min_rank=min_rank
+        models[0].extra_data or {}, None, min_rank=min_rank
     )
     return hero_image_url
 
@@ -544,7 +554,15 @@ def _select_title_hero_image_url(
 def _serialize_title_detail(title: Title) -> TitleDetailSchema:
     min_rank = get_minimum_display_rank()
     model_objs = list(title.machine_models.all())
-    machines = [serialize_title_machine(pm, min_rank=min_rank) for pm in model_objs]
+    variant_ids: list[int] = []
+    for pm in model_objs:
+        if "variants" in getattr(pm, "_prefetched_objects_cache", {}):
+            variant_ids.extend(v.pk for v in pm.variants.all())
+    media_by_model = fetch_model_media_map([pm.pk for pm in model_objs] + variant_ids)
+    machines = [
+        serialize_title_machine(pm, min_rank=min_rank, media_by_model=media_by_model)
+        for pm in model_objs
+    ]
     series = (
         EntityRef(name=title.series.name, slug=title.series.slug)
         if title.series
@@ -695,7 +713,16 @@ def list_titles(request: HttpRequest, display: str = "") -> list[TitleListItemSc
         .order_by("name")
     )
     min_rank = get_minimum_display_rank()
-    return [_serialize_title_list(t, min_rank=min_rank) for t in qs]
+    titles = list(qs)
+    media_by_model = fetch_model_media_map(
+        first.pk
+        for t in titles
+        if (first := next(iter(t.machine_models.all()), None)) is not None
+    )
+    return [
+        _serialize_title_list(t, min_rank=min_rank, media_by_model=media_by_model)
+        for t in titles
+    ]
 
 
 @titles_router.get("/all/", response=list[TitleListItemSchema])
@@ -789,15 +816,15 @@ def list_all_titles(request: HttpRequest) -> HttpResponse:
 
     # --- Batch thumbnail fetch ---
     primary_model_ids = [r.primary_model_id for r in title_rows if r.primary_model_id]
+    media_by_model = fetch_model_media_map(primary_model_ids)
     thumb_data: dict[int, str | None] = {}
     for mid, extra_data in MachineModel.objects.filter(
         id__in=primary_model_ids
     ).values_list("id", "extra_data"):
-        if extra_data:
-            thumb, _ = extract_image_urls(extra_data, min_rank=min_rank)
-            thumb_data[mid] = thumb
-        else:
-            thumb_data[mid] = None
+        thumb, _ = extract_image_urls(
+            extra_data or {}, media_by_model.get(mid), min_rank=min_rank
+        )
+        thumb_data[mid] = thumb
 
     # --- Bulk abbreviations and series ---
     title_ids = [r.id for r in title_rows]

--- a/backend/apps/catalog/resolve/_media.py
+++ b/backend/apps/catalog/resolve/_media.py
@@ -8,12 +8,14 @@ from datetime import datetime
 from typing import NamedTuple, cast
 
 from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
 
 from apps.core.types import ClaimIdentity, EntityKey
 from apps.media.models import EntityMedia, MediaAsset, MediaSupportedModel
 from apps.provenance.models import Claim
 from apps.provenance.typing import HasEffectivePriority
 
+from ..cache import invalidate_all
 from ._claim_values import MediaAttachmentClaimValue
 from ._helpers import _annotate_priority
 
@@ -296,3 +298,6 @@ def resolve_media_attachments(
         EntityMedia.objects.bulk_update(
             list(rows.values()), ["category", "is_primary"], batch_size=2000
         )
+
+    if to_delete_pks or to_create or to_update:
+        transaction.on_commit(invalidate_all)

--- a/backend/apps/catalog/signals.py
+++ b/backend/apps/catalog/signals.py
@@ -47,8 +47,11 @@ def _cache_invalidating_models() -> list[type[models.Model]]:
     # Not covered here: MachineModel* through-rows (MachineModelTheme, etc.)
     # and AliasModel subclasses. Those are written by the claims resolver,
     # which calls invalidate_all() directly via transaction.on_commit (see
-    # resolve/_dispatch.py). Direct edits outside the claims pipeline would
-    # bypass this signal, but that's a policy violation, not a missed path.
+    # resolve/_dispatch.py). EntityMedia is also written via the resolver
+    # (resolve/_media.py uses bulk_create, which doesn't fire post_save), and
+    # busts the cache the same way. Direct edits outside the claims pipeline
+    # would bypass this signal, but that's a policy violation, not a missed
+    # path.
     return [*derived, *extras]
 
 

--- a/backend/apps/catalog/tests/test_api_titles.py
+++ b/backend/apps/catalog/tests/test_api_titles.py
@@ -524,6 +524,131 @@ class TestTitlesAllFacets:
         display_slugs = [d["slug"] for d in data[0]["display_types"]]
         assert "lcd" not in display_slugs
 
+    def test_all_titles_thumbnail_prefers_uploaded_backglass(
+        self, client, db, williams_entity, django_user_model
+    ):
+        """A title's primary model with an uploaded backglass returns the
+        upload's thumb URL on the /all/ endpoint, not the extra_data URL."""
+        from django.contrib.contenttypes.models import ContentType
+
+        from apps.media.models import EntityMedia, MediaAsset
+        from apps.media.storage import build_public_url, build_storage_key
+
+        title = Title.objects.create(name="MM", slug="mm", opdb_id="MM")
+        pm = make_machine_model(
+            name="MM",
+            slug="mm-1",
+            title=title,
+            corporate_entity=williams_entity,
+            year=1997,
+            extra_data={"opdb.images": SAMPLE_IMAGES},
+        )
+        user = django_user_model.objects.create_user(username="up")
+        asset = MediaAsset.objects.create(
+            kind=MediaAsset.Kind.IMAGE,
+            status=MediaAsset.Status.READY,
+            original_filename="bg.jpg",
+            mime_type="image/jpeg",
+            byte_size=1,
+            width=800,
+            height=600,
+            uploaded_by=user,
+        )
+        EntityMedia.objects.create(
+            content_type=ContentType.objects.get_for_model(MachineModel),
+            object_id=pm.pk,
+            asset=asset,
+            category="backglass",
+            is_primary=True,
+        )
+
+        resp = client.get("/api/titles/all/")
+        data = resp.json()
+        item = next(i for i in data if i["slug"] == "mm")
+        expected = build_public_url(build_storage_key(asset.uuid, "thumb"))
+        assert item["thumbnail_url"] == expected
+
+    def test_all_titles_thumbnail_falls_back_to_extra_data(
+        self, client, db, williams_entity
+    ):
+        """No upload → existing OPDB thumbnail URL still wins."""
+        title = Title.objects.create(name="MM2", slug="mm2", opdb_id="MM2")
+        make_machine_model(
+            name="MM2",
+            slug="mm2-1",
+            title=title,
+            corporate_entity=williams_entity,
+            year=1997,
+            extra_data={"opdb.images": SAMPLE_IMAGES},
+        )
+        resp = client.get("/api/titles/all/")
+        data = resp.json()
+        item = next(i for i in data if i["slug"] == "mm2")
+        assert item["thumbnail_url"] == "https://img.opdb.org/md.jpg"
+
+    def test_all_titles_cache_invalidates_on_media_attachment_resolve(
+        self,
+        client,
+        db,
+        williams_entity,
+        django_user_model,
+        django_capture_on_commit_callbacks,
+    ):
+        """Resolving a media_attachment claim busts the cached /all/ payload
+        so the next call reflects the new thumbnail.  Mirrors the production
+        upload path, which writes EntityMedia via bulk_create (no post_save)
+        and relies on transaction.on_commit(invalidate_all) inside the
+        resolver.
+        """
+        from django.contrib.contenttypes.models import ContentType
+
+        from apps.catalog.claims import build_media_attachment_claim
+        from apps.catalog.resolve import resolve_media_attachments
+        from apps.media.models import MediaAsset
+        from apps.media.storage import build_public_url, build_storage_key
+        from apps.provenance.models import Claim
+
+        title = Title.objects.create(name="MM3", slug="mm3", opdb_id="MM3")
+        pm = make_machine_model(
+            name="MM3",
+            slug="mm3-1",
+            title=title,
+            corporate_entity=williams_entity,
+            year=1997,
+            extra_data={"opdb.images": SAMPLE_IMAGES},
+        )
+
+        # Prime the cache with the third-party thumbnail.
+        resp = client.get("/api/titles/all/")
+        item = next(i for i in resp.json() if i["slug"] == "mm3")
+        assert item["thumbnail_url"] == "https://img.opdb.org/md.jpg"
+
+        user = django_user_model.objects.create_user(username="up3")
+        asset = MediaAsset.objects.create(
+            kind=MediaAsset.Kind.IMAGE,
+            status=MediaAsset.Status.READY,
+            original_filename="bg.jpg",
+            mime_type="image/jpeg",
+            byte_size=1,
+            width=800,
+            height=600,
+            uploaded_by=user,
+        )
+        ct = ContentType.objects.get_for_model(MachineModel)
+        claim_key, claim_value = build_media_attachment_claim(
+            pm, asset.pk, category="backglass", is_primary=False
+        )
+        with django_capture_on_commit_callbacks(execute=True):
+            Claim.objects.assert_claim(
+                pm, "media_attachment", claim_value, user=user, claim_key=claim_key
+            )
+            resolve_media_attachments(content_type_id=ct.id, subject_ids={pm.pk})
+
+        resp = client.get("/api/titles/all/")
+        item = next(i for i in resp.json() if i["slug"] == "mm3")
+        expected = build_public_url(build_storage_key(asset.uuid, "thumb"))
+        assert item["thumbnail_url"] == expected
+
     def test_all_titles_empty_title(self, client, db):
         """Title with no models returns empty facet arrays."""
         Title.objects.create(name="Empty", slug="empty", opdb_id="EMPTY")

--- a/backend/apps/catalog/tests/test_image_licensing.py
+++ b/backend/apps/catalog/tests/test_image_licensing.py
@@ -185,7 +185,7 @@ class TestExtractImageUrlsWithThreshold:
             "opdb.images.__license_slug": "not-allowed",
             "opdb.images.__permissiveness_rank": 0,
         }
-        thumb, hero = extract_image_urls(extra_data)
+        thumb, hero = extract_image_urls(extra_data, None)
         assert thumb is None
         assert hero is None
 
@@ -205,7 +205,7 @@ class TestExtractImageUrlsWithThreshold:
             "ipdb.image_urls": ["https://ipdb.org/ipdb.jpg"],
             "ipdb.image_urls.__permissiveness_rank": 85,  # above threshold
         }
-        thumb, _ = extract_image_urls(extra_data)
+        thumb, _ = extract_image_urls(extra_data, None)
         assert thumb == "https://ipdb.org/ipdb.jpg"
 
     def test_null_rank_uses_unknown_rank(self):
@@ -223,7 +223,7 @@ class TestExtractImageUrlsWithThreshold:
             "opdb.images.__permissiveness_rank": None,  # unknown
         }
         # With "licensed-only" (min_rank=38), unknown (rank 5) should be hidden.
-        thumb, hero = extract_image_urls(extra_data)
+        thumb, hero = extract_image_urls(extra_data, None)
         assert thumb is None
         assert hero is None
 
@@ -244,7 +244,7 @@ class TestExtractImageUrlsWithThreshold:
             "opdb.images.__permissiveness_rank": 0,
         }
         with override_config(CONTENT_DISPLAY_POLICY="show-all"):
-            thumb, _ = extract_image_urls(extra_data)
+            thumb, _ = extract_image_urls(extra_data, None)
         assert thumb == "https://img.opdb.org/m.jpg"
 
     def test_include_unknown_shows_null_rank(self):
@@ -264,5 +264,5 @@ class TestExtractImageUrlsWithThreshold:
             "opdb.images.__permissiveness_rank": None,
         }
         with override_config(CONTENT_DISPLAY_POLICY="include-unknown"):
-            thumb, _ = extract_image_urls(extra_data)
+            thumb, _ = extract_image_urls(extra_data, None)
         assert thumb == "https://img.opdb.org/m.jpg"

--- a/backend/apps/media/tests/test_api_response.py
+++ b/backend/apps/media/tests/test_api_response.py
@@ -173,8 +173,8 @@ class TestUploadedFirstFallback:
         assert hero is None
 
     def test_no_primary_media_param_uses_external(self):
-        """When primary_media is not passed (None), falls through to external."""
-        thumb, hero = extract_image_urls(OPDB_EXTRA_DATA)
+        """When primary_media is None, falls through to external."""
+        thumb, hero = extract_image_urls(OPDB_EXTRA_DATA, None)
 
         assert thumb == "https://img.opdb.org/m.jpg"
         assert hero == "https://img.opdb.org/l.jpg"


### PR DESCRIPTION
## Summary

- List endpoints across the site (titles, manufacturers, people, series, systems, themes, taxonomy, franchises, models, role-people) built `thumbnail_url` from `extra_data` only, so cards never reflected uploaded backglass — even when the title detail hero did. Plumb prefetched primary `EntityMedia` through `extract_image_urls(extra_data, primary_media=...)` via a new `fetch_model_media_map()` (and `fetch_title_media_map()` shorthand).
- `resolve_media_attachments` writes `EntityMedia` via `bulk_create`, which doesn't fire `post_save` — a signal-based cache-invalidation hook would silently miss real uploads. Bust the `/all/` caches from inside the resolver via `transaction.on_commit(invalidate_all)`. Regression test exercises the actual claim→resolve path under `django_capture_on_commit_callbacks`.
- `extract_image_urls` / `extract_image_attribution` now require `primary_media` as a positional argument (no default). The optional default is what allowed list endpoints to silently regress when uploads were introduced. Forcing the decision at every callsite surfaced four additional endpoints carrying the same bug as Doctor Who: `/api/titles/` (paginated), `/api/models/recent/`, `/api/models/all/`, and the taxonomy role-people listing. All four now bulk-fetch media.

## Phase-2 follow-ups deliberately not in this PR

- `/api/titles/all/` checks only the title's primary model; uploads on a sibling model still won't surface on the card. Title detail still scans all models so its hero behavior is correct.
- `fetch_model_media_map` is hardcoded to `MachineModel`; title-level uploads (which would close the sibling-model gap) need a generic `fetch_entity_media_map`.
- `first_thumbnail` (locations endpoint) doesn't check uploaded media yet — currently passes `None` explicitly with a comment.

## Test plan

- [x] Backend: 1887 tests pass (`pytest apps/catalog apps/media apps/provenance`)
- [x] Type check: mypy clean on changed files
- [x] Lint: ruff check + format clean
- [x] Manual: uploaded a backglass on a previously-imageless title; kiosk card showed the upload after a normal page reload (no manual cache-clear needed); detail hero unchanged
- [ ] Smoke-test the four newly-fixed list endpoints (paginated titles, /models/recent, /models/all, role-people) on staging once a few entities have uploaded media

🤖 Generated with [Claude Code](https://claude.com/claude-code)