### PR TITLE
media: uploaded-thumbnails follow-ups

### DIFF
--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -131,7 +131,6 @@ def list_series(request: HttpRequest) -> list[SeriesListItemSchema]:
                 "titles__machine_models",
                 queryset=MachineModel.objects.active()
                 .filter(variant_of__isnull=True)
-                .exclude(extra_data={})
                 .order_by(F("year").asc(nulls_last=True))
                 .only("id", "extra_data"),
             )

--- a/frontend/src/lib/components/media/MediaUploadZone.svelte
+++ b/frontend/src/lib/components/media/MediaUploadZone.svelte
@@ -90,15 +90,12 @@
 
 <div class="upload-page">
   <div class="options">
-    <label class="option-label">
-      Category
-      <select bind:value={category} class="category-select">
-        <option value="" disabled>Choose a category…</option>
-        {#each categories as cat (cat)}
-          <option value={cat}>{cat}</option>
-        {/each}
-      </select>
-    </label>
+    <select bind:value={category} class="category-select">
+      <option value="" disabled>Choose a category…</option>
+      {#each categories as cat (cat)}
+        <option value={cat}>{cat}</option>
+      {/each}
+    </select>
   </div>
 
   <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -179,14 +176,6 @@
     gap: var(--size-4);
     flex-wrap: wrap;
     margin-bottom: var(--size-4);
-  }
-
-  .option-label {
-    display: flex;
-    align-items: center;
-    gap: var(--size-2);
-    font-size: var(--font-size-1);
-    color: var(--color-text-muted);
   }
 
   .category-select {

--- a/frontend/src/lib/focus-mode.ts
+++ b/frontend/src/lib/focus-mode.ts
@@ -11,7 +11,6 @@ import { matchDetailSubroute } from './detail-subroute-match';
  *   /:entity/:slug/edit-history          audit: changeset history
  *   /:entity/:slug/sources               audit: source claims
  *   /kiosk                               museum kiosk visitor grid
- *   /kiosk/configure                     kiosk staff setup
  *
  * `edit`, `delete`, `edit-history`, and `sources` require a slug segment
  * before them so a catalog record with slug='edit' / 'sources' / etc. (e.g.
@@ -23,7 +22,7 @@ import { matchDetailSubroute } from './detail-subroute-match';
  */
 const FOCUS_SUBROUTES_NESTED = new Set(['edit']);
 const FOCUS_SUBROUTES_TERMINAL = new Set(['delete', 'edit-history', 'sources']);
-const FOCUS_EXACT_PATHS = new Set(['/kiosk', '/kiosk/configure']);
+const FOCUS_EXACT_PATHS = new Set(['/kiosk']);
 
 export function isFocusModePath(pathname: string): boolean {
   if (FOCUS_EXACT_PATHS.has(pathname)) return true;

--- a/frontend/src/lib/kiosk/KioskHome.svelte
+++ b/frontend/src/lib/kiosk/KioskHome.svelte
@@ -53,7 +53,7 @@
 </script>
 
 <svelte:head>
-  <title>{config?.title ?? 'Kiosk'}</title>
+  <title>{config?.title || 'Kiosk'}</title>
 </svelte:head>
 
 <div class="kiosk">
@@ -68,25 +68,29 @@
       </p>
     </div>
   {:else}
-    <h1 class="title">{config.title}</h1>
+    {#if config.title}
+      <h1 class="title">{config.title}</h1>
+    {/if}
     <div class="grid">
       {#each cards as card (card.slug)}
         <a class="card" href={resolveHref(`/titles/${card.slug}`)}>
-          {#if card.thumbnailUrl}
-            <img src={card.thumbnailUrl} alt="" class="card-img" loading="lazy" />
-          {:else}
-            <div class="card-img placeholder"></div>
-          {/if}
-          <div class="card-body">
-            <h2 class="card-name">{card.name}</h2>
-            <div class="card-meta">
-              {#if card.manufacturer}<span>{card.manufacturer}</span>{/if}
-              {#if card.year}<span>{card.year}</span>{/if}
-            </div>
-            {#if card.hook}
-              <p class="card-hook">{card.hook}</p>
+          <div class="card-media">
+            {#if card.thumbnailUrl}
+              <img src={card.thumbnailUrl} alt="" class="card-img" loading="lazy" />
+            {:else}
+              <div class="card-img placeholder"></div>
             {/if}
+            <div class="card-overlay">
+              <h2 class="card-name">{card.name}</h2>
+              <div class="card-meta">
+                {#if card.manufacturer}<span>{card.manufacturer}</span>{/if}
+                {#if card.year}<span>{card.year}</span>{/if}
+              </div>
+            </div>
           </div>
+          {#if card.hook}
+            <p class="card-hook">{card.hook}</p>
+          {/if}
         </a>
       {/each}
     </div>
@@ -133,37 +137,54 @@
     box-shadow: 0 4px 16px rgb(0 0 0 / 0.12);
   }
 
-  .card-img {
+  .card-media {
+    position: relative;
     width: 100%;
     height: 14rem;
-    object-fit: cover;
     background: var(--color-surface-muted, #f0f0f0);
+  }
+
+  .card-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
   }
 
   .card-img.placeholder {
     background: var(--color-surface-muted, #f0f0f0);
   }
 
-  .card-body {
-    padding: var(--size-4);
+  .card-overlay {
+    position: absolute;
+    inset: auto 0 0 0;
+    padding: var(--size-5) var(--size-4) var(--size-3);
+    background: linear-gradient(
+      to top,
+      rgb(0 0 0 / 0.85) 0%,
+      rgb(0 0 0 / 0.55) 50%,
+      rgb(0 0 0 / 0) 100%
+    );
+    color: #fff;
     display: flex;
     flex-direction: column;
-    gap: var(--size-2);
-    flex: 1;
+    gap: var(--size-1);
   }
 
   .card-name {
     font-size: var(--font-size-4);
-    font-weight: 600;
+    font-weight: 700;
     margin: 0;
-    line-height: 1.2;
+    line-height: 1.15;
+    text-shadow: 0 1px 2px rgb(0 0 0 / 0.5);
   }
 
   .card-meta {
     display: flex;
     flex-wrap: wrap;
     font-size: var(--font-size-1);
-    color: var(--color-text-muted);
+    color: rgb(255 255 255 / 0.9);
+    text-shadow: 0 1px 2px rgb(0 0 0 / 0.5);
   }
 
   .card-meta span:not(:last-child)::after {
@@ -172,6 +193,7 @@
   }
 
   .card-hook {
+    padding: var(--size-3) var(--size-4) var(--size-4);
     font-size: var(--font-size-2);
     color: var(--color-text-primary);
     margin: 0;

--- a/frontend/src/routes/kiosk/configure/+page.svelte
+++ b/frontend/src/routes/kiosk/configure/+page.svelte
@@ -21,6 +21,9 @@
   import { normalizeText } from '$lib/utils';
   import { matchesQuery } from '$lib/facet-engine';
   import Button from '$lib/components/Button.svelte';
+  import Page from '$lib/components/Page.svelte';
+  import TwoColumnLayout from '$lib/components/TwoColumnLayout.svelte';
+  import SidebarSection from '$lib/components/SidebarSection.svelte';
   import type { TitleListItemSchema } from '$lib/api/schema';
 
   let title = $state(DEFAULT_TITLE);
@@ -59,7 +62,7 @@
 
   function buildConfig(): KioskConfig {
     return {
-      title: title.trim() || DEFAULT_TITLE,
+      title: title.trim(),
       idleSeconds: idleSeconds > 0 ? idleSeconds : DEFAULT_IDLE_SECONDS,
       items: items.map((i) => ({
         titleSlug: i.titleSlug,
@@ -113,117 +116,159 @@
   <title>Configure Kiosk</title>
 </svelte:head>
 
-<div class="page">
-  <header class="header">
-    <h1>Configure Kiosk</h1>
-    {#if kioskActive}
-      <Button type="button" onclick={handleExit}>Exit Kiosk Mode</Button>
-    {:else}
-      <Button type="button" onclick={handleEnter}>Enter Kiosk Mode</Button>
-    {/if}
-  </header>
+<Page width="extra-wide">
+  <TwoColumnLayout>
+    {#snippet main()}
+      <header class="header header-mobile">
+        {#if kioskActive}
+          <Button type="button" variant="secondary" onclick={handleExit}>Exit Kiosk Mode</Button>
+        {:else}
+          <Button type="button" onclick={handleEnter}>Enter Kiosk Mode</Button>
+        {/if}
+      </header>
 
-  <section class="settings">
-    <label>
-      <span>Title</span>
-      <input type="text" bind:value={title} maxlength="60" />
-    </label>
-    <label>
-      <span>Idle timeout (seconds)</span>
-      <input type="number" min="10" max="3600" bind:value={idleSeconds} />
-    </label>
-  </section>
+      <section class="settings">
+        <label>
+          <span>Title</span>
+          <input type="text" bind:value={title} maxlength="60" />
+        </label>
+        <label>
+          <span>Idle timeout (seconds)</span>
+          <input type="number" min="10" max="3600" bind:value={idleSeconds} />
+        </label>
+      </section>
 
-  <section class="machines">
-    <label class="search">
-      <span>Add a machine</span>
-      <input type="search" placeholder="Search by name…" bind:value={search} autocomplete="off" />
-    </label>
+      <section class="machines">
+        <label class="search">
+          <span>Add a machine</span>
+          <input
+            type="search"
+            placeholder="Search by name…"
+            bind:value={search}
+            autocomplete="off"
+          />
+        </label>
 
-    {#if searchResults.length > 0}
-      <ul class="results">
-        {#each searchResults as t (t.slug)}
-          <li>
-            <button type="button" onclick={() => addTitle(t.slug)}>
-              <strong>{t.name}</strong>
-              <span class="result-meta">
-                {#if t.manufacturer}{t.manufacturer.name}{/if}
-                {#if t.year}· {t.year}{/if}
-              </span>
-            </button>
-          </li>
-        {/each}
-      </ul>
-    {/if}
+        {#if searchResults.length > 0}
+          <ul class="results">
+            {#each searchResults as t (t.slug)}
+              <li>
+                <button type="button" onclick={() => addTitle(t.slug)}>
+                  <strong>{t.name}</strong>
+                  <span class="result-meta">
+                    {#if t.manufacturer}{t.manufacturer.name}{/if}
+                    {#if t.year}· {t.year}{/if}
+                  </span>
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
 
-    <h2>Machines ({items.length})</h2>
+        <hr class="divider" />
 
-    {#if items.length === 0}
-      <p class="empty">No machines added yet.</p>
-    {:else}
-      <ol class="items">
-        {#each items as item, i (item.titleSlug)}
-          {@const t = titleBySlug.get(item.titleSlug)}
-          <li class="item">
-            <div class="item-header">
-              <span class="item-name">
-                {t?.name ?? item.titleSlug}
-                {#if t?.year}<span class="dim"> · {t.year}</span>{/if}
-                {#if t?.manufacturer}<span class="dim"> · {t.manufacturer.name}</span>{/if}
-              </span>
-              <div class="item-actions">
-                <button
-                  type="button"
-                  onclick={() => moveUp(i)}
-                  disabled={i === 0}
-                  aria-label="Move up">↑</button
-                >
-                <button
-                  type="button"
-                  onclick={() => moveDown(i)}
-                  disabled={i === items.length - 1}
-                  aria-label="Move down">↓</button
-                >
-                <button type="button" onclick={() => removeAt(i)} aria-label="Remove">✕</button>
-              </div>
-            </div>
-            <input
-              type="text"
-              placeholder="Hook (optional, e.g. 'First talking pinball machine')"
-              bind:value={item.hook}
-              maxlength={HOOK_MAX_LENGTH}
-            />
-          </li>
-        {/each}
-      </ol>
-    {/if}
-  </section>
-</div>
+        {#if items.length === 0}
+          <p class="empty">No machines added yet.</p>
+        {:else}
+          <ol class="items">
+            {#each items as item, i (item.titleSlug)}
+              {@const t = titleBySlug.get(item.titleSlug)}
+              <li class="item">
+                <div class="item-header">
+                  <span class="item-name">
+                    {t?.name ?? item.titleSlug}
+                    {#if t?.year}<span class="dim"> · {t.year}</span>{/if}
+                    {#if t?.manufacturer}<span class="dim"> · {t.manufacturer.name}</span>{/if}
+                  </span>
+                  <div class="item-actions">
+                    <button
+                      type="button"
+                      onclick={() => moveUp(i)}
+                      disabled={i === 0}
+                      aria-label="Move up">↑</button
+                    >
+                    <button
+                      type="button"
+                      onclick={() => moveDown(i)}
+                      disabled={i === items.length - 1}
+                      aria-label="Move down">↓</button
+                    >
+                    <button type="button" onclick={() => removeAt(i)} aria-label="Remove">✕</button>
+                  </div>
+                </div>
+                <input
+                  type="text"
+                  placeholder="Hook (optional, e.g. 'First talking pinball machine')"
+                  bind:value={item.hook}
+                  maxlength={HOOK_MAX_LENGTH}
+                />
+              </li>
+            {/each}
+          </ol>
+        {/if}
+      </section>
+    {/snippet}
+
+    {#snippet sidebar()}
+      <SidebarSection heading="Configure Kiosk">
+        <p class="about">
+          Kiosk mode turns the front door of this browser into a curated display of specific pinball
+          machines — for use on an in-museum kiosk.
+        </p>
+        <p class="about">
+          Pick the machines you want to feature, and set how long the browser sits idle before
+          resetting to the kiosk home screen.
+        </p>
+        <p class="about">This configuration is specific to this browser on this machine.</p>
+        <div class="sidebar-action">
+          {#if kioskActive}
+            <Button type="button" variant="secondary" onclick={handleExit}>Exit Kiosk Mode</Button>
+          {:else}
+            <Button type="button" onclick={handleEnter}>Enter Kiosk Mode</Button>
+          {/if}
+        </div>
+      </SidebarSection>
+    {/snippet}
+  </TwoColumnLayout>
+</Page>
 
 <style>
-  .page {
-    max-width: 60rem;
-    margin: 0 auto;
-    padding: var(--size-5) var(--size-4);
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-5);
-  }
-
   .header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
+    margin-bottom: var(--size-5);
   }
 
-  .header h1 {
-    margin: 0;
+  .about {
+    font-size: var(--font-size-1);
+    color: var(--color-text-muted);
+    margin: 0 0 var(--size-2);
+    line-height: 1.5;
+  }
+
+  .about:last-child {
+    margin-bottom: 0;
+  }
+
+  .sidebar-action {
+    margin-top: var(--size-3);
+  }
+
+  /* Keep in sync with LAYOUT_BREAKPOINT (52rem) — the breakpoint at which
+     TwoColumnLayout reveals the sidebar. Above it, the sidebar's button is
+     visible, so the in-main copy must hide. */
+  @media (min-width: 52rem) {
+    .header-mobile {
+      display: none;
+    }
   }
 
   .settings {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: var(--size-4);
+    margin-bottom: var(--size-5);
   }
 
   label {
@@ -246,8 +291,10 @@
     font-size: var(--font-size-1);
   }
 
-  .machines h2 {
+  .divider {
     margin: var(--size-5) 0 var(--size-3);
+    border: none;
+    border-top: 3px solid var(--color-border-soft);
   }
 
   .results {


### PR DESCRIPTION
## Summary
- Kiosk: redesign configure page with two-column layout and sidebar; overlay card titles on the thumbnail with a gradient scrim; allow blank kiosk title.
- Media upload: drop the redundant "Category" label wrapping the select.
- Series API: stop excluding empty-`extra_data` models from list thumbnails.

## Test plan
- [ ] Visit `/kiosk/configure` — sidebar copy + Enter/Exit button render; mobile shows the inline button instead.
- [ ] Configure a kiosk with a blank title and confirm `/kiosk` renders without a heading.
- [ ] Confirm card titles appear overlaid on thumbnails with readable contrast.
- [ ] Open the media upload page and confirm the category select renders without a leading label.
- [ ] Confirm series list pages show thumbnails for models that have empty `extra_data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)