### PR TITLE
nav: redesign navigation

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -45,6 +45,9 @@ class AuthStatusSchema(Schema):
     is_authenticated: bool
     id: int | None = None
     username: str | None = None
+    is_superuser: bool = False
+    first_name: str = ""
+    last_name: str = ""
 
 
 class EntityContributionSchema(Schema):
@@ -162,6 +165,9 @@ def auth_me(request: HttpRequest) -> AuthStatusSchema:
             is_authenticated=True,
             id=user.id,
             username=user.username,
+            is_superuser=user.is_superuser,
+            first_name=user.first_name,
+            last_name=user.last_name,
         )
     assert isinstance(user, AnonymousUser)
     return AuthStatusSchema(is_authenticated=False)

--- a/backend/apps/accounts/tests/test_workos_auth.py
+++ b/backend/apps/accounts/tests/test_workos_auth.py
@@ -274,11 +274,36 @@ class TestAuthMe:
         resp = client.get("/api/auth/me/")
         data = resp.json()
         assert data["is_authenticated"] is False
+        assert data["is_superuser"] is False
+        assert data["first_name"] == ""
+        assert data["last_name"] == ""
 
     def test_me_authenticated(self, client):
-        user = User.objects.create_user(username="alice")
+        user = User.objects.create_user(
+            username="alice", first_name="Alice", last_name="Anderson"
+        )
         client.force_login(user)
         resp = client.get("/api/auth/me/")
         data = resp.json()
         assert data["is_authenticated"] is True
         assert data["username"] == "alice"
+        assert data["is_superuser"] is False
+        assert data["first_name"] == "Alice"
+        assert data["last_name"] == "Anderson"
+
+    def test_me_authenticated_no_names(self, client):
+        user = User.objects.create_user(username="bob")
+        client.force_login(user)
+        resp = client.get("/api/auth/me/")
+        data = resp.json()
+        assert data["is_authenticated"] is True
+        assert data["first_name"] == ""
+        assert data["last_name"] == ""
+
+    def test_me_superuser(self, client):
+        user = User.objects.create_superuser(username="admin", email="a@b.test")
+        client.force_login(user)
+        resp = client.get("/api/auth/me/")
+        data = resp.json()
+        assert data["is_authenticated"] is True
+        assert data["is_superuser"] is True

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -4,19 +4,39 @@ interface AuthState {
   isAuthenticated: boolean;
   id: number | null;
   username: string | null;
+  isSuperuser: boolean;
+  firstName: string;
+  lastName: string;
 }
 
-const ANONYMOUS: AuthState = { isAuthenticated: false, id: null, username: null };
+const ANONYMOUS: AuthState = {
+  isAuthenticated: false,
+  id: null,
+  username: null,
+  isSuperuser: false,
+  firstName: '',
+  lastName: '',
+};
 
 function createAuthStore() {
   let state = $state<AuthState>({ ...ANONYMOUS });
   let loaded = $state(false);
 
-  function set(data: { is_authenticated: boolean; id?: number | null; username?: string | null }) {
+  function set(data: {
+    is_authenticated: boolean;
+    id?: number | null;
+    username?: string | null;
+    is_superuser?: boolean;
+    first_name?: string;
+    last_name?: string;
+  }) {
     state = {
       isAuthenticated: data.is_authenticated,
       id: data.id ?? null,
       username: data.username ?? null,
+      isSuperuser: data.is_superuser ?? false,
+      firstName: data.first_name ?? '',
+      lastName: data.last_name ?? '',
     };
     loaded = true;
   }
@@ -41,6 +61,15 @@ function createAuthStore() {
     },
     get username() {
       return state.username;
+    },
+    get isSuperuser() {
+      return state.isSuperuser;
+    },
+    get firstName() {
+      return state.firstName;
+    },
+    get lastName() {
+      return state.lastName;
     },
     get loaded() {
       return loaded;

--- a/frontend/src/lib/components/ActionMenu.dom.test.ts
+++ b/frontend/src/lib/components/ActionMenu.dom.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import ActionMenuFixture from './ActionMenu.fixture.svelte';
 import ActionMenuListboxFixture from './ActionMenu.listbox.fixture.svelte';
+import ActionMenuTriggerFixture from './ActionMenu.trigger.fixture.svelte';
 
 describe('ActionMenu', () => {
   function renderMenu() {
@@ -119,6 +120,27 @@ describe('ActionMenu', () => {
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  describe('custom trigger snippet', () => {
+    it('renders the snippet inside the button and keeps keyboard/ARIA wiring', async () => {
+      const user = userEvent.setup();
+      render(ActionMenuTriggerFixture);
+
+      const trigger = screen.getByRole('button', { name: 'Account' });
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+      const customContent = screen.getByTestId('custom-trigger');
+      expect(trigger).toContainElement(customContent);
+      expect(customContent).toHaveTextContent('AB');
+
+      trigger.focus();
+      await user.keyboard('{ArrowDown}');
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('menuitem', { name: 'Profile' })).toHaveFocus();
+    });
   });
 
   describe('pill variant + listbox role', () => {

--- a/frontend/src/lib/components/ActionMenu.svelte
+++ b/frontend/src/lib/components/ActionMenu.svelte
@@ -4,9 +4,10 @@
   type Props = {
     label: string;
     disabled?: boolean;
-    variant?: 'default' | 'heading' | 'pill';
+    variant?: 'default' | 'heading' | 'pill' | 'bare';
     role?: 'menu' | 'listbox';
     ariaLabel?: string;
+    trigger?: Snippet;
     children: Snippet;
   };
 
@@ -16,6 +17,7 @@
     variant = 'default',
     role: roleProp,
     ariaLabel,
+    trigger,
     children,
   }: Props = $props();
 
@@ -208,15 +210,16 @@
     class="trigger"
     class:heading={variant === 'heading'}
     class:pill={variant === 'pill'}
+    class:bare={variant === 'bare'}
     {disabled}
     aria-haspopup={role === 'listbox' ? 'listbox' : 'menu'}
     aria-expanded={open}
     aria-controls={open ? menuId : undefined}
-    aria-label={ariaLabel}
+    aria-label={ariaLabel ?? (trigger ? label : undefined)}
     onclick={toggleMenu}
     onkeydown={handleTriggerKeydown}
   >
-    {label}
+    {#if trigger}{@render trigger()}{:else}{label}{/if}
   </button>
   {#if open}
     <div
@@ -252,9 +255,17 @@
     font-family: inherit;
   }
 
-  .trigger::after {
+  .trigger:not(.bare)::after {
     content: ' \25BE';
     font-size: 0.75em;
+  }
+
+  .trigger.bare {
+    color: inherit;
+    font-size: inherit;
+    line-height: 0;
+    display: inline-flex;
+    align-items: center;
   }
 
   .trigger.heading {
@@ -280,6 +291,13 @@
   .trigger:hover,
   .trigger[aria-expanded='true'] {
     color: var(--color-accent);
+  }
+
+  /* Bare variant defers fully to its parent's color, including on hover —
+     the parent decides idle and hover colors via inheritance. */
+  .trigger.bare:hover,
+  .trigger.bare[aria-expanded='true'] {
+    color: inherit;
   }
 
   .trigger:disabled {

--- a/frontend/src/lib/components/ActionMenu.trigger.fixture.svelte
+++ b/frontend/src/lib/components/ActionMenu.trigger.fixture.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import ActionMenu from './ActionMenu.svelte';
+  import MenuItem from './MenuItem.svelte';
+</script>
+
+<ActionMenu label="Account" variant="bare">
+  {#snippet trigger()}
+    <span data-testid="custom-trigger">AB</span>
+  {/snippet}
+  <MenuItem href="/profile">Profile</MenuItem>
+  <MenuItem href="/logout">Sign Out</MenuItem>
+</ActionMenu>

--- a/frontend/src/lib/components/Avatar.dom.test.ts
+++ b/frontend/src/lib/components/Avatar.dom.test.ts
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+import Avatar, { initialsFor } from './Avatar.svelte';
+
+describe('initialsFor', () => {
+  it('uses first + last initial when both present', () => {
+    expect(initialsFor({ firstName: 'Alice', lastName: 'Anderson', username: 'alice' })).toBe('AA');
+  });
+
+  it('falls back to first initial when last name is empty', () => {
+    expect(initialsFor({ firstName: 'Alice', lastName: '', username: 'alice' })).toBe('A');
+  });
+
+  it('falls back to first two username chars when no names', () => {
+    expect(initialsFor({ firstName: '', lastName: '', username: 'bobby' })).toBe('BO');
+  });
+
+  it('handles whitespace-only names as missing', () => {
+    expect(initialsFor({ firstName: '  ', lastName: '  ', username: 'carol' })).toBe('CA');
+  });
+
+  it('uppercases lowercase input', () => {
+    expect(initialsFor({ firstName: 'dan', lastName: 'doe', username: 'dan' })).toBe('DD');
+  });
+
+  it('treats null/undefined names as missing', () => {
+    expect(initialsFor({ firstName: null, lastName: undefined, username: 'eve' })).toBe('EV');
+  });
+});
+
+describe('Avatar', () => {
+  it('renders the computed initials', () => {
+    render(Avatar, { firstName: 'Alice', lastName: 'Anderson', username: 'alice' });
+    expect(screen.getByTestId('avatar')).toHaveTextContent('AA');
+  });
+});

--- a/frontend/src/lib/components/Avatar.svelte
+++ b/frontend/src/lib/components/Avatar.svelte
@@ -1,0 +1,45 @@
+<script lang="ts" module>
+  export function initialsFor(input: {
+    firstName?: string | null;
+    lastName?: string | null;
+    username: string;
+  }): string {
+    const first = (input.firstName ?? '').trim();
+    const last = (input.lastName ?? '').trim();
+    if (first && last) return (first[0] + last[0]).toUpperCase();
+    if (first) return first[0].toUpperCase();
+    return input.username.slice(0, 2).toUpperCase();
+  }
+</script>
+
+<script lang="ts">
+  type Props = {
+    firstName?: string | null;
+    lastName?: string | null;
+    username: string;
+    size?: string;
+  };
+
+  let { firstName, lastName, username, size = '2rem' }: Props = $props();
+
+  const initials = $derived(initialsFor({ firstName, lastName, username }));
+</script>
+
+<span class="avatar" style:width={size} style:height={size} aria-hidden="true" data-testid="avatar">
+  {initials}
+</span>
+
+<style>
+  .avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--color-accent);
+    color: #fff;
+    font-size: 0.75em;
+    font-weight: 600;
+    line-height: 1;
+    user-select: none;
+  }
+</style>

--- a/frontend/src/lib/components/MenuDivider.svelte
+++ b/frontend/src/lib/components/MenuDivider.svelte
@@ -1,0 +1,10 @@
+<hr class="menu-divider" />
+
+<style>
+  .menu-divider {
+    height: 1px;
+    margin: var(--size-1) 0;
+    border: none;
+    background: var(--color-border-soft);
+  }
+</style>

--- a/frontend/src/lib/components/MenuItem.svelte
+++ b/frontend/src/lib/components/MenuItem.svelte
@@ -6,12 +6,15 @@
     onclick = undefined,
     disabled = false,
     current = false,
+    reload = false,
     children,
   }: {
     href?: string;
     onclick?: () => void;
     disabled?: boolean;
     current?: boolean;
+    /** Force a full-page navigation. Set for non-SvelteKit routes (e.g. Django views). */
+    reload?: boolean;
     children: Snippet;
   } = $props();
 
@@ -32,7 +35,15 @@
     {@render children()}
   </span>
 {:else if href}
-  <a class="menu-item" {href} role={itemRole} aria-selected={ariaSelected} tabindex="-1">
+  <a
+    class:current
+    class="menu-item"
+    {href}
+    role={itemRole}
+    aria-selected={ariaSelected}
+    tabindex="-1"
+    data-sveltekit-reload={reload ? '' : undefined}
+  >
     {@render children()}
   </a>
 {:else}
@@ -50,11 +61,14 @@
 {/if}
 
 <style>
+  /* Parents may override --menu-item-font-size and --menu-item-padding via
+     inheritance to retune density (e.g. nav uses larger items than the
+     compact image-category picker). */
   .menu-item {
     display: block;
     width: 100%;
-    padding: var(--size-1) var(--size-3);
-    font-size: var(--font-size-0);
+    padding: var(--menu-item-padding, var(--size-1) var(--size-3));
+    font-size: var(--menu-item-font-size, var(--font-size-0));
     font-family: inherit;
     color: var(--color-text-primary);
     text-decoration: none;
@@ -65,17 +79,34 @@
     white-space: nowrap;
   }
 
+  /* Hover/focus uses an ink-tinted overlay in light mode (pure white on
+     warm-cream looked harsh). Dark mode keeps the existing flat surface. */
   .menu-item:hover,
   .menu-item:focus-visible {
-    background: var(--color-surface);
+    background: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
     color: var(--color-accent);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .menu-item:hover,
+    .menu-item:focus-visible {
+      background: var(--color-surface);
+    }
   }
 
   .menu-item.current {
     font-weight: 600;
   }
 
-  .menu-item.current::before {
+  /* Menus: "you are here" gets a tinted background that adapts to both
+     themes (ink on warm-cream in light mode, light gray on near-black in
+     dark mode). */
+  .menu-item.current[role='menuitem'] {
+    background: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
+  }
+
+  /* Listboxes: the selected option gets a checkmark, like a native <select>. */
+  .menu-item.current[role='option']::before {
     content: '✓ ';
   }
 

--- a/frontend/src/lib/components/MenuSectionHeader.svelte
+++ b/frontend/src/lib/components/MenuSectionHeader.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let { children }: { children: Snippet } = $props();
+</script>
+
+<div class="menu-section-header">
+  {@render children()}
+</div>
+
+<style>
+  /* Same density hooks as MenuItem so a parent can scale headers + items
+     together via inheritance. */
+  .menu-section-header {
+    padding: var(--menu-item-padding, var(--size-1) var(--size-3));
+    font-size: var(--menu-section-header-font-size, 0.8rem);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+    user-select: none;
+  }
+</style>

--- a/frontend/src/lib/components/Nav.dom.test.ts
+++ b/frontend/src/lib/components/Nav.dom.test.ts
@@ -1,0 +1,124 @@
+// Responsive bar layout (desktop vs tablet vs mobile) is verified visually,
+// not in JSDOM — these tests cover the menu contents per auth state.
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { pageState, auth } = vi.hoisted(() => ({
+  pageState: {
+    url: new URL('http://localhost:5173/'),
+    params: {} as Record<string, string>,
+  },
+  auth: {
+    isAuthenticated: false,
+    isSuperuser: false,
+    username: null as string | null,
+    firstName: '',
+    lastName: '',
+    loaded: true,
+    load: () => Promise.resolve(),
+    logout: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock('$app/state', () => ({ page: pageState }));
+vi.mock('$app/paths', () => ({ resolve: (p: string) => p }));
+vi.mock('$lib/auth.svelte', () => ({ auth }));
+
+import Nav from './Nav.svelte';
+
+function setAuth(overrides: Partial<typeof auth>) {
+  Object.assign(auth, {
+    isAuthenticated: false,
+    isSuperuser: false,
+    username: null,
+    firstName: '',
+    lastName: '',
+    loaded: true,
+    logout: vi.fn(() => Promise.resolve()),
+  });
+  Object.assign(auth, overrides);
+}
+
+describe('Nav', () => {
+  beforeEach(() => {
+    pageState.url = new URL('http://localhost:5173/');
+  });
+
+  it('anonymous: renders Sign in link, no avatar, no admin items', async () => {
+    const user = userEvent.setup();
+    setAuth({});
+    render(Nav);
+
+    expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.queryByTestId('avatar')).not.toBeInTheDocument();
+
+    // Open the hamburger and confirm there's no admin section.
+    await user.click(screen.getByRole('button', { name: 'Menu' }));
+    expect(screen.queryByText('admin')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Django Admin' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Sign In' })).toBeInTheDocument();
+  });
+
+  it('authed non-superuser: avatar with initials, menu has My Contributions + Sign Out, no admin', async () => {
+    const user = userEvent.setup();
+    setAuth({
+      isAuthenticated: true,
+      username: 'alice',
+      firstName: 'Alice',
+      lastName: 'Anderson',
+    });
+    render(Nav);
+
+    expect(screen.getByTestId('avatar')).toHaveTextContent('AA');
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+    expect(screen.getByRole('menuitem', { name: 'My Contributions' })).toHaveAttribute(
+      'href',
+      '/users/alice',
+    );
+    expect(screen.getByRole('menuitem', { name: 'Sign Out' })).toBeInTheDocument();
+    expect(screen.queryByText('admin')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Django Admin' })).not.toBeInTheDocument();
+  });
+
+  it('authed superuser: account menu shows admin section with Kiosk Config and Django Admin', async () => {
+    const user = userEvent.setup();
+    setAuth({
+      isAuthenticated: true,
+      isSuperuser: true,
+      username: 'root',
+      firstName: 'Root',
+      lastName: 'User',
+    });
+    render(Nav);
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+
+    expect(screen.getByText('admin')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Kiosk Config' })).toHaveAttribute(
+      'href',
+      '/kiosk/configure',
+    );
+    expect(screen.getByRole('menuitem', { name: 'Django Admin' })).toHaveAttribute(
+      'href',
+      '/admin/',
+    );
+  });
+
+  it('Sign Out menu item calls auth.logout()', async () => {
+    const user = userEvent.setup();
+    setAuth({
+      isAuthenticated: true,
+      username: 'alice',
+      firstName: 'Alice',
+      lastName: 'Anderson',
+    });
+    render(Nav);
+
+    await user.click(screen.getByRole('button', { name: 'Account menu' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Sign Out' }));
+
+    expect(auth.logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -1,34 +1,51 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { faBars, faMagnifyingGlass, faXmark } from '@fortawesome/free-solid-svg-icons';
+  import { faBars, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
   import FaIcon from './FaIcon.svelte';
   import CoffeeStain from './effects/CoffeeStain.svelte';
+  import ActionMenu from './ActionMenu.svelte';
+  import MenuItem from './MenuItem.svelte';
+  import MenuSectionHeader from './MenuSectionHeader.svelte';
+  import MenuDivider from './MenuDivider.svelte';
+  import Avatar from './Avatar.svelte';
   import { SITE_NAME } from '$lib/constants';
   import { resolveHref } from '$lib/utils';
   import { auth } from '$lib/auth.svelte';
-
-  let mobileNavOpen = $state(false);
 
   const navItems = [
     { href: '/titles' as const, label: 'Titles' },
     { href: '/manufacturers' as const, label: 'Manufacturers' },
     { href: '/people' as const, label: 'People' },
-    { href: '/changesets' as const, label: 'Changelog' },
   ];
+  const changelogHref = '/changesets' as const;
 
   function isActive(href: string) {
     return page.url.pathname.startsWith(href);
   }
 
-  let toggleIcon = $derived(mobileNavOpen ? faXmark : faBars);
+  let isMobile = $state(false);
 
   $effect(() => {
     auth.load();
   });
 
+  $effect(() => {
+    const mq = window.matchMedia('(width < 40.0625rem)');
+    isMobile = mq.matches;
+    const handler = (event: MediaQueryListEvent) => {
+      isMobile = event.matches;
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  });
+
   async function handleLogout() {
     await auth.logout();
+  }
+
+  function loginHref() {
+    return `/api/auth/login/?next=${encodeURIComponent(page.url.pathname)}`;
   }
 
   const randInt = (max: number) => Math.floor(Math.random() * max);
@@ -63,14 +80,20 @@
   <div class="header-inner">
     <a href={resolve('/')} class="site-title">{SITE_NAME}</a>
 
-    <nav class="site-nav" class:open={mobileNavOpen}>
+    <nav class="primary-nav desktop-nav" aria-label="Primary">
       {#each navItems as { href, label } (href)}
-        <a
-          href={resolve(href)}
-          class="nav-link"
-          class:active={isActive(href)}
-          onclick={() => (mobileNavOpen = false)}
-        >
+        <a href={resolve(href)} class="nav-link" class:active={isActive(href)}>
+          {label}
+        </a>
+      {/each}
+      <a href={resolve(changelogHref)} class="nav-link" class:active={isActive(changelogHref)}>
+        Changelog
+      </a>
+    </nav>
+
+    <nav class="primary-nav tablet-nav" aria-label="Primary">
+      {#each navItems as { href, label } (href)}
+        <a href={resolve(href)} class="nav-link" class:active={isActive(href)}>
           {label}
         </a>
       {/each}
@@ -87,25 +110,77 @@
       </a>
 
       {#if auth.loaded}
-        {#if auth.isAuthenticated}
-          <a href={resolveHref(`/users/${auth.username}`)} class="auth-user">{auth.username}</a>
-          <button class="auth-link" onclick={handleLogout}>Sign out</button>
-        {:else}
-          <a
-            href={`/api/auth/login/?next=${encodeURIComponent(page.url.pathname)}`}
-            class="auth-link">Sign in</a
-          >
-        {/if}
-      {/if}
+        <div class="desktop-account">
+          {#if auth.isAuthenticated}
+            <ActionMenu label="Account" variant="bare" ariaLabel="Account menu">
+              {#snippet trigger()}
+                <Avatar
+                  firstName={auth.firstName}
+                  lastName={auth.lastName}
+                  username={auth.username!}
+                />
+              {/snippet}
+              {#if auth.isSuperuser}
+                <MenuSectionHeader>admin</MenuSectionHeader>
+                <MenuItem href={resolve('/kiosk/configure')} current={isActive('/kiosk/configure')}>
+                  Kiosk Config
+                </MenuItem>
+                <MenuItem href="/admin/" reload>Django Admin</MenuItem>
+                <MenuDivider />
+              {/if}
+              <MenuSectionHeader>{auth.username}</MenuSectionHeader>
+              <MenuItem
+                href={resolveHref(`/users/${auth.username}`)}
+                current={isActive(`/users/${auth.username}`)}
+              >
+                My Contributions
+              </MenuItem>
+              <MenuItem onclick={handleLogout}>Sign Out</MenuItem>
+            </ActionMenu>
+          {:else}
+            <a href={loginHref()} class="auth-link" data-sveltekit-reload>Sign in</a>
+          {/if}
+        </div>
 
-      <button
-        class="mobile-toggle"
-        onclick={() => (mobileNavOpen = !mobileNavOpen)}
-        aria-label="Toggle navigation"
-        aria-expanded={mobileNavOpen}
-      >
-        <FaIcon icon={toggleIcon} size="1.25rem" />
-      </button>
+        <div class="hamburger">
+          <ActionMenu label="Menu" variant="bare" ariaLabel="Menu">
+            {#snippet trigger()}
+              <FaIcon icon={faBars} size="1.25rem" />
+            {/snippet}
+            {#if isMobile}
+              {#each navItems as { href, label } (href)}
+                <MenuItem href={resolve(href)} current={isActive(href)}>{label}</MenuItem>
+              {/each}
+              <MenuDivider />
+            {/if}
+            <MenuSectionHeader>activity</MenuSectionHeader>
+            <MenuItem href={resolve(changelogHref)} current={isActive(changelogHref)}>
+              Changelog
+            </MenuItem>
+            {#if auth.isSuperuser}
+              <MenuDivider />
+              <MenuSectionHeader>admin</MenuSectionHeader>
+              <MenuItem href={resolve('/kiosk/configure')} current={isActive('/kiosk/configure')}>
+                Kiosk Config
+              </MenuItem>
+              <MenuItem href="/admin/" reload>Django Admin</MenuItem>
+            {/if}
+            <MenuDivider />
+            {#if auth.isAuthenticated}
+              <MenuSectionHeader>{auth.username}</MenuSectionHeader>
+              <MenuItem
+                href={resolveHref(`/users/${auth.username}`)}
+                current={isActive(`/users/${auth.username}`)}
+              >
+                My Contributions
+              </MenuItem>
+              <MenuItem onclick={handleLogout}>Sign Out</MenuItem>
+            {:else}
+              <MenuItem href={loginHref()} reload>Sign In</MenuItem>
+            {/if}
+          </ActionMenu>
+        </div>
+      {/if}
     </div>
   </div>
 
@@ -205,6 +280,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: var(--size-4);
     z-index: 10;
   }
 
@@ -219,7 +295,7 @@
     color: var(--color-accent);
   }
 
-  .site-nav {
+  .primary-nav {
     display: flex;
     gap: var(--size-5);
   }
@@ -267,25 +343,10 @@
     color: var(--color-accent);
   }
 
-  .auth-user {
-    font-size: var(--font-size-2);
-    color: var(--header-ink-muted);
-    text-decoration: none;
-    transition: color 0.15s var(--ease-2);
-  }
-
-  .auth-user:hover {
-    color: var(--header-ink);
-  }
-
   .auth-link {
     font-size: var(--font-size-2);
     color: var(--header-ink-muted);
     text-decoration: none;
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0;
     font-weight: 500;
     transition: color 0.15s var(--ease-2);
   }
@@ -294,34 +355,61 @@
     color: var(--header-ink);
   }
 
-  .mobile-toggle {
-    display: none;
-    background: none;
-    border: none;
-    color: var(--header-ink);
-    cursor: pointer;
-    padding: var(--size-1);
+  /* Hamburger / desktop-account wrappers: ActionMenu's `bare` trigger inherits
+     color from us, so we own idle and hover styling via inheritance. The
+     custom properties scale MenuItem / MenuSectionHeader densities up from
+     their compact defaults, since this menu has fewer items than e.g. the
+     image-category picker and doubles as the primary nav on mobile. */
+  .hamburger,
+  .desktop-account {
+    --menu-item-font-size: var(--font-size-2);
+    --menu-item-padding: var(--size-2) var(--size-4);
+    --menu-section-header-font-size: 0.875rem;
+    display: flex;
+    align-items: center;
+    color: var(--header-ink-muted);
+    transition: color 0.15s var(--ease-2);
   }
 
-  @media (max-width: 640px) {
-    .mobile-toggle {
-      display: block;
-    }
+  .hamburger:hover,
+  .desktop-account:hover {
+    color: var(--header-ink);
+  }
 
-    .site-nav {
+  /* ── Three responsive tiers via Media Queries Level 4 range syntax ── */
+  .tablet-nav {
+    display: none;
+  }
+  .hamburger {
+    display: none;
+  }
+
+  @media (width >= 40.0625rem) and (width < 52rem) {
+    .desktop-nav {
       display: none;
-      flex-direction: column;
-      position: absolute;
-      top: 100%;
-      left: 0;
-      right: 0;
-      background-color: var(--header-bg);
-      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-      padding: var(--size-3) var(--size-5);
-      gap: var(--size-2);
     }
+    .tablet-nav {
+      display: flex;
+    }
+    .desktop-account {
+      display: none;
+    }
+    .hamburger {
+      display: flex;
+    }
+  }
 
-    .site-nav.open {
+  @media (width < 40.0625rem) {
+    .desktop-nav {
+      display: none;
+    }
+    .tablet-nav {
+      display: none;
+    }
+    .desktop-account {
+      display: none;
+    }
+    .hamburger {
       display: flex;
     }
   }
@@ -349,12 +437,6 @@
 
     .site-header::before {
       background: none;
-    }
-
-    @media (max-width: 640px) {
-      .site-nav {
-        border-bottom-color: var(--color-border-soft);
-      }
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- Splits the header into three responsive tiers via CSS range syntax (`<40.0625rem`, `40.0625-52rem`, `≥52rem`): desktop keeps the four primary links inline plus an avatar account menu; tablet collapses Changelog and account into a hamburger; mobile pulls everything except logo/search/hamburger out of the bar.
- Adds an avatar (initials ladder: first+last → first → username[0..2]) plus new `MenuSectionHeader` / `MenuDivider` for `admin` (superuser-only) and account sections, current-page highlighting via `MenuItem`'s `current` prop, and an ink-tinted hover/current background that adapts to light & dark themes.
- Backend: `AuthStatusSchema` gains `is_superuser`, `first_name`, `last_name` (empty-string defaults). `ActionMenu` gains an optional `trigger` snippet + `bare` variant; `MenuItem` gains a `reload` prop that emits `data-sveltekit-reload` for cross-app links (Django Admin, Sign In).

## Test plan
- [ ] Anonymous: Sign In visible at all widths; no avatar; no admin section in hamburger.
- [ ] Authed non-superuser: avatar shows correct initials; account menu has username header + My Contributions + Sign Out; no admin section.
- [ ] Authed superuser: account menu shows admin section with Kiosk Config + Django Admin; Django Admin does a hard navigation.
- [ ] Tablet (641-832px): Changelog moves into hamburger under "activity"; primary nav still inline.
- [ ] Mobile (<641px): Titles/Manufacturers/People also move into hamburger; bar shows only logo/search/☰.
- [ ] Current-page highlight visible in both themes; hover style consistent with current highlight in light mode.
- [ ] Hamburger closes on Escape, outside click, and after selecting an item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)