### PR TITLE
nav: review follow-ups from PR #337

### DIFF
--- a/frontend/src/lib/components/MenuItem.svelte
+++ b/frontend/src/lib/components/MenuItem.svelte
@@ -13,7 +13,9 @@
     onclick?: () => void;
     disabled?: boolean;
     current?: boolean;
-    /** Force a full-page navigation. Set for non-SvelteKit routes (e.g. Django views). */
+    /** Force a full-page navigation. Only meaningful when `href` is set —
+     *  ignored for button-style items. Set for non-SvelteKit routes
+     *  (e.g. Django views). */
     reload?: boolean;
     children: Snippet;
   } = $props();
@@ -62,8 +64,8 @@
 
 <style>
   /* Parents may override --menu-item-font-size and --menu-item-padding via
-     inheritance to retune density (e.g. nav uses larger items than the
-     compact image-category picker). */
+     inheritance to retune density. Defaults are sized for compact in-page
+     menus; the site nav scales them up. */
   .menu-item {
     display: block;
     width: 100%;
@@ -100,9 +102,15 @@
 
   /* Menus: "you are here" gets a tinted background that adapts to both
      themes (ink on warm-cream in light mode, light gray on near-black in
-     dark mode). */
+     dark mode). On hover/focus, deepen the tint so the item visibly
+     reacts even though it's already highlighted. */
   .menu-item.current[role='menuitem'] {
     background: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
+  }
+
+  .menu-item.current[role='menuitem']:hover,
+  .menu-item.current[role='menuitem']:focus-visible {
+    background: color-mix(in srgb, var(--color-text-primary) 18%, transparent);
   }
 
   /* Listboxes: the selected option gets a checkmark, like a native <select>. */

--- a/frontend/src/lib/components/MenuSectionHeader.svelte
+++ b/frontend/src/lib/components/MenuSectionHeader.svelte
@@ -4,7 +4,9 @@
   let { children }: { children: Snippet } = $props();
 </script>
 
-<div class="menu-section-header">
+<!-- role="presentation" keeps this label out of the AT menu-item list while
+     leaving its text content visible to sighted users. -->
+<div class="menu-section-header" role="presentation">
   {@render children()}
 </div>
 

--- a/frontend/src/lib/components/Nav.dom.test.ts
+++ b/frontend/src/lib/components/Nav.dom.test.ts
@@ -1,8 +1,10 @@
 // Responsive bar layout (desktop vs tablet vs mobile) is verified visually,
-// not in JSDOM — these tests cover the menu contents per auth state.
+// not in JSDOM — these tests cover the menu contents per auth state. The
+// mobile-menu test mocks matchMedia to flip the isMobile flag; everything
+// else relies on the default JSDOM matchMedia stub (matches: false).
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { pageState, auth } = vi.hoisted(() => ({
   pageState: {
@@ -26,6 +28,7 @@ vi.mock('$app/paths', () => ({ resolve: (p: string) => p }));
 vi.mock('$lib/auth.svelte', () => ({ auth }));
 
 import Nav from './Nav.svelte';
+import { toast } from '$lib/toast/toast.svelte';
 
 function setAuth(overrides: Partial<typeof auth>) {
   Object.assign(auth, {
@@ -43,6 +46,7 @@ function setAuth(overrides: Partial<typeof auth>) {
 describe('Nav', () => {
   beforeEach(() => {
     pageState.url = new URL('http://localhost:5173/');
+    toast._resetForTest();
   });
 
   it('anonymous: renders Sign in link, no avatar, no admin items', async () => {
@@ -50,7 +54,7 @@ describe('Nav', () => {
     setAuth({});
     render(Nav);
 
-    expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sign In' })).toBeInTheDocument();
     expect(screen.queryByTestId('avatar')).not.toBeInTheDocument();
 
     // Open the hamburger and confirm there's no admin section.
@@ -120,5 +124,68 @@ describe('Nav', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Sign Out' }));
 
     expect(auth.logout).toHaveBeenCalledTimes(1);
+    // Wait a microtask for the awaited logout to resolve before checking the toast.
+    await Promise.resolve();
+    expect(toast.messages.map((m) => m.text)).toContain('Signed out');
+  });
+
+  it('hamburger renders even when auth has not loaded yet', async () => {
+    setAuth({ loaded: false });
+    render(Nav);
+
+    // Hamburger trigger must always be reachable so mobile users can open
+    // the primary nav before /api/auth/me/ resolves.
+    expect(screen.getByRole('button', { name: 'Menu' })).toBeInTheDocument();
+    // Auth-dependent menu items must not appear yet.
+    expect(screen.queryByRole('menuitem', { name: 'Sign In' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Sign Out' })).not.toBeInTheDocument();
+  });
+
+  describe('mobile (width <= 40rem)', () => {
+    let originalMatchMedia: typeof window.matchMedia;
+
+    beforeEach(() => {
+      originalMatchMedia = window.matchMedia;
+      window.matchMedia = ((query: string) => ({
+        matches: query === '(max-width: 40rem)',
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+        onchange: null,
+      })) as unknown as typeof window.matchMedia;
+    });
+
+    afterEach(() => {
+      window.matchMedia = originalMatchMedia;
+    });
+
+    it('hamburger menu includes Titles / Manufacturers / People plus Changelog', async () => {
+      const user = userEvent.setup();
+      setAuth({});
+      render(Nav);
+
+      await user.click(screen.getByRole('button', { name: 'Menu' }));
+      expect(screen.getByRole('menuitem', { name: 'Titles' })).toHaveAttribute('href', '/titles');
+      expect(screen.getByRole('menuitem', { name: 'Manufacturers' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'People' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Changelog' })).toBeInTheDocument();
+    });
+  });
+
+  it('tablet (default JSDOM matchMedia): hamburger menu does NOT include primary nav items', async () => {
+    const user = userEvent.setup();
+    setAuth({});
+    render(Nav);
+
+    await user.click(screen.getByRole('button', { name: 'Menu' }));
+    // Primary nav stays in the bar at tablet width; only Changelog appears
+    // in the menu (under "activity").
+    expect(screen.queryByRole('menuitem', { name: 'Titles' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Manufacturers' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'People' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Changelog' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -12,6 +12,8 @@
   import { SITE_NAME } from '$lib/constants';
   import { resolveHref } from '$lib/utils';
   import { auth } from '$lib/auth.svelte';
+  import { createIsMobileFlag } from '$lib/use-is-mobile.svelte';
+  import { toast } from '$lib/toast/toast.svelte';
 
   const navItems = [
     { href: '/titles' as const, label: 'Titles' },
@@ -24,29 +26,27 @@
     return page.url.pathname.startsWith(href);
   }
 
-  let isMobile = $state(false);
+  // Matches the mobile CSS tier below: width <= 40rem (640px). Used to
+  // decide whether the hamburger menu duplicates the primary nav items —
+  // tablet keeps them in the bar, mobile collapses them in.
+  const isMobileFlag = createIsMobileFlag(40);
+  const isMobile = $derived(isMobileFlag.current === true);
 
   $effect(() => {
     auth.load();
   });
 
-  $effect(() => {
-    const mq = window.matchMedia('(width < 40.0625rem)');
-    isMobile = mq.matches;
-    const handler = (event: MediaQueryListEvent) => {
-      isMobile = event.matches;
-    };
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  });
-
   async function handleLogout() {
     await auth.logout();
+    toast.success('Signed out');
   }
 
   function loginHref() {
     return `/api/auth/login/?next=${encodeURIComponent(page.url.pathname)}`;
   }
+
+  const myContributionsHref = $derived(resolveHref(`/users/${auth.username}`));
+  const myContributionsActive = $derived(isActive(`/users/${auth.username}`));
 
   const randInt = (max: number) => Math.floor(Math.random() * max);
 
@@ -80,23 +80,35 @@
   <div class="header-inner">
     <a href={resolve('/')} class="site-title">{SITE_NAME}</a>
 
-    <nav class="primary-nav desktop-nav" aria-label="Primary">
+    {#snippet adminSection()}
+      <MenuSectionHeader>admin</MenuSectionHeader>
+      <MenuItem href={resolve('/kiosk/configure')} current={isActive('/kiosk/configure')}>
+        Kiosk Config
+      </MenuItem>
+      <MenuItem href="/admin/" reload>Django Admin</MenuItem>
+    {/snippet}
+
+    {#snippet userSection()}
+      <MenuSectionHeader>{auth.username}</MenuSectionHeader>
+      <MenuItem href={myContributionsHref} current={myContributionsActive}>
+        My Contributions
+      </MenuItem>
+      <MenuItem onclick={handleLogout}>Sign Out</MenuItem>
+    {/snippet}
+
+    <nav class="primary-nav" aria-label="Primary">
       {#each navItems as { href, label } (href)}
         <a href={resolve(href)} class="nav-link" class:active={isActive(href)}>
           {label}
         </a>
       {/each}
-      <a href={resolve(changelogHref)} class="nav-link" class:active={isActive(changelogHref)}>
+      <a
+        href={resolve(changelogHref)}
+        class="nav-link changelog-link"
+        class:active={isActive(changelogHref)}
+      >
         Changelog
       </a>
-    </nav>
-
-    <nav class="primary-nav tablet-nav" aria-label="Primary">
-      {#each navItems as { href, label } (href)}
-        <a href={resolve(href)} class="nav-link" class:active={isActive(href)}>
-          {label}
-        </a>
-      {/each}
     </nav>
 
     <div class="header-actions">
@@ -117,70 +129,53 @@
                 <Avatar
                   firstName={auth.firstName}
                   lastName={auth.lastName}
-                  username={auth.username!}
+                  username={auth.username ?? ''}
                 />
               {/snippet}
               {#if auth.isSuperuser}
-                <MenuSectionHeader>admin</MenuSectionHeader>
-                <MenuItem href={resolve('/kiosk/configure')} current={isActive('/kiosk/configure')}>
-                  Kiosk Config
-                </MenuItem>
-                <MenuItem href="/admin/" reload>Django Admin</MenuItem>
+                {@render adminSection()}
                 <MenuDivider />
               {/if}
-              <MenuSectionHeader>{auth.username}</MenuSectionHeader>
-              <MenuItem
-                href={resolveHref(`/users/${auth.username}`)}
-                current={isActive(`/users/${auth.username}`)}
-              >
-                My Contributions
-              </MenuItem>
-              <MenuItem onclick={handleLogout}>Sign Out</MenuItem>
+              {@render userSection()}
             </ActionMenu>
           {:else}
-            <a href={loginHref()} class="auth-link" data-sveltekit-reload>Sign in</a>
+            <a href={loginHref()} class="auth-link" data-sveltekit-reload>Sign In</a>
           {/if}
         </div>
+      {/if}
 
-        <div class="hamburger">
-          <ActionMenu label="Menu" variant="bare" ariaLabel="Menu">
-            {#snippet trigger()}
-              <FaIcon icon={faBars} size="1.25rem" />
-            {/snippet}
-            {#if isMobile}
-              {#each navItems as { href, label } (href)}
-                <MenuItem href={resolve(href)} current={isActive(href)}>{label}</MenuItem>
-              {/each}
-              <MenuDivider />
-            {/if}
-            <MenuSectionHeader>activity</MenuSectionHeader>
-            <MenuItem href={resolve(changelogHref)} current={isActive(changelogHref)}>
-              Changelog
-            </MenuItem>
+      <!-- Hamburger renders unconditionally so mobile users always have a way
+           to reach Titles / Manufacturers / People, even before auth resolves.
+           Auth-dependent sections inside skip rendering until auth.loaded. -->
+      <div class="hamburger">
+        <ActionMenu label="Menu" variant="bare" ariaLabel="Menu">
+          {#snippet trigger()}
+            <FaIcon icon={faBars} size="1.25rem" />
+          {/snippet}
+          {#if isMobile}
+            {#each navItems as { href, label } (href)}
+              <MenuItem href={resolve(href)} current={isActive(href)}>{label}</MenuItem>
+            {/each}
+            <MenuDivider />
+          {/if}
+          <MenuSectionHeader>activity</MenuSectionHeader>
+          <MenuItem href={resolve(changelogHref)} current={isActive(changelogHref)}>
+            Changelog
+          </MenuItem>
+          {#if auth.loaded}
             {#if auth.isSuperuser}
               <MenuDivider />
-              <MenuSectionHeader>admin</MenuSectionHeader>
-              <MenuItem href={resolve('/kiosk/configure')} current={isActive('/kiosk/configure')}>
-                Kiosk Config
-              </MenuItem>
-              <MenuItem href="/admin/" reload>Django Admin</MenuItem>
+              {@render adminSection()}
             {/if}
             <MenuDivider />
             {#if auth.isAuthenticated}
-              <MenuSectionHeader>{auth.username}</MenuSectionHeader>
-              <MenuItem
-                href={resolveHref(`/users/${auth.username}`)}
-                current={isActive(`/users/${auth.username}`)}
-              >
-                My Contributions
-              </MenuItem>
-              <MenuItem onclick={handleLogout}>Sign Out</MenuItem>
+              {@render userSection()}
             {:else}
               <MenuItem href={loginHref()} reload>Sign In</MenuItem>
             {/if}
-          </ActionMenu>
-        </div>
-      {/if}
+          {/if}
+        </ActionMenu>
+      </div>
     </div>
   </div>
 
@@ -376,20 +371,19 @@
     color: var(--header-ink);
   }
 
-  /* ── Three responsive tiers via Media Queries Level 4 range syntax ── */
-  .tablet-nav {
-    display: none;
-  }
+  /* ── Three responsive tiers via Media Queries Level 4 range syntax ──
+     Mobile (≤ 40rem / 640px): only logo, search, hamburger.
+     Tablet (40rem–52rem / 641–831px): bar shows primary nav minus Changelog,
+       plus hamburger; account menu collapses into hamburger.
+     Desktop (≥ 52rem / 832px): full bar including Changelog and account menu;
+       hamburger hidden. */
   .hamburger {
     display: none;
   }
 
-  @media (width >= 40.0625rem) and (width < 52rem) {
-    .desktop-nav {
+  @media (width <= 40rem) {
+    .primary-nav {
       display: none;
-    }
-    .tablet-nav {
-      display: flex;
     }
     .desktop-account {
       display: none;
@@ -399,11 +393,8 @@
     }
   }
 
-  @media (width < 40.0625rem) {
-    .desktop-nav {
-      display: none;
-    }
-    .tablet-nav {
+  @media (width > 40rem) and (width < 52rem) {
+    .changelog-link {
       display: none;
     }
     .desktop-account {


### PR DESCRIPTION
## Summary

Follow-ups from #337 (the nav redesign). Architectural fixes first, then polish, plus a small feature.

### Architectural

- **Hamburger renders before auth loads.** Previously the hamburger was inside `{#if auth.loaded}`, so mobile users saw a navless header until `/api/auth/me/` resolved — losing access to Titles / Manufacturers / People. Now only the auth-dependent menu sections wait on `auth.loaded`.
- **Single `<nav>` element.** Collapsed `desktop-nav` + `tablet-nav` (which had duplicate items) into one `.primary-nav`; Changelog hides at the tablet tier via `.changelog-link { display: none }`. Adding a primary link is now one place.
- **Shared menu snippets.** Extracted `adminSection` and `userSection` snippets so the desktop account menu and the hamburger menu share their auth-dependent contents instead of duplicating them.
- **Mobile-branch test coverage.** New `Nav.dom.test.ts` cases override `window.matchMedia` to flip `isMobile`, asserting the hamburger contains Titles/Manufacturers/People on mobile and *doesn't* on tablet. Plus a regression test that the hamburger trigger renders before auth loads.
- **Reuse `createIsMobileFlag(40)`** instead of an inline `matchMedia` effect, matching the convention in `TaxonomyDetailBaseLayout` and friends.
- **Drop `40.0625rem` magic number.** With the duplicated nav gone, the breakpoints simplify to `<= 40rem` / `> 40rem` range syntax.

### Polish

- Unify capitalization to "Sign In" on the desktop link (was "Sign in", didn't match the hamburger menuitem).
- `role="presentation"` on `MenuSectionHeader` so it stays out of the AT menuitem list.
- Replace `auth.username!` non-null assertion with `?? ''`; `initialsFor` handles empty username.
- Make a hovered current menu item visibly react (deeper tint) rather than no-op.
- Tighten the `MenuItem` density-tokens comment and clarify in JSDoc that `reload` only applies when `href` is set.

### Feature

- Show a `toast.success('Signed out')` after `auth.logout()` resolves. Toast lives at the call site (Nav), consistent with every other `toast.success` in the codebase — stores stay UI-agnostic.

## Test plan

- [x] `pnpm vitest run` — 1051/1051 pass
- [x] `make lint` — clean
- [x] `pnpm svelte-check` — 0 errors / 0 warnings
- [ ] Manual browser check at three widths (≤640, 641–831, ≥832), light + dark, anonymous / authed / superuser
- [ ] Sign Out toast appears after the logout request resolves
- [ ] Mobile users can open the hamburger before auth loads and reach Titles/Manufacturers/People

🤖 Generated with [Claude Code](https://claude.com/claude-code)