### PR TITLE
fix(frontend): portal wikilink dropdown via Floating UI to escape modal clipping

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.7.6",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "diff": "^9.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@floating-ui/dom':
+        specifier: ^1.7.6
+        version: 1.7.6
       '@fortawesome/fontawesome-svg-core':
         specifier: ^7.2.0
         version: 7.2.0
@@ -413,6 +416,15 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@fortawesome/fontawesome-common-types@7.2.0':
     resolution: {integrity: sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==}
@@ -2950,6 +2962,17 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0': {}
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@fortawesome/fontawesome-common-types@7.2.0': {}
 

--- a/frontend/src/lib/actions/floating.ts
+++ b/frontend/src/lib/actions/floating.ts
@@ -1,0 +1,135 @@
+/**
+ * Svelte action that portals an element out of its original location and
+ * positions it relative to an anchor (DOM element or virtual reference) using
+ * Floating UI.
+ *
+ * Solves two problems at once:
+ * 1. Portaling escapes ancestor `overflow: hidden` clipping (e.g. inside Modal).
+ * 2. Floating UI handles flip/shift/size so dropdowns stay in the viewport.
+ *
+ * The portal target is the topmost element under `<body>` that contains the
+ * node — i.e. the Svelte mount root — so delegated event handlers
+ * (`onclick`, `onkeydown`, etc.) on the portaled subtree continue to fire.
+ *
+ * `@floating-ui/dom` is dynamically imported so anonymous readers don't pay for
+ * code that only editors hit.
+ */
+
+import type { Action } from 'svelte/action';
+
+type VirtualElement = {
+  getBoundingClientRect: () => DOMRect;
+  contextElement?: Element;
+};
+
+type FloatingUiModule = typeof import('@floating-ui/dom');
+
+export type FloatingAnchor = Element | VirtualElement;
+
+export type FloatingOptions = {
+  anchor: FloatingAnchor;
+  placement?:
+    | 'top'
+    | 'top-start'
+    | 'top-end'
+    | 'bottom'
+    | 'bottom-start'
+    | 'bottom-end'
+    | 'left'
+    | 'left-start'
+    | 'left-end'
+    | 'right'
+    | 'right-start'
+    | 'right-end';
+  /** Gap between anchor and floating element, in px. */
+  offset?: number;
+  /** Padding from the viewport edge for `flip`/`shift`, in px. */
+  padding?: number;
+};
+
+let modulePromise: Promise<FloatingUiModule> | undefined;
+function loadFloatingUi(): Promise<FloatingUiModule> {
+  modulePromise ??= import('@floating-ui/dom');
+  return modulePromise;
+}
+
+function findPortalTarget(node: Element): HTMLElement {
+  let el: Element = node;
+  while (el.parentElement && el.parentElement !== document.body) {
+    el = el.parentElement;
+  }
+  return (el.parentElement === document.body ? el : document.body) as HTMLElement;
+}
+
+export const floating: Action<HTMLElement, FloatingOptions> = (node, options) => {
+  let currentOptions = options;
+  let destroyed = false;
+  let fui: FloatingUiModule | undefined;
+  let cleanupAutoUpdate: (() => void) | undefined;
+  let subscribedAnchor: FloatingAnchor | undefined;
+
+  // Hide until the first position resolves to avoid a top-left flash on first
+  // open (the dynamic import is async, so the floating element would otherwise
+  // be visible briefly at translate(0,0) before computePosition runs).
+  const originalVisibility = node.style.visibility;
+  node.style.visibility = 'hidden';
+  node.style.position = 'fixed';
+  node.style.top = '0';
+  node.style.left = '0';
+
+  const portalTarget = findPortalTarget(node);
+  portalTarget.appendChild(node);
+
+  function reposition() {
+    if (!fui) return;
+    const opts = currentOptions;
+    const middleware = [
+      fui.offset(opts.offset ?? 4),
+      fui.flip({ padding: opts.padding ?? 8 }),
+      fui.shift({ padding: opts.padding ?? 8 }),
+    ];
+
+    void fui
+      .computePosition(opts.anchor, node, {
+        placement: opts.placement ?? 'bottom-start',
+        strategy: 'fixed',
+        middleware,
+      })
+      .then(({ x, y }) => {
+        if (destroyed) return;
+        node.style.transform = `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
+        node.style.visibility = originalVisibility;
+      });
+  }
+
+  function subscribe() {
+    if (!fui) return;
+    cleanupAutoUpdate?.();
+    subscribedAnchor = currentOptions.anchor;
+    cleanupAutoUpdate = fui.autoUpdate(subscribedAnchor, node, reposition);
+  }
+
+  void loadFloatingUi().then((mod) => {
+    if (destroyed) return;
+    fui = mod;
+    subscribe();
+  });
+
+  return {
+    update(next: FloatingOptions) {
+      currentOptions = next;
+      if (next.anchor !== subscribedAnchor) {
+        subscribe();
+      } else {
+        reposition();
+      }
+    },
+    destroy() {
+      destroyed = true;
+      cleanupAutoUpdate?.();
+      if (node.parentElement === portalTarget) {
+        node.remove();
+      }
+    },
+  };
+};

--- a/frontend/src/lib/components/form/MarkdownTextArea.svelte
+++ b/frontend/src/lib/components/form/MarkdownTextArea.svelte
@@ -4,6 +4,7 @@
   import WikilinkAutocomplete from './WikilinkAutocomplete.svelte';
   import { fetchLinkTypes } from '$lib/api/link-types';
   import { detectTrigger, spliceLink } from './wikilink-helpers';
+  import { floating } from '$lib/actions/floating';
   import {
     toggleMarker,
     wrapSelection,
@@ -48,17 +49,22 @@
   let open = $state(false);
   let triggerStart = $state(-1);
   let initialType: string | undefined = $state();
-  let dropdownLeft = $state(0);
-  let dropdownTop = $state(0);
+  let cursorRect = $state<DOMRect>(new DOMRect());
   let textareaBlurTimeout: ReturnType<typeof setTimeout> | undefined;
   let autocompleteBlurTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  // Virtual reference element for Floating UI: returns the current cursor's
+  // viewport rect so the dropdown anchors to the caret position in the textarea.
+  const cursorAnchor = {
+    getBoundingClientRect: () => cursorRect,
+  };
 
   // -----------------------------------------------------------------------
   // Cursor position via mirror div
   // -----------------------------------------------------------------------
 
-  function getCursorPosition(): { left: number; top: number } {
-    if (!textareaEl || !mirrorEl) return { left: 0, top: 0 };
+  function getCursorRect(): DOMRect {
+    if (!textareaEl || !mirrorEl) return new DOMRect();
 
     // Copy textarea styles to mirror
     const computed = window.getComputedStyle(textareaEl);
@@ -82,16 +88,20 @@
     mirrorEl.innerHTML = escaped + '<span data-cursor></span>';
 
     const cursorSpan = mirrorEl.querySelector('[data-cursor]');
-    if (!cursorSpan) return { left: 0, top: 0 };
+    if (!cursorSpan) return new DOMRect();
 
-    const cursorRect = cursorSpan.getBoundingClientRect();
+    // Mirror replicates textarea layout but lives elsewhere in the DOM. The
+    // span's offset within the mirror equals the caret's offset within the
+    // textarea, so add the textarea's viewport position and subtract scroll.
+    const spanRect = cursorSpan.getBoundingClientRect();
+    const mirrorRect = mirrorEl.getBoundingClientRect();
     const textareaRect = textareaEl.getBoundingClientRect();
-
-    let left = cursorRect.left - textareaRect.left + textareaEl.scrollLeft;
-    let top = cursorRect.top - textareaRect.top - textareaEl.scrollTop + cursorSpan.clientHeight;
-    top = Math.min(top, textareaEl.offsetHeight - 20);
-
-    return { left, top };
+    return new DOMRect(
+      textareaRect.left + (spanRect.left - mirrorRect.left) - textareaEl.scrollLeft,
+      textareaRect.top + (spanRect.top - mirrorRect.top) - textareaEl.scrollTop,
+      1,
+      cursorSpan.clientHeight,
+    );
   }
 
   // -----------------------------------------------------------------------
@@ -114,9 +124,7 @@
 
   function openDropdown() {
     clearBlurTimeouts();
-    const pos = getCursorPosition();
-    dropdownLeft = pos.left;
-    dropdownTop = pos.top;
+    cursorRect = getCursorRect();
     open = true;
   }
 
@@ -247,11 +255,13 @@
     }
   }
 
-  // Click outside to close
+  // Click outside to close. The dropdown is portaled to <body>, so check both
+  // the wrapper (for the textarea/toolbar) and the dropdown itself.
   $effect(() => {
     if (!open) return;
     function onPointerDown(e: PointerEvent) {
-      if (!wrapperEl?.contains(e.target as Node)) {
+      const target = e.target as Node;
+      if (!wrapperEl?.contains(target) && !autocompleteEl?.contains(target)) {
         closeDropdown();
       }
     }
@@ -354,10 +364,9 @@
     <div
       class="link-dropdown"
       role="presentation"
-      style:left="{dropdownLeft}px"
-      style:top="{dropdownTop}px"
       bind:this={autocompleteEl}
-      onmousedown={(e) => {
+      use:floating={{ anchor: cursorAnchor, placement: 'bottom-start', offset: 4 }}
+      onmousedown={(e: MouseEvent) => {
         if (!(e.target instanceof HTMLInputElement)) e.preventDefault();
       }}
       onfocusout={handleAutocompleteFocusout}
@@ -403,7 +412,7 @@
   /* ----- Dropdown ----- */
 
   .link-dropdown {
-    position: absolute;
+    /* Position is set by the `floating` action (portaled to <body>). */
     z-index: var(--z-dropdown);
     min-width: 16rem;
     max-width: 24rem;


### PR DESCRIPTION
Closes #341 for the wikilink dropdown.

## Problem

The link-dropdown opened from `MarkdownTextArea` inside a Modal was clipped by `.modal-dialog`'s `overflow: hidden`. Not a z-index issue — `overflow: hidden` clips descendants regardless of stacking order.

The same trap is latent in `ActionMenu`, `SearchableSelect`, and `CitationTooltip`, which also use `position: absolute` with hardcoded z-index inside potentially-clipped ancestors.

## Fix

Introduces a small `floating` Svelte action ([frontend/src/lib/actions/floating.ts](frontend/src/lib/actions/floating.ts)) that:

- Portals the element out of its original location so ancestor `overflow: hidden` can't clip it.
- Positions it relative to an anchor (DOM element or virtual reference) using `@floating-ui/dom` — `flip` + `shift` + `offset` middleware, plus `autoUpdate` for scroll/resize tracking.
- Dynamically imports `@floating-ui/dom` so anonymous readers don't pay for editor-only code (~6KB lands in an async chunk loaded by edit-page route nodes).

Migrates `MarkdownTextArea`'s `.link-dropdown` to use it. The cursor caret has no DOM element, so the action is fed a virtual reference whose `getBoundingClientRect()` returns the caret's viewport position.

`ActionMenu` / `SearchableSelect` / `CitationTooltip` are deliberately untouched in this PR — they each have their own latent issues (manual `up` flip prop, fixed `max-height`, etc.) worth separate review.

## Subtle gotcha worth knowing

The portal target is the **Svelte mount root** (the topmost element under `<body>` containing the node), not `<body>` itself. Svelte 5 delegates events (`onclick`, `onkeydown`, `onfocusout`, ...) at the mount root — elements moved outside that root silently stop receiving handlers. Discovered while debugging a citation-dropdown test that started failing after the initial `<body>` portal.

This will matter for the future ActionMenu / SearchableSelect / CitationTooltip migrations.

## Test plan

- [x] All 1051 frontend tests pass (including DOM tests that exercise dropdown keyboard nav, focus management, and the citation `stopPropagation` chain — all of which would have broken if the portal target was outside Svelte's delegation tree).
- [x] `pnpm build` confirms `@floating-ui/dom` lands in async-only chunks loaded by edit-page nodes, not the main bundle.
- [x] `svelte-check` clean on changed files.
- [ ] **Manual repro from #341 (please verify):** Bally → Description → Edit → click link button in markdown toolbar → dropdown should no longer be clipped by modal edge.

## Out of scope (potential follow-ups)

- Adopt the same action for `ActionMenu` (replace the manual `up` prop with auto-flip).
- Adopt for `SearchableSelect` (use `size` middleware to set `max-height` from available viewport space instead of fixed `18rem`).
- Adopt for `CitationTooltip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)