### PR TITLE
fix(frontend): forward Cookie header on cross-origin SSR fetches

### DIFF
--- a/docs/ApiDesign.md
+++ b/docs/ApiDesign.md
@@ -144,7 +144,7 @@ Be skeptical of SSR routes that call multiple backend endpoints from `load()`. T
 
 Server-side Svelte routes should call Django through `createServerClient` from `$lib/api/server`, not through ad hoc fetch wrappers or direct backend internals.
 
-`createServerClient(fetch, url)` resolves `INTERNAL_API_BASE_URL` (direct-to-Django in production) with a fallback to the request origin (Vite proxy in dev). See `docs/Svelte.md` for the full pattern.
+`createServerClient(fetch, url, request)` resolves `INTERNAL_API_BASE_URL` (direct-to-Django in production) with a fallback to the request origin (Vite proxy in dev). The `request` argument is required so the user's Cookie header is forwarded across origins. See `docs/Svelte.md` for the full pattern.
 
 This keeps the boundary clean:
 

--- a/docs/SSRConversion.md
+++ b/docs/SSRConversion.md
@@ -26,7 +26,7 @@ For a typical detail page conversion:
 2. tag it `tags=["private"]`
 3. reuse existing serializer/query logic when the existing resource endpoint already returns the right page model
 4. replace `+layout.ts` or `+page.ts` with `+layout.server.ts` or `+page.server.ts`
-5. use `createServerClient(fetch, url)` from `$lib/api/server`
+5. use `createServerClient(fetch, url, request)` from `$lib/api/server`
 6. audit every child route before removing inherited `ssr = false`
 7. remove the old resource detail endpoint and migrate its tests (see [Removing the Old Detail Endpoint](#removing-the-old-detail-endpoint))
 8. add frontend SSR tests (backend coverage comes from step 7)
@@ -55,7 +55,7 @@ When converting the route loader:
 
 - replace `+page.ts` with `+page.server.ts`, or `+layout.ts` with `+layout.server.ts`
 - remove browser `client` usage from the server load path
-- use `createServerClient(fetch, url)` from `$lib/api/server`
+- use `createServerClient(fetch, url, request)` from `$lib/api/server` — the `request` argument is required so the user's Cookie header is forwarded across origins to Django
 - `$lib/api/server` imports `$env/dynamic/private` and can only be used in server-side files (`+page.server.ts`, `+layout.server.ts`) — importing it from a universal `+page.ts` will error
 - fetch one backend endpoint that already matches the page
 - return the page model directly to the route
@@ -67,8 +67,13 @@ import { error } from "@sveltejs/kit";
 import { createServerClient } from "$lib/api/server";
 import type { LayoutServerLoad } from "./$types";
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({
+  fetch,
+  url,
+  request,
+  params,
+}) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET("/api/pages/title/{slug}", {
     params: { path: { slug: params.slug } },
   });

--- a/docs/Svelte.md
+++ b/docs/Svelte.md
@@ -82,8 +82,8 @@ Use `createServerClient` from `$lib/api/server`:
 ```ts
 import { createServerClient } from "$lib/api/server";
 
-export const load: PageServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: PageServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET("/api/pages/title/{public_id}", {
     params: { path: { public_id: params.slug } },
   });
@@ -91,7 +91,7 @@ export const load: PageServerLoad = async ({ fetch, url, params }) => {
 };
 ```
 
-`createServerClient` resolves `INTERNAL_API_BASE_URL` (direct-to-Django in production) with a fallback to the request origin (Vite proxy in dev). Every SSR load function should use this helper instead of constructing the client manually.
+`createServerClient` resolves `INTERNAL_API_BASE_URL` (direct-to-Django in production) with a fallback to the request origin (Vite proxy in dev). Every SSR load function should use this helper instead of constructing the client manually. Passing `request` is required: in production SSR crosses origins to reach Django, and SvelteKit's `event.fetch` only forwards cookies same-origin, so the helper forwards the user's `Cookie` header from the incoming request — without it, every authenticated endpoint sees an anonymous request.
 
 This keeps:
 

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -4,7 +4,7 @@ import client, { createApiClient } from './client';
 describe('api client', () => {
   it('throws if the default client is used on the server', () => {
     expect(() => client.GET).toThrow(
-      'The default API client is browser-only. Server-side routes must use createApiClient(fetch, baseUrl?) instead.',
+      'The default API client is browser-only. Server-side routes must use createServerClient(fetch, url, request) from $lib/api/server instead.',
     );
   });
 
@@ -22,6 +22,42 @@ describe('api client', () => {
     const request = fetch.mock.calls[0]?.[0];
     expect(request).toBeInstanceOf(Request);
     expect(request.url).toBe('http://localhost:5173/api/health');
+  });
+
+  describe('cookie forwarding for SSR', () => {
+    it('forwards the Cookie header from the incoming request', async () => {
+      const fetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      const incoming = new Request('https://flipcommons.org/kiosk/edit', {
+        headers: { cookie: 'sessionid=abc; csrftoken=xyz' },
+      });
+      const apiClient = createApiClient(fetch, 'http://127.0.0.1:8000', incoming);
+
+      await apiClient.GET('/api/auth/me/');
+
+      const request = fetch.mock.calls[0]?.[0] as Request;
+      expect(request.headers.get('cookie')).toBe('sessionid=abc; csrftoken=xyz');
+    });
+
+    it('does not set a Cookie header when the incoming request has none', async () => {
+      const fetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      const incoming = new Request('https://flipcommons.org/kiosk/edit');
+      const apiClient = createApiClient(fetch, 'http://127.0.0.1:8000', incoming);
+
+      await apiClient.GET('/api/auth/me/');
+
+      const request = fetch.mock.calls[0]?.[0] as Request;
+      expect(request.headers.get('cookie')).toBeNull();
+    });
   });
 
   describe('public_id path-param slash preservation', () => {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -7,7 +7,11 @@ export function getCsrfToken(): string | undefined {
   return match?.[1];
 }
 
-export function createApiClient(fetchImpl: typeof fetch = fetch, baseUrl = '') {
+export function createApiClient(
+  fetchImpl: typeof fetch = fetch,
+  baseUrl = '',
+  incomingRequest?: Request,
+) {
   const client = createClient<paths>({
     baseUrl,
     fetch: fetchImpl,
@@ -15,6 +19,12 @@ export function createApiClient(fetchImpl: typeof fetch = fetch, baseUrl = '') {
       'Content-Type': 'application/json',
     },
   });
+
+  // SvelteKit's event.fetch only forwards cookies for same-origin requests.
+  // When INTERNAL_API_BASE_URL points SSR at Django on a different origin
+  // (e.g. http://127.0.0.1:8000 in prod), we must forward the user's Cookie
+  // header manually or authenticated endpoints see an anonymous request.
+  const forwardedCookie = incomingRequest?.headers.get('cookie') ?? null;
 
   client.use({
     async onRequest({ request }) {
@@ -25,6 +35,10 @@ export function createApiClient(fetchImpl: typeof fetch = fetch, baseUrl = '') {
       if (decoded !== url.pathname) {
         url.pathname = decoded;
         request = new Request(url, request);
+      }
+
+      if (forwardedCookie) {
+        request.headers.set('cookie', forwardedCookie);
       }
 
       const method = request.method.toUpperCase();
@@ -46,7 +60,7 @@ let browserClient: ReturnType<typeof createApiClient> | null = null;
 function getBrowserClient() {
   if (typeof window === 'undefined') {
     throw new Error(
-      'The default API client is browser-only. Server-side routes must use createApiClient(fetch, baseUrl?) instead.',
+      'The default API client is browser-only. Server-side routes must use createServerClient(fetch, url, request) from $lib/api/server instead.',
     );
   }
   browserClient ??= createApiClient(window.fetch.bind(window));

--- a/frontend/src/lib/api/server.ts
+++ b/frontend/src/lib/api/server.ts
@@ -1,22 +1,26 @@
 /**
  * Server-side API client factory for SSR load functions.
  *
- * Resolves INTERNAL_API_BASE_URL (direct-to-Django in production)
- * with a fallback to the request origin (Vite proxy in dev).
+ * Resolves INTERNAL_API_BASE_URL (direct-to-Django in production) with a
+ * fallback to the request origin (Vite proxy in dev). The incoming `request`
+ * is required so the user's Cookie header is forwarded to Django: SvelteKit's
+ * `event.fetch` only forwards cookies same-origin, and in production SSR
+ * crosses origins to reach Django, so without this any auth-protected
+ * endpoint would see an anonymous request.
  *
  * Usage in +page.server.ts / +layout.server.ts:
  *
  *   import { createServerClient } from '$lib/api/server';
  *
- *   export const load = async ({ fetch, url, params }) => {
- *       const client = createServerClient(fetch, url);
+ *   export const load = async ({ fetch, url, request, params }) => {
+ *       const client = createServerClient(fetch, url, request);
  *       ...
  *   };
  */
 import { env } from '$env/dynamic/private';
 import { createApiClient } from './client';
 
-export function createServerClient(fetchImpl: typeof fetch, url: URL) {
+export function createServerClient(fetchImpl: typeof fetch, url: URL, request: Request) {
   const baseUrl = env.INTERNAL_API_BASE_URL?.trim() || url.origin;
-  return createApiClient(fetchImpl, baseUrl);
+  return createApiClient(fetchImpl, baseUrl, request);
 }

--- a/frontend/src/lib/provenance-loaders.test.ts
+++ b/frontend/src/lib/provenance-loaders.test.ts
@@ -16,9 +16,11 @@ const MOCK_SOURCES_PAYLOAD = {
 };
 
 function makeEvent(fetch: typeof globalThis.fetch, path: string) {
+  const url = new URL(`http://localhost:5173${path}`);
   return {
     fetch,
-    url: new URL(`http://localhost:5173${path}`),
+    url,
+    request: new Request(url),
   };
 }
 

--- a/frontend/src/lib/provenance-loaders.ts
+++ b/frontend/src/lib/provenance-loaders.ts
@@ -12,6 +12,7 @@ import type { CatalogEntityKey } from '$lib/api/catalog-meta';
 type LoadEvent = {
   fetch: typeof fetch;
   url: URL;
+  request: Request;
 };
 
 export async function loadEditHistory(
@@ -19,7 +20,7 @@ export async function loadEditHistory(
   entityType: CatalogEntityKey,
   public_id: string,
 ) {
-  const client = createServerClient(event.fetch, event.url);
+  const client = createServerClient(event.fetch, event.url, event.request);
   const { data, response } = await client.GET(
     '/api/pages/edit-history/{entity_type}/{public_id}/',
     {
@@ -39,7 +40,7 @@ export async function loadSources(
   entityType: CatalogEntityKey,
   public_id: string,
 ) {
-  const client = createServerClient(event.fetch, event.url);
+  const client = createServerClient(event.fetch, event.url, event.request);
   const { data, response } = await client.GET('/api/pages/sources/{entity_type}/{public_id}/', {
     params: { path: { entity_type: entityType, public_id } },
   });

--- a/frontend/src/routes/cabinets/[slug]/+layout.server.ts
+++ b/frontend/src/routes/cabinets/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/cabinet/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/corporate-entities/[slug]/+layout.server.ts
+++ b/frontend/src/routes/corporate-entities/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/corporate-entity/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/credit-roles/[slug]/+layout.server.ts
+++ b/frontend/src/routes/credit-roles/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/credit-role/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/display-subtypes/[slug]/+layout.server.ts
+++ b/frontend/src/routes/display-subtypes/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/display-subtype/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/display-types/[slug]/+layout.server.ts
+++ b/frontend/src/routes/display-types/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/display-type/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/franchises/[slug]/+layout.server.ts
+++ b/frontend/src/routes/franchises/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/franchise/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/game-formats/[slug]/+layout.server.ts
+++ b/frontend/src/routes/game-formats/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/game-format/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/gameplay-features/[slug]/+layout.server.ts
+++ b/frontend/src/routes/gameplay-features/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/gameplay-feature/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/kiosk/+page.server.ts
+++ b/frontend/src/routes/kiosk/+page.server.ts
@@ -1,14 +1,14 @@
 import { createServerClient } from '$lib/api/server';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ fetch, url, cookies }) => {
+export const load: PageServerLoad = async ({ fetch, url, request, cookies }) => {
   if (cookies.get('mode') !== 'kiosk') return { kioskConfig: null };
 
   const rawId = cookies.get('kioskConfigId');
   const id = rawId ? Number(rawId) : NaN;
   if (!Number.isInteger(id) || id <= 0) return { kioskConfig: null };
 
-  const client = createServerClient(fetch, url);
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/kiosk/{config_id}/', {
     params: { path: { config_id: id } },
   });

--- a/frontend/src/routes/kiosk/edit/+layout.server.ts
+++ b/frontend/src/routes/kiosk/edit/+layout.server.ts
@@ -3,8 +3,8 @@ import { resolve } from '$app/paths';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request }) => {
+  const client = createServerClient(fetch, url, request);
   const { data } = await client.GET('/api/auth/me/');
 
   if (!data?.is_authenticated) throw redirect(302, resolve('/login'));

--- a/frontend/src/routes/kiosk/edit/+page.server.ts
+++ b/frontend/src/routes/kiosk/edit/+page.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ fetch, url, cookies }) => {
-  const client = createServerClient(fetch, url);
+export const load: PageServerLoad = async ({ fetch, url, request, cookies }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/kiosk/configs/');
   if (!data) throw error(response?.status || 500, 'Failed to load kiosks');
 

--- a/frontend/src/routes/kiosk/edit/[id]/+page.server.ts
+++ b/frontend/src/routes/kiosk/edit/[id]/+page.server.ts
@@ -2,11 +2,11 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ fetch, url, params }) => {
+export const load: PageServerLoad = async ({ fetch, url, request, params }) => {
   const id = Number(params.id);
   if (!Number.isInteger(id) || id <= 0) throw error(404, 'Kiosk not found');
 
-  const client = createServerClient(fetch, url);
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/kiosk/configs/{config_id}/', {
     params: { path: { config_id: id } },
   });

--- a/frontend/src/routes/kiosk/edit/[id]/page-server.test.ts
+++ b/frontend/src/routes/kiosk/edit/[id]/page-server.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { GET, createServerClient } = vi.hoisted(() => {
+  const get = vi.fn();
+  return {
+    GET: get,
+    createServerClient: vi.fn(() => ({ GET: get })),
+  };
+});
+
+vi.mock('$lib/api/server', () => ({ createServerClient }));
+
+import { load } from './+page.server';
+
+function makeEvent(id: string) {
+  const url = new URL(`http://localhost/kiosk/edit/${id}`);
+  const request = new Request(url, { headers: { cookie: 'sessionid=abc' } });
+  return {
+    fetch: globalThis.fetch,
+    url,
+    request,
+    params: { id },
+  };
+}
+
+describe('/kiosk/edit/[id]/+page.server.ts load', () => {
+  beforeEach(() => {
+    GET.mockReset();
+    createServerClient.mockClear();
+  });
+
+  it('forwards request to createServerClient so SSR sees the user session', async () => {
+    GET.mockResolvedValue({ data: { id: 5 }, response: { status: 200 } });
+    const event = makeEvent('5');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await load(event as any);
+    expect(createServerClient).toHaveBeenCalledWith(event.fetch, event.url, event.request);
+  });
+});

--- a/frontend/src/routes/kiosk/edit/layout-server.test.ts
+++ b/frontend/src/routes/kiosk/edit/layout-server.test.ts
@@ -14,9 +14,12 @@ vi.mock('$app/paths', () => ({ resolve: (p: string) => p }));
 import { load } from './+layout.server';
 
 function makeEvent() {
+  const url = new URL('http://localhost/kiosk/edit');
+  const request = new Request(url, { headers: { cookie: 'sessionid=abc' } });
   return {
     fetch: globalThis.fetch,
-    url: new URL('http://localhost/kiosk/edit'),
+    url,
+    request,
   };
 }
 
@@ -35,6 +38,15 @@ async function expectRedirectTo(target: string) {
 describe('/kiosk/edit auth gate', () => {
   beforeEach(() => {
     GET.mockReset();
+    createServerClient.mockClear();
+  });
+
+  it('forwards the incoming request to createServerClient (cookie plumbing)', async () => {
+    GET.mockResolvedValue({ data: { is_authenticated: true, is_superuser: true } });
+    const event = makeEvent();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await load(event as any);
+    expect(createServerClient).toHaveBeenCalledWith(event.fetch, event.url, event.request);
   });
 
   it('redirects anon to /login', async () => {

--- a/frontend/src/routes/kiosk/edit/page-server.test.ts
+++ b/frontend/src/routes/kiosk/edit/page-server.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { GET, createServerClient } = vi.hoisted(() => {
+  const get = vi.fn();
+  return {
+    GET: get,
+    createServerClient: vi.fn(() => ({ GET: get })),
+  };
+});
+
+vi.mock('$lib/api/server', () => ({ createServerClient }));
+
+import { load } from './+page.server';
+
+function makeEvent(cookieMap: Record<string, string> = {}) {
+  const url = new URL('http://localhost/kiosk/edit');
+  const request = new Request(url, { headers: { cookie: 'sessionid=abc' } });
+  return {
+    fetch: globalThis.fetch,
+    url,
+    request,
+    cookies: { get: (k: string) => cookieMap[k] },
+  };
+}
+
+describe('/kiosk/edit/+page.server.ts load', () => {
+  beforeEach(() => {
+    GET.mockReset();
+    createServerClient.mockClear();
+  });
+
+  it('forwards request to createServerClient so SSR sees the user session', async () => {
+    GET.mockResolvedValue({ data: [], response: { status: 200 } });
+    const event = makeEvent();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await load(event as any);
+    expect(createServerClient).toHaveBeenCalledWith(event.fetch, event.url, event.request);
+  });
+});

--- a/frontend/src/routes/kiosk/page-server.test.ts
+++ b/frontend/src/routes/kiosk/page-server.test.ts
@@ -16,9 +16,11 @@ type Cookies = { get: (name: string) => string | undefined };
 
 function makeEvent(cookieMap: Record<string, string>) {
   const cookies: Cookies = { get: (k) => cookieMap[k] };
+  const url = new URL('http://localhost/kiosk');
   return {
     fetch: globalThis.fetch,
-    url: new URL('http://localhost/kiosk'),
+    url,
+    request: new Request(url),
     cookies,
   };
 }

--- a/frontend/src/routes/locations/[...path]/+layout.server.ts
+++ b/frontend/src/routes/locations/[...path]/+layout.server.ts
@@ -2,9 +2,9 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
   const path = params.path ?? '';
-  const client = createServerClient(fetch, url);
+  const client = createServerClient(fetch, url, request);
 
   // Two routes: ``/`` for the global root, ``/{location_path}`` for any
   // concrete location. The path converter accepts slashes, so a single

--- a/frontend/src/routes/manufacturers/[slug]/+layout.server.ts
+++ b/frontend/src/routes/manufacturers/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/manufacturer/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/models/[slug]/+layout.server.ts
+++ b/frontend/src/routes/models/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/model/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/people/[slug]/+layout.server.ts
+++ b/frontend/src/routes/people/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/person/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/reward-types/[slug]/+layout.server.ts
+++ b/frontend/src/routes/reward-types/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/reward-type/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/series/[slug]/+layout.server.ts
+++ b/frontend/src/routes/series/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/series/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/systems/[slug]/+layout.server.ts
+++ b/frontend/src/routes/systems/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/system/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/tags/[slug]/+layout.server.ts
+++ b/frontend/src/routes/tags/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/tag/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/technology-generations/[slug]/+layout.server.ts
+++ b/frontend/src/routes/technology-generations/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/technology-generation/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/technology-subgenerations/[slug]/+layout.server.ts
+++ b/frontend/src/routes/technology-subgenerations/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/technology-subgeneration/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/themes/[slug]/+layout.server.ts
+++ b/frontend/src/routes/themes/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/theme/{public_id}', {
     params: { path: { public_id: params.slug } },
   });

--- a/frontend/src/routes/titles/[slug]/+layout.server.ts
+++ b/frontend/src/routes/titles/[slug]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ fetch, url, params }) => {
-  const client = createServerClient(fetch, url);
+export const load: LayoutServerLoad = async ({ fetch, url, request, params }) => {
+  const client = createServerClient(fetch, url, request);
   const { data, response } = await client.GET('/api/pages/title/{public_id}', {
     params: { path: { public_id: params.slug } },
   });


### PR DESCRIPTION
## Summary

- **Bug:** in production, logged-in superusers visiting `/kiosk/edit` were redirected to `/login`. SvelteKit's `event.fetch` only forwards cookies same-origin, but prod sets `INTERNAL_API_BASE_URL=http://127.0.0.1:8000` so SSR crosses origins to reach Django — `/api/auth/me/` saw an anonymous request and the layout gate redirected. The bug doesn't reproduce on `make dev` because `INTERNAL_API_BASE_URL` is unset and SSR stays same-origin.
- **Fix:** `createServerClient` now requires the incoming `Request` and forwards its `Cookie` header to Django. Updated all 21 existing SSR call sites; forwarding cookies on calls to public endpoints is harmless.
- **Future-proofing:** `request` is required (not optional), so any future authenticated SSR load can't silently lose the session. Updated the browser-client error message and docs (`Svelte.md`, `ApiDesign.md`, `SSRConversion.md`) to teach the new signature.

## Test plan

- [x] New unit tests assert `createApiClient` forwards the `Cookie` header from the incoming request, and that no `Cookie` is set when the request has none.
- [x] New route tests for `/kiosk/edit/+page.server.ts` and `/kiosk/edit/[id]/+page.server.ts` assert `request` is plumbed through to `createServerClient`.
- [x] Updated layout-server test asserts the same for the auth gate.
- [x] `pnpm check` (typecheck) clean — TypeScript will now block any new SSR load that omits `request`.
- [x] Full vitest suite: 1084/1084 pass.
- [ ] Manual verification on a preview/prod build: log in, hit `/kiosk/edit`, confirm no redirect to `/login`. Locally requires `INTERNAL_API_BASE_URL=http://127.0.0.1:8000 pnpm dev` (with browser hitting `localhost:5173`) to reproduce the cross-origin condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)