### PR TITLE
feat(backend): show unlicensed content to kiosk-mode devices

### DIFF
--- a/backend/apps/catalog/api/locations.py
+++ b/backend/apps/catalog/api/locations.py
@@ -20,7 +20,7 @@ from apps.core.models import active_status_q
 from apps.provenance.helpers import active_claims, claims_prefetch
 from apps.provenance.schemas import RichTextSchema
 
-from ..cache import LOCATIONS_TREE_KEY
+from ..cache import locations_tree_key
 from ..models import (
     CorporateEntity,
     CorporateEntityLocation,
@@ -124,7 +124,7 @@ def _get_location_tree() -> _LocationTree:
 
     Results are cached; invalidated by ``invalidate_all()``.
     """
-    result = cache.get(LOCATIONS_TREE_KEY)
+    result = cache.get(locations_tree_key())
     if result is not None:
         return cast(_LocationTree, result)
 
@@ -177,7 +177,7 @@ def _get_location_tree() -> _LocationTree:
         children_index.setdefault(parent_path, []).append(loc.location_path)
 
     tree = (nodes, children_index)
-    cache.set(LOCATIONS_TREE_KEY, tree, timeout=None)
+    cache.set(locations_tree_key(), tree, timeout=None)
     return tree
 
 

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -40,7 +40,7 @@ from apps.provenance.schemas import (
     RichTextSchema,
 )
 
-from ..cache import MODELS_ALL_KEY, get_cached_response, set_cached_response
+from ..cache import get_cached_response, models_all_key, set_cached_response
 from ..models import (
     Cabinet,
     CorporateEntity,
@@ -758,7 +758,7 @@ def list_all_models(
     bulk through-table queries for M2M data.  See ``list_all_titles`` for
     the full explanation of this pattern.
     """
-    response = get_cached_response(MODELS_ALL_KEY)
+    response = get_cached_response(models_all_key())
     if response is not None:
         return response
 
@@ -908,7 +908,7 @@ def list_all_models(
                 "title_slug": r.title_slug,
             }
         )
-    return set_cached_response(MODELS_ALL_KEY, _ALL_ADAPTER, result)
+    return set_cached_response(models_all_key(), _ALL_ADAPTER, result)
 
 
 @models_router.get("/edit-options/", response=ModelEditOptionsSchema)

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -25,7 +25,7 @@ from apps.media.schemas import UploadedMediaSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
 from apps.provenance.schemas import RichTextSchema
 
-from ..cache import MANUFACTURERS_ALL_KEY, get_cached_response, set_cached_response
+from ..cache import get_cached_response, manufacturers_all_key, set_cached_response
 from ..models import (
     CorporateEntity,
     CorporateEntityAlias,
@@ -287,7 +287,7 @@ def list_all_manufacturers(
     deep prefetch + Python iteration.  See ``list_all_titles`` for the
     full explanation of this pattern.
     """
-    response = get_cached_response(MANUFACTURERS_ALL_KEY)
+    response = get_cached_response(manufacturers_all_key())
     if response is not None:
         return response
 
@@ -488,7 +488,7 @@ def list_all_manufacturers(
                 "tech_generations": _dedup_facet_dicts(mfr_tech_gens.get(mfr_id, [])),
             }
         )
-    return set_cached_response(MANUFACTURERS_ALL_KEY, _ALL_ADAPTER, result)
+    return set_cached_response(manufacturers_all_key(), _ALL_ADAPTER, result)
 
 
 @manufacturers_router.patch(

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -37,7 +37,7 @@ from apps.provenance.rate_limits import (
 )
 from apps.provenance.schemas import ChangeSetInputSchema, RichTextSchema
 
-from ..cache import PEOPLE_ALL_KEY, get_cached_response, set_cached_response
+from ..cache import get_cached_response, people_all_key, set_cached_response
 from ..models import Credit, MachineModel, Person
 from ._typing import HasCreditCount
 from .constants import DEFAULT_PAGE_SIZE
@@ -250,7 +250,7 @@ def list_all_people(
     thumbnails, instead of prefetching all credits and iterating in Python.
     See ``list_all_titles`` for the full explanation of this pattern.
     """
-    response = get_cached_response(PEOPLE_ALL_KEY)
+    response = get_cached_response(people_all_key())
     if response is not None:
         return response
 
@@ -306,7 +306,7 @@ def list_all_people(
                 "thumbnail_url": thumb,
             }
         )
-    return set_cached_response(PEOPLE_ALL_KEY, _ALL_ADAPTER, result)
+    return set_cached_response(people_all_key(), _ALL_ADAPTER, result)
 
 
 @people_router.patch(

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -54,7 +54,7 @@ from apps.provenance.schemas import (
     RichTextSchema,
 )
 
-from ..cache import TITLES_ALL_KEY, get_cached_response, set_cached_response
+from ..cache import get_cached_response, set_cached_response, titles_all_key
 from ..models import (
     Credit,
     MachineModel,
@@ -746,7 +746,7 @@ def list_all_titles(request: HttpRequest) -> HttpResponse:
     This reduces cold-cache rebuild from ~3.5s to ~0.5s locally
     (~30s to ~5s on production hardware).
     """
-    response = get_cached_response(TITLES_ALL_KEY)
+    response = get_cached_response(titles_all_key())
     if response is not None:
         return response
 
@@ -956,7 +956,7 @@ def list_all_titles(request: HttpRequest) -> HttpResponse:
                 ),
             }
         )
-    return set_cached_response(TITLES_ALL_KEY, _ALL_ADAPTER, result)
+    return set_cached_response(titles_all_key(), _ALL_ADAPTER, result)
 
 
 @titles_router.patch(

--- a/backend/apps/catalog/cache.py
+++ b/backend/apps/catalog/cache.py
@@ -1,4 +1,12 @@
-"""Cache keys and invalidation helpers for the catalog app."""
+"""Cache keys and invalidation helpers for the catalog app.
+
+Cache slots are scoped by content audience (``default`` or ``kiosk``) so that
+kiosk requests, which see show-all content, do not share a slot with
+public visitors who must not see unlicensed content. The active audience
+is determined per request by ``apps.core.licensing.current_audience()``,
+which the ``KioskDisplayPolicyMiddleware`` sets from the ``mode=kiosk``
+cookie.
+"""
 
 from __future__ import annotations
 
@@ -11,11 +19,43 @@ from django.core.cache import cache
 from django.http import HttpResponse
 from pydantic import TypeAdapter
 
-MODELS_ALL_KEY = "catalog:models:all"
-MANUFACTURERS_ALL_KEY = "catalog:manufacturers:all"
-PEOPLE_ALL_KEY = "catalog:people:all"
-TITLES_ALL_KEY = "catalog:titles:all"
-LOCATIONS_TREE_KEY = "catalog:locations:tree"
+from apps.core.licensing import current_audience
+
+_MODELS_ALL_BASE = "catalog:models:all"
+_MANUFACTURERS_ALL_BASE = "catalog:manufacturers:all"
+_PEOPLE_ALL_BASE = "catalog:people:all"
+_TITLES_ALL_BASE = "catalog:titles:all"
+_LOCATIONS_TREE_BASE = "catalog:locations:tree"
+
+_BASES: tuple[str, ...] = (
+    _MODELS_ALL_BASE,
+    _MANUFACTURERS_ALL_BASE,
+    _PEOPLE_ALL_BASE,
+    _TITLES_ALL_BASE,
+    _LOCATIONS_TREE_BASE,
+)
+
+_AUDIENCES: tuple[str, ...] = ("default", "kiosk")
+
+
+def models_all_key() -> str:
+    return f"{_MODELS_ALL_BASE}:{current_audience()}"
+
+
+def manufacturers_all_key() -> str:
+    return f"{_MANUFACTURERS_ALL_BASE}:{current_audience()}"
+
+
+def people_all_key() -> str:
+    return f"{_PEOPLE_ALL_BASE}:{current_audience()}"
+
+
+def titles_all_key() -> str:
+    return f"{_TITLES_ALL_BASE}:{current_audience()}"
+
+
+def locations_tree_key() -> str:
+    return f"{_LOCATIONS_TREE_BASE}:{current_audience()}"
 
 
 def get_cached_response(cache_key: str) -> HttpResponse | None:
@@ -32,6 +72,7 @@ def get_cached_response(cache_key: str) -> HttpResponse | None:
     json_bytes, etag = cached
     response = HttpResponse(json_bytes, content_type="application/json")
     response["ETag"] = etag
+    response["Vary"] = "Cookie"
     return response
 
 
@@ -55,13 +96,12 @@ def set_cached_response(
     cache.set(cache_key, (json_bytes, etag), timeout=None)
     response = HttpResponse(json_bytes, content_type="application/json")
     response["ETag"] = etag
+    response["Vary"] = "Cookie"
     return response
 
 
 def invalidate_all() -> None:
-    """Delete all cached /all/ endpoint data."""
-    cache.delete(MODELS_ALL_KEY)
-    cache.delete(MANUFACTURERS_ALL_KEY)
-    cache.delete(PEOPLE_ALL_KEY)
-    cache.delete(TITLES_ALL_KEY)
-    cache.delete(LOCATIONS_TREE_KEY)
+    """Delete all cached /all/ endpoint data, across every audience slot."""
+    for base in _BASES:
+        for audience in _AUDIENCES:
+            cache.delete(f"{base}:{audience}")

--- a/backend/apps/catalog/tests/test_api_cache.py
+++ b/backend/apps/catalog/tests/test_api_cache.py
@@ -2,7 +2,7 @@ import pytest
 from constance.signals import config_updated
 from django.core.cache import cache
 
-from apps.catalog.cache import MODELS_ALL_KEY, TITLES_ALL_KEY
+from apps.catalog.cache import models_all_key, titles_all_key
 from apps.catalog.models import (
     Cabinet,
     CorporateEntity,
@@ -41,18 +41,18 @@ class TestAllEndpointCache:
     def test_models_all_caches_on_second_request(self, client, machine_model):
         resp1 = client.get("/api/models/all/")
         assert resp1.status_code == 200
-        assert cache.get(MODELS_ALL_KEY) is not None
+        assert cache.get(models_all_key()) is not None
 
         resp2 = client.get("/api/models/all/")
         assert resp2.json() == resp1.json()
 
     def test_model_save_invalidates_cache(self, client, machine_model):
         client.get("/api/models/all/")
-        assert cache.get(MODELS_ALL_KEY) is not None
+        assert cache.get(models_all_key()) is not None
 
         machine_model.name = "Medieval Madness LE"
         machine_model.save()
-        assert cache.get(MODELS_ALL_KEY) is None
+        assert cache.get(models_all_key()) is None
 
     def test_new_model_appears_after_invalidation(self, client, machine_model):
         resp1 = client.get("/api/models/all/")
@@ -65,7 +65,7 @@ class TestAllEndpointCache:
     def test_titles_all_caches_on_second_request(self, client, machine_model):
         resp1 = client.get("/api/titles/all/")
         assert resp1.status_code == 200
-        assert cache.get(TITLES_ALL_KEY) is not None
+        assert cache.get(titles_all_key()) is not None
 
         resp2 = client.get("/api/titles/all/")
         assert resp2.json() == resp1.json()
@@ -75,11 +75,11 @@ class TestAllEndpointCache:
             name="Cactus Canyon", slug="cactus-canyon", opdb_id="CC1"
         )
         client.get("/api/titles/all/")
-        assert cache.get(TITLES_ALL_KEY) is not None
+        assert cache.get(titles_all_key()) is not None
 
         title.name = "Cactus Canyon Continued"
         title.save()
-        assert cache.get(TITLES_ALL_KEY) is None
+        assert cache.get(titles_all_key()) is None
 
     def test_new_title_appears_after_invalidation(self, client, machine_model):
         resp1 = client.get("/api/titles/all/")
@@ -136,8 +136,13 @@ class TestPolicyChangeInvalidation:
         cache.clear()
 
     def test_policy_change_invalidates_cache(self, client, machine_model):
+        # Populate both audience slots — default via a vanilla request, kiosk
+        # via a request carrying the mode=kiosk cookie. The policy-change
+        # signal must clear both.
         client.get("/api/models/all/")
-        assert cache.get(MODELS_ALL_KEY) is not None
+        client.get("/api/models/all/", HTTP_COOKIE="mode=kiosk")
+        assert cache.get("catalog:models:all:default") is not None
+        assert cache.get("catalog:models:all:kiosk") is not None
 
         config_updated.send(
             sender=None,
@@ -145,11 +150,12 @@ class TestPolicyChangeInvalidation:
             old_value="licensed-only",
             new_value="show-all",
         )
-        assert cache.get(MODELS_ALL_KEY) is None
+        assert cache.get("catalog:models:all:default") is None
+        assert cache.get("catalog:models:all:kiosk") is None
 
     def test_unrelated_key_change_does_not_invalidate(self, client, machine_model):
         client.get("/api/models/all/")
-        assert cache.get(MODELS_ALL_KEY) is not None
+        assert cache.get(models_all_key()) is not None
 
         config_updated.send(
             sender=None,
@@ -157,7 +163,58 @@ class TestPolicyChangeInvalidation:
             old_value="a",
             new_value="b",
         )
-        assert cache.get(MODELS_ALL_KEY) is not None
+        assert cache.get(models_all_key()) is not None
+
+
+class TestKioskAudienceCacheIsolation:
+    """Kiosk and default audiences must populate separate cache slots.
+
+    The middleware reads ``mode=kiosk`` from request cookies and flips a
+    contextvar that ``current_audience()`` reads, which is what
+    ``models_all_key()`` / ``titles_all_key()`` / etc. fold into the
+    cache key.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        cache.clear()
+        yield
+        cache.clear()
+
+    def test_kiosk_request_populates_kiosk_slot_only(self, client, machine_model):
+        client.get("/api/models/all/", HTTP_COOKIE="mode=kiosk")
+        assert cache.get("catalog:models:all:kiosk") is not None
+        assert cache.get("catalog:models:all:default") is None
+
+    def test_default_request_populates_default_slot_only(self, client, machine_model):
+        client.get("/api/models/all/")
+        assert cache.get("catalog:models:all:default") is not None
+        assert cache.get("catalog:models:all:kiosk") is None
+
+    def test_invalidate_all_clears_both_audience_slots(self, client, machine_model):
+        from apps.catalog.cache import invalidate_all
+
+        client.get("/api/models/all/")
+        client.get("/api/models/all/", HTTP_COOKIE="mode=kiosk")
+        assert cache.get("catalog:models:all:default") is not None
+        assert cache.get("catalog:models:all:kiosk") is not None
+
+        invalidate_all()
+
+        assert cache.get("catalog:models:all:default") is None
+        assert cache.get("catalog:models:all:kiosk") is None
+
+    def test_kiosk_payload_not_served_to_default_request(self, client, machine_model):
+        # Warm only the kiosk slot.
+        client.get("/api/models/all/", HTTP_COOKIE="mode=kiosk")
+        assert cache.get("catalog:models:all:kiosk") is not None
+        assert cache.get("catalog:models:all:default") is None
+
+        # A subsequent default-audience request must not reuse the kiosk
+        # slot — it populates its own slot fresh.
+        resp = client.get("/api/models/all/")
+        assert resp.status_code == 200
+        assert cache.get("catalog:models:all:default") is not None
 
 
 class TestConditionalGet:
@@ -191,8 +248,8 @@ class TestConditionalGet:
     @pytest.mark.parametrize(
         ("path", "cache_key"),
         [
-            ("/api/models/all/", MODELS_ALL_KEY),
-            ("/api/titles/all/", TITLES_ALL_KEY),
+            ("/api/models/all/", models_all_key()),
+            ("/api/titles/all/", titles_all_key()),
         ],
     )
     def test_cache_stores_bytes_and_etag(self, client, machine_model, path, cache_key):

--- a/backend/apps/core/licensing.py
+++ b/backend/apps/core/licensing.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from contextvars import ContextVar, Token
+from typing import Literal, TypedDict
 
 from apps.core.models import License
 
@@ -31,9 +32,33 @@ DISPLAY_POLICY_RANKS: dict[str, int] = {
 # Effective rank for null (unknown) license.
 UNKNOWN_LICENSE_RANK = 5
 
+# Per-request override: when True, the request is treated as the "kiosk"
+# audience and sees show-all content, regardless of the global Constance
+# policy. The override is task-local — it does not propagate across
+# sync_to_async or threadpool boundaries.
+_kiosk_audience: ContextVar[bool] = ContextVar("kiosk_audience", default=False)
+
+
+def set_kiosk_audience() -> Token[bool]:
+    """Mark the current request as the kiosk audience. Returns a Token for reset."""
+    return _kiosk_audience.set(True)
+
+
+def reset_kiosk_audience(token: Token[bool]) -> None:
+    """Reset the kiosk-audience override using the token from set_kiosk_audience."""
+    _kiosk_audience.reset(token)
+
+
+def current_audience() -> Literal["kiosk", "default"]:
+    """Return the active audience for the current request: ``"kiosk"`` or ``"default"``."""
+    return "kiosk" if _kiosk_audience.get() else "default"
+
 
 def get_minimum_display_rank() -> int:
     """Return the current minimum permissiveness_rank for displaying content."""
+    if _kiosk_audience.get():
+        return DISPLAY_POLICY_RANKS["show-all"]
+
     from constance import config
 
     return DISPLAY_POLICY_RANKS.get(config.CONTENT_DISPLAY_POLICY, 38)

--- a/backend/apps/core/middleware.py
+++ b/backend/apps/core/middleware.py
@@ -1,0 +1,39 @@
+"""Request-scoped middleware for the core app.
+
+The audience override set here is task-local via ``contextvars``. It is
+read on the same task that processed the request — there is no
+``sync_to_async`` or threadpool boundary in the catalog cache hot path
+that would lose it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from django.http import HttpRequest, HttpResponse
+
+from apps.core.licensing import reset_kiosk_audience, set_kiosk_audience
+
+
+class KioskDisplayPolicyMiddleware:
+    """Mark requests from kiosk devices as the ``kiosk`` content audience.
+
+    A device opts into kiosk mode by setting the ``mode=kiosk`` cookie
+    (managed by the SvelteKit kiosk routes). For the duration of such a
+    request, ``apps.core.licensing.get_minimum_display_rank()`` returns
+    the most permissive rank, so unlicensed images and other restricted
+    content are shown.
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        token = None
+        if request.COOKIES.get("mode") == "kiosk":
+            token = set_kiosk_audience()
+        try:
+            return self.get_response(request)
+        finally:
+            if token is not None:
+                reset_kiosk_audience(token)

--- a/backend/apps/core/tests/test_licensing.py
+++ b/backend/apps/core/tests/test_licensing.py
@@ -1,0 +1,55 @@
+"""Tests for the kiosk-audience contextvar override in apps.core.licensing."""
+
+from __future__ import annotations
+
+from constance.test import override_config
+
+from apps.core.licensing import (
+    DISPLAY_POLICY_RANKS,
+    current_audience,
+    get_minimum_display_rank,
+    reset_kiosk_audience,
+    set_kiosk_audience,
+)
+
+
+class TestKioskAudienceOverride:
+    """``set_kiosk_audience`` flips ``get_minimum_display_rank`` to show-all."""
+
+    def test_default_audience_reads_constance_policy(self):
+        with override_config(CONTENT_DISPLAY_POLICY="licensed-only"):
+            assert current_audience() == "default"
+            assert get_minimum_display_rank() == DISPLAY_POLICY_RANKS["licensed-only"]
+
+    def test_kiosk_audience_returns_show_all_rank(self):
+        token = set_kiosk_audience()
+        try:
+            with override_config(CONTENT_DISPLAY_POLICY="licensed-only"):
+                assert current_audience() == "kiosk"
+                assert get_minimum_display_rank() == DISPLAY_POLICY_RANKS["show-all"]
+                assert get_minimum_display_rank() == 0
+        finally:
+            reset_kiosk_audience(token)
+
+    def test_kiosk_override_ignores_constance_value(self):
+        # Across every Constance choice, kiosk audience is always show-all.
+        for policy in DISPLAY_POLICY_RANKS:
+            token = set_kiosk_audience()
+            try:
+                with override_config(CONTENT_DISPLAY_POLICY=policy):
+                    assert get_minimum_display_rank() == 0
+            finally:
+                reset_kiosk_audience(token)
+
+    def test_reset_restores_default_audience(self):
+        assert current_audience() == "default"
+        token = set_kiosk_audience()
+        assert current_audience() == "kiosk"
+        reset_kiosk_audience(token)
+        assert current_audience() == "default"
+
+    def test_unknown_constance_value_falls_back_to_licensed_only_rank(self):
+        # Documents the existing fallback in get_minimum_display_rank: an
+        # unrecognised policy returns rank 38 (the licensed-only floor).
+        with override_config(CONTENT_DISPLAY_POLICY="bogus-value"):
+            assert get_minimum_display_rank() == 38

--- a/backend/apps/core/tests/test_middleware.py
+++ b/backend/apps/core/tests/test_middleware.py
@@ -1,0 +1,75 @@
+"""Tests for KioskDisplayPolicyMiddleware."""
+
+from __future__ import annotations
+
+import contextlib
+
+from django.http import HttpRequest, HttpResponse
+
+from apps.core.licensing import current_audience
+from apps.core.middleware import KioskDisplayPolicyMiddleware
+
+
+def _make_request(cookie: str | None = None) -> HttpRequest:
+    request = HttpRequest()
+    if cookie is not None:
+        request.COOKIES["mode"] = cookie
+    return request
+
+
+class TestKioskDisplayPolicyMiddleware:
+    """The middleware reads ``mode=kiosk`` cookies into the audience contextvar."""
+
+    def test_kiosk_cookie_sets_audience_during_request(self):
+        observed: list[str] = []
+
+        def view(_request: HttpRequest) -> HttpResponse:
+            observed.append(current_audience())
+            return HttpResponse()
+
+        middleware = KioskDisplayPolicyMiddleware(view)
+        middleware(_make_request(cookie="kiosk"))
+
+        assert observed == ["kiosk"]
+
+    def test_audience_resets_after_request(self):
+        middleware = KioskDisplayPolicyMiddleware(lambda _r: HttpResponse())
+        middleware(_make_request(cookie="kiosk"))
+        assert current_audience() == "default"
+
+    def test_audience_resets_even_when_view_raises(self):
+        class BoomError(Exception):
+            pass
+
+        def view(_request: HttpRequest) -> HttpResponse:
+            raise BoomError
+
+        middleware = KioskDisplayPolicyMiddleware(view)
+        with contextlib.suppress(BoomError):
+            middleware(_make_request(cookie="kiosk"))
+
+        assert current_audience() == "default"
+
+    def test_no_cookie_leaves_audience_default(self):
+        observed: list[str] = []
+
+        def view(_request: HttpRequest) -> HttpResponse:
+            observed.append(current_audience())
+            return HttpResponse()
+
+        middleware = KioskDisplayPolicyMiddleware(view)
+        middleware(_make_request(cookie=None))
+
+        assert observed == ["default"]
+
+    def test_unrelated_cookie_value_leaves_audience_default(self):
+        observed: list[str] = []
+
+        def view(_request: HttpRequest) -> HttpResponse:
+            observed.append(current_audience())
+            return HttpResponse()
+
+        middleware = KioskDisplayPolicyMiddleware(view)
+        middleware(_make_request(cookie="something-else"))
+
+        assert observed == ["default"]

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -62,6 +62,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "apps.core.middleware.KioskDisplayPolicyMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"


### PR DESCRIPTION
## Summary

- Kiosk devices (identified by `mode=kiosk` cookie) bypass the global `CONTENT_DISPLAY_POLICY` and always see show-all content; public visitors are unaffected.
- A `KioskDisplayPolicyMiddleware` sets a contextvar that `get_minimum_display_rank()` reads, so the ~30 existing call sites are unchanged.
- Catalog `/all/` and locations-tree caches are now keyed by audience (`default` / `kiosk`) so the two cohorts cannot share a cache slot. `invalidate_all()` and the existing Constance `config_updated` handler clear both slots.
- `Vary: Cookie` added to cached responses as defense-in-depth against any URL-keyed HTTP cache upstream.

## Test plan

- [x] Backend pytest suite (2445 passing) including new `TestKioskAudienceCacheIsolation`, `TestKioskAudienceOverride`, and `TestKioskDisplayPolicyMiddleware`
- [x] Frontend vitest suite (1084 passing)
- [x] `make lint` clean (no new mypy errors)
- [x] Manual end-to-end: with `CONTENT_DISPLAY_POLICY=licensed-only`, two browser sessions verify unlicensed images render only for the kiosk-cookie session
- [x] Reverse-proxy / CDN check: confirmed nothing in front of Django caches `/api/...` by URL alone