### PR TITLE
fix(frontend): show 'Exit Kiosk Mode' on editor when device is active

### DIFF
--- a/frontend/src/routes/kiosk/edit/[id]/+page.server.ts
+++ b/frontend/src/routes/kiosk/edit/[id]/+page.server.ts
@@ -2,7 +2,7 @@ import { error } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ fetch, url, request, params }) => {
+export const load: PageServerLoad = async ({ fetch, url, request, params, cookies }) => {
   const id = Number(params.id);
   if (!Number.isInteger(id) || id <= 0) throw error(404, 'Kiosk not found');
 
@@ -16,5 +16,9 @@ export const load: PageServerLoad = async ({ fetch, url, request, params }) => {
     throw error(response?.status || 500, 'Failed to load kiosk');
   }
 
-  return { config: data };
+  const rawId = cookies.get('kioskConfigId');
+  const parsed = rawId ? Number(rawId) : NaN;
+  const activeId = Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+
+  return { config: data, activeId };
 };

--- a/frontend/src/routes/kiosk/edit/[id]/+page.svelte
+++ b/frontend/src/routes/kiosk/edit/[id]/+page.svelte
@@ -37,6 +37,12 @@
   // here.
   // svelte-ignore state_referenced_locally
   const config = data.config;
+  // activeId comes from +page.server.ts (reads kioskConfigId cookie).
+  // Local mutable copy so exitKioskMode() can clear it without a full
+  // reload. Reading it server-side avoids an SSR/hydration flash.
+  // svelte-ignore state_referenced_locally
+  let activeId = $state<number | null>(data.activeId);
+  let isActive = $derived(activeId === config.id);
 
   type EditorItem = { titleSlug: string; titleName: string; hook: string };
 
@@ -211,6 +217,11 @@
     location.assign('/kiosk');
   }
 
+  function handleExit() {
+    clearKioskCookies();
+    activeId = null;
+  }
+
   async function deleteKiosk() {
     if (deleting) return;
     if (!confirm(`Delete kiosk ${idLabel}? This cannot be undone.`)) return;
@@ -255,7 +266,11 @@
         <Button variant="destructive" fullWidth onclick={deleteKiosk} disabled={deleting}>
           {deleting ? 'Deleting…' : 'Delete Kiosk'}
         </Button>
-        <Button variant="primary" fullWidth onclick={handleEnter}>Enter Kiosk Mode</Button>
+        {#if isActive}
+          <Button variant="primary" fullWidth onclick={handleExit}>Exit Kiosk Mode</Button>
+        {:else}
+          <Button variant="primary" fullWidth onclick={handleEnter}>Enter Kiosk Mode</Button>
+        {/if}
       </div>
 
       {#if errorMessage}
@@ -358,7 +373,11 @@
             </Button>
           </div>
           <div class="sidebar-action">
-            <Button variant="primary" fullWidth onclick={handleEnter}>Enter Kiosk Mode</Button>
+            {#if isActive}
+              <Button variant="primary" fullWidth onclick={handleExit}>Exit Kiosk Mode</Button>
+            {:else}
+              <Button variant="primary" fullWidth onclick={handleEnter}>Enter Kiosk Mode</Button>
+            {/if}
           </div>
         </SidebarSection>
       </div>

--- a/frontend/src/routes/kiosk/edit/[id]/editor-page.dom.test.ts
+++ b/frontend/src/routes/kiosk/edit/[id]/editor-page.dom.test.ts
@@ -21,6 +21,7 @@ import { toast } from '$lib/toast/toast.svelte';
 
 function makeData(
   overrides: Partial<{ id: number; page_heading: string; idle_seconds: number }> = {},
+  activeId: number | null = null,
 ) {
   return {
     config: {
@@ -30,6 +31,7 @@ function makeData(
       items: [],
       ...overrides,
     },
+    activeId,
   };
 }
 
@@ -208,5 +210,44 @@ describe('/kiosk/edit/[id] editor — autosave on blur', () => {
 
     await waitFor(() => expect(PATCH).toHaveBeenCalled());
     await waitFor(() => expect(document.cookie).toContain('kioskIdleSeconds=120'));
+  });
+});
+
+describe('/kiosk/edit/[id] editor — Enter/Exit Kiosk Mode button', () => {
+  beforeEach(() => {
+    goto.mockReset().mockResolvedValue(undefined);
+    GET.mockReset().mockResolvedValue({ data: [] });
+    clearKioskCookies();
+  });
+
+  it('shows "Enter Kiosk Mode" when this device is not the active kiosk', () => {
+    render(Page, { data: makeData({}, null) });
+    expect(screen.getAllByRole('button', { name: 'Enter Kiosk Mode' }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'Exit Kiosk Mode' })).toBeNull();
+  });
+
+  it('shows "Enter Kiosk Mode" when active kiosk is a different config', () => {
+    render(Page, { data: makeData({}, 99) });
+    expect(screen.getAllByRole('button', { name: 'Enter Kiosk Mode' }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'Exit Kiosk Mode' })).toBeNull();
+  });
+
+  it('shows "Exit Kiosk Mode" when this config is active on this device', () => {
+    render(Page, { data: makeData({}, 7) });
+    expect(screen.getAllByRole('button', { name: 'Exit Kiosk Mode' }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'Enter Kiosk Mode' })).toBeNull();
+  });
+
+  it('clicking "Exit Kiosk Mode" clears cookies and swaps the button to "Enter Kiosk Mode"', async () => {
+    const user = userEvent.setup();
+    setKioskCookies(7, 60);
+
+    render(Page, { data: makeData({}, 7) });
+    await user.click(screen.getAllByRole('button', { name: 'Exit Kiosk Mode' })[0]);
+
+    expect(document.cookie).not.toContain('kioskConfigId=7');
+    expect(document.cookie).not.toContain('mode=kiosk');
+    expect(screen.queryByRole('button', { name: 'Exit Kiosk Mode' })).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Enter Kiosk Mode' }).length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/routes/kiosk/edit/[id]/page-server.test.ts
+++ b/frontend/src/routes/kiosk/edit/[id]/page-server.test.ts
@@ -12,7 +12,7 @@ vi.mock('$lib/api/server', () => ({ createServerClient }));
 
 import { load } from './+page.server';
 
-function makeEvent(id: string) {
+function makeEvent(id: string, cookieJar: Record<string, string> = {}) {
   const url = new URL(`http://localhost/kiosk/edit/${id}`);
   const request = new Request(url, { headers: { cookie: 'sessionid=abc' } });
   return {
@@ -20,6 +20,7 @@ function makeEvent(id: string) {
     url,
     request,
     params: { id },
+    cookies: { get: (name: string) => cookieJar[name] },
   };
 }
 
@@ -35,5 +36,29 @@ describe('/kiosk/edit/[id]/+page.server.ts load', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await load(event as any);
     expect(createServerClient).toHaveBeenCalledWith(event.fetch, event.url, event.request);
+  });
+
+  it('returns activeId from kioskConfigId cookie when set', async () => {
+    GET.mockResolvedValue({ data: { id: 5 }, response: { status: 200 } });
+    const event = makeEvent('5', { kioskConfigId: '5' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await load(event as any);
+    expect(result).toEqual({ config: { id: 5 }, activeId: 5 });
+  });
+
+  it('returns activeId=null when kioskConfigId cookie is absent', async () => {
+    GET.mockResolvedValue({ data: { id: 5 }, response: { status: 200 } });
+    const event = makeEvent('5');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await load(event as any);
+    expect(result).toEqual({ config: { id: 5 }, activeId: null });
+  });
+
+  it('returns activeId=null when kioskConfigId cookie is malformed', async () => {
+    GET.mockResolvedValue({ data: { id: 5 }, response: { status: 200 } });
+    const event = makeEvent('5', { kioskConfigId: 'nope' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await load(event as any);
+    expect(result).toEqual({ config: { id: 5 }, activeId: null });
   });
 });


### PR DESCRIPTION
## Summary
- The kiosk editor at `/kiosk/edit/[id]` always rendered "Enter Kiosk Mode", even when this device was already running that kiosk.
- Mirror the list page: read `kioskConfigId` cookie in `+page.server.ts`, expose `activeId`, and swap the button to "Exit Kiosk Mode" (clears cookies) when `activeId === config.id`. Applies to both mobile actions and sidebar.

## Test plan
- [x] Unit tests added for server load (`activeId` from cookie, missing, malformed)
- [x] DOM tests added for button swap and exit click clearing cookies
- [x] `pnpm vitest run src/routes/kiosk/` passes (31/31)
- [x] Visually confirmed in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)