### PR TITLE
docs(auth): add authz, social account sync, and user banning plans

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -106,6 +106,11 @@ CACHES = {
 
 AUTH_USER_MODEL = "accounts.User"
 
+# auth.W004: User.email is USERNAME_FIELD without unique=True. Uniqueness is
+# enforced case-insensitively via the Lower("email") UniqueConstraint on the
+# User model; adding unique=True would layer on a redundant case-sensitive one.
+SILENCED_SYSTEM_CHECKS = ["auth.W004"]
+
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"

--- a/docs/plans/auth/Authz.md
+++ b/docs/plans/auth/Authz.md
@@ -1,0 +1,66 @@
+# Editorial Activity Authorization
+
+## Problem
+
+We need to be able to put checks around editor and moderator activity without wiring every call site to one specific check.
+
+Email verification -- [Verification.md](Verification.md) -- is the first concrete case: catalog edits should require a verified email so disposable email-password accounts cannot immediately write claims. But the authorization decision should not be named or modeled as "email verification" at every Svelte editor, API endpoint, or claims write helper. That would make the next constraint -- moderator role, account age, rate limit state, reputation, abuse flag, scoped delete permission, etc. -- require another audit of every edit path.
+
+The product rule we care about is not "has verified email." It is "may perform this activity." Email verification is only one input into that decision.
+
+## Proposal
+
+Introduce a small policy/capability layer for user activities. Call sites ask whether a user may perform a named activity, and the centralized policy decides which checks currently apply.
+
+Examples of activity names:
+
+- `catalog.edit`
+- `catalog.create`
+- `catalog.delete`
+- `claim.revert`
+- `moderation.action`
+
+Backend write paths should depend on activity authorization, not directly on `email_verified`. For example, a catalog claim write should require `catalog.edit`; the policy for `catalog.edit` can initially require authentication, an active account, and verified email. Later, the same policy can add account-age, role, reputation, moderation, or rate-limit constraints without changing every catalog editor.
+
+The frontend should follow the same language but must not reimplement the policy. The backend exposes capabilities (e.g. a `/me/capabilities` endpoint, or per-resource hints embedded in resource responses) and the frontend reflects them for UX. Structured denial responses return stable blocker codes from a closed registry -- `verification_required`, `moderator_required`, etc. -- mapped to user-facing copy in one place, so shared UI can explain the problem without each editor knowing the underlying authorization rules.
+
+This is the standard policy-based / capability-based authorization shape: call sites request an action, central policy evaluates roles and attributes. For Flipcommons, a lightweight in-repo policy module is enough; adopting a full external authorization engine would be premature.
+
+## Principles
+
+- **Object-level from day one.** The policy signature is `check(user, activity, target=None)`. Early rules may ignore `target`, but `claim.revert` and `catalog.delete` will need it soon, and retrofitting object-level later is the same costly audit this design is meant to avoid.
+- **Backend is the source of truth; the frontend reflects.** Never mirror policy logic in JS. Two engines will drift.
+- **Activities are product-meaningful, not data-model-shaped.** Resist granularity like `catalog.edit.title.scalar` -- that leaks the schema into the policy namespace and dissolves the abstraction.
+- **Don't use Django's permission framework.** This activity layer is parallel to Django perms, not built on top. Per-model perms compose poorly with attribute checks (verified email, account age, rate limit), and we'd end up wrapping them anyway.
+- **Denial codes are a closed enum.** One registry, mapped to user-facing copy. No ad-hoc strings spelled differently across editors.
+- **Rate-limiting is policy-aware, not policy-owned.** Enforce early in the request path -- as early as the limit's scope allows (per-IP/per-user floods in middleware; activity- or target-scoped limits where the target is known). The policy may reflect rate-limit state for UX but is not the sole gate.
+
+## Initial activities
+
+The launch set. Each row is what the policy enforces today; later constraints (account age, reputation, rate limits, moderation flags) layer in without changing call sites.
+
+| Activity            | Rules at launch                                     | Notes                                                                                                                                                                                                  |
+| ------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `catalog.edit`      | authenticated, active, email-verified               | The default gate for claim writes on existing entities.                                                                                                                                                |
+| `catalog.create`    | authenticated, active, email-verified               | Same bar as edit at launch; separated so creation can tighten independently (e.g. account age) without touching edit paths.                                                                            |
+| `catalog.delete`    | authenticated, active, email-verified, target-aware | Object-level: deletion of a populated entity should escalate (moderator role) before non-moderator deletes are allowed. Launch behavior may simply forbid non-moderator deletes of non-empty entities. |
+| `claim.revert`      | authenticated, active, email-verified, target-aware | Object-level: a user can revert their own claims; reverting another user's claim requires `moderation.action`.                                                                                         |
+| `moderation.action` | authenticated, active, moderator role               | The umbrella capability for moderator-only operations. Email verification is implied by being a moderator.                                                                                             |
+
+"Active" means the account is not disabled or banned. "Authenticated" means a logged-in session, not anonymous. The shared prerequisites (authenticated + active) live in one place in the policy module so each activity's rule is just the delta beyond them.
+
+## Surfaces to classify before implementation
+
+Before implementing the policy layer, audit every authenticated mutating backend route and assign it to one activity, or explicitly mark it out of scope.
+
+Known surfaces include:
+
+- catalog claim writes
+- catalog creates, deletes, and restores
+- claim revert and changeset undo
+- media upload, detach, category, and primary-image mutations
+- citation source, link, extraction, and citation-instance mutations
+- kiosk config mutations
+- factory-registered CRUD routes
+
+Keep the exhaustive route inventory in code or tests, not this document, so it can be mechanically checked instead of going stale.

--- a/docs/plans/auth/SocialAccountSync.md
+++ b/docs/plans/auth/SocialAccountSync.md
@@ -1,0 +1,158 @@
+# Social Account Sync
+
+This document proposes capturing each user's underlying OAuth identities (Google `sub`, Apple `sub`, etc.) on every login into a local `accounts.SocialAccount` table.
+
+## Status — deferred
+
+Deferred; revisit when one of the problems below becomes urgent.
+
+## Problem
+
+**Reactivation safety.** The custom-user-model reactivation flow gates on `email_verified` and `banned_at IS NULL`, but doesn't catch the corporate-email-reassignment case (Alice leaves the company, Bob inherits `alice@oldcompany.com`, Bob signs in via the company SSO and could in principle claim Alice's history). A stable per-provider identifier on file would let us refuse the reactivation when the inbound `sub` doesn't match the prior one.
+
+**Account-linking UX.** Supporting account-merge or explicit "link another provider" surfaces — or surfacing the error "this Google account is already linked to another user" — needs durable identity rows to compare against.
+
+## NOT a problem
+
+**Auth provider switching.** A migration from WorkOS to another auth provider or self-hosting would _appear_ to be reason to want this data already in our DB, but it isn't a real driver: at switch time we can call WorkOS's `/users/{id}/identities` once per user as part of the cutover and import the `(provider, sub)` pairs in bulk. The data we'd accumulate by capturing on every login is the same data we'd download from WorkOS during a planned migration — there's no information we can only get _now_. Capture-on-login would be insurance against an emergency switch where WorkOS's API is also down, which is narrow enough not to justify the ongoing complexity.
+
+## Prerequisites and project invariants
+
+**BYO OAuth credentials for every social provider — no exceptions.** We register the OAuth client at Google / Apple / GitHub / Microsoft ourselves and hand the `client_id`/`secret` to WorkOS, rather than using WorkOS's default credentials. This is the load-bearing detail that makes `SocialAccount` worth populating: with our own client, the `sub` Google returns is scoped to _our_ OAuth app, not WorkOS's. When we eventually plug those same credentials into a different managed provider (or self-host), Google issues the _same_ `sub` for the same human, so our stored `(google, sub)` pairs match and the new provider can pre-link without forcing re-login.
+
+If we ever switched to WorkOS-owned credentials (or used them for a new provider), the `sub` values we'd accumulate would be scoped to WorkOS's client and useless after a switch — silently undermining the migration story. So this isn't a one-time setup detail, it's a permanent project invariant: when adding any new social provider, register the OAuth app under our own account first.
+
+Currently confirmed BYO: **Google** (registered under our Google Cloud project, configured in WorkOS).
+
+## Spike findings
+
+**Underlying OAuth `sub` — not on the auth response; a separate API call is required.** Verified against the installed `workos` Python SDK: `AuthKitAuthenticationResponse` (returned by `authenticate_with_code`) carries `access_token`, `refresh_token`, `authentication_method`, `user`, `oauth_tokens`, etc. — no `sub` and no `identities`. The `User` object has no provider-issued identifier either; its `external_id` field is merchant-set, not provider-set. `OAuthTokens` carries the provider's access/refresh tokens but not the `sub`.
+
+The `sub` is exposed only via `GET https://api.workos.com/user_management/users/{id}/identities`, which returns a JSON array of `{idp_id, type, provider}` objects. `idp_id` is documented as "the unique ID of the user in the external identity provider" — that's the OAuth `sub`. `provider` follows the same `GoogleOAuth` / `AppleOAuth` / `MicrosoftOAuth` naming the SDK already uses on `AuthenticationMethod`.
+
+**SDK gap.** The Python SDK has no typed wrapper for this endpoint (no `client.user_management.list_user_identities()`). Add a thin helper in `apps/accounts/workos_client.py` that calls the endpoint via `httpx` with `Authorization: Bearer ${WORKOS_API_KEY}` and returns a `list[Identity]` (a local TypedDict mirroring `{idp_id, type, provider}`). Don't reach through the SDK's underscored `_http_client` — that's a private surface that can change between SDK versions.
+
+**Cache strategy — per-provider, not per-user.** Only call on a user's first login via each provider. In `get_or_create_django_user`, map `auth_response.authentication_method` (`GoogleOAuth`, `AppleOAuth`, …) to a provider key (`google`, `apple`, …) and check `user.social_accounts.filter(provider=provider).exists()`. If false, fetch identities and upsert all returned rows — the endpoint returns every linked identity for the user, so a single call also backfills any providers linked outside our capture window. Email/password logins (`Password`, `Passkey`, `MagicAuth`) skip the call entirely.
+
+## Proposed model
+
+`accounts.SocialAccount` records each OAuth identity linked to a local user. The shape is just the natural OIDC mirror: provider id, the `sub` claim, when it was linked, when it was last used, and an allowlisted claims payload for forensics. Field names are chosen for clarity in our context, not to track any particular library.
+
+```python
+class SocialAccount(models.Model):
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="social_accounts",
+    )
+
+    # OAuth provider id. "google", "apple", "github", "microsoft", etc.
+    # No choices — the set grows as we enable providers.
+    provider = models.CharField(max_length=64)
+
+    # The OIDC `sub` claim from the underlying provider. Stable for a given
+    # human-at-provider across managed-auth-provider switches.
+    provider_sub = models.CharField(max_length=255)
+
+    # When this identity was first linked to this user.
+    linked_at = models.DateTimeField(auto_now_add=True)
+
+    # When this identity was last used to sign in. Distinct from User.last_login
+    # (which records any login, regardless of which identity was used).
+    last_used_at = models.DateTimeField(auto_now=True)
+
+    # Allowlisted OIDC claims we extracted from the inbound auth response.
+    # Allowlist (not deny-list) so adding new keys is an explicit decision
+    # rather than passively persisting whatever the provider chose to send.
+    # Populated by the auth callback via OAUTH_PAYLOAD_ALLOWED_KEYS; the
+    # save() override is a defense-in-depth strip in case a caller passes
+    # a wider dict.
+    oauth_payload = models.JSONField(default=dict)
+
+    # Keys we intentionally keep from the inbound payload. Everything else
+    # is dropped before persistence. Standard OIDC claims plus a couple of
+    # forensic non-PII fields (issued-at, issuer).
+    OAUTH_PAYLOAD_ALLOWED_KEYS = frozenset({
+        "sub",
+        "email",
+        "email_verified",
+        "name",
+        "given_name",
+        "family_name",
+        "picture",
+        "iat",
+        "iss",
+    })
+
+    def save(self, *args, **kwargs):
+        if isinstance(self.oauth_payload, dict):
+            self.oauth_payload = {
+                k: v for k, v in self.oauth_payload.items()
+                if k in self.OAUTH_PAYLOAD_ALLOWED_KEYS
+            }
+        super().save(*args, **kwargs)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["provider", "provider_sub"],
+                name="accounts_socialaccount_unique_provider_sub",
+            ),
+            field_not_blank("provider"),
+            field_not_blank("provider_sub"),
+        ]
+```
+
+Notes:
+
+- **OAuth users only.** Email/password sign-ups don't get a `SocialAccount` row — there's no underlying provider `sub`, only a WorkOS-side password hash. They're anchored to `User.workos_user_id` until we switch managed providers, at which point they need the password-reset path described in [ProviderSwitching.md](ProviderSwitching.md).
+- **`(provider, provider_sub)` is globally unique.** A given Google account can be linked to at most one local user. Attempting to link an already-claimed Google account raises and the SPA shows "this account is already linked to another user."
+- **CASCADE on `user`.** If a row is hard-deleted (a future GDPR purge command), its identities go too. Soft-delete (`is_active=False`) leaves the rows intact — they're needed for reactivation disambiguation.
+- **Allowlist, not deny-list, in `save()`.** "Don't persist `access_token`/`refresh_token`/`id_token`" is the kind of rule that gets forgotten in a future code path, and id_token specifically embeds PII (email, name, picture URL) inside a JWT that anyone with DB read access can decode. Rather than a strip-list that has to grow when providers add claims, we keep an `OAUTH_PAYLOAD_ALLOWED_KEYS` allowlist of decoded claims we actually use. The `save()` override filters to that allowlist as defense in depth — even if a caller passes the raw inbound payload, only the allowed keys land in the column. Bypass paths (`bulk_create`, queryset `update`) exist but aren't in our planned write paths; the rule for any future caller is "go through `save()` or filter explicitly."
+
+## Reactivation guard tightening
+
+Once `SocialAccount` rows exist, extend the `get_or_create_django_user` reactivation predicate (defined in [CustomUserModel.md](CustomUserModel.md)) with a third clause:
+
+**OAuth `sub` must match (when present).** If the user has any `SocialAccount` rows and the inbound login carries an OAuth `sub`, the inbound `(provider, sub)` must match one of them. A mismatch means "different human, don't reactivate" — this is the principled fix for the corporate-email-reassignment case. When the inbound login is email/password (no provider sub) and the user has only an email/password history (no `SocialAccount` rows), this check is a no-op.
+
+The reactivation predicate becomes `is_active=False AND banned_at IS NULL AND inbound.email_verified=True AND (no sub mismatch with existing SocialAccount rows)`.
+
+## Implementation steps
+
+1. **Add the `SocialAccount` model** to `apps/accounts/models.py` with the constraints above.
+2. **Add the WorkOS identities helper** at `apps/accounts/workos_client.py:fetch_user_identities(workos_user_id) -> list[Identity]` — `httpx` call, `Authorization: Bearer ${WORKOS_API_KEY}`, local TypedDict. Don't use the SDK's private `_http_client`.
+3. **Wire the upsert into `get_or_create_django_user`.** For OAuth logins, derive the provider key from `auth_response.authentication_method`; if no `SocialAccount` row exists for `(user, provider)`, fetch identities and upsert every returned row.
+
+   Use explicit get-or-create-with-conflict-detection — not `get_or_create`, not `update_or_create`. Both have hazards: `get_or_create` doesn't refresh the existing row, so `last_used_at` (auto_now) freezes at link-time and `oauth_payload` never reflects later claim changes. `update_or_create` would silently re-bind a row to a new user when the same `(provider, provider_sub)` pair exists under a different `user_id` — that's exactly the "different local user already claims this account" case we want to refuse loudly. So:
+
+   ```python
+   try:
+       sa = SocialAccount.objects.get(provider=p, provider_sub=s)
+   except SocialAccount.DoesNotExist:
+       SocialAccount.objects.create(user=user, provider=p, provider_sub=s, oauth_payload=claims)
+   else:
+       if sa.user_id != user.id:
+           raise SocialAccountConflict(...)  # different local user owns this Google/Apple/etc. account
+       sa.oauth_payload = claims
+       sa.save(update_fields=["oauth_payload", "last_used_at"])
+   ```
+
+   `last_used_at` _must_ appear in `update_fields` even though it's `auto_now=True` — when `update_fields` is specified, Django writes only the listed columns, and auto_now-on-save only takes effect for columns that will actually be written. Easy to miss; spell it out.
+
+   `oauth_payload` is reassigned (not mutated in place) so `SocialAccount.save()`'s allowlist filter runs on the new payload, stripping any new bearer tokens or unrecognized claims the provider added since the row was created.
+
+4. **Tighten the reactivation guard** with the `(provider, provider_sub)` mismatch check described above.
+5. **Register `SocialAccount` with a read-only admin.** Rows are written by the auth flow at login, not by hand — read-only prevents an admin from accidentally creating a row that would let someone log in as another user.
+6. **Backfill (optional).** For existing users, run a one-time management command that calls `fetch_user_identities` for each user with a `workos_user_id` and inserts their identities. Skip if launching this with no user base, or if WorkOS's identities API is the part we're trying to migrate away from (in that case backfill from the new provider instead).
+
+## Coordination with other auth plans
+
+- **[CustomUserModel.md](CustomUserModel.md)** — defines `User.workos_user_id` (managed-provider pointer) and the v1 reactivation guards (email_verified + banned_at). This doc adds the OAuth-layer identifiers that survive a managed-provider switch and tightens the reactivation guard.
+- **[Verification.md](Verification.md)** — originally proposed an external-identity table; this is that table, deferred until needed.
+- **[ProviderSwitching.md](ProviderSwitching.md)** — depends on this data when re-linking users post-switch. If we ship a switch before this lands, the playbook is "force re-link via email" instead of "pre-link by `(provider, sub)`."
+
+## Non-goals
+
+- **Account merge for the same human across two providers.** Future doc.
+- **Backfilling for users who pre-date this feature, when WorkOS itself is the part we're migrating off.** A switch-time backfill from the _new_ provider is cleaner.

--- a/docs/plans/auth/UserBanning.md
+++ b/docs/plans/auth/UserBanning.md
@@ -1,0 +1,103 @@
+# User Banning
+
+This document proposes adding the ability for admins to ban users.
+
+This would add moderation-ban state to `accounts.User` — distinct from the provider-soft-delete state that `is_active=False` already covers.
+
+## Status — deferred
+
+Deferred; revisit when one of the problems below becomes urgent. Until then, an admin can disable a user by toggling `is_active=False` in the Django admin — that blocks login (Django's `ModelBackend.user_can_authenticate()` honors it) and is reversible the same way. The cost is that a determined returning user could trigger reactivation through the signup flow and undo the disable; without abusive users to defend against, that's acceptable.
+
+## Problem
+
+**Bans need to survive reactivation.** [CustomUserModel.md](CustomUserModel.md) defines a reactivation path: a returning user whose `is_active=False` row matches by email gets `is_active=True` flipped back. That's the right behavior for users who deleted their auth account and came back, but it means that without a separate "banned" marker, banning is reversible by signing out and signing back in. The two states (provider-soft-delete vs. moderation-ban) need to be distinguishable on next login.
+
+**Bans need an audit trail.** "Who banned this user, and when" is information moderators want before unbanning, and that we want to keep even after the banning admin's account is deleted.
+
+**Defense in depth on the request path.** A freshly-banned user with a live session cookie should stop being authenticated on the very next request, not after their session expires.
+
+## Proposed model additions
+
+Two columns on `accounts.User`:
+
+```python
+# Moderation marker. NULL = not banned. Set when an admin (or future
+# Clerk-style provider ban event) bans the user; we also flip is_active=False
+# at the same time. The reactivation path on signup explicitly refuses rows
+# with banned_at IS NOT NULL — without this column, banning is a sign-out-and
+# -sign-back-in away from being undone.
+banned_at = models.DateTimeField(null=True, blank=True)
+
+# Who issued the ban. NULL = never banned, or banned by a provider event,
+# or banner has since been deleted. SET_NULL because audit records outlive
+# the actor.
+banned_by = models.ForeignKey(
+    "self",
+    on_delete=models.SET_NULL,
+    null=True,
+    blank=True,
+    related_name="bans_issued",
+)
+```
+
+Plus a Meta CHECK constraint:
+
+```python
+# Ban consistency: a banned user must not be active. Catches the
+# admin-flips-is_active=True-while-banned_at-is-set footgun even
+# though the admin UI funnels through actions; per DataModeling.md
+# "validate in the database."
+models.CheckConstraint(
+    condition=Q(banned_at__isnull=True) | Q(is_active=False),
+    name="accounts_user_banned_implies_inactive",
+),
+```
+
+Notes:
+
+- **`banned_at` distinguishes bans from provider-soft-deletes; everything else stays on `is_active`.** `is_active` is Django's canonical login gate (admin shows it, `ModelBackend.user_can_authenticate()` honors it). For both moderation bans and provider-`user.deleted` events we set `is_active=False`. The two are distinguished by whether `banned_at` is set — that's enough for the reactivation guard below. We deliberately don't add a separate `is_banned` boolean: the timestamp's nullness is the flag, and there's no second source of truth to drift.
+- **`banned_reason` is deferred** until we actually have abusive users to annotate; the failure mode without it is a missing audit detail, not a correctness gap.
+
+## Reactivation guard tightening
+
+Add a clause to the `get_or_create_django_user` reactivation predicate (defined in [CustomUserModel.md](CustomUserModel.md)):
+
+**`banned_at` must be NULL.** Otherwise banning is reversible by signing out and back in: ban → `is_active=False` → reactivation path flips it back to `True` and re-binds.
+
+The predicate becomes `is_active=False AND banned_at IS NULL AND inbound.email_verified=True`. If the email matches a row but `banned_at` is set, refuse the login with a clear error — don't silently create a fresh row, since that would orphan the banned user's contributions.
+
+## Admin
+
+In `apps/accounts/admin.py`, add `ban_users` / `unban_users` admin actions that flip `is_active`, `banned_at`, and `banned_by` together:
+
+- `ban_users` sets `banned_at=now`, `banned_by=request.user`, `is_active=False`
+- `unban_users` clears `banned_at`/`banned_by` and sets `is_active=True`
+
+Put `banned_at` and `banned_by` in `readonly_fields` so the actions are the _only_ path that can mutate them. Without that, an admin could set one without the others and produce a half-banned state. `is_active` itself stays editable — temporarily disabling a staff account is a legitimate use, and the worst an admin can do by accident is produce a soft-delete (a real distinct state), never a half-ban.
+
+## Defense in depth — `WorkOSBackend.get_user()`
+
+Tighten `apps/accounts/backends.py: WorkOSBackend.get_user()` to filter banned users out:
+
+```python
+def get_user(self, user_id):
+    try:
+        return User.objects.get(pk=user_id, is_active=True, banned_at__isnull=True)
+    except User.DoesNotExist:
+        return None
+```
+
+The login path (`get_or_create_django_user`) refuses banned users at signin, but `get_user()` runs on every authenticated request via `AuthenticationMiddleware`. Filtering here means a freshly-banned user with a live session cookie stops being authenticated on the very next request, with no need to flush sessions.
+
+(In CustomUserModel.md's v1 shape, `get_user()` filters on `is_active=True` only — sufficient when there's no separate ban state.)
+
+## Coordination with other auth plans
+
+- **[CustomUserModel.md](CustomUserModel.md)** — defines the v1 reactivation predicate `is_active=False AND inbound.email_verified=True`. This doc adds the `banned_at` clause.
+- **[Webhooks.md](Webhooks.md)** — the proposed `is_banned` mirroring (Clerk-only `user.banned`/`user.unbanned` events) wires into this model: handler sets `banned_at=now` and `is_active=False` together. Until this doc lands, the v1 webhook handler just sets `is_active=False` (see CustomUserModel.md coordination notes).
+
+## Non-goals
+
+- **Per-context bans (banned from comments but not edits).** Future doc; v1 is a single account-level ban.
+- **Ban reasons / appeals workflow.** Future doc; v1 is action + audit-log.
+- **Time-limited bans.** Future doc.


### PR DESCRIPTION
## Summary

Adds planning documents for upcoming auth work (authorization, social account sync, user banning) and silences Django's `auth.W004` warning since email uniqueness is enforced case-insensitively via a `Lower("email")` UniqueConstraint on the custom User model.

- New plans under `docs/plans/auth/`: `Authz.md`, `SocialAccountSync.md`, `UserBanning.md`
- `SILENCED_SYSTEM_CHECKS = ["auth.W004"]` with a comment explaining why `unique=True` on `email` would be redundant

## Test plan

- [ ] `cd backend && uv run python manage.py check` shows no `auth.W004` warning
- [ ] Plan docs render correctly on GitHub