### PR TITLE
feat: refresh running SPA clients after deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,12 @@ WORKDIR /frontend
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-# Copy source and build
+# Copy source and build. RAILWAY_GIT_COMMIT_SHA is auto-injected by Railway
+# for GitHub-triggered deploys; it stamps the SvelteKit build version so open
+# browser tabs can detect a new deploy via version.json polling. Outside
+# Railway the ARG falls back to "dev" and polling is disabled.
+ARG RAILWAY_GIT_COMMIT_SHA=dev
+ENV RAILWAY_GIT_COMMIT_SHA=$RAILWAY_GIT_COMMIT_SHA
 COPY frontend/ .
 RUN pnpm build
 # Keep only runtime dependencies for the Node SSR server we copy below.

--- a/docs/Hosting.md
+++ b/docs/Hosting.md
@@ -116,6 +116,12 @@ Use a shared backend in production. On Railway, the simplest options are:
 
 Dev + tests run fine with `LocMemCache` because there's only one process. Document the limit-per-worker behavior if you ever ship multi-worker without a shared backend.
 
+### Stamping the deploy version
+
+The SvelteKit build reads `RAILWAY_GIT_COMMIT_SHA` and writes it into `version.json`; the SPA polls that file hourly and, on a detected change, swaps the next client-side navigation for a full page reload. That's how an open browser tab picks up new JS (and drops in-memory caches) after a deploy without disrupting the user mid-task.
+
+Railway auto-injects `RAILWAY_GIT_COMMIT_SHA` as a Docker build arg for any deploy triggered from GitHub — no service-side configuration required, just the `ARG RAILWAY_GIT_COMMIT_SHA` declaration in the [Dockerfile](../Dockerfile). Outside Railway (local `docker build`), the arg falls back to `dev` and version polling is disabled. The `version.json` in the built image (`/app/frontend_runtime/build/client/_app/version.json`) is the ground truth for which SHA was stamped.
+
 ### 3. Deploy
 
 Push to `main`. Railway builds the Docker image and deploys. The

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,12 +1,22 @@
 <script lang="ts">
   import '../app.css';
-  import { page } from '$app/state';
+  import { page, updated } from '$app/state';
+  import { beforeNavigate } from '$app/navigation';
   import SiteShell from '$lib/components/SiteShell.svelte';
   import FocusSiteShell from '$lib/components/FocusSiteShell.svelte';
   import ToastHost from '$lib/toast/ToastHost.svelte';
   import { isFocusModePath } from '$lib/focus-mode';
   import { isKioskCookieSet } from '$lib/kiosk/config';
   import { onMount } from 'svelte';
+
+  // When SvelteKit's version.json poll detects a new deploy, swap the next
+  // soft navigation for a full reload so the user picks up new JS (and any
+  // in-memory caches drop) without disrupting them mid-task.
+  beforeNavigate(({ willUnload, to }) => {
+    if (updated.current && !willUnload && to?.url) {
+      location.href = to.url.href;
+    }
+  });
 
   let { children } = $props();
 

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -23,6 +23,12 @@ const config = {
   preprocess: [injectCustomMedia, vitePreprocess()],
   kit: {
     adapter: adapter(),
+    version: {
+      name: process.env.RAILWAY_GIT_COMMIT_SHA || 'dev',
+      // Only poll when a real SHA is stamped (production builds). In dev the
+      // version stays 'dev' forever, so polling would just be noise.
+      pollInterval: process.env.RAILWAY_GIT_COMMIT_SHA ? 60 * 60 * 1000 : 0,
+    },
     prerender: {
       origin: process.env.SITE_ORIGIN || 'http://localhost:5173',
       handleHttpError: ({ path, message }) => {


### PR DESCRIPTION
## Summary

- Stamp `RAILWAY_GIT_COMMIT_SHA` into SvelteKit's `version.json` at build time (auto-injected by Railway for GitHub-triggered deploys; falls back to `dev` locally).
- Poll `version.json` hourly in the browser; when a new build is detected, `beforeNavigate` swaps the next client-side navigation for a full page reload so open tabs pick up new JS without disrupting users mid-task.
- Document the mechanism in `docs/Hosting.md`.

This is groundwork for the upcoming `/me/capabilities` client-side cache (Authz Phase 7): a hard reload after deploy is what keeps cached policy verdicts honest across releases.

## Test plan

- [ ] Local `pnpm dev` — `RAILWAY_GIT_COMMIT_SHA` is unset, `version.name` is `'dev'`, `pollInterval` is `0`, no polling traffic.
- [ ] Local `docker build --build-arg RAILWAY_GIT_COMMIT_SHA=abc123 .` — confirm `frontend/build/client/_app/version.json` contains `"version":"abc123"`.
- [ ] Deploy commit A to Railway, open the site, confirm `version.json` shows commit A's SHA.
- [ ] Deploy commit B with the tab still open. After the hourly poll fires (or temporarily shorten `pollInterval` for the test), click an internal link and confirm DevTools shows a full-document reload, not an `_app/` chunk fetch.
- [ ] Confirm staying on the same page after the poll detects a new version does NOT trigger a reload — the refresh only happens on next navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic deploy detection and refresh: open browser tabs now automatically perform a full page reload when a new version is deployed, ensuring users always have access to the latest version without manual intervention.

* **Documentation**
  * Added documentation explaining the deploy version stamping and automatic refresh feature.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/The-Flip/flipcommons/pull/363)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->