### PR TITLE
fix(frontend): transition wikilink dropdown to citation when toolbar clicked mid-flow

### DIFF
--- a/frontend/src/lib/components/form/WikilinkAutocomplete.svelte
+++ b/frontend/src/lib/components/form/WikilinkAutocomplete.svelte
@@ -73,14 +73,20 @@
   fetchLinkTypes()
     .then((types) => {
       linkTypes = types;
-      if (initialType) {
-        const match = types.find((t) => t.name === initialType);
-        if (match) selectType(match);
-      }
     })
     .catch(() => {
       // Degraded state: type picker will be empty
     });
+
+  // Honor initialType both at mount and when it changes after mount (e.g.
+  // user typed `[[` to open the type picker, then clicked the Citation
+  // toolbar button — the parent updates `initialType` on the already-mounted
+  // component, so we react here to advance past the type picker).
+  $effect(() => {
+    if (!initialType || stage !== 'type' || linkTypes.length === 0) return;
+    const match = linkTypes.find((t) => t.name === initialType);
+    if (match) selectType(match);
+  });
 
   // -----------------------------------------------------------------------
   // Type picker stage

--- a/frontend/src/lib/components/form/markdown-toolbar.dom.test.ts
+++ b/frontend/src/lib/components/form/markdown-toolbar.dom.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, fireEvent } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import MarkdownTextArea from './MarkdownTextArea.svelte';
@@ -166,6 +166,31 @@ describe('MarkdownToolbar', () => {
     await user.click(getToolbarButton('Citation'));
 
     // Should skip the type picker ("Insert link") and go straight to citation
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Insert link')).not.toBeInTheDocument();
+      expect(screen.getByText(/search.*source/i)).toBeInTheDocument();
+    });
+  });
+
+  it('switches an open type-picker dropdown into the citation flow when Citation is clicked', async () => {
+    renderTextArea();
+    const user = userEvent.setup();
+    const textarea = getTextarea();
+
+    // Type `[[` to open the type picker (userEvent treats `[` as a key
+    // descriptor, so set value + selection and fire `input` directly).
+    textarea.focus();
+    textarea.value = '[[';
+    textarea.selectionStart = 2;
+    textarea.selectionEnd = 2;
+    fireEvent.input(textarea);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Insert link')).toBeInTheDocument();
+    });
+
+    await user.click(getToolbarButton('Citation'));
+
     await vi.waitFor(() => {
       expect(screen.queryByText('Insert link')).not.toBeInTheDocument();
       expect(screen.getByText(/search.*source/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- When the Citation toolbar button is clicked after typing `[[`, the WikilinkAutocomplete is already mounted and only `initialType` changes. The prior code honored `initialType` only inside the one-shot `fetchLinkTypes().then(...)` callback, so the stage stayed on the type picker; with nothing inside the dropdown autofocusing, the textarea-blur timeout then closed it — the "flash and disappear" symptom.
- Move the type-picker transition into a `$effect` so post-mount `initialType` changes also advance past it.

## Test plan
- [ ] `pnpm --filter frontend test markdown-toolbar.dom` passes
- [ ] Manually: type `[[`, then click the Citation toolbar button — dropdown transitions to citation stage instead of flashing closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)