### PR TITLE
docs: add Python.md typing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,14 +221,14 @@ For new behavior, include tests. Consider writing the test first, though sometim
 
 ## Strong Typing (backend)
 
-Backend code should be as strongly typed as possible. Annotations are documentation the compiler enforces.
+Code MUST be as strongly typed as possible.
 
-Smells — sometimes legitimate, usually a sign the type can be tightened:
+The following smells are _sometimes_ legitimate, but are usually a sign the type can be tightened:
 
-- Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING` , `# type: ignore`, `# noqa`
+- Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING`, `# type: ignore`, `# noqa`
 - `tuple[...]` with 3+ positional fields, or the same tuple shape repeated across modules
 
-Prefer NamedTuple, dataclass, or TypedDict. Full catalogue, legitimate exception shapes (Django management `**kwargs`, signal receivers, Ninja dispatch, etc.), and the ruff ANN401 ratchet: [docs/plans/types/TypeFixing.md](plans/types/TypeFixing.md).
+Prefer NamedTuple, dataclass, or TypedDict. For the full catalogue and legitimate exceptions, see [docs/Python.md](Python.md).
 
 ### Running mypy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,14 +215,14 @@ For new behavior, include tests. Consider writing the test first, though sometim
 
 ## Strong Typing (backend)
 
-Backend code should be as strongly typed as possible. Annotations are documentation the compiler enforces.
+Code MUST be as strongly typed as possible.
 
-Smells — sometimes legitimate, usually a sign the type can be tightened:
+The following smells are _sometimes_ legitimate, but are usually a sign the type can be tightened:
 
-- Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING` , `# type: ignore`, `# noqa`
+- Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING`, `# type: ignore`, `# noqa`
 - `tuple[...]` with 3+ positional fields, or the same tuple shape repeated across modules
 
-Prefer NamedTuple, dataclass, or TypedDict. Full catalogue, legitimate exception shapes (Django management `**kwargs`, signal receivers, Ninja dispatch, etc.), and the ruff ANN401 ratchet: [docs/plans/types/TypeFixing.md](plans/types/TypeFixing.md).
+Prefer NamedTuple, dataclass, or TypedDict. For the full catalogue and legitimate exceptions, see [docs/Python.md](Python.md).
 
 ### Running mypy
 

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -254,14 +254,14 @@ For new behavior, include tests. Consider writing the test first, though sometim
 
 ## Strong Typing (backend)
 
-Backend code should be as strongly typed as possible. Annotations are documentation the compiler enforces.
+Code MUST be as strongly typed as possible.
 
-Smells — sometimes legitimate, usually a sign the type can be tightened:
+The following smells are _sometimes_ legitimate, but are usually a sign the type can be tightened:
 
-- Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING` , `# type: ignore`, `# noqa`
+- Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING`, `# type: ignore`, `# noqa`
 - `tuple[...]` with 3+ positional fields, or the same tuple shape repeated across modules
 
-Prefer NamedTuple, dataclass, or TypedDict. Full catalogue, legitimate exception shapes (Django management `**kwargs`, signal receivers, Ninja dispatch, etc.), and the ruff ANN401 ratchet: [docs/plans/types/TypeFixing.md](plans/types/TypeFixing.md).
+Prefer NamedTuple, dataclass, or TypedDict. For the full catalogue and legitimate exceptions, see [docs/Python.md](Python.md).
 
 ### Running mypy
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -9,6 +9,7 @@ It does not try to restate every project rule. Instead, it points to the more sp
 - [../README.md](../README.md) for setup, commands, and local development
 - [Architecture.md](Architecture.md) for the top-level system map
 - [WebArchitecture.md](WebArchitecture.md) for the Django + SvelteKit web stack
+- [Python.md](Python.md) for backend Python typing and style decisions
 - [Svelte.md](Svelte.md) for route-level rendering choices and SvelteKit page conventions
 - [ApiDesign.md](ApiDesign.md) for frontend/backend API design rules for pages and SSR
 - [Authz.md](Authz.md) for authorization and capability surfaces

--- a/docs/Python.md
+++ b/docs/Python.md
@@ -1,0 +1,57 @@
+# Python Development
+
+## Typing
+
+Code MUST be as strongly typed as possible.
+
+The following smells are _sometimes_ legitimate, but are usually a sign the type can be tightened:
+
+- Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING`, `# type: ignore`, `# noqa`
+- `tuple[...]` with 3+ positional fields, or the same tuple shape repeated across modules
+
+### Valid exceptions to strong types
+
+Broad types are acceptable when required by a third party:
+
+- Django management-command `**kwargs` / `**options`
+- Django signal receivers and auth-backend hooks
+- Django-Ninja dispatch edges where schemas validate runtime shape
+- Third-party APIs that genuinely discard type information
+- Unavoidable django-stubs limitations
+
+Every exception needs a short reason at the use site.
+
+### Choosing a data shape
+
+- Use Ninja/Pydantic `Schema` for API request/response shapes
+- Use `TypedDict` for internal dicts with stable keys
+- Use `Protocol` for structural contracts
+- Use `NamedTuple` or dataclass for records with named fields
+- Do not use a type alias to hide positional tuple structure (e.g. `UserRow = tuple[int, str, datetime]`) — use a `NamedTuple` instead
+- Do not use `dict[str, Any]` for JSON-shaped data:
+  - Use `apps.core.types.JsonData` for read-side JSON mappings
+  - Use `apps.core.types.JsonBody` for mutable/test-client JSON bodies
+
+### Django typing idioms
+
+For helpers generic over model classes, prefer `_default_manager` over `.objects`; django-stubs can see `_default_manager` on `type[Model]`.
+
+Do not replace `obj.fk_id is not None` with `obj.fk is not None` just to satisfy mypy. The first is a column check; the second may fetch the related object. If you need the related object narrowed, bind it locally after the `_id` guard and assert it is not `None`.
+
+For queryset-annotated attributes, prefer a narrow structural `Protocol` over widening the whole model to `Any`.
+
+### Pydantic and Ninja
+
+Serialization helpers should usually return Ninja/Pydantic `Schema` instances, not dicts that are later revalidated into the same schema.
+
+Use dict returns only when the dict is the real runtime contract, such as cached JSON-byte hot paths.
+
+When a Ninja response type is a union of schemas with shared fields, make dispatch structurally unambiguous: required distinguishing fields on the richer schema, and `extra="forbid"` on the minimal schema where needed.
+
+### Suppressions
+
+If you use `# type: ignore[code]` or `# noqa: RULE`, you MUST include a reason.
+
+`ANN401` applies to top-level `Any` parameters and return annotations. It does not apply to nested `dict[str, Any]` or `cast(Any, ...)`; do not add `# noqa: ANN401` there. Use a plain comment if the broad type is intentional.
+
+NEVER silence a warning when the underlying type can be expressed.

--- a/docs/Reviewing.md
+++ b/docs/Reviewing.md
@@ -75,7 +75,7 @@ In particular:
 
 ### Type strength (backend)
 
-When a change touches Python signatures, return types, or data structures, check [docs/plans/types/TypeFixing.md](plans/types/TypeFixing.md) for the smell catalogue and the legitimate exception shapes.
+When a change touches Python signatures, return types, or data structures, check [Python.md](Python.md) for the smell catalogue and legitimate exception shapes.
 
 Treat each of these as a closer-look trigger, not an automatic finding:
 
@@ -86,9 +86,9 @@ Treat each of these as a closer-look trigger, not an automatic finding:
 - `isinstance` checks on values whose upstream signature could be narrower
 - `TYPE_CHECKING`-only imports paired with `cast` or stringified annotations
 - bare or unexplained `# type: ignore` (should be `# type: ignore[<code>]` with a reason)
-- bare or unexplained `# noqa` (should be `# noqa: <code>` with a reason; ANN401 noqas matching TypeFixing.md's exception shapes are correct, not findings)
+- bare or unexplained `# noqa` (should be `# noqa: <code>` with a reason; ANN401 noqas matching [Python.md](Python.md)'s exception shapes are correct, not findings)
 
-The fix is usually a NamedTuple, dataclass, or TypedDict — not a type alias, which leaves callers indexing by position. Don't flag a hit that TypeFixing.md lists as a legitimate exception (Django management `**kwargs`, signal receivers, Ninja dispatch, JSON parse results, framework-owned callback surfaces).
+The fix is usually a NamedTuple, dataclass, or TypedDict — not a type alias, which leaves callers indexing by position. Don't flag a hit that [Python.md](Python.md) lists as a legitimate exception (Django management `**kwargs`, signal receivers, Ninja dispatch, JSON parse results, framework-owned callback surfaces).
 
 ### Deployment/runtime assumptions
 

--- a/docs/plans/types/TypeFixing.md
+++ b/docs/plans/types/TypeFixing.md
@@ -2,6 +2,8 @@
 
 Status: DONE
 
+Stable backend Python typing policy now lives in [Python.md](../../Python.md). This file is the historical execution plan for the type-smell cleanup.
+
 ## Background
 
 The backend is in the process of eliminating `mypy-baseline.txt` entries. Most of that work has been mechanical — adding return annotations, typing management-command `handle()` methods, etc. But a second category keeps surfacing on review: annotations that satisfy mypy yet communicate nothing, because they reach for `Any` / `object` / untagged tuples when the real shape is already obvious from the body.


### PR DESCRIPTION
## Summary

Extract stable backend Python typing policy from the (DONE) `docs/plans/types/TypeFixing.md` execution plan into a new top-level `docs/Python.md`, and cross-link from Development, Reviewing, and the agent docs.

- New `docs/Python.md`: type smells, valid third-party exceptions, data-shape decision list, Django typing idioms, Pydantic/Ninja guidance, suppression rules + ANN401 scope clarification
- Reviewing.md and AGENTS.src.md now point at Python.md instead of the historical plan
- TypeFixing.md gets a header note redirecting current policy questions to Python.md
- Type-smell trigger list intentionally duplicated in AGENTS.src.md so always-loaded context still surfaces the cue

## Test plan

- [ ] Skim `docs/Python.md` for accuracy
- [ ] Confirm Reviewing.md / AGENTS.src.md / Development.md links resolve to Python.md