### PR TITLE
refactor(frontend): migrate ActionMenu to floating action

### DIFF
--- a/frontend/src/lib/actions/floating.ts
+++ b/frontend/src/lib/actions/floating.ts
@@ -68,15 +68,21 @@ export const floating: Action<HTMLElement, FloatingOptions> = (node, options) =>
   let cleanupAutoUpdate: (() => void) | undefined;
   let subscribedAnchor: FloatingAnchor | undefined;
 
-  // Hide until the first position resolves to avoid a top-left flash on first
-  // open (the dynamic import is async, so the floating element would otherwise
-  // be visible briefly at translate(0,0) before computePosition runs).
-  // Use opacity rather than visibility so the element stays in the
-  // accessibility tree — testing-library's getByRole skips visibility:hidden.
-  const originalOpacity = node.style.opacity;
-  node.style.opacity = '0';
+  // Park the element far offscreen until the first computePosition resolves,
+  // to avoid a top-left flash while the dynamic floating-ui import is loading.
+  // We deliberately do NOT use visibility/opacity/pointer-events to hide:
+  //   - visibility:hidden removes the element from the a11y tree (testing-
+  //     library's getByRole skips it).
+  //   - opacity:0 keeps it in the a11y tree but leaves it clickable at (0,0),
+  //     and pointer-events:none on the parent doesn't help — menu items are
+  //     children with `auto` and would still be hit (and it trips up
+  //     @testing-library/user-event, which refuses to interact with any
+  //     descendant of a pointer-events:none ancestor).
+  // Offscreen positioning sidesteps all of that: the element remains
+  // measurable for computePosition and stays in the a11y tree, but a real
+  // pointer can't reach it.
   node.style.position = 'fixed';
-  node.style.top = '0';
+  node.style.top = '-9999px';
   node.style.left = '0';
 
   const portalTarget = findPortalTarget(node);
@@ -99,8 +105,8 @@ export const floating: Action<HTMLElement, FloatingOptions> = (node, options) =>
       })
       .then(({ x, y }) => {
         if (destroyed) return;
+        node.style.top = '0';
         node.style.transform = `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
-        node.style.opacity = originalOpacity;
       });
   }
 

--- a/frontend/src/lib/actions/floating.ts
+++ b/frontend/src/lib/actions/floating.ts
@@ -71,8 +71,10 @@ export const floating: Action<HTMLElement, FloatingOptions> = (node, options) =>
   // Hide until the first position resolves to avoid a top-left flash on first
   // open (the dynamic import is async, so the floating element would otherwise
   // be visible briefly at translate(0,0) before computePosition runs).
-  const originalVisibility = node.style.visibility;
-  node.style.visibility = 'hidden';
+  // Use opacity rather than visibility so the element stays in the
+  // accessibility tree — testing-library's getByRole skips visibility:hidden.
+  const originalOpacity = node.style.opacity;
+  node.style.opacity = '0';
   node.style.position = 'fixed';
   node.style.top = '0';
   node.style.left = '0';
@@ -98,7 +100,7 @@ export const floating: Action<HTMLElement, FloatingOptions> = (node, options) =>
       .then(({ x, y }) => {
         if (destroyed) return;
         node.style.transform = `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
-        node.style.visibility = originalVisibility;
+        node.style.opacity = originalOpacity;
       });
   }
 

--- a/frontend/src/lib/components/ActionMenu.dom.test.ts
+++ b/frontend/src/lib/components/ActionMenu.dom.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import ActionMenuFixture from './ActionMenu.fixture.svelte';
 import ActionMenuListboxFixture from './ActionMenu.listbox.fixture.svelte';
+import ActionMenuPortalFixture from './ActionMenu.portal.fixture.svelte';
 import ActionMenuTriggerFixture from './ActionMenu.trigger.fixture.svelte';
 
 describe('ActionMenu', () => {
@@ -24,12 +25,26 @@ describe('ActionMenu', () => {
     await user.click(trigger);
 
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getByRole('menu')).toBeInTheDocument();
+    const menu = screen.getByRole('menu');
+    expect(menu).toBeInTheDocument();
+    expect(menu).toHaveAttribute('data-placement', 'bottom-end');
     expect(screen.getByRole('menuitem', { name: 'Sources' })).toHaveAttribute(
       'href',
       '/models/medieval-madness/sources',
     );
     expect(trigger).toHaveFocus();
+  });
+
+  it('portals the menu out of clipping ancestors', async () => {
+    const user = userEvent.setup();
+
+    render(ActionMenuPortalFixture);
+
+    await user.click(screen.getByRole('button', { name: 'Tools' }));
+
+    const menu = screen.getByRole('menu');
+    const wrapper = screen.getByTestId('clip-wrapper');
+    expect(wrapper).not.toContainElement(menu);
   });
 
   it('opens from the keyboard and focuses the first item', async () => {
@@ -155,6 +170,7 @@ describe('ActionMenu', () => {
 
       const listbox = screen.getByRole('listbox');
       expect(listbox).toBeInTheDocument();
+      expect(listbox).toHaveAttribute('data-placement', 'top-start');
 
       const options = screen.getAllByRole('option');
       expect(options.map((o) => o.textContent?.trim())).toEqual([

--- a/frontend/src/lib/components/ActionMenu.dom.test.ts
+++ b/frontend/src/lib/components/ActionMenu.dom.test.ts
@@ -155,7 +155,6 @@ describe('ActionMenu', () => {
 
       const listbox = screen.getByRole('listbox');
       expect(listbox).toBeInTheDocument();
-      expect(listbox).toHaveClass('opens-up');
 
       const options = screen.getAllByRole('option');
       expect(options.map((o) => o.textContent?.trim())).toEqual([

--- a/frontend/src/lib/components/ActionMenu.portal.fixture.svelte
+++ b/frontend/src/lib/components/ActionMenu.portal.fixture.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import ActionMenu from './ActionMenu.svelte';
+  import MenuItem from './MenuItem.svelte';
+</script>
+
+<div data-testid="clip-wrapper" class="clip-wrapper">
+  <ActionMenu label="Tools">
+    <MenuItem href="/a">A</MenuItem>
+    <MenuItem href="/b">B</MenuItem>
+  </ActionMenu>
+</div>
+
+<style>
+  .clip-wrapper {
+    overflow: hidden;
+    width: 40px;
+    height: 40px;
+  }
+</style>

--- a/frontend/src/lib/components/ActionMenu.svelte
+++ b/frontend/src/lib/components/ActionMenu.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { setContext, untrack, type Snippet } from 'svelte';
 
+  import { floating } from '$lib/actions/floating';
+
   type Props = {
     label: string;
     disabled?: boolean;
@@ -22,6 +24,9 @@
   }: Props = $props();
 
   const role: 'menu' | 'listbox' = $derived(roleProp ?? (variant === 'pill' ? 'listbox' : 'menu'));
+  const placement = $derived(
+    variant === 'pill' ? 'top-start' : variant === 'heading' ? 'bottom-start' : 'bottom-end',
+  );
   // Context captures the role at construction time and is read once by descendants;
   // role is stable for the lifetime of the component for all current call sites.
   setContext<'menu' | 'listbox'>(
@@ -203,47 +208,40 @@
   });
 </script>
 
-<div class="action-menu">
-  <button
-    bind:this={triggerEl}
-    type="button"
-    class="trigger"
-    class:heading={variant === 'heading'}
-    class:pill={variant === 'pill'}
-    class:bare={variant === 'bare'}
-    {disabled}
-    aria-haspopup={role === 'listbox' ? 'listbox' : 'menu'}
-    aria-expanded={open}
-    aria-controls={open ? menuId : undefined}
-    aria-label={ariaLabel ?? (trigger ? label : undefined)}
-    onclick={toggleMenu}
-    onkeydown={handleTriggerKeydown}
+<button
+  bind:this={triggerEl}
+  type="button"
+  class="trigger"
+  class:heading={variant === 'heading'}
+  class:pill={variant === 'pill'}
+  class:bare={variant === 'bare'}
+  {disabled}
+  aria-haspopup={role === 'listbox' ? 'listbox' : 'menu'}
+  aria-expanded={open}
+  aria-controls={open ? menuId : undefined}
+  aria-label={ariaLabel ?? (trigger ? label : undefined)}
+  onclick={toggleMenu}
+  onkeydown={handleTriggerKeydown}
+>
+  {#if trigger}{@render trigger()}{:else}{label}{/if}
+</button>
+{#if open && triggerEl}
+  <div
+    bind:this={menuEl}
+    id={menuId}
+    class="menu"
+    {role}
+    tabindex="-1"
+    aria-label={ariaLabel ?? label}
+    use:floating={{ anchor: triggerEl, placement }}
+    onkeydown={handleMenuKeydown}
+    onclick={handleMenuClick}
   >
-    {#if trigger}{@render trigger()}{:else}{label}{/if}
-  </button>
-  {#if open}
-    <div
-      bind:this={menuEl}
-      id={menuId}
-      class="menu"
-      class:align-start={variant === 'heading' || variant === 'pill'}
-      class:opens-up={variant === 'pill'}
-      {role}
-      tabindex="-1"
-      aria-label={ariaLabel ?? label}
-      onkeydown={handleMenuKeydown}
-      onclick={handleMenuClick}
-    >
-      {@render children()}
-    </div>
-  {/if}
-</div>
+    {@render children()}
+  </div>
+{/if}
 
 <style>
-  .action-menu {
-    position: relative;
-  }
-
   .trigger {
     color: var(--color-text-muted);
     cursor: pointer;
@@ -315,9 +313,6 @@
   }
 
   .menu {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 4px);
     background: var(--color-background);
     border: 1px solid var(--color-border-soft);
     border-radius: var(--radius-2);
@@ -325,15 +320,5 @@
     min-width: 7rem;
     z-index: var(--z-dropdown);
     box-shadow: var(--shadow-popover);
-  }
-
-  .menu.align-start {
-    right: auto;
-    left: 0;
-  }
-
-  .menu.opens-up {
-    top: auto;
-    bottom: calc(100% + 4px);
   }
 </style>

--- a/frontend/src/lib/components/ActionMenu.svelte
+++ b/frontend/src/lib/components/ActionMenu.svelte
@@ -233,6 +233,7 @@
     {role}
     tabindex="-1"
     aria-label={ariaLabel ?? label}
+    data-placement={placement}
     use:floating={{ anchor: triggerEl, placement }}
     onkeydown={handleMenuKeydown}
     onclick={handleMenuClick}


### PR DESCRIPTION
## Summary

Migrate `ActionMenu` off bespoke CSS positioning onto the shared `use:floating` action (Floating UI + portal), and harden the `floating` action's pre-position hide so it stays in the a11y tree without leaking clicks or breaking user-event.

Addresses scope item 1 of #352 (ActionMenu). `SearchableSelect` and `CitationTooltip` remain — leaving #352 open.

- `ActionMenu.svelte`: drop the `.action-menu` wrapper, `.align-start`, and `.opens-up` modifier classes. Placement is derived from `variant` (`pill` → `top-start`, `heading` → `bottom-start`, else `bottom-end`) and passed to `use:floating`. `flip()` auto-detects vertical overflow; `shift()` covers horizontal overflow; portaling escapes `overflow: hidden` ancestors (modals).
- `floating.ts`: park the floating element offscreen (`top: -9999px`) until the first `computePosition` resolves, instead of `visibility: hidden` (removed from a11y tree) or `opacity: 0` (leaves it clickable at (0,0) and trips up `@testing-library/user-event`'s pointer-events ancestor check).
- Tests: add a `data-placement` attribute to the menu and assert it for the `bottom-end` and `top-start` variants (replaces the lost `.opens-up` class assertion). Add a portal-escape test verifying the menu renders outside an `overflow: hidden` ancestor.

## Test plan

- [ ] `bare` variant (Nav, row kebabs) opens below, right-aligned
- [ ] `heading` variant (edit-section picker) opens below, left-aligned
- [ ] `pill` variant (MediaCard caption selector) opens above, left-aligned
- [ ] No top-left flash on first open after page load
- [ ] Menu shifts/flips near viewport edges
- [ ] Menu stays anchored to trigger when page scrolls
- [ ] Outside click and Esc close the menu; Esc restores focus to trigger
- [ ] Keyboard: ↓/↑/Home/End/Enter/Tab work as before
- [ ] Disabled trigger doesn't open
- [ ] **Portal regression**: ActionMenu opened inside a Modal renders above the scrim and isn't clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)