### PR TITLE
refactor(frontend): migrate CitationTooltip to floating action

### DIFF
--- a/frontend/src/lib/components/CitationTooltip.dom.test.ts
+++ b/frontend/src/lib/components/CitationTooltip.dom.test.ts
@@ -160,33 +160,6 @@ describe('CitationTooltip', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
-  it('repositions on resize and scroll while visible', async () => {
-    renderTooltip('<p>Move <sup data-cite-id="1" tabindex="0">[1]</sup>.</p>');
-    await vi.waitFor(() => expect(GET).toHaveBeenCalledTimes(1));
-
-    await fireEvent.mouseEnter(getCitation('1'));
-    const tooltip = (await screen.findByRole('tooltip')) as HTMLDivElement;
-
-    await vi.waitFor(() => {
-      expect(tooltip.style.left).toBe('22px');
-      expect(tooltip.style.top).toBe('74px');
-    });
-
-    anchorRect = rect({ left: 220, top: 260, width: 24, height: 16 });
-    await fireEvent(window, new Event('resize'));
-    await vi.waitFor(() => {
-      expect(tooltip.style.left).toBe('142px');
-      expect(tooltip.style.top).toBe('174px');
-    });
-
-    anchorRect = rect({ left: 260, top: 280, width: 24, height: 16 });
-    await fireEvent(window, new Event('scroll'));
-    await vi.waitFor(() => {
-      expect(tooltip.style.left).toBe('182px');
-      expect(tooltip.style.top).toBe('194px');
-    });
-  });
-
   describe('citations prop (no-fetch)', () => {
     const propCitations: InlineCitation[] = [
       {

--- a/frontend/src/lib/components/CitationTooltip.svelte
+++ b/frontend/src/lib/components/CitationTooltip.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-  import { tick } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
   import client from '$lib/api/client';
+  import { floating } from '$lib/actions/floating';
   import {
-    computePosition,
     reduceTooltip,
     type CitationInfo,
     type InlineCitation,
@@ -35,7 +34,6 @@
     }
   });
   let tipState: TooltipState = $state({ activeId: null, pinned: false });
-  let above = $state(true);
   let tooltipEl: HTMLDivElement | undefined = $state();
   let hideTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -72,52 +70,8 @@
     return result;
   }
 
-  async function updatePosition(anchor: HTMLElement) {
-    if (!tooltipEl) return;
-    // Render offscreen to measure
-    tooltipEl.style.visibility = 'hidden';
-    tooltipEl.style.left = '0px';
-    tooltipEl.style.top = '0px';
-    await tick();
-    if (!tooltipEl) return;
-    const anchorRect = anchor.getBoundingClientRect();
-    const tooltipRect = tooltipEl.getBoundingClientRect();
-    const result = computePosition(
-      anchorRect,
-      tooltipRect.width,
-      tooltipRect.height,
-      window.innerWidth,
-      window.innerHeight,
-    );
-    above = result.above;
-    tooltipEl.style.left = `${result.x}px`;
-    tooltipEl.style.top = `${result.y}px`;
-    tooltipEl.style.visibility = 'visible';
-  }
-
-  // Track the current anchor element for repositioning
+  // Track the current anchor element so `floating` can reposition against it.
   let currentAnchor: HTMLElement | null = $state(null);
-
-  $effect(() => {
-    if (tipState.activeId != null && activeCitation && currentAnchor) {
-      updatePosition(currentAnchor);
-    }
-  });
-
-  // Reposition on scroll/resize while visible
-  $effect(() => {
-    if (tipState.activeId == null) return;
-
-    function onScrollResize() {
-      if (currentAnchor) updatePosition(currentAnchor);
-    }
-    window.addEventListener('scroll', onScrollResize, { passive: true });
-    window.addEventListener('resize', onScrollResize, { passive: true });
-    return () => {
-      window.removeEventListener('scroll', onScrollResize);
-      window.removeEventListener('resize', onScrollResize);
-    };
-  });
 
   // Click outside handler
   $effect(() => {
@@ -236,12 +190,12 @@
   });
 </script>
 
-{#if tipState.activeId != null && activeCitation}
+{#if tipState.activeId != null && activeCitation && currentAnchor}
   <div
     class="citation-tooltip"
-    class:above
     bind:this={tooltipEl}
     role="tooltip"
+    use:floating={{ anchor: currentAnchor, placement: 'top' }}
     onmouseenter={() => dispatch({ type: 'tooltip-mouseenter' })}
     onmouseleave={() => dispatch({ type: 'tooltip-mouseleave' })}
     onfocusin={() => dispatch({ type: 'tooltip-mouseenter' })}
@@ -268,7 +222,6 @@
 
 <style>
   .citation-tooltip {
-    position: fixed;
     z-index: var(--z-tooltip);
     max-width: 320px;
     padding: var(--size-2) var(--size-3);

--- a/frontend/src/lib/components/citation-tooltip.test.ts
+++ b/frontend/src/lib/components/citation-tooltip.test.ts
@@ -1,43 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { computePosition, reduceTooltip } from './citation-tooltip';
+import { reduceTooltip } from './citation-tooltip';
 import type { TooltipState } from './citation-tooltip';
-
-// ── computePosition ────���────────────────────────────────────────
-
-describe('computePosition', () => {
-  const anchor = (top: number, left: number, width: number, height: number) =>
-    ({ top, left, width, height, bottom: top + height, right: left + width }) as DOMRect;
-
-  it('positions above the anchor by default', () => {
-    const pos = computePosition(anchor(200, 100, 20, 16), 160, 80, 1024, 768);
-    expect(pos.above).toBe(true);
-    // Should be above: y = anchorTop - tooltipHeight - gap
-    expect(pos.y).toBeLessThan(200);
-  });
-
-  it('centers horizontally on the anchor', () => {
-    const pos = computePosition(anchor(200, 500, 20, 16), 160, 80, 1024, 768);
-    // Center of anchor = 500 + 10 = 510. Tooltip left = 510 - 80 = 430.
-    expect(pos.x).toBe(430);
-  });
-
-  it('flips below when near the top of viewport', () => {
-    const pos = computePosition(anchor(20, 100, 20, 16), 160, 80, 1024, 768);
-    expect(pos.above).toBe(false);
-    // Should be below: y = anchorBottom + gap
-    expect(pos.y).toBeGreaterThan(36);
-  });
-
-  it('clamps to left edge', () => {
-    const pos = computePosition(anchor(200, 0, 20, 16), 160, 80, 1024, 768);
-    expect(pos.x).toBeGreaterThanOrEqual(8);
-  });
-
-  it('clamps to right edge', () => {
-    const pos = computePosition(anchor(200, 1010, 20, 16), 160, 80, 1024, 768);
-    expect(pos.x).toBeLessThanOrEqual(1024 - 160 - 8);
-  });
-});
 
 // ── reduceTooltip ───────────────────────────────────────���───────
 

--- a/frontend/src/lib/components/citation-tooltip.ts
+++ b/frontend/src/lib/components/citation-tooltip.ts
@@ -1,7 +1,7 @@
 /**
- * Pure logic for the citation tooltip: types, positioning, and interaction
- * state machine. Extracted so it's unit-testable without DOM or component
- * lifecycle.
+ * Pure logic for the citation tooltip: types and interaction state machine.
+ * Extracted so it's unit-testable without DOM or component lifecycle.
+ * Positioning is handled by the `floating` action.
  */
 
 // ── Types ───────────────────────────────────────────────────────
@@ -23,38 +23,6 @@ export interface CitationInfo {
  *  and scroll navigation. */
 export interface InlineCitation extends CitationInfo {
   index: number;
-}
-
-// ── Positioning ─────────────────────────────────────────────────
-
-export interface TooltipPosition {
-  x: number;
-  y: number;
-  above: boolean;
-}
-
-const DEFAULT_GAP = 6;
-const EDGE_PADDING = 8;
-
-export function computePosition(
-  anchorRect: DOMRect,
-  tooltipWidth: number,
-  tooltipHeight: number,
-  viewportWidth: number,
-  _viewportHeight: number,
-  gap: number = DEFAULT_GAP,
-): TooltipPosition {
-  const anchorCenterX = anchorRect.left + anchorRect.width / 2;
-  let x = anchorCenterX - tooltipWidth / 2;
-
-  // Clamp horizontal
-  x = Math.max(EDGE_PADDING, Math.min(x, viewportWidth - tooltipWidth - EDGE_PADDING));
-
-  // Default above; flip below if not enough room
-  const above = anchorRect.top - tooltipHeight - gap >= 0;
-  const y = above ? anchorRect.top - tooltipHeight - gap : anchorRect.bottom + gap;
-
-  return { x, y, above };
 }
 
 // ── Interaction state machine ───────────────────────────────────


### PR DESCRIPTION
## Summary

Migrates `CitationTooltip` from manual fixed-positioning + scroll/resize listeners to the shared `floating` action, fixing tooltips clipped inside ancestors with `overflow: hidden` and replacing bespoke positioning math with floating-ui's `flip`/`shift`/`autoUpdate`. Placement preference stays "above" (`placement: 'top'`).

- Deletes dead `computePosition` helper, `TooltipPosition` type, and `above` state (which had no CSS attached).
- Drops the pixel-exact reposition test — floating-ui's `autoUpdate` owns that behavior and is tested upstream.

Refs #352. Second of three components from that issue; `SearchableSelect` is still outstanding (will need `size` middleware added to the action).

## Test plan

- [ ] Hover a citation `<sup>` — tooltip appears above, horizontally centered
- [ ] Scroll so a citation is near the top of the viewport — tooltip auto-flips below
- [ ] Citation near left/right edge — tooltip stays within viewport (shift)
- [ ] Hover-to-tooltip keep-alive: hover sup, move onto tooltip body within ~100ms — stays open
- [ ] Click to pin / click same sup to unpin / click another sup to switch
- [ ] Click outside dismisses pinned tooltip
- [ ] Tab to a sup → tooltip shows on focus; Escape dismisses
- [ ] Show tooltip, scroll/resize page — tooltip tracks the anchor
- [ ] Tooltip rendered inside a clipping ancestor (modal/card) is no longer clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)