### PR TITLE
test(frontend): cover CitationTooltip keep-alive through portaled tooltip

### DIFF
--- a/frontend/src/lib/components/CitationTooltip.dom.test.ts
+++ b/frontend/src/lib/components/CitationTooltip.dom.test.ts
@@ -130,6 +130,30 @@ describe('CitationTooltip', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
+  it('keeps the tooltip open when the pointer moves from anchor onto the tooltip', async () => {
+    renderTooltip('<p>Keep <sup data-cite-id="1" tabindex="0">[1]</sup>.</p>');
+    await vi.waitFor(() => expect(GET).toHaveBeenCalledTimes(1));
+
+    await fireEvent.mouseEnter(getCitation('1'));
+    const tooltip = await screen.findByRole('tooltip');
+
+    // User moves off the anchor (schedules hide) then onto the tooltip
+    // (must cancel the hide) before HIDE_DELAY elapses.
+    await fireEvent.mouseLeave(getCitation('1'));
+    await vi.advanceTimersByTimeAsync(50);
+    await fireEvent.mouseEnter(tooltip);
+
+    // Past the original hide delay, the tooltip must still be there —
+    // this is what makes clickable links inside the tooltip reachable.
+    await vi.advanceTimersByTimeAsync(200);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    // Leaving the tooltip itself schedules and completes the hide.
+    await fireEvent.mouseLeave(tooltip);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
   it('shows on focus and closes on escape', async () => {
     renderTooltip('<p>Focus <sup data-cite-id="1" tabindex="0">[1]</sup>.</p>');
     await vi.waitFor(() => expect(GET).toHaveBeenCalledTimes(1));

--- a/frontend/src/lib/components/CitationTooltip.svelte
+++ b/frontend/src/lib/components/CitationTooltip.svelte
@@ -73,6 +73,12 @@
   // Track the current anchor element so `floating` can reposition against it.
   let currentAnchor: HTMLElement | null = $state(null);
 
+  // Drop the anchor reference once the tooltip is hidden so we don't retain a
+  // pointer to a `<sup>` that may be replaced when the surrounding HTML rerenders.
+  $effect(() => {
+    if (tipState.activeId == null) currentAnchor = null;
+  });
+
   // Click outside handler
   $effect(() => {
     if (!tipState.pinned) return;


### PR DESCRIPTION
## Summary

Adds a dom test that exercises the hover keep-alive path (mouse from anchor onto tooltip cancels the pending hide) through the portaled tooltip. That path depends on Svelte's delegated event handlers still firing on a subtree the `floating` action has moved out of the component's original location — which was the failure mode the previous `visibility:hidden`→`opacity:0` switch guarded against, but nothing tested end-to-end.

Also drops the `currentAnchor` reference when the tooltip hides, so we don't retain a pointer to a `<sup>` that may be replaced when the surrounding HTML rerenders.

Follow-up to #374. Refs #352.

## Test plan

- [ ] `pnpm vitest run src/lib/components/CitationTooltip.dom.test.ts` passes
- [ ] New `keeps the tooltip open when the pointer moves from anchor onto the tooltip` test fails if `use:floating` is removed from `CitationTooltip.svelte` (sanity check that the test actually exercises the portal path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)