### PR TITLE
refactor(frontend): migrate SearchableSelect to floating action

### DIFF
--- a/frontend/src/lib/actions/floating.ts
+++ b/frontend/src/lib/actions/floating.ts
@@ -43,8 +43,16 @@ export type FloatingOptions = {
     | 'right-end';
   /** Gap between anchor and floating element, in px. */
   offset?: number;
-  /** Padding from the viewport edge for `flip`/`shift`, in px. */
+  /** Padding from the viewport edge for `flip`/`shift`/`size`, in px. */
   padding?: number;
+  /** Set the floating element's width to match the anchor's width. */
+  matchAnchorWidth?: boolean;
+  /**
+   * Constrain the floating element's max-height. `'available'` fits it to the
+   * remaining viewport space along the placement axis (so a dropdown near the
+   * bottom shrinks instead of overflowing). A number sets a fixed px cap.
+   */
+  maxHeight?: 'available' | number;
 };
 
 let modulePromise: Promise<FloatingUiModule> | undefined;
@@ -91,11 +99,30 @@ export const floating: Action<HTMLElement, FloatingOptions> = (node, options) =>
   function reposition() {
     if (!fui) return;
     const opts = currentOptions;
+    const padding = opts.padding ?? 8;
     const middleware = [
       fui.offset(opts.offset ?? 4),
-      fui.flip({ padding: opts.padding ?? 8 }),
-      fui.shift({ padding: opts.padding ?? 8 }),
+      fui.flip({ padding }),
+      fui.shift({ padding }),
     ];
+
+    if (opts.matchAnchorWidth || opts.maxHeight != null) {
+      middleware.push(
+        fui.size({
+          padding,
+          apply({ rects, availableHeight }) {
+            if (opts.matchAnchorWidth) {
+              node.style.width = `${rects.reference.width}px`;
+            }
+            if (opts.maxHeight === 'available') {
+              node.style.maxHeight = `${Math.max(0, Math.floor(availableHeight))}px`;
+            } else if (typeof opts.maxHeight === 'number') {
+              node.style.maxHeight = `${Math.min(opts.maxHeight, Math.floor(availableHeight))}px`;
+            }
+          },
+        }),
+      );
+    }
 
     void fui
       .computePosition(opts.anchor, node, {

--- a/frontend/src/lib/components/SearchableSelect.clip.fixture.svelte
+++ b/frontend/src/lib/components/SearchableSelect.clip.fixture.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import SearchableSelect from './SearchableSelect.svelte';
+
+  const options = [
+    { slug: 'stern', label: 'Stern Pinball', count: 5 },
+    { slug: 'bally', label: 'Bally', count: 3 },
+  ];
+</script>
+
+<div data-testid="clip-wrapper" class="clip-wrapper">
+  <SearchableSelect {options} label="Manufacturer" placeholder="Search..." selected={null} />
+</div>
+
+<style>
+  .clip-wrapper {
+    overflow: hidden;
+    width: 200px;
+    height: 40px;
+  }
+</style>

--- a/frontend/src/lib/components/SearchableSelect.dom.test.ts
+++ b/frontend/src/lib/components/SearchableSelect.dom.test.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import SearchableSelect from './SearchableSelect.svelte';
+import SearchableSelectClipFixture from './SearchableSelect.clip.fixture.svelte';
 
 const OPTIONS = [
   { slug: 'stern', label: 'Stern Pinball', count: 5 },
@@ -163,6 +164,65 @@ describe('SearchableSelect', () => {
     expect(screen.getByRole('listbox')).toBeInTheDocument();
     expect(getCombobox()).toHaveValue('wil');
     expect(screen.queryByRole('button', { name: /clear selection/i })).not.toBeInTheDocument();
+  });
+
+  it('portals the listbox out of clipping ancestors', async () => {
+    const user = userEvent.setup();
+    render(SearchableSelectClipFixture);
+
+    await user.click(getCombobox());
+
+    const listbox = screen.getByRole('listbox');
+    const wrapper = screen.getByTestId('clip-wrapper');
+    expect(wrapper).not.toContainElement(listbox);
+  });
+
+  it('syncs activeIndex with pointer hover so it does not conflict with keyboard nav', async () => {
+    const user = userEvent.setup();
+    renderSingle();
+
+    await user.click(getCombobox());
+
+    // Hover Bally — it should become the active option.
+    const bally = screen.getByRole('option', { name: /bally/i });
+    await fireEvent.pointerEnter(bally);
+
+    expect(bally).toHaveAttribute('data-active', 'true');
+    expect(getCombobox()).toHaveAttribute('aria-activedescendant', bally.id);
+
+    // Keyboard-arrowing should move activity off Bally to exactly one other option.
+    await user.keyboard('{ArrowDown}');
+    expect(bally).toHaveAttribute('data-active', 'false');
+    expect(document.querySelectorAll('[data-active="true"]')).toHaveLength(1);
+  });
+
+  it('closes when focus moves outside the component (e.g. Tab to next field)', async () => {
+    const user = userEvent.setup();
+    renderSingle();
+    const after = document.createElement('button');
+    after.id = 'after';
+    after.textContent = 'After';
+    document.body.appendChild(after);
+
+    await user.click(getCombobox());
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    after.focus();
+    fireEvent.focusIn(after);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('closes when clicking outside the portaled listbox', async () => {
+    const user = userEvent.setup();
+    render(SearchableSelectClipFixture);
+
+    await user.click(getCombobox());
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
 
   it('does not leave queued scroll work behind after keyboard navigation unmounts', async () => {

--- a/frontend/src/lib/components/SearchableSelect.svelte
+++ b/frontend/src/lib/components/SearchableSelect.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { floating } from '$lib/actions/floating';
   import { normalizeText } from '$lib/utils';
   import FieldGroup from './form/FieldGroup.svelte';
 
@@ -33,6 +34,7 @@
   let open = $state(false);
   let activeIndex = $state(-1);
   let inputEl: HTMLInputElement | undefined = $state();
+  let inputWrapEl: HTMLDivElement | undefined = $state();
   let listEl: HTMLUListElement | undefined = $state();
 
   let filteredOptions = $derived.by(() => {
@@ -145,18 +147,32 @@
     activeIndex = -1;
   });
 
-  // Click outside to close
+  // Click or focus outside to close
   $effect(() => {
     if (!open) return;
+    function isOutside(target: Node | null): boolean {
+      if (!target) return true;
+      const insideSelect = inputEl?.closest('.searchable-select')?.contains(target);
+      // The dropdown is portaled out of `.searchable-select`, so check it too.
+      const insideDropdown = listEl?.contains(target);
+      return !insideSelect && !insideDropdown;
+    }
+    function close() {
+      open = false;
+      query = '';
+    }
     function onPointerDown(e: PointerEvent) {
-      const target = e.target as Node;
-      if (!inputEl?.closest('.searchable-select')?.contains(target)) {
-        open = false;
-        query = '';
-      }
+      if (isOutside(e.target as Node)) close();
+    }
+    function onFocusIn(e: FocusEvent) {
+      if (isOutside(e.target as Node)) close();
     }
     document.addEventListener('pointerdown', onPointerDown);
-    return () => document.removeEventListener('pointerdown', onPointerDown);
+    document.addEventListener('focusin', onFocusIn);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('focusin', onFocusIn);
+    };
   });
 
   const inputId = `searchable-select-${Math.random().toString(36).slice(2, 8)}`;
@@ -165,7 +181,7 @@
 </script>
 
 {#snippet body()}
-  <div class="input-wrap">
+  <div class="input-wrap" bind:this={inputWrapEl}>
     <input
       id={inputId}
       bind:this={inputEl}
@@ -220,8 +236,19 @@
     </div>
   {/if}
 
-  {#if open}
-    <ul bind:this={listEl} id={listboxId} role="listbox" class="dropdown">
+  {#if open && inputWrapEl}
+    <ul
+      bind:this={listEl}
+      id={listboxId}
+      role="listbox"
+      class="dropdown"
+      use:floating={{
+        anchor: inputWrapEl,
+        placement: 'bottom-start',
+        matchAnchorWidth: true,
+        maxHeight: 'available',
+      }}
+    >
       {#each filteredOptions as opt, i (opt.slug)}
         <li
           id={`${listboxId}-${i}`}
@@ -233,6 +260,9 @@
           class:selected={isSelected(opt.slug)}
           class:disabled={isDisabled(opt)}
           class:active={i === activeIndex}
+          onpointerenter={() => {
+            if (!isDisabled(opt)) activeIndex = i;
+          }}
           onpointerdown={(e) => {
             e.preventDefault();
             if (!isDisabled(opt)) toggle(opt.slug);
@@ -274,10 +304,6 @@
 {/if}
 
 <style>
-  .searchable-select {
-    position: relative;
-  }
-
   .filter-label {
     display: block;
     font-size: var(--font-size-0);
@@ -346,13 +372,7 @@
   }
 
   .dropdown {
-    position: absolute;
     z-index: var(--z-dropdown);
-    top: 100%;
-    left: 0;
-    right: 0;
-    margin-top: var(--size-1);
-    max-height: 18rem;
     overflow-y: auto;
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
@@ -360,6 +380,7 @@
     box-shadow: var(--shadow-popover);
     list-style: none;
     padding: var(--size-1) 0;
+    margin: 0;
   }
 
   .option {
@@ -371,7 +392,6 @@
     font-size: var(--font-size-1);
   }
 
-  .option:hover,
   .option.active {
     background-color: var(--color-input-focus-ring);
   }
@@ -384,10 +404,6 @@
     color: var(--color-text-muted);
     opacity: 0.5;
     cursor: default;
-  }
-
-  .option.disabled:hover {
-    background-color: transparent;
   }
 
   .check {


### PR DESCRIPTION
## Summary

Closes #352 — the third and final component in the floating-action migration (after ActionMenu #371 and CitationTooltip #374).

- Migrates `SearchableSelect`'s dropdown to the `floating` Svelte action: auto-flip when near the viewport bottom, horizontal shift when near narrow-container edges, viewport-fit `max-height` (replacing the 18rem guess), and portaling out of modal/drawer `overflow: hidden` clipping.
- Extends `floating` with two high-level props driving the `size` middleware: `matchAnchorWidth` (dropdown width tracks the input) and `maxHeight: 'available' | number`. No other caller yet, so this bundles cleanly with the migration per the discussion in the issue.
- Fixes two pre-existing bugs surfaced while hardening the component (TDD — failing test, then fix):
  - **Dropdown stayed open when Tab moved focus to another field**, leaving stacked dropdowns on screen. Close-on-outside now listens for `focusin` alongside `pointerdown`.
  - **Hovered and keyboard-active options could both render the active highlight** simultaneously, because `:hover` and `.active` shared a background. `pointerenter` now syncs `activeIndex` so there's one source of truth, and `:hover` is gone.

## Test plan

- [x] Existing 14 SearchableSelect tests pass
- [x] +3 new tests (portaling out of clipping ancestors, focus-outside close, hover/keyboard non-conflict)
- [x] Full frontend suite green (1115 tests)
- [x] ESLint + svelte-check clean
- [x] Manual verification on `/titles` (manufacturer + theme typeaheads): flip near viewport bottom, viewport-fit height, width-match, focus-outside close, hover+keyboard single-highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)