### PR TITLE
refactor(backend): typing tightening pass on catalog + soft-delete

### DIFF
--- a/backend/apps/catalog/api/entity_crud.py
+++ b/backend/apps/catalog/api/entity_crud.py
@@ -27,7 +27,7 @@ its own.
 """
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NamedTuple
 
 from django.db.models import Q, QuerySet
 from django.http import HttpRequest
@@ -73,6 +73,21 @@ from .soft_delete import (
     plan_soft_delete,
     serialize_blocking_referrer,
 )
+
+
+class CreateExtras(NamedTuple):
+    """Return type of ``extra_create_fields_builder``.
+
+    *row_kwargs* are merged into the ``model_cls.objects.create`` call; field
+    set varies per caller (e.g. Location supplies ``location_type``,
+    ``divisions``, ``location_path``), so it stays as a kwargs dict at the
+    Django boundary. *claim_specs* are appended to the create ChangeSet's
+    claims.
+    """
+
+    row_kwargs: dict[str, Any]
+    claim_specs: list[ClaimSpec]
+
 
 # ---------------------------------------------------------------------------
 # Registrars
@@ -290,7 +305,7 @@ def register_entity_create[ModelT: CatalogModel, SchemaT: Schema](
     body_schema: type[EntityCreateInputSchema] | None = None,
     extra_create_fields_builder: Callable[
         [EntityCreateInputSchema, CatalogModel | None],
-        tuple[dict[str, Any], list[ClaimSpec]],
+        CreateExtras,
     ]
     | None = None,
     op_id_suffix: str = "",
@@ -436,11 +451,9 @@ def register_entity_create[ModelT: CatalogModel, SchemaT: Schema](
             )
 
         if extra_create_fields_builder is not None:
-            extra_row_kwargs, extra_claim_specs = extra_create_fields_builder(
-                data, parent
-            )
-            row_kwargs.update(extra_row_kwargs)
-            claim_specs.extend(extra_claim_specs)
+            extras = extra_create_fields_builder(data, parent)
+            row_kwargs.update(extras.row_kwargs)
+            claim_specs.extend(extras.claim_specs)
 
         # Pre-check the public-id column (slug for shipped models;
         # location_path for Location). Runs after extra_create_fields_builder

--- a/backend/apps/catalog/api/locations_write.py
+++ b/backend/apps/catalog/api/locations_write.py
@@ -54,7 +54,11 @@ from .edit_claims import (
     raise_form_error,
     validate_scalar_fields,
 )
-from .entity_crud import register_entity_create, register_entity_delete_restore
+from .entity_crud import (
+    CreateExtras,
+    register_entity_create,
+    register_entity_delete_restore,
+)
 from .locations import LocationDetailSchema, _get_location_detail
 from .schemas import EntityCreateInputSchema
 
@@ -189,19 +193,20 @@ def _top_level_scope(_data: EntityCreateInputSchema, _parent: CatalogModel | Non
 
 def _top_level_extras(
     data: EntityCreateInputSchema, _parent: CatalogModel | None
-) -> tuple[dict[str, Any], list[ClaimSpec]]:
+) -> CreateExtras:
     assert isinstance(data, LocationTopLevelCreateSchema)
     divisions = data.divisions
-    row_kwargs: dict[str, Any] = {
-        "location_type": "country",
-        "divisions": divisions,
-        "location_path": compute_location_path(None, data.slug),
-    }
-    claim_specs = [
-        ClaimSpec(field_name="location_type", value="country"),
-        ClaimSpec(field_name="divisions", value=divisions),
-    ]
-    return row_kwargs, claim_specs
+    return CreateExtras(
+        row_kwargs={
+            "location_type": "country",
+            "divisions": divisions,
+            "location_path": compute_location_path(None, data.slug),
+        },
+        claim_specs=[
+            ClaimSpec(field_name="location_type", value="country"),
+            ClaimSpec(field_name="divisions", value=divisions),
+        ],
+    )
 
 
 register_entity_create(
@@ -230,16 +235,17 @@ def _child_scope(_data: EntityCreateInputSchema, parent: CatalogModel | None) ->
 
 def _child_extras(
     data: EntityCreateInputSchema, parent: CatalogModel | None
-) -> tuple[dict[str, Any], list[ClaimSpec]]:
+) -> CreateExtras:
     assert parent is not None
     assert isinstance(parent, Location)
     location_type = derive_child_location_type(parent)
-    row_kwargs: dict[str, Any] = {
-        "location_type": location_type,
-        "location_path": compute_location_path(parent, data.slug),
-    }
-    claim_specs = [ClaimSpec(field_name="location_type", value=location_type)]
-    return row_kwargs, claim_specs
+    return CreateExtras(
+        row_kwargs={
+            "location_type": location_type,
+            "location_path": compute_location_path(parent, data.slug),
+        },
+        claim_specs=[ClaimSpec(field_name="location_type", value=location_type)],
+    )
 
 
 register_entity_create(

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -306,7 +306,7 @@ def _build_model_list_qs(
 
 def _serialize_model_list(
     pm: MachineModel, *, min_rank: int | None = None
-) -> dict[str, Any]:
+) -> ModelListItemSchema:
     thumbnail_url, _ = extract_image_urls(
         pm.extra_data or {}, primary_media(pm), min_rank=min_rank
     )
@@ -315,33 +315,33 @@ def _serialize_model_list(
         if pm.corporate_entity and pm.corporate_entity.manufacturer
         else None
     )
-    return {
-        "name": pm.name,
-        "slug": pm.slug,
-        "manufacturer": {"name": mfr.name, "slug": mfr.slug} if mfr else None,
-        "year": pm.year,
-        "technology_generation": (
-            {
-                "name": pm.technology_generation.name,
-                "slug": pm.technology_generation.slug,
-            }
+    # Note: technology_subgeneration not included in list view
+    return ModelListItemSchema(
+        name=pm.name,
+        slug=pm.slug,
+        manufacturer=EntityRef(name=mfr.name, slug=mfr.slug) if mfr else None,
+        year=pm.year,
+        technology_generation=(
+            EntityRef(
+                name=pm.technology_generation.name,
+                slug=pm.technology_generation.slug,
+            )
             if pm.technology_generation
             else None
         ),
-        "display_type": (
-            {"name": pm.display_type.name, "slug": pm.display_type.slug}
+        display_type=(
+            EntityRef(name=pm.display_type.name, slug=pm.display_type.slug)
             if pm.display_type
             else None
         ),
-        "ipdb_id": pm.ipdb_id,
-        # Note: technology_subgeneration not included in list view
-        "ipdb_rating": float(pm.ipdb_rating) if pm.ipdb_rating is not None else None,
-        "pinside_rating": float(pm.pinside_rating)
-        if pm.pinside_rating is not None
-        else None,
-        "themes": [{"name": t.name, "slug": t.slug} for t in pm.themes.all()],
-        "thumbnail_url": thumbnail_url,
-    }
+        ipdb_id=pm.ipdb_id,
+        ipdb_rating=float(pm.ipdb_rating) if pm.ipdb_rating is not None else None,
+        pinside_rating=(
+            float(pm.pinside_rating) if pm.pinside_rating is not None else None
+        ),
+        themes=[EntityRef(name=t.name, slug=t.slug) for t in pm.themes.all()],
+        thumbnail_url=thumbnail_url,
+    )
 
 
 def _serialize_model_detail(pm: MachineModel) -> ModelDetailSchema:
@@ -635,7 +635,7 @@ def list_models(
     year_max: int | None = None,
     person: str = "",
     ordering: str = "-year",
-) -> list[dict[str, Any]]:
+) -> list[ModelListItemSchema]:
     qs = _build_model_list_qs(
         manufacturer=manufacturer,
         type=type,

--- a/backend/apps/catalog/api/soft_delete.py
+++ b/backend/apps/catalog/api/soft_delete.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import TypeGuard, cast
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
@@ -95,14 +95,16 @@ class SoftDeletePlan:
         return bool(self.blockers)
 
 
-def _has_status(model_class: type[db_models.Model]) -> bool:
+def _has_status(
+    model_class: type[db_models.Model],
+) -> TypeGuard[type[LifecycleStatusModel]]:
     return issubclass(model_class, LifecycleStatusModel)
 
 
 def _is_active(entity: db_models.Model) -> bool:
     """An entity is active unless its resolved ``status`` is ``deleted``.
 
-    Null status is treated as active (matches ``CatalogQuerySet.active``).
+    Null status is treated as active (matches ``LifecycleQuerySet.active``).
     """
     status = getattr(entity, "status", None)
     return status != "deleted"
@@ -180,11 +182,7 @@ def _iter_protect_referrers(
             if not _has_status(remote_model):
                 continue
             fk_name = remote_field.name
-            qs = (
-                cast(Any, remote_model)
-                ._default_manager.active()
-                .filter(**{fk_name: entity})
-            )
+            qs = remote_model.objects.active().filter(**{fk_name: entity})
             for ref in qs:
                 yield ref, fk_name
         elif on_delete in (db_models.SET_NULL, db_models.SET_DEFAULT):
@@ -205,7 +203,7 @@ def _iter_usage_blockers(
     ``soft_delete_usage_blockers`` — M2M through-rows and self-ref hierarchy.
 
     Each manager name must resolve to a reverse manager that supports
-    ``.active()`` (i.e. whose remote model is a ``CatalogQuerySet`` user,
+    ``.active()`` (i.e. whose remote model is a ``LifecycleQuerySet`` user,
     via ``LifecycleStatusModel``). Yielded referrers are always active.
     """
     manager_names: Iterable[str] = getattr(

--- a/backend/apps/catalog/api/soft_delete.py
+++ b/backend/apps/catalog/api/soft_delete.py
@@ -34,9 +34,9 @@ application layer".
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import TypeGuard, cast
+from typing import TypeGuard
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
@@ -101,21 +101,23 @@ def _has_status(
     return issubclass(model_class, LifecycleStatusModel)
 
 
-def _is_active(entity: db_models.Model) -> bool:
+def _is_active(entity: CatalogModel) -> bool:
     """An entity is active unless its resolved ``status`` is ``deleted``.
 
     Null status is treated as active (matches ``LifecycleQuerySet.active``).
     """
-    status = getattr(entity, "status", None)
-    return status != "deleted"
+    return entity.status != "deleted"
 
 
 def _entity_type(entity: db_models.Model) -> str:
     """Canonical hyphenated entity_type for wire-format serialization.
 
-    All soft-delete roots and blockers are CatalogModel subclasses today.
-    If that ever changes, add an explicit policy here rather than silently
-    leaking the Django-internal concatenated ``_meta.model_name``.
+    Roots reach this only as ``CatalogModel`` (statically enforced by the
+    walker's signatures). Blockers, however, come from the iterators as
+    ``db_models.Model`` — those need the runtime ``CatalogModel`` check so
+    we don't silently leak Django's concatenated ``_meta.model_name`` into
+    the wire format. If the iterators ever start yielding non-CatalogModel
+    referrers, add an explicit policy here.
     """
     cls = type(entity)
     if not issubclass(cls, CatalogModel):
@@ -130,7 +132,7 @@ def _entity_key(entity: db_models.Model) -> tuple[str, int]:
     return (entity._meta.label_lower, entity.pk)
 
 
-def _cascade_targets(root: db_models.Model) -> list[CatalogModel]:
+def _cascade_targets(root: CatalogModel) -> list[CatalogModel]:
     """Walk ``soft_delete_cascade_relations`` to produce the ordered cascade.
 
     Deterministic order (parent before children, siblings by pk) so the
@@ -138,7 +140,7 @@ def _cascade_targets(root: db_models.Model) -> list[CatalogModel]:
     """
     result: list[CatalogModel] = []
     seen: set[tuple[str, int]] = set()
-    stack: list[CatalogModel] = [cast(CatalogModel, root)]
+    stack: list[CatalogModel] = [root]
     while stack:
         entity = stack.pop(0)
         key = _entity_key(entity)
@@ -146,10 +148,7 @@ def _cascade_targets(root: db_models.Model) -> list[CatalogModel]:
             continue
         seen.add(key)
         result.append(entity)
-        relation_names: Iterable[str] = getattr(
-            type(entity), "soft_delete_cascade_relations", frozenset()
-        )
-        for rel_name in relation_names:
+        for rel_name in type(entity).soft_delete_cascade_relations:
             manager = getattr(entity, rel_name)
             qs = manager.active().order_by("pk")
             stack.extend(qs)
@@ -157,7 +156,7 @@ def _cascade_targets(root: db_models.Model) -> list[CatalogModel]:
 
 
 def _iter_protect_referrers(
-    entity: db_models.Model,
+    entity: CatalogModel,
 ) -> Iterator[tuple[db_models.Model, str]]:
     """Yield ``(referrer, relation_name)`` for active PROTECT referrers.
 
@@ -197,7 +196,7 @@ def _iter_protect_referrers(
 
 
 def _iter_usage_blockers(
-    entity: db_models.Model,
+    entity: CatalogModel,
 ) -> Iterator[tuple[db_models.Model, str]]:
     """Yield ``(referrer, manager_name)`` for active referrers reachable via
     ``soft_delete_usage_blockers`` — M2M through-rows and self-ref hierarchy.
@@ -206,35 +205,26 @@ def _iter_usage_blockers(
     ``.active()`` (i.e. whose remote model is a ``LifecycleQuerySet`` user,
     via ``LifecycleStatusModel``). Yielded referrers are always active.
     """
-    manager_names: Iterable[str] = getattr(
-        type(entity), "soft_delete_usage_blockers", frozenset()
-    )
-    for manager_name in manager_names:
+    for manager_name in type(entity).soft_delete_usage_blockers:
         manager = getattr(entity, manager_name)
         for ref in manager.active():
             yield ref, manager_name
 
 
-def plan_soft_delete(root: db_models.Model) -> SoftDeletePlan:
+def plan_soft_delete(root: CatalogModel) -> SoftDeletePlan:
     """Plan a soft-delete of *root* plus every active cascade child.
 
     Returns both the entities that would receive ``status=deleted`` claims
     and any active PROTECT or usage-M2M referrers that would block the
     delete.
     """
-    if not _has_status(type(root)):
-        raise TypeError(
-            f"{type(root).__name__} does not use LifecycleStatusModel; "
-            "soft-delete planning is not supported."
-        )
-
     cascade = _cascade_targets(root)
     cascade_keys = {_entity_key(e) for e in cascade}
 
     blockers: list[BlockingReferrer] = []
     seen_blockers: set[tuple[tuple[str, int], str]] = set()
 
-    def _record(ref: db_models.Model, relation: str, target: db_models.Model) -> None:
+    def _record(ref: db_models.Model, relation: str, target: CatalogModel) -> None:
         key = (_entity_key(ref), relation)
         if key in seen_blockers:
             return
@@ -294,7 +284,7 @@ class SoftDeleteBlockedError(Exception):
 
 
 def execute_soft_delete(
-    root: db_models.Model,
+    root: CatalogModel,
     *,
     user: _UserLike,
     note: str = "",

--- a/backend/apps/catalog/models/base.py
+++ b/backend/apps/catalog/models/base.py
@@ -88,5 +88,12 @@ class CatalogModel(LinkableModel, LifecycleStatusModel, ClaimControlledModel):
     # See LifecycleStatusModel.objects for why pyright is ignored here.
     objects: ClassVar[LifecycleManager[Self]] = LifecycleManager()  # pyright: ignore[reportInvalidTypeForm]
 
+    # Soft-delete walker policy — see apps/catalog/api/soft_delete.py.
+    # Concrete subclasses override these frozensets when they need to
+    # cascade deletion to dependent entities or block deletion when M2M /
+    # self-ref usage exists. Empty defaults keep the walker generic.
+    soft_delete_cascade_relations: ClassVar[frozenset[str]] = frozenset()
+    soft_delete_usage_blockers: ClassVar[frozenset[str]] = frozenset()
+
     class Meta:
         abstract = True

--- a/backend/apps/catalog/models/base.py
+++ b/backend/apps/catalog/models/base.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Self
 from django.db import models
 
 from apps.core.models import (
-    CatalogManager,
+    LifecycleManager,
     LifecycleStatusModel,
     LinkableModel,
 )
@@ -79,16 +79,14 @@ class CatalogModel(LinkableModel, LifecycleStatusModel, ClaimControlledModel):
     defines its own ``Meta``.
     """
 
-    # ``ClassVar[CatalogManager[Self]]`` gets us both halves: the custom
-    # manager type (so ``.active()`` is visible) and per-subclass model binding
-    # (so ``Manufacturer.objects`` types as ``CatalogManager[Manufacturer]``,
-    # not ``CatalogManager[CatalogModel]``). Without ``Self``, django-types'
-    # default descriptor strips the custom manager class. Declared here rather
-    # than on ``LifecycleStatusModel`` because every concrete
-    # ``LifecycleStatusModel`` subclass goes through ``CatalogModel`` —
-    # there's no consumer that needs ``.active()`` typed against the bare
-    # lifecycle base.
-    objects: ClassVar[CatalogManager[Self]] = CatalogManager()
+    # Redeclared from ``LifecycleStatusModel`` so ``Self`` rebinds at the
+    # catalog level — mypy walks the TypeVar bound, not the concrete class,
+    # so without this ``model_cls.objects.active()`` (where
+    # ``model_cls: type[ModelT: CatalogModel]``) types as
+    # ``LifecycleManager[LifecycleStatusModel]`` rather than
+    # ``LifecycleManager[ModelT]``.
+    # See LifecycleStatusModel.objects for why pyright is ignored here.
+    objects: ClassVar[LifecycleManager[Self]] = LifecycleManager()  # pyright: ignore[reportInvalidTypeForm]
 
     class Meta:
         abstract = True

--- a/backend/apps/catalog/tests/test_entity_crud_registrar.py
+++ b/backend/apps/catalog/tests/test_entity_crud_registrar.py
@@ -18,7 +18,7 @@ from django.test import RequestFactory
 from ninja import Router, Schema
 
 from apps.catalog.api.edit_claims import ClaimSpec
-from apps.catalog.api.entity_crud import register_entity_create
+from apps.catalog.api.entity_crud import CreateExtras, register_entity_create
 from apps.catalog.api.schemas import EntityCreateInputSchema
 from apps.catalog.models import Theme
 from apps.provenance.models import Claim
@@ -161,20 +161,19 @@ def test_scope_filter_builder_unparented_invoked(user):
 
 @pytest.mark.django_db
 def test_extra_create_fields_builder_row_kwargs_and_claims_reach_row(user):
-    """The tuple ``(row_kwargs, claim_specs)`` returned by the builder
-    is merged into row kwargs and appended to the claim list. Mirrors
-    the realistic Location pattern where ``location_type`` lands as both
-    a row column and a claim — without a matching claim, the post-create
-    claim resolver would reset the column to default. This test exercises
-    both halves at once: the row column survives resolution iff both
-    halves are wired correctly."""
+    """The ``CreateExtras`` returned by the builder is merged into row
+    kwargs and appended to the claim list. Mirrors the realistic Location
+    pattern where ``location_type`` lands as both a row column and a claim
+    — without a matching claim, the post-create claim resolver would reset
+    the column to default. This test exercises both halves at once: the
+    row column survives resolution iff both halves are wired correctly."""
 
     def _build_extras(data, parent):
         assert parent is None  # unparented Theme registration
         description = f"auto: {data.name}"
-        return (
-            {"description": description},
-            [ClaimSpec(field_name="description", value=description)],
+        return CreateExtras(
+            row_kwargs={"description": description},
+            claim_specs=[ClaimSpec(field_name="description", value=description)],
         )
 
     router = Router()

--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar, Self, TypeVar
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -236,8 +236,8 @@ class EntityStatus(models.TextChoices):
 _LifecycleModel = TypeVar("_LifecycleModel", bound="LifecycleStatusModel")
 
 
-class CatalogQuerySet(models.QuerySet[_LifecycleModel]):
-    def active(self) -> CatalogQuerySet[_LifecycleModel]:
+class LifecycleQuerySet(models.QuerySet[_LifecycleModel]):
+    def active(self) -> LifecycleQuerySet[_LifecycleModel]:
         """Return entities considered live in the catalog.
 
         Includes ``status='active'`` and ``status IS NULL`` for legacy ingest
@@ -249,7 +249,7 @@ class CatalogQuerySet(models.QuerySet[_LifecycleModel]):
         )
 
 
-CatalogManager = models.Manager.from_queryset(CatalogQuerySet)
+LifecycleManager = models.Manager.from_queryset(LifecycleQuerySet)
 
 
 def active_status_q(relation: str) -> models.Q:
@@ -261,7 +261,7 @@ def active_status_q(relation: str) -> models.Q:
         Count("machine_models", filter=Q(...) & active_status_q("machine_models"))
 
     Null-inclusive for legacy ingest compatibility — tighten alongside
-    ``CatalogQuerySet.active()`` once every ingest path creates status claims.
+    ``LifecycleQuerySet.active()`` once every ingest path creates status claims.
     """
     return models.Q(**{f"{relation}__status": EntityStatus.ACTIVE}) | models.Q(
         **{f"{relation}__status__isnull": True}
@@ -287,6 +287,24 @@ class LifecycleStatusModel(models.Model):
         null=True,
         blank=True,
     )
+
+    # ``ClassVar[LifecycleManager[Self]]`` gets us both halves: the custom
+    # manager type (so ``.active()`` is visible) and per-subclass model
+    # binding (so ``Manufacturer.objects`` types as
+    # ``LifecycleManager[Manufacturer]``, not ``LifecycleManager[LifecycleStatusModel]``).
+    # Without ``Self``, django-types' default descriptor strips the custom
+    # manager class. ``CatalogModel`` redeclares this so ``Self`` rebinds at
+    # the catalog level — mypy walks the TypeVar bound, not the concrete class,
+    # so without the redeclaration ``model_cls.objects.active()`` (where
+    # ``model_cls: type[ModelT: CatalogModel]``) types as
+    # ``LifecycleManager[LifecycleStatusModel]``.
+    # pyright: ignore on the annotation — ``LifecycleManager`` is the result of
+    # ``models.Manager.from_queryset(...)``, which Pylance sees as a variable
+    # assignment rather than a class declaration (``reportInvalidTypeForm``).
+    # mypy + django-stubs accept it; converting to a ``class LifecycleManager(...)``
+    # statement either loses the ``[Self]`` subscript or crashes the django-stubs
+    # plugin under multiple inheritance, so we keep the assignment form.
+    objects: ClassVar[LifecycleManager[Self]] = LifecycleManager()  # pyright: ignore[reportInvalidTypeForm]
 
     class Meta:
         abstract = True


### PR DESCRIPTION
## Summary

A small typing-tightening pass across the catalog API and the soft-delete walker:

- **`_serialize_model_list`** returns `ModelListItemSchema` instead of `dict[str, Any]`; `list_models` flips to `list[ModelListItemSchema]`.
- **`register_entity_create`**'s `extra_create_fields_builder` hook returns a `CreateExtras` NamedTuple instead of a bare `(dict, list)` tuple, naming the boundary into Django's `objects.create`.
- **Soft-delete walker:**
  - `cast(Any, remote_model)._default_manager.active()` → `remote_model.objects.active()` via `_has_status` as a `TypeGuard[type[LifecycleStatusModel]]`.
  - `cast(CatalogModel, root)` gone; root params on `_cascade_targets`, `plan_soft_delete`, `execute_soft_delete`, `_iter_*` narrowed to `CatalogModel`.
  - `_is_active` drops its defensive `getattr` read; `entity.status` is now statically typed.
  - `soft_delete_cascade_relations` / `soft_delete_usage_blockers` declared on `CatalogModel` with `frozenset()` defaults, removing two `getattr(type(entity), …, frozenset())` accesses.
  - The runtime `TypeError` in `plan_soft_delete` that guarded against non-`LifecycleStatusModel` inputs is removed — the type system enforces this at the call boundary, and per CLAUDE.md we don't validate scenarios the types already prevent at internal boundaries.
- **Lifecycle manager rehomed.** `objects: ClassVar[CatalogManager[Self]] = CatalogManager()` moved from `CatalogModel` back onto `LifecycleStatusModel` (where the queryset's typevar was already bound). `CatalogModel` keeps a `Self`-rebinding redeclaration so `model_cls.objects.active()` with `model_cls: type[ModelT: CatalogModel]` types as `LifecycleManager[ModelT]` rather than collapsing to the bound.
- **Renamed** `CatalogQuerySet` / `CatalogManager` → `LifecycleQuerySet` / `LifecycleManager` — they were always lifecycle-shaped (typevar `bound="LifecycleStatusModel"`); the "Catalog" prefix was just where the manager used to attach.

No behaviour changes. `makemigrations --dry-run` clean.

## Test plan

- [x] `uv run mypy apps/` — clean across 360 files
- [x] `uv run ruff check apps/ && uv run ruff format --check apps/` — clean
- [x] `uv run pytest` — 2599 passed / 1 skipped
- [x] `uv run python manage.py makemigrations --dry-run` — no changes detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)