### PR TITLE
refactor(catalog): narrow Model annotations toward CatalogModel / AliasModel / ClaimControlledModel

### DIFF
--- a/backend/apps/catalog/api/entity_create.py
+++ b/backend/apps/catalog/api/entity_create.py
@@ -30,7 +30,7 @@ from django.db import IntegrityError, transaction
 from django.db import models as db_models
 from django.db.models import Q
 
-from apps.catalog.models import CatalogModel
+from apps.catalog.models import AliasModel, CatalogModel
 from apps.catalog.naming import normalize_catalog_name
 from apps.core.models import meta_unique_fields
 from apps.core.validators import SLUG_FORMAT_MESSAGE, SLUG_RE
@@ -89,8 +89,8 @@ def validate_name(name: str, *, max_length: int) -> str:
 
 
 def _resolve_alias_relation(
-    model_cls: type[db_models.Model],
-) -> tuple[type[db_models.Model], str] | None:
+    model_cls: type[CatalogModel],
+) -> tuple[type[AliasModel], str] | None:
     """Return ``(alias_model, parent_fk_name)`` if *model_cls* exposes an
     ``aliases`` reverse manager, else ``None``.
 
@@ -104,7 +104,7 @@ def _resolve_alias_relation(
         if rel.get_accessor_name() == "aliases":
             related_model = rel.related_model
             assert isinstance(related_model, type)
-            assert issubclass(related_model, db_models.Model)
+            assert issubclass(related_model, AliasModel)
             return related_model, rel.field.name
     return None
 

--- a/backend/apps/catalog/api/soft_delete.py
+++ b/backend/apps/catalog/api/soft_delete.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import TypeGuard
+from typing import NamedTuple, TypeGuard
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
@@ -51,6 +51,18 @@ from .edit_claims import ClaimSpec, execute_multi_entity_claims
 from .schemas import BlockingReferrerSchema
 
 _UserLike = AbstractBaseUser | AnonymousUser
+
+
+class EntityKey(NamedTuple):
+    """Dedup key for a soft-delete cascade member or blocker.
+
+    ``label_lower`` (``app_label.model_name``) plus ``pk`` uniquely
+    identifies a row across the heterogeneous set of models the walker
+    touches.
+    """
+
+    label_lower: str
+    pk: int
 
 
 @dataclass(frozen=True)
@@ -128,8 +140,8 @@ def _entity_type(entity: db_models.Model) -> str:
     return cls.entity_type
 
 
-def _entity_key(entity: db_models.Model) -> tuple[str, int]:
-    return (entity._meta.label_lower, entity.pk)
+def _entity_key(entity: db_models.Model) -> EntityKey:
+    return EntityKey(entity._meta.label_lower, entity.pk)
 
 
 def _cascade_targets(root: CatalogModel) -> list[CatalogModel]:
@@ -139,7 +151,7 @@ def _cascade_targets(root: CatalogModel) -> list[CatalogModel]:
     resulting ChangeSet replays identically in tests.
     """
     result: list[CatalogModel] = []
-    seen: set[tuple[str, int]] = set()
+    seen: set[EntityKey] = set()
     stack: list[CatalogModel] = [root]
     while stack:
         entity = stack.pop(0)
@@ -222,7 +234,7 @@ def plan_soft_delete(root: CatalogModel) -> SoftDeletePlan:
     cascade_keys = {_entity_key(e) for e in cascade}
 
     blockers: list[BlockingReferrer] = []
-    seen_blockers: set[tuple[tuple[str, int], str]] = set()
+    seen_blockers: set[tuple[EntityKey, str]] = set()
 
     def _record(ref: db_models.Model, relation: str, target: CatalogModel) -> None:
         key = (_entity_key(ref), relation)

--- a/backend/apps/catalog/management/commands/validate_catalog.py
+++ b/backend/apps/catalog/management/commands/validate_catalog.py
@@ -25,6 +25,7 @@ from django.db.models import Count, F, Model, Q
 from django.db.models.functions import Lower
 
 from apps.catalog.models import (
+    CatalogModel,
     Credit,
     CreditRole,
     GameplayFeature,
@@ -370,7 +371,7 @@ class _M2mCheck(NamedTuple):
 
     field_name: str
     pk_key: str
-    model_class: type[Model]
+    model_class: type[CatalogModel]
 
 
 def check_unresolved_m2m_claims(result: ValidationResult) -> None:

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import logging
 
-from django.db import models
 from django.utils import timezone
 
 from apps.core.types import JsonBody
@@ -30,7 +29,7 @@ from ._helpers import (
 logger = logging.getLogger(__name__)
 
 
-def _sync_markdown_references(obj: models.Model) -> None:
+def _sync_markdown_references(obj: ClaimControlledModel) -> None:
     """Sync RecordReference table for all markdown fields on the object.
 
     Always calls sync_references, even for empty fields, so that stale

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -17,6 +17,8 @@ from apps.provenance.models import Claim, ClaimControlledModel
 
 from .._alias_registry import AliasType, discover_alias_types
 from ..models import (
+    AliasModel,
+    CatalogModel,
     CorporateEntity,
     CorporateEntityLocation,
     Credit,
@@ -77,7 +79,7 @@ class M2MFieldSpec:
 
     field_name: str  # claim field_name (also the value dict key): "theme", "tag"
     m2m_attr: str  # model attribute: "themes", "tags", "gameplay_features"
-    target_model: type[Model]  # Theme, Tag, GameplayFeature
+    target_model: type[CatalogModel]  # Theme, Tag, GameplayFeature
 
 
 M2M_FIELDS: dict[str, M2MFieldSpec] = {
@@ -611,7 +613,9 @@ def resolve_all_model_abbreviations(
 # ------------------------------------------------------------------
 
 
-def _get_alias_rel_info(parent: type[Model]) -> tuple[type[Model], str]:
+def _get_alias_rel_info(
+    parent: type[ClaimControlledModel],
+) -> tuple[type[AliasModel], str]:
     """Return (alias_model, fk_col) for ``parent``'s GenericRelation ``aliases``.
 
     ``parent.aliases.rel`` — and ``.rel.related_model`` / ``.rel.field.name`` —
@@ -620,12 +624,12 @@ def _get_alias_rel_info(parent: type[Model]) -> tuple[type[Model], str]:
     caller bodies.
     """
     rel = parent.aliases.rel  # type: ignore[attr-defined]
-    alias_model: type[Model] = rel.related_model
+    alias_model: type[AliasModel] = rel.related_model
     fk_col: str = rel.field.name + "_id"
     return alias_model, fk_col
 
 
-def _get_parents_through(parent: type[Model]) -> type[Model]:
+def _get_parents_through(parent: type[ClaimControlledModel]) -> type[Model]:
     """Return the through model for ``parent``'s self-referential ``parents`` M2M.
 
     ``parent.parents.through`` is a runtime-generated descriptor (same category
@@ -637,7 +641,7 @@ def _get_parents_through(parent: type[Model]) -> type[Model]:
 
 
 def _resolve_aliases(
-    parent_model: type[Model],
+    parent_model: type[ClaimControlledModel],
     claim_field_name: str,
 ) -> None:
     """Bulk-resolve alias claims into alias model rows.


### PR DESCRIPTION
## Summary

Tighten several catalog helpers that took bare `django.db.models.Model` to the narrowest abstraction their callers actually use — `CatalogModel`, `AliasModel`, or `ClaimControlledModel`. Pure typing changes; no runtime behavior is affected.

- `entity_create._resolve_alias_relation` → `type[CatalogModel]` in, `type[AliasModel]` out (matches its sole caller and the `issubclass` assertion it relies on).
- `resolve/_entities._sync_markdown_references` → `ClaimControlledModel` (matches the surrounding resolver helpers).
- `resolve/_relationships.M2MFieldSpec.target_model` → `type[CatalogModel]` (Theme/Tag/RewardType).
- `resolve/_relationships._get_alias_rel_info` / `_resolve_aliases` → `type[ClaimControlledModel]` in (matches `AliasType.parent_model` from the alias registry); alias helper now returns `type[AliasModel]`.
- `validate_catalog._M2mCheck.model_class` → `type[CatalogModel]` (same shape as `M2MFieldSpec.target_model`).

## Test plan

- [x] `uv run mypy apps/catalog` clean
- [x] Pre-commit hooks pass (ruff, mypy, backend tests)