### PR TITLE
refactor(frontend): extract Dialog primitive; add focus trap to MediaLightbox

### DIFF
--- a/frontend/src/lib/components/Dialog.dom.test.ts
+++ b/frontend/src/lib/components/Dialog.dom.test.ts
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import DialogFixture from './Dialog.fixture.svelte';
+
+describe('Dialog', () => {
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  it('opens, exposes role+name, locks scroll, restores focus on Escape', async () => {
+    const user = userEvent.setup();
+    render(DialogFixture);
+
+    const opener = screen.getByRole('button', { name: 'Open dialog' });
+    await user.click(opener);
+
+    expect(screen.getByRole('dialog', { name: 'Test Dialog' })).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog', { name: 'Test Dialog' })).not.toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('');
+    expect(opener).toHaveFocus();
+    expect(screen.getByTestId('close-count')).toHaveTextContent('1');
+  });
+
+  it('supports ariaLabelledBy as the accessible-name source', async () => {
+    const user = userEvent.setup();
+    render(DialogFixture, { props: { useAriaLabelledBy: true } });
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    expect(screen.getByRole('dialog', { name: 'Dialog Title' })).toBeInTheDocument();
+  });
+
+  it('closes on backdrop click', async () => {
+    const user = userEvent.setup();
+    const { container } = render(DialogFixture);
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    const backdrop = container.querySelector('.backdrop-dismiss');
+    expect(backdrop).toBeInTheDocument();
+    await user.click(backdrop as Element);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('close-count')).toHaveTextContent('1');
+  });
+
+  it('focuses the first focusable descendant by default', async () => {
+    const user = userEvent.setup();
+    render(DialogFixture);
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    const first = screen.getByRole('button', { name: 'First' });
+    await vi.waitFor(() => {
+      expect(first).toHaveFocus();
+    });
+  });
+
+  it('focuses initialFocus when provided and connected', async () => {
+    const user = userEvent.setup();
+    render(DialogFixture, { props: { useInitialFocus: true } });
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    const second = screen.getByRole('button', { name: 'Second' });
+    await vi.waitFor(() => {
+      expect(second).toHaveFocus();
+    });
+  });
+
+  it('falls back to first focusable when initialFocus is a stale (disconnected) ref', async () => {
+    const user = userEvent.setup();
+    render(DialogFixture, { props: { useStaleInitialFocus: true } });
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    const first = screen.getByRole('button', { name: 'First' });
+    await vi.waitFor(() => {
+      expect(first).toHaveFocus();
+    });
+  });
+
+  it('traps focus when tabbing forward and backward', async () => {
+    const user = userEvent.setup();
+    render(DialogFixture);
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    const first = screen.getByRole('button', { name: 'First' });
+    const second = screen.getByRole('button', { name: 'Second' });
+
+    await vi.waitFor(() => {
+      expect(first).toHaveFocus();
+    });
+
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(second).toHaveFocus();
+
+    await user.keyboard('{Tab}');
+    expect(first).toHaveFocus();
+  });
+});

--- a/frontend/src/lib/components/Dialog.fixture.svelte
+++ b/frontend/src/lib/components/Dialog.fixture.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import Dialog from './Dialog.svelte';
+
+  let {
+    useInitialFocus = false,
+    useStaleInitialFocus = false,
+    useAriaLabelledBy = false,
+  }: {
+    useInitialFocus?: boolean;
+    useStaleInitialFocus?: boolean;
+    useAriaLabelledBy?: boolean;
+  } = $props();
+
+  let open = $state(false);
+  let closeCount = $state(0);
+
+  let firstBtnEl: HTMLButtonElement | undefined = $state();
+  let secondBtnEl: HTMLButtonElement | undefined = $state();
+
+  // A detached element to simulate a stale ref
+  let detachedEl: HTMLElement | undefined = $state();
+  if (typeof document !== 'undefined') {
+    detachedEl = document.createElement('button');
+  }
+
+  function openDialog() {
+    open = true;
+  }
+
+  function closeDialog() {
+    closeCount++;
+    open = false;
+  }
+
+  let initialFocusEl = $derived(
+    useStaleInitialFocus ? detachedEl : useInitialFocus ? secondBtnEl : undefined,
+  );
+</script>
+
+<button type="button" onclick={openDialog}>Open dialog</button>
+
+{#if useAriaLabelledBy}
+  <Dialog {open} onclose={closeDialog} ariaLabelledBy="dialog-title" initialFocus={initialFocusEl}>
+    <div class="panel">
+      <h2 id="dialog-title">Dialog Title</h2>
+      <button type="button" bind:this={firstBtnEl}>First</button>
+      <button type="button" bind:this={secondBtnEl}>Second</button>
+    </div>
+  </Dialog>
+{:else}
+  <Dialog {open} onclose={closeDialog} ariaLabel="Test Dialog" initialFocus={initialFocusEl}>
+    <div class="panel">
+      <button type="button" bind:this={firstBtnEl}>First</button>
+      <button type="button" bind:this={secondBtnEl}>Second</button>
+    </div>
+  </Dialog>
+{/if}
+
+<p data-testid="close-count">{closeCount}</p>
+
+<style>
+  .panel {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--color-background);
+    padding: var(--size-3);
+  }
+</style>

--- a/frontend/src/lib/components/Dialog.svelte
+++ b/frontend/src/lib/components/Dialog.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import type { Snippet } from 'svelte';
+  import { acquireScrollLock } from './scroll-lock';
+
+  type DialogProps = {
+    open: boolean;
+    onclose: () => void;
+    scrim?: 'default' | 'strong';
+    ariaDescribedBy?: string;
+    initialFocus?: HTMLElement;
+    children: Snippet;
+  } & (
+    | { ariaLabel: string; ariaLabelledBy?: never }
+    | { ariaLabelledBy: string; ariaLabel?: never }
+  );
+
+  let {
+    open,
+    onclose,
+    scrim = 'default',
+    ariaLabel,
+    ariaLabelledBy,
+    ariaDescribedBy,
+    initialFocus,
+    children,
+  }: DialogProps = $props();
+
+  const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(', ');
+
+  let dialogEl: HTMLDivElement | undefined = $state();
+
+  function getFocusableElements() {
+    if (!dialogEl) return [];
+    // The aria-hidden filter is load-bearing: .backdrop-dismiss is a <button>
+    // and matches FOCUSABLE_SELECTOR, but is aria-hidden + tabindex="-1" so
+    // it must stay out of the focus trap and initial-focus fallback.
+    return Array.from(dialogEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+      (element) =>
+        !element.hasAttribute('hidden') && element.getAttribute('aria-hidden') !== 'true',
+    );
+  }
+
+  $effect(() => {
+    if (!open) return;
+
+    const opener = document.activeElement as HTMLElement | undefined;
+
+    const releaseScrollLock = acquireScrollLock();
+
+    let cancelled = false;
+    void tick().then(() => {
+      if (cancelled) return;
+      if (initialFocus?.isConnected) {
+        initialFocus.focus();
+        return;
+      }
+      const [first] = getFocusableElements();
+      if (first) first.focus();
+      else dialogEl?.focus();
+    });
+
+    function handleKeydown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onclose();
+        return;
+      }
+
+      if (e.key !== 'Tab') return;
+
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length === 0) {
+        e.preventDefault();
+        dialogEl?.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (e.shiftKey && activeElement === firstElement) {
+        e.preventDefault();
+        lastElement.focus();
+      } else if (!e.shiftKey && activeElement === lastElement) {
+        e.preventDefault();
+        firstElement.focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeydown);
+
+    return () => {
+      cancelled = true;
+      releaseScrollLock();
+      document.removeEventListener('keydown', handleKeydown);
+      if (opener?.isConnected) {
+        opener.focus();
+      }
+    };
+  });
+</script>
+
+{#if open}
+  <div
+    class="dialog-backdrop"
+    role="dialog"
+    aria-modal="true"
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledBy}
+    aria-describedby={ariaDescribedBy}
+    tabindex="-1"
+    bind:this={dialogEl}
+    data-scrim={scrim}
+  >
+    <button
+      type="button"
+      class="backdrop-dismiss"
+      tabindex="-1"
+      aria-hidden="true"
+      onclick={onclose}
+    ></button>
+    {@render children()}
+  </div>
+{/if}
+
+<style>
+  .dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: var(--z-modal);
+    background: var(--color-scrim);
+  }
+
+  .dialog-backdrop[data-scrim='strong'] {
+    background: var(--color-scrim-strong);
+  }
+
+  .backdrop-dismiss {
+    position: absolute;
+    inset: 0;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { tick } from 'svelte';
   import type { Snippet } from 'svelte';
-  import { acquireScrollLock } from './scroll-lock';
+  import Dialog from './Dialog.svelte';
 
   let {
     title,
@@ -21,16 +20,6 @@
     children: Snippet;
   } = $props();
 
-  const FOCUSABLE_SELECTOR = [
-    'a[href]',
-    'button:not([disabled])',
-    'input:not([disabled])',
-    'select:not([disabled])',
-    'textarea:not([disabled])',
-    '[tabindex]:not([tabindex="-1"])',
-  ].join(', ');
-
-  let dialogEl: HTMLDivElement | undefined = $state();
   let closeButtonEl: HTMLButtonElement | undefined = $state();
   const uid = $props.id();
   const titleId = `${uid}-title`;
@@ -39,147 +28,60 @@
   function close() {
     onclose();
   }
-
-  function getFocusableElements() {
-    if (!dialogEl) return [];
-    return Array.from(dialogEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
-      (element) =>
-        !element.hasAttribute('hidden') && element.getAttribute('aria-hidden') !== 'true',
-    );
-  }
-
-  // Keyboard ownership and focus restoration still assume one active dialog,
-  // but scroll locking is delegated to a shared reference-counted manager so
-  // concurrent or switching modals can't leak the lock.
-  // Capture the element that had focus when the modal opened, move focus
-  // into the dialog, lock body scroll, and listen for Escape.
-  // Focus is restored in cleanup so it works for every close path,
-  // including parent-controlled closes.
-  $effect(() => {
-    if (!open) return;
-
-    const opener = document.activeElement as HTMLElement | undefined;
-
-    const releaseScrollLock = acquireScrollLock();
-
-    let cancelled = false;
-    void tick().then(() => {
-      if (cancelled) return;
-      if (closeButtonEl) closeButtonEl.focus();
-      else dialogEl?.focus();
-    });
-
-    function handleKeydown(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        close();
-        return;
-      }
-
-      if (e.key !== 'Tab') return;
-
-      const focusableElements = getFocusableElements();
-      if (focusableElements.length === 0) {
-        e.preventDefault();
-        dialogEl?.focus();
-        return;
-      }
-
-      const firstElement = focusableElements[0];
-      const lastElement = focusableElements[focusableElements.length - 1];
-      const activeElement = document.activeElement;
-
-      if (e.shiftKey && activeElement === firstElement) {
-        e.preventDefault();
-        lastElement.focus();
-      } else if (!e.shiftKey && activeElement === lastElement) {
-        e.preventDefault();
-        firstElement.focus();
-      }
-    }
-
-    document.addEventListener('keydown', handleKeydown);
-
-    return () => {
-      cancelled = true;
-      releaseScrollLock();
-      document.removeEventListener('keydown', handleKeydown);
-      if (opener?.isConnected) {
-        opener.focus();
-      }
-    };
-  });
 </script>
 
-{#if open}
-  <div class="modal-backdrop">
-    <button type="button" class="backdrop-dismiss" tabindex="-1" aria-hidden="true" onclick={close}
-    ></button>
-
-    <div
-      class="modal-dialog"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
-      aria-describedby={bodyId}
-      tabindex="-1"
-      bind:this={dialogEl}
-    >
-      <header class="modal-header">
-        <div class="header-main">
-          <h2 id={titleId}>
-            {#if titleContent}
-              {@render titleContent()}
-            {:else}
-              {title}
-            {/if}
-          </h2>
-          {#if headerActions}
-            <div class="header-actions">
-              {@render headerActions()}
-            </div>
+<Dialog
+  {open}
+  {onclose}
+  ariaLabelledBy={titleId}
+  ariaDescribedBy={bodyId}
+  initialFocus={closeButtonEl}
+>
+  <div class="modal-dialog">
+    <header class="modal-header">
+      <div class="header-main">
+        <h2 id={titleId}>
+          {#if titleContent}
+            {@render titleContent()}
+          {:else}
+            {title}
           {/if}
-        </div>
-        <button
-          type="button"
-          class="close-btn"
-          aria-label="Close"
-          onclick={close}
-          bind:this={closeButtonEl}>&times;</button
-        >
-      </header>
-
-      <div class="modal-body" id={bodyId}>
-        {@render children()}
+        </h2>
+        {#if headerActions}
+          <div class="header-actions">
+            {@render headerActions()}
+          </div>
+        {/if}
       </div>
+      <button
+        type="button"
+        class="close-btn"
+        aria-label="Close"
+        onclick={close}
+        bind:this={closeButtonEl}>&times;</button
+      >
+    </header>
 
-      {#if footer}
-        <footer class="modal-footer">
-          {@render footer()}
-        </footer>
-      {/if}
+    <div class="modal-body" id={bodyId}>
+      {@render children()}
     </div>
+
+    {#if footer}
+      <footer class="modal-footer">
+        {@render footer()}
+      </footer>
+    {/if}
   </div>
-{/if}
+</Dialog>
 
 <style>
-  .modal-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--color-scrim);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: var(--size-4);
-  }
-
   .modal-dialog {
-    position: relative;
-    z-index: 1;
-    width: 100%;
-    max-width: 48rem;
-    max-height: calc(100vh - var(--size-6) * 2);
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(48rem, calc(100vw - 2 * var(--size-4)));
+    max-height: calc(100vh - 2 * var(--size-4));
     background: var(--color-background);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-3);
@@ -187,15 +89,6 @@
     flex-direction: column;
     box-shadow: var(--shadow-modal);
     overflow: hidden;
-  }
-
-  .backdrop-dismiss {
-    position: absolute;
-    inset: 0;
-    border: 0;
-    padding: 0;
-    background: transparent;
-    cursor: pointer;
   }
 
   .modal-header {
@@ -260,14 +153,13 @@
   }
 
   @media (--breakpoint-narrow) {
-    .modal-backdrop {
-      padding: 0;
-    }
-
     .modal-dialog {
-      max-width: none;
+      top: 0;
+      left: 0;
+      transform: none;
+      width: 100vw;
+      height: 100vh;
       max-height: none;
-      height: 100%;
       border-radius: 0;
       border: none;
     }

--- a/frontend/src/lib/components/SectionEditorModal.dom.test.ts
+++ b/frontend/src/lib/components/SectionEditorModal.dom.test.ts
@@ -180,6 +180,20 @@ describe('SectionEditorModal', () => {
     expect(screen.getByTestId('last-switched')).toHaveTextContent('technology');
   });
 
+  it('focuses Close on open even when the section switcher precedes it in DOM order', async () => {
+    const user = userEvent.setup();
+    render(SectionEditorModalFixture, {
+      props: { showSwitcher: true },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Open editor' }));
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    await vi.waitFor(() => {
+      expect(closeButton).toHaveFocus();
+    });
+  });
+
   it('disables the section switcher when switcherDisabled is true', async () => {
     const user = userEvent.setup();
     render(SectionEditorModalFixture, {

--- a/frontend/src/lib/components/media/MediaLightbox.dom.test.ts
+++ b/frontend/src/lib/components/media/MediaLightbox.dom.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import MediaLightbox from './MediaLightbox.svelte';
 import { MEDIA_ITEMS } from './media-test-fixtures';
 
@@ -15,6 +15,10 @@ function renderLightbox(initialIndex = 0) {
 }
 
 describe('MediaLightbox', () => {
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
   it('locks body scroll while mounted and restores it on unmount', () => {
     const { unmount } = renderLightbox();
 
@@ -26,14 +30,16 @@ describe('MediaLightbox', () => {
 
   it('exposes dialog semantics and closes on Escape and backdrop dismiss', async () => {
     const user = userEvent.setup();
-    const { onclose } = renderLightbox();
+    const { container, onclose } = renderLightbox();
 
     expect(screen.getByRole('dialog', { name: /media viewer/i })).toBeInTheDocument();
 
     await user.keyboard('{Escape}');
     expect(onclose).toHaveBeenCalledTimes(1);
 
-    await user.click(screen.getByRole('button', { name: /dismiss media viewer/i }));
+    const backdrop = container.querySelector('.backdrop-dismiss');
+    expect(backdrop).toBeInTheDocument();
+    await user.click(backdrop as Element);
     expect(onclose).toHaveBeenCalledTimes(2);
   });
 
@@ -51,5 +57,33 @@ describe('MediaLightbox', () => {
 
     await fireEvent.keyDown(window, { key: 'ArrowLeft' });
     expect(screen.getByText('1 / 2')).toBeInTheDocument();
+  });
+
+  it('traps focus within the lightbox when tabbing forward and backward', async () => {
+    const user = userEvent.setup();
+    renderLightbox();
+
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    await vi.waitFor(() => {
+      expect(closeBtn).toHaveFocus();
+    });
+
+    // Forward through all focusables, then wrap back to close.
+    const next = screen.getByRole('button', { name: /next/i });
+    const uploaderLink = screen.getByRole('link');
+
+    await user.keyboard('{Tab}');
+    expect(next).toHaveFocus();
+
+    await user.keyboard('{Tab}');
+    expect(uploaderLink).toHaveFocus();
+
+    // From last focusable, Tab wraps back to close.
+    await user.keyboard('{Tab}');
+    expect(closeBtn).toHaveFocus();
+
+    // Shift+Tab from first wraps to last.
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(uploaderLink).toHaveFocus();
   });
 });

--- a/frontend/src/lib/components/media/MediaLightbox.svelte
+++ b/frontend/src/lib/components/media/MediaLightbox.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { resolveHref } from '$lib/utils';
   import type { UploadedMediaSchema } from '$lib/api/schema';
+  import Dialog from '../Dialog.svelte';
 
   type UploadedMedia = UploadedMediaSchema;
 
@@ -21,6 +22,8 @@
 
   let item = $derived(media[index]);
 
+  let closeBtnEl: HTMLButtonElement | undefined = $state();
+
   function prev() {
     if (index > 0) index--;
   }
@@ -30,32 +33,28 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') onclose();
-    else if (e.key === 'ArrowLeft') prev();
+    if (e.key === 'ArrowLeft') prev();
     else if (e.key === 'ArrowRight') next();
   }
-
-  // Lock body scroll while lightbox is open
-  $effect(() => {
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  });
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="lightbox-backdrop">
-  <button type="button" class="backdrop-dismiss" aria-label="Dismiss media viewer" onclick={onclose}
-  ></button>
+<Dialog open={true} {onclose} ariaLabel="Media viewer" scrim="strong" initialFocus={closeBtnEl}>
+  <button class="close-btn" onclick={onclose} aria-label="Close" bind:this={closeBtnEl}
+    >&times;</button
+  >
 
-  <div class="lightbox-content" role="dialog" aria-modal="true" aria-label="Media viewer">
-    <button class="close-btn" onclick={onclose} aria-label="Close">&times;</button>
-
+  <div class="lightbox-content">
     {#if item}
       <img src={item.renditions.display} alt="" class="display-img" />
+
+      {#if index > 0}
+        <button class="nav-btn nav-btn--prev" onclick={prev} aria-label="Previous">&#8249;</button>
+      {/if}
+      {#if index < media.length - 1}
+        <button class="nav-btn nav-btn--next" onclick={next} aria-label="Next">&#8250;</button>
+      {/if}
 
       <div class="lightbox-footer">
         {#if item.category}
@@ -72,44 +71,19 @@
         <span class="counter">{index + 1} / {media.length}</span>
       </div>
     {/if}
-
-    {#if index > 0}
-      <button class="nav-btn nav-btn--prev" onclick={prev} aria-label="Previous">&#8249;</button>
-    {/if}
-    {#if index < media.length - 1}
-      <button class="nav-btn nav-btn--next" onclick={next} aria-label="Next">&#8250;</button>
-    {/if}
   </div>
-</div>
+</Dialog>
 
 <style>
-  .lightbox-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: var(--z-modal);
-    background: var(--color-scrim-strong);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .backdrop-dismiss {
-    position: absolute;
-    inset: 0;
-    border: 0;
-    padding: 0;
-    background: transparent;
-    cursor: pointer;
-  }
-
   .lightbox-content {
-    position: relative;
-    z-index: 1;
-    max-width: 90vw;
-    max-height: 90vh;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     display: flex;
     flex-direction: column;
     align-items: center;
+    gap: var(--size-2);
   }
 
   .display-img {
@@ -121,8 +95,8 @@
 
   .close-btn {
     position: absolute;
-    top: -2.5rem;
-    right: -0.5rem;
+    top: var(--size-3);
+    right: var(--size-3);
     background: none;
     border: none;
     color: var(--color-text-inverse);
@@ -171,7 +145,6 @@
     align-items: center;
     justify-content: center;
     gap: var(--size-3);
-    margin-top: var(--size-2);
     color: var(--color-text-inverse-muted);
     font-size: var(--font-size-1);
   }


### PR DESCRIPTION
## Summary

- MediaLightbox lacked a focus trap — Tab from inside the lightbox leaked to elements behind it. Fixed by extracting Modal's behavioral shell into a new `Dialog` primitive that both consume.
- `Modal` becomes a chromed consumer of `Dialog`; `MediaLightbox` becomes a chromeless consumer. Public APIs of both are unchanged.
- New `initialFocus` prop with stale-ref-safe fallback chain (`isConnected` check → first focusable → dialog container) lets consumers override which element gets focus on open. Needed because Modal's `titleContent` slot (e.g. SectionEditorModal's section switcher) and MediaLightbox's footer link both inject focusables before the desired initial-focus target.

## Architecture notes

- `role="dialog"` moves from the inner panel (`.modal-dialog`, `.lightbox-content`) to the backdrop element. Existing `getByRole('dialog', { name })` queries continue to work because the accessible name moves with the role.
- Dialog does not impose layout — backdrop is fixed, full-viewport, with a scrim. Consumers absolute-position their own content. This lets `MediaLightbox` keep prev/next anchored next to the image rather than to a wrapper.
- Scrim strength is a prop (`scrim?: 'default' | 'strong'`).
- Accessible name is a discriminated requirement: exactly one of `ariaLabel` or `ariaLabelledBy` must be passed.
- Arrow-key handling stays in `MediaLightbox` (`svelte:window`); `Dialog` only owns Esc.

## Test plan

- [x] `pnpm test` — 1124 pass (157 files), including 7 new Dialog tests, a new MediaLightbox focus-trap test, and a new SectionEditorModal regression test asserting Close gets initial focus when the section switcher precedes it in DOM order.
- [x] `pnpm lint` clean
- [x] `pnpm check` clean
- [ ] Manual browser check: open a media lightbox, Tab cycles only between lightbox controls; Shift+Tab cycles backward; Esc closes and returns focus to the thumbnail; ←/→ navigates images; clicking the dark backdrop dismisses; nav buttons are visually next to the image (not at viewport edges); SectionEditorModal still focus-traps and Esc-closes; narrow viewport — SectionEditorModal still goes fullscreen, MediaLightbox still centers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)