### PR TITLE
refactor(frontend): drop legacy --color-* aliases

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -170,14 +170,6 @@
   --z-dropdown: 1050; /* popovers, autocomplete, action menus — above modals so popovers launched from inside a modal aren't covered */
   --z-toast: 1100; /* always above modals */
   --z-tooltip: 1200; /* always above everything */
-
-  /* ---- Aliases (legacy names — keep until all consumers migrate) ---- */
-  --color-background: var(--color-bg);
-  --color-text-primary: var(--color-text);
-  --color-success: var(--color-success-text);
-  --color-warning: var(--color-warning-text);
-  --color-error: var(--color-error-text);
-  --color-danger: var(--color-error-text);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -270,8 +262,8 @@
    ======================================== */
 html {
   font-family: var(--font-body);
-  background-color: var(--color-background);
-  color: var(--color-text-primary);
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 a {
@@ -308,7 +300,7 @@ a:hover {
   font-size: var(--font-size-1);
   font-family: inherit;
   background-color: var(--color-input-bg);
-  color: var(--color-text-primary);
+  color: var(--color-text);
   border: 1px solid var(--color-input-border);
   border-radius: var(--radius-2);
 }
@@ -322,7 +314,7 @@ a:hover {
   font-size: var(--font-size-1);
   font-family: inherit;
   background-color: var(--color-input-bg);
-  color: var(--color-text-primary);
+  color: var(--color-text);
   border: 1px solid var(--color-input-border);
   border-radius: var(--radius-2);
 }
@@ -349,7 +341,7 @@ a:hover {
 }
 
 :where(input, textarea, select)[aria-invalid='true'] {
-  border-color: var(--color-error);
+  border-color: var(--color-error-text);
 }
 
 /* ========================================

--- a/frontend/src/lib/components/AccordionSection.svelte
+++ b/frontend/src/lib/components/AccordionSection.svelte
@@ -114,7 +114,7 @@
     font-size: var(--font-size-2);
     font-weight: 600;
     min-width: 0;
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .edit-link {

--- a/frontend/src/lib/components/ActionMenu.svelte
+++ b/frontend/src/lib/components/ActionMenu.svelte
@@ -314,7 +314,7 @@
   }
 
   .menu {
-    background: var(--color-background);
+    background: var(--color-bg);
     border: 1px solid var(--color-border-soft);
     border-radius: var(--radius-2);
     padding: var(--size-1) 0;

--- a/frontend/src/lib/components/Breadcrumb.svelte
+++ b/frontend/src/lib/components/Breadcrumb.svelte
@@ -42,11 +42,11 @@
   }
 
   a:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
     text-decoration: underline;
   }
 
   li[aria-current='page'] {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 </style>

--- a/frontend/src/lib/components/Button.svelte
+++ b/frontend/src/lib/components/Button.svelte
@@ -65,12 +65,12 @@
     /* Subtle neutral tint that reads in both light and dark — 8% of the
        text color over transparent gives a soft fill in either palette. */
     background: color-mix(in srgb, var(--color-text) 8%, transparent);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     border-color: var(--color-text-muted);
   }
 
   .btn-destructive {
-    background: var(--color-danger);
+    background: var(--color-error-text);
     color: var(--color-text-inverse);
     border: none;
   }

--- a/frontend/src/lib/components/ChipGroup.svelte
+++ b/frontend/src/lib/components/ChipGroup.svelte
@@ -63,7 +63,7 @@
     font-size: var(--font-size-0);
     font-family: var(--font-body);
     background-color: var(--color-surface);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-2);
     cursor: pointer;

--- a/frontend/src/lib/components/CitationTooltip.svelte
+++ b/frontend/src/lib/components/CitationTooltip.svelte
@@ -237,7 +237,7 @@
     box-shadow: var(--shadow-popover);
     font-size: var(--font-size-1);
     line-height: var(--font-lineheight-3);
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .source-name {

--- a/frontend/src/lib/components/CreatePage.svelte
+++ b/frontend/src/lib/components/CreatePage.svelte
@@ -255,12 +255,12 @@
   }
 
   .parent-breadcrumb a:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
     text-decoration: underline;
   }
 
   .save-error {
-    color: var(--color-error);
+    color: var(--color-error-text);
     font-size: var(--font-size-1);
     margin: 0;
   }

--- a/frontend/src/lib/components/CreditsList.svelte
+++ b/frontend/src/lib/components/CreditsList.svelte
@@ -46,7 +46,7 @@
   h2 {
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-3);
   }
 

--- a/frontend/src/lib/components/DeletePage.svelte
+++ b/frontend/src/lib/components/DeletePage.svelte
@@ -227,7 +227,7 @@
   }
 
   .save-error {
-    color: var(--color-error);
+    color: var(--color-error-text);
     font-size: var(--font-size-1);
     margin: 0;
   }

--- a/frontend/src/lib/components/Dialog.fixture.svelte
+++ b/frontend/src/lib/components/Dialog.fixture.svelte
@@ -64,7 +64,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background: var(--color-background);
+    background: var(--color-bg);
     padding: var(--size-3);
   }
 </style>

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -341,7 +341,7 @@
     flex-wrap: wrap;
     align-items: baseline;
     gap: var(--size-1);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     overflow-wrap: break-word;
     flex: 1;
   }
@@ -391,8 +391,8 @@
   }
 
   .btn-revert:hover {
-    border-color: var(--color-danger);
-    color: var(--color-danger);
+    border-color: var(--color-error-text);
+    color: var(--color-error-text);
   }
 
   .btn-revert-dim {
@@ -423,9 +423,9 @@
   .btn-revert-submit {
     font-size: var(--font-size-00, 0.75rem);
     padding: 0.25em 0.75em;
-    border: 1px solid var(--color-danger);
+    border: 1px solid var(--color-error-text);
     border-radius: var(--radius-1);
-    background: var(--color-danger);
+    background: var(--color-error-text);
     color: var(--color-text-inverse);
     cursor: pointer;
   }
@@ -447,7 +447,7 @@
 
   .revert-error {
     font-size: var(--font-size-00, 0.75rem);
-    color: var(--color-danger);
+    color: var(--color-error-text);
     margin: 0;
   }
 
@@ -460,7 +460,7 @@
     font-size: var(--font-size-00, 0.75rem);
     padding: 0.1em 0.4em;
     border-radius: var(--radius-1);
-    background: var(--color-danger);
+    background: var(--color-error-text);
     color: var(--color-text-inverse);
     font-weight: 500;
     text-transform: uppercase;

--- a/frontend/src/lib/components/EntitySources.svelte
+++ b/frontend/src/lib/components/EntitySources.svelte
@@ -196,7 +196,7 @@
   h2 {
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-3);
   }
 
@@ -252,7 +252,7 @@
   .sources-group h3 {
     font-size: var(--font-size-1);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-2);
   }
 
@@ -291,7 +291,7 @@
     flex-direction: column;
     gap: var(--size-1);
     font-size: var(--font-size-0);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     overflow-wrap: break-word;
   }
 

--- a/frontend/src/lib/components/FilterDrawer.svelte
+++ b/frontend/src/lib/components/FilterDrawer.svelte
@@ -81,7 +81,7 @@
     font-size: var(--font-size-1);
     font-family: var(--font-body);
     background-color: var(--color-surface);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-2);
     cursor: pointer;
@@ -105,7 +105,7 @@
   }
 
   .drawer-close:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   /* Backdrop — only visible on mobile */
@@ -134,7 +134,7 @@
       left: 0;
       bottom: 0;
       width: min(20rem, 85vw);
-      background-color: var(--color-background);
+      background-color: var(--color-bg);
       z-index: var(--z-drawer);
       padding: var(--size-4);
       overflow-y: auto;

--- a/frontend/src/lib/components/FocusContentShell.svelte
+++ b/frontend/src/lib/components/FocusContentShell.svelte
@@ -62,7 +62,7 @@
   }
 
   .back-link:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .record-name {
@@ -73,7 +73,7 @@
     white-space: nowrap;
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     text-decoration: none;
   }
 

--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -41,7 +41,7 @@
   }
 
   .footer-links a:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .copyright {

--- a/frontend/src/lib/components/GroupedTaxonomyList.svelte
+++ b/frontend/src/lib/components/GroupedTaxonomyList.svelte
@@ -68,7 +68,7 @@
     padding: var(--size-3) 0;
     border-bottom: 1px solid var(--color-border-soft);
     text-decoration: none;
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .parent-row:hover,

--- a/frontend/src/lib/components/HeroHeader.svelte
+++ b/frontend/src/lib/components/HeroHeader.svelte
@@ -97,7 +97,7 @@
   h1 {
     font-size: var(--font-size-7);
     font-weight: 700;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-2);
   }
 
@@ -110,7 +110,7 @@
 
   .alias-label {
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-right: var(--size-1);
   }
 

--- a/frontend/src/lib/components/HierarchicalTaxonomyMobileMetaBar.svelte
+++ b/frontend/src/lib/components/HierarchicalTaxonomyMobileMetaBar.svelte
@@ -61,7 +61,7 @@
 
   .label {
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-right: var(--size-1);
   }
 

--- a/frontend/src/lib/components/Markdown.svelte
+++ b/frontend/src/lib/components/Markdown.svelte
@@ -55,7 +55,7 @@
 <style>
   .content {
     font-size: var(--font-size-2);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     line-height: var(--font-lineheight-3);
   }
 
@@ -151,7 +151,7 @@
   .content :global(h5),
   .content :global(h6) {
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-2);
   }
 

--- a/frontend/src/lib/components/MenuItem.svelte
+++ b/frontend/src/lib/components/MenuItem.svelte
@@ -72,7 +72,7 @@
     padding: var(--menu-item-padding, var(--size-1) var(--size-3));
     font-size: var(--menu-item-font-size, var(--font-size-0));
     font-family: inherit;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     text-decoration: none;
     background: none;
     border: none;
@@ -85,7 +85,7 @@
      warm-cream looked harsh). Dark mode keeps the existing flat surface. */
   .menu-item:hover,
   .menu-item:focus-visible {
-    background: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
+    background: color-mix(in srgb, var(--color-text) 10%, transparent);
     color: var(--color-link);
   }
 
@@ -105,12 +105,12 @@
      dark mode). On hover/focus, deepen the tint so the item visibly
      reacts even though it's already highlighted. */
   .menu-item.current[role='menuitem'] {
-    background: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
+    background: color-mix(in srgb, var(--color-text) 10%, transparent);
   }
 
   .menu-item.current[role='menuitem']:hover,
   .menu-item.current[role='menuitem']:focus-visible {
-    background: color-mix(in srgb, var(--color-text-primary) 18%, transparent);
+    background: color-mix(in srgb, var(--color-text) 18%, transparent);
   }
 
   /* Listboxes: the selected option gets a checkmark, like a native <select>. */

--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -82,7 +82,7 @@
     transform: translate(-50%, -50%);
     width: min(48rem, calc(100vw - 2 * var(--size-4)));
     max-height: calc(100vh - 2 * var(--size-4));
-    background: var(--color-background);
+    background: var(--color-bg);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-3);
     display: flex;
@@ -114,7 +114,7 @@
     font-size: var(--font-size-3);
     font-weight: 600;
     margin: 0;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     min-width: 0;
   }
 
@@ -133,7 +133,7 @@
   }
 
   .close-btn:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .modal-body {

--- a/frontend/src/lib/components/ModelSpecsSidebar.svelte
+++ b/frontend/src/lib/components/ModelSpecsSidebar.svelte
@@ -148,6 +148,6 @@
   }
 
   dd {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 </style>

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -423,7 +423,7 @@
   @media (prefers-color-scheme: dark) {
     .site-header {
       --header-bg: #26221d;
-      --header-ink: var(--color-text-primary);
+      --header-ink: var(--color-text);
       --header-ink-muted: var(--color-text-muted);
     }
 

--- a/frontend/src/lib/components/NeedsReviewBanner.svelte
+++ b/frontend/src/lib/components/NeedsReviewBanner.svelte
@@ -28,17 +28,17 @@
 
 <style>
   .review-banner {
-    background-color: color-mix(in srgb, var(--color-warning) 12%, transparent);
-    border: 1px solid var(--color-warning);
+    background-color: color-mix(in srgb, var(--color-warning-text) 12%, transparent);
+    border: 1px solid var(--color-warning-text);
     border-radius: var(--radius-2);
     padding: var(--size-3) var(--size-4);
     margin-bottom: var(--size-5);
     font-size: var(--font-size-1);
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .review-banner strong {
-    color: var(--color-warning);
+    color: var(--color-warning-text);
   }
 
   .review-banner p {
@@ -46,7 +46,7 @@
   }
 
   .review-links a {
-    color: var(--color-warning);
+    color: var(--color-warning-text);
     text-decoration: underline;
   }
 </style>

--- a/frontend/src/lib/components/PageHeader.svelte
+++ b/frontend/src/lib/components/PageHeader.svelte
@@ -53,7 +53,7 @@
   h1 {
     font-size: var(--font-size-7);
     font-weight: 700;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--page-header-title-mb, var(--size-4));
   }
 

--- a/frontend/src/lib/components/ReferencesSection.svelte
+++ b/frontend/src/lib/components/ReferencesSection.svelte
@@ -78,7 +78,7 @@
   }
 
   .toggle:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   ol {

--- a/frontend/src/lib/components/SearchResults.svelte
+++ b/frontend/src/lib/components/SearchResults.svelte
@@ -221,7 +221,7 @@
   .result-group h2 {
     font-size: var(--font-size-4);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-3);
     display: flex;
     align-items: baseline;

--- a/frontend/src/lib/components/SearchableSelect.svelte
+++ b/frontend/src/lib/components/SearchableSelect.svelte
@@ -336,7 +336,7 @@
   }
 
   .clear-btn:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .selected-tags {
@@ -368,7 +368,7 @@
   }
 
   .tag-remove:hover {
-    color: var(--color-error);
+    color: var(--color-error-text);
   }
 
   .dropdown {
@@ -435,7 +435,7 @@
 
   .field-error {
     font-size: var(--font-size-0);
-    color: var(--color-error);
+    color: var(--color-error-text);
     margin: var(--size-1) 0 0;
   }
 </style>

--- a/frontend/src/lib/components/SectionEditorForm.svelte
+++ b/frontend/src/lib/components/SectionEditorForm.svelte
@@ -52,7 +52,7 @@
 
 <style>
   .save-error {
-    color: var(--color-error);
+    color: var(--color-error-text);
     font-size: var(--font-size-1);
     margin: 0 0 var(--size-3);
   }
@@ -68,7 +68,7 @@
     margin-right: calc(-1 * var(--size-4));
     margin-bottom: calc(-1 * var(--size-4));
     padding: var(--size-3) var(--size-4);
-    background: var(--color-background);
+    background: var(--color-bg);
     border-top: 1px solid var(--color-border-soft);
   }
 </style>

--- a/frontend/src/lib/components/SidebarSection.svelte
+++ b/frontend/src/lib/components/SidebarSection.svelte
@@ -34,7 +34,7 @@
     gap: var(--size-2);
     font-size: var(--font-size-1);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-1);
     text-transform: uppercase;
     letter-spacing: 0.04em;

--- a/frontend/src/lib/components/StatusMessage.svelte
+++ b/frontend/src/lib/components/StatusMessage.svelte
@@ -25,6 +25,6 @@
   }
 
   .error {
-    color: var(--color-error);
+    color: var(--color-error-text);
   }
 </style>

--- a/frontend/src/lib/components/TaxonomyListPage.svelte
+++ b/frontend/src/lib/components/TaxonomyListPage.svelte
@@ -196,7 +196,7 @@
     padding: var(--size-3) 0;
     border-bottom: 1px solid var(--color-border-soft);
     text-decoration: none;
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .item-row:hover {

--- a/frontend/src/lib/components/TitleList.svelte
+++ b/frontend/src/lib/components/TitleList.svelte
@@ -46,7 +46,7 @@
   h2 {
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-3);
   }
 

--- a/frontend/src/lib/components/cards/WearEffect.svelte
+++ b/frontend/src/lib/components/cards/WearEffect.svelte
@@ -197,7 +197,7 @@
     position: absolute;
     width: 100%;
     height: 100%;
-    background: var(--color-background);
+    background: var(--color-bg);
     clip-path: polygon(
       0% 0%,
       100% 0%,
@@ -253,7 +253,7 @@
     }
 
     .torn-corner::before {
-      background: var(--color-background);
+      background: var(--color-bg);
     }
 
     .crease::before {

--- a/frontend/src/lib/components/editors/FeaturesEditor.svelte
+++ b/frontend/src/lib/components/editors/FeaturesEditor.svelte
@@ -297,7 +297,7 @@
 
   .row-error {
     font-size: var(--font-size-0);
-    color: var(--color-error);
+    color: var(--color-error-text);
     margin: 0;
   }
 
@@ -330,8 +330,8 @@
   }
 
   .remove-btn:hover {
-    color: var(--color-danger);
-    border-color: var(--color-danger);
+    color: var(--color-error-text);
+    border-color: var(--color-error-text);
   }
 
   .add-btn {

--- a/frontend/src/lib/components/editors/MediaEditor.svelte
+++ b/frontend/src/lib/components/editors/MediaEditor.svelte
@@ -145,7 +145,7 @@
   }
 
   .action-error {
-    color: var(--color-error);
+    color: var(--color-error-text);
     font-size: var(--font-size-1);
     margin: 0;
   }

--- a/frontend/src/lib/components/editors/PeopleEditor.svelte
+++ b/frontend/src/lib/components/editors/PeopleEditor.svelte
@@ -173,7 +173,7 @@
 
   .row-error {
     font-size: var(--font-size-0);
-    color: var(--color-error);
+    color: var(--color-error-text);
     margin: 0;
   }
 
@@ -189,8 +189,8 @@
   }
 
   .remove-btn:hover {
-    color: var(--color-danger);
-    border-color: var(--color-danger);
+    color: var(--color-error-text);
+    border-color: var(--color-error-text);
   }
 
   .add-btn {

--- a/frontend/src/lib/components/form/DropdownHeader.svelte
+++ b/frontend/src/lib/components/form/DropdownHeader.svelte
@@ -53,6 +53,6 @@
   }
 
   .back-btn:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 </style>

--- a/frontend/src/lib/components/form/DropdownSearchInput.svelte
+++ b/frontend/src/lib/components/form/DropdownSearchInput.svelte
@@ -48,7 +48,7 @@
     font-size: var(--font-size-1);
     font-family: inherit;
     background-color: var(--color-input-bg);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     border: 1px solid var(--color-input-border);
     border-radius: var(--radius-2);
   }

--- a/frontend/src/lib/components/form/EditCitationField.svelte
+++ b/frontend/src/lib/components/form/EditCitationField.svelte
@@ -129,7 +129,7 @@
     border: 1px solid var(--color-border-soft);
     border-radius: var(--radius-2);
     background: var(--color-surface);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     font-size: var(--font-size-1);
   }
 
@@ -144,7 +144,7 @@
     border: 1px solid var(--color-input-border);
     border-radius: var(--radius-2);
     background: var(--color-input-bg);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     font: inherit;
     cursor: pointer;
   }
@@ -162,7 +162,7 @@
   .citation-error {
     margin: 0;
     font-size: var(--font-size-0);
-    color: var(--color-error);
+    color: var(--color-error-text);
   }
 
   .citation-picker {

--- a/frontend/src/lib/components/form/FieldGroup.svelte
+++ b/frontend/src/lib/components/form/FieldGroup.svelte
@@ -55,7 +55,7 @@
 
   .field-error {
     font-size: var(--font-size-0);
-    color: var(--color-error);
+    color: var(--color-error-text);
     margin: 0;
   }
 </style>

--- a/frontend/src/lib/components/form/MarkdownToolbar.svelte
+++ b/frontend/src/lib/components/form/MarkdownToolbar.svelte
@@ -90,7 +90,7 @@
     padding: 2px 6px;
     font-size: var(--font-size-0);
     white-space: nowrap;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     background: var(--color-surface);
     border: 1px solid var(--color-input-border);
     border-radius: var(--radius-1);

--- a/frontend/src/lib/components/form/TagInput.svelte
+++ b/frontend/src/lib/components/form/TagInput.svelte
@@ -110,6 +110,6 @@
   }
 
   .tag-remove:hover {
-    color: var(--color-error);
+    color: var(--color-error-text);
   }
 </style>

--- a/frontend/src/lib/components/form/citation/CitationAutocomplete.svelte
+++ b/frontend/src/lib/components/form/citation/CitationAutocomplete.svelte
@@ -159,7 +159,7 @@
 <style>
   .submit-error {
     padding: var(--size-2) var(--size-3);
-    color: var(--color-danger);
+    color: var(--color-error-text);
     font-size: var(--font-size-0);
     text-align: center;
   }

--- a/frontend/src/lib/components/form/citation/CitationCreateStage.svelte
+++ b/frontend/src/lib/components/form/citation/CitationCreateStage.svelte
@@ -226,7 +226,7 @@
     border: 1px solid var(--color-input-border);
     border-radius: var(--radius-2);
     background-color: var(--color-input-bg);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     cursor: pointer;
     text-transform: capitalize;
   }
@@ -243,7 +243,7 @@
   }
 
   .form-error {
-    color: var(--color-danger);
+    color: var(--color-error-text);
     font-size: var(--font-size-0);
   }
 
@@ -254,7 +254,7 @@
     border: 1px solid var(--color-input-border);
     border-radius: var(--radius-2);
     background-color: var(--color-input-focus-ring);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     cursor: pointer;
   }
 

--- a/frontend/src/lib/components/form/citation/CitationIdentifyBySearchStage.svelte
+++ b/frontend/src/lib/components/form/citation/CitationIdentifyBySearchStage.svelte
@@ -331,6 +331,6 @@
   }
 
   .status-error {
-    color: var(--color-danger);
+    color: var(--color-error-text);
   }
 </style>

--- a/frontend/src/lib/components/form/citation/CitationLocatorStage.svelte
+++ b/frontend/src/lib/components/form/citation/CitationLocatorStage.svelte
@@ -102,7 +102,7 @@
     border: 1px solid var(--color-input-border);
     border-radius: var(--radius-2);
     background-color: var(--color-input-focus-ring);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     cursor: pointer;
   }
 
@@ -121,6 +121,6 @@
   }
 
   .skip-btn:hover {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 </style>

--- a/frontend/src/lib/components/form/citation/CitationSearchStage.svelte
+++ b/frontend/src/lib/components/form/citation/CitationSearchStage.svelte
@@ -515,7 +515,7 @@
     border: 1px solid var(--color-input-border);
     border-radius: var(--radius-2);
     background-color: var(--color-input-focus-ring);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     cursor: pointer;
     align-self: flex-start;
   }
@@ -531,7 +531,7 @@
 
   .create-error {
     padding: var(--size-2) var(--size-3);
-    color: var(--color-danger);
+    color: var(--color-error-text);
     font-size: var(--font-size-0);
     text-align: center;
   }

--- a/frontend/src/lib/components/grid/PaginatedSection.svelte
+++ b/frontend/src/lib/components/grid/PaginatedSection.svelte
@@ -38,7 +38,7 @@
   h2 {
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-3);
   }
 

--- a/frontend/src/lib/components/grid/SearchableGrid.svelte
+++ b/frontend/src/lib/components/grid/SearchableGrid.svelte
@@ -79,7 +79,7 @@
 
   .error {
     text-align: center;
-    color: var(--color-error);
+    color: var(--color-error-text);
     padding: var(--size-6) 0;
   }
 </style>

--- a/frontend/src/lib/components/media/MediaCard.svelte
+++ b/frontend/src/lib/components/media/MediaCard.svelte
@@ -183,7 +183,7 @@
   }
 
   .action-btn--danger:hover {
-    color: var(--color-error);
-    border-color: var(--color-error);
+    color: var(--color-error-text);
+    border-color: var(--color-error-text);
   }
 </style>

--- a/frontend/src/lib/components/media/MediaUploadZone.svelte
+++ b/frontend/src/lib/components/media/MediaUploadZone.svelte
@@ -270,7 +270,7 @@
   }
 
   .file-entry.error {
-    color: var(--color-error);
+    color: var(--color-error-text);
   }
 
   .file-name {

--- a/frontend/src/lib/kiosk/KioskHome.svelte
+++ b/frontend/src/lib/kiosk/KioskHome.svelte
@@ -141,7 +141,7 @@
   .card-hook {
     padding: var(--size-3) var(--size-4) var(--size-4);
     font-size: var(--font-size-2);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin: 0;
     line-height: 1.4;
   }

--- a/frontend/src/routes/(legal)/+layout.svelte
+++ b/frontend/src/routes/(legal)/+layout.svelte
@@ -14,14 +14,14 @@
   .prose :global(h1) {
     font-size: var(--font-size-7);
     font-weight: 700;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-2);
   }
 
   .prose :global(h2) {
     font-size: var(--font-size-4);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-top: var(--size-7);
     margin-bottom: var(--size-3);
   }
@@ -29,7 +29,7 @@
   .prose :global(h3) {
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-top: var(--size-5);
     margin-bottom: var(--size-2);
   }
@@ -37,7 +37,7 @@
   .prose :global(p) {
     font-size: var(--font-size-2);
     line-height: var(--font-lineheight-3);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-4);
   }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -164,7 +164,7 @@
   .recent-heading {
     font-size: var(--font-size-4);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-4);
   }
 

--- a/frontend/src/routes/api-docs/+page.svelte
+++ b/frontend/src/routes/api-docs/+page.svelte
@@ -6,10 +6,10 @@
 
   const scalarCustomCss = `
 		.scalar-api-reference {
-			--scalar-background-1: var(--color-background);
+			--scalar-background-1: var(--color-bg);
 			--scalar-background-2: var(--color-surface);
-			--scalar-background-3: var(--color-background);
-			--scalar-color-1: var(--color-text-primary);
+			--scalar-background-3: var(--color-bg);
+			--scalar-color-1: var(--color-text);
 			--scalar-color-2: var(--color-text-muted);
 			--scalar-color-3: var(--color-text-muted);
 			--scalar-color-accent: var(--color-accent);
@@ -125,7 +125,7 @@
   .hero h1 {
     font-size: var(--font-size-7);
     font-weight: 700;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-3);
   }
 
@@ -139,7 +139,7 @@
   h2 {
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-4);
   }
 
@@ -155,7 +155,7 @@
   }
 
   .error-message {
-    color: var(--color-error);
+    color: var(--color-error-text);
   }
 
   .developer-resources {
@@ -173,7 +173,7 @@
   .resource-card h3 {
     font-size: var(--font-size-2);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-2);
   }
 
@@ -185,7 +185,7 @@
   }
 
   pre {
-    background-color: var(--color-background);
+    background-color: var(--color-bg);
     border: 1px solid var(--color-border-soft);
     border-radius: var(--radius-2);
     padding: var(--size-3) var(--size-4);

--- a/frontend/src/routes/changesets/+page.svelte
+++ b/frontend/src/routes/changesets/+page.svelte
@@ -311,7 +311,7 @@
   .page-header h1 {
     font-size: var(--font-size-5);
     font-weight: 700;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin: 0;
   }
 
@@ -345,7 +345,7 @@
     border: 1px solid var(--color-border-soft);
     border-radius: var(--radius-1);
     background-color: var(--color-surface);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     font-size: var(--font-size-1);
   }
 
@@ -396,7 +396,7 @@
     align-items: baseline;
     gap: var(--size-2);
     text-decoration: none;
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .entity-link:hover .entity-name {
@@ -493,7 +493,7 @@
     flex-wrap: wrap;
     align-items: baseline;
     gap: var(--size-1);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     overflow-wrap: break-word;
   }
 
@@ -527,13 +527,13 @@
 
   .retraction-label {
     font-weight: 600;
-    color: var(--color-danger);
+    color: var(--color-error-text);
     font-size: var(--font-size-00, 0.7rem);
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 1px var(--size-2);
     border-radius: var(--radius-1);
-    background-color: color-mix(in srgb, var(--color-danger) 10%, transparent);
+    background-color: color-mix(in srgb, var(--color-error-text) 10%, transparent);
   }
 
   /* Status messages */
@@ -544,7 +544,7 @@
   }
 
   .status-message.error {
-    color: var(--color-danger);
+    color: var(--color-error-text);
   }
 
   .no-changes {

--- a/frontend/src/routes/corporate-entities/+page.svelte
+++ b/frontend/src/routes/corporate-entities/+page.svelte
@@ -72,7 +72,7 @@
 
   .entity-name {
     font-size: var(--font-size-2);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     font-weight: 500;
   }
 

--- a/frontend/src/routes/corporate-entities/[slug]/+layout.svelte
+++ b/frontend/src/routes/corporate-entities/[slug]/+layout.svelte
@@ -204,7 +204,7 @@
 <style>
   .sidebar-value {
     font-size: var(--font-size-1);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin: 0;
   }
 

--- a/frontend/src/routes/manufacturers/+page.svelte
+++ b/frontend/src/routes/manufacturers/+page.svelte
@@ -127,7 +127,7 @@
 
   .error {
     text-align: center;
-    color: var(--color-error);
+    color: var(--color-error-text);
     padding: var(--size-6) 0;
   }
 

--- a/frontend/src/routes/manufacturers/[slug]/+layout.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+layout.svelte
@@ -282,7 +282,7 @@
 
   .entity-name {
     font-weight: 500;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     text-decoration: none;
   }
 
@@ -297,7 +297,7 @@
 
   .sidebar-value {
     font-size: var(--font-size-1);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin: 0;
   }
 </style>

--- a/frontend/src/routes/manufacturers/[slug]/+page.svelte
+++ b/frontend/src/routes/manufacturers/[slug]/+page.svelte
@@ -193,7 +193,7 @@
 
   .entity-name {
     font-weight: 500;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     text-decoration: none;
   }
 

--- a/frontend/src/routes/people/[slug]/+page.svelte
+++ b/frontend/src/routes/people/[slug]/+page.svelte
@@ -147,7 +147,7 @@
   }
 
   .bio-meta dd {
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin: 0;
   }
 </style>

--- a/frontend/src/routes/review/+page.svelte
+++ b/frontend/src/routes/review/+page.svelte
@@ -101,7 +101,7 @@
     font-size: var(--font-size-0);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: var(--color-warning);
+    color: var(--color-warning-text);
   }
 
   .source {
@@ -137,7 +137,7 @@
   }
 
   .claim-links a {
-    color: var(--color-warning);
+    color: var(--color-warning-text);
     text-decoration: underline;
   }
 </style>

--- a/frontend/src/routes/reward-types/[slug]/+page.svelte
+++ b/frontend/src/routes/reward-types/[slug]/+page.svelte
@@ -42,7 +42,7 @@
   h2 {
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-3);
   }
 

--- a/frontend/src/routes/systems/+page.svelte
+++ b/frontend/src/routes/systems/+page.svelte
@@ -121,7 +121,7 @@
 
   .system-name {
     font-size: var(--font-size-2);
-    color: var(--color-text-primary);
+    color: var(--color-text);
     font-weight: 500;
   }
 

--- a/frontend/src/routes/systems/[slug]/+page.svelte
+++ b/frontend/src/routes/systems/[slug]/+page.svelte
@@ -42,7 +42,7 @@
   h2 {
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-3);
   }
 

--- a/frontend/src/routes/titles/+page.svelte
+++ b/frontend/src/routes/titles/+page.svelte
@@ -144,7 +144,7 @@
 
   .error {
     text-align: center;
-    color: var(--color-error);
+    color: var(--color-error-text);
     padding: var(--size-6) 0;
   }
 

--- a/frontend/src/routes/titles/[slug]/+layout.svelte
+++ b/frontend/src/routes/titles/[slug]/+layout.svelte
@@ -419,7 +419,7 @@
   }
 
   dd {
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .muted {

--- a/frontend/src/routes/users/[username]/+page.svelte
+++ b/frontend/src/routes/users/[username]/+page.svelte
@@ -83,7 +83,7 @@
   .profile-header h1 {
     font-size: var(--font-size-5);
     font-weight: 700;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin: 0 0 var(--size-1) 0;
   }
 
@@ -100,7 +100,7 @@
   .section h2 {
     font-size: var(--font-size-3);
     font-weight: 600;
-    color: var(--color-text-primary);
+    color: var(--color-text);
     margin-bottom: var(--size-3);
   }
 
@@ -134,7 +134,7 @@
     align-items: baseline;
     gap: var(--size-2);
     text-decoration: none;
-    color: var(--color-text-primary);
+    color: var(--color-text);
   }
 
   .entity-link:hover .entity-name {


### PR DESCRIPTION
## Summary

Migrates the ~165 consumers of the legacy `--color-*` aliases to their canonical tokens, then deletes the alias declarations from `app.css`. Closes the legacy-alias half of #347.

- `--color-background` → `--color-bg`
- `--color-text-primary` → `--color-text`
- `--color-success` / `--color-warning` / `--color-error` / `--color-danger` → the corresponding `--color-{status}-text` token (matches prior behavior — aliases resolved to the same `-text` value)
- The 4 stylelint baseline entries that remain (Nav, WearEffect, Card, MediaCard) are explicitly out of scope per #347 and tracked in #348.

The 12 status-color callsites used as borders/backgrounds (e.g. invalid-input borders, danger button bg, soft-tint banner backgrounds via `color-mix`) were eyeballed individually — all preserve intentional prior behavior.

## Test plan

- [x] `pnpm lint` clean
- [x] `svelte-check` clean
- [x] Pre-commit hooks pass (lint, type check, tests)
- [ ] Spot-check rendered pages for status colors (errors, warnings, success, page bg, body text) in light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)