### PR TITLE
refactor(frontend): resolve component-private decorative hex (#348)

### DIFF
--- a/frontend/.stylelintrc.cjs
+++ b/frontend/.stylelintrc.cjs
@@ -149,17 +149,13 @@ module.exports = {
         'csstools/value-no-unknown-custom-properties': null,
       },
     },
-    // Components with pre-stylelint hex/rgb violations. Remove entries as
-    // each file is cleaned up.
+    // Components whose decorative texture is built from many rgba black/
+    // white gradient stops (shadow/highlight intensities, not themed
+    // colors). Promoting these to tokens would add indirection without
+    // enabling retheming. Intentional exception, not a cleanup target.
     {
-      files: [
-        'src/lib/components/Nav.svelte',
-        'src/lib/components/cards/WearEffect.svelte',
-        'src/lib/components/cards/Card.svelte',
-        'src/lib/components/media/MediaCard.svelte',
-      ],
+      files: ['src/lib/components/cards/WearEffect.svelte'],
       rules: {
-        'color-no-hex': null,
         'function-disallowed-list': null,
       },
     },

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -115,8 +115,39 @@
   --color-input-focus: #0078d4;
   --color-input-focus-ring: var(--color-focus-ring);
 
+  /* ---- Header chrome (warm paper tones, intentionally distinct from
+     --color-bg / --color-text to make the sticky nav read as its own
+     surface). Dark mode flips bg to a deep warm brown and lets text
+     fall back to the page text tokens. */
+  --color-header-bg: #efe8dc;
+  --color-header-text: #3d3529;
+  --color-header-text-muted: #6b5d4d;
+
+  /* ---- Card (polaroid-style listing cards: Card.svelte and friends).
+     Distinct from the white `--color-surface` family used by tooltips,
+     drawers, MediaCard, etc. `-bg-dim` is a recessed/placeholder
+     variant within the card body. */
+  --color-card-bg: #faf6f0;
+  --color-card-bg-dim: #e8e0d4;
+  --color-card-text: #3d3529;
+  /* Folded-corner variants: the lit and shadowed sides of a creased/
+     dog-eared card edge. WearEffect.svelte dims these via filter in
+     dark mode rather than redefining them, so no dark-mode override. */
+  --color-card-fold-light: #e8e0d0;
+  --color-card-fold-dark: #ded5c4;
+  /* Aged-paper tint applied as a translucent overlay on cards. Consumers
+     mix this token with `transparent` at a randomized per-card alpha
+     (see Card.svelte `--paper-yellow`) so the strength varies but the
+     hue is a single brand decision. */
+  --color-card-tint: #b49650;
+
   /* ---- Highlight ---- */
   --color-highlight-bg: #fff3cd; /* inline marks / search hits */
+
+  /* ---- Featured (theme-INVARIANT — accents a "chosen one" affordance,
+     e.g. the star on a primary image badge). Warm gold; sits over
+     arbitrary photo content, not a themed surface. */
+  --color-featured: #e8b923;
 
   /* ---- Diff (special-purpose) ---- */
   --color-diff-ins-bg: rgb(22 163 74 / 0.15);
@@ -231,6 +262,17 @@
     --color-input-border: #404040;
     --color-input-focus: #0078d4;
     --color-input-focus-ring: rgb(0 120 212 / 0.25);
+
+    /* ---- Header chrome ---- */
+    --color-header-bg: #26221d;
+    --color-header-text: var(--color-text);
+    --color-header-text-muted: var(--color-text-muted);
+
+    /* ---- Card ---- */
+    --color-card-bg: #2e2a24;
+    --color-card-bg-dim: #3a342b;
+    --color-card-text: #c8bfb0;
+    --color-card-tint: #8c6e3c;
 
     /* ---- Highlight ---- */
     --color-highlight-bg: rgb(251 191 36 / 0.2);

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -229,15 +229,10 @@
   }
 
   .site-header {
-    /* Color tokens — overridden in dark mode */
-    --header-bg: #efe8dc;
-    --header-ink: #3d3529;
-    --header-ink-muted: #6b5d4d;
-
     position: sticky;
     top: 0;
     z-index: var(--z-header);
-    background-color: var(--header-bg);
+    background-color: var(--color-header-bg);
     border-bottom: none;
   }
 
@@ -246,6 +241,10 @@
     content: '';
     position: absolute;
     inset: 0;
+    /* Paper-grain texture: stops are intentionally near-transparent black,
+       not themed colors. Promoting these to tokens would add indirection
+       without enabling any real retheming. */
+    /* stylelint-disable function-disallowed-list */
     background: repeating-linear-gradient(
       0deg,
       transparent,
@@ -253,6 +252,7 @@
       rgba(0, 0, 0, 0.01) 2px,
       rgba(0, 0, 0, 0.01) 4px
     );
+    /* stylelint-enable function-disallowed-list */
     pointer-events: none;
     z-index: 1;
   }
@@ -264,7 +264,7 @@
     left: 0;
     right: 0;
     height: 8px;
-    background: var(--header-bg);
+    background: var(--color-header-bg);
     pointer-events: none;
     z-index: 3;
   }
@@ -284,7 +284,7 @@
   .site-title {
     font-size: var(--font-size-4);
     font-weight: 700;
-    color: var(--header-ink);
+    color: var(--color-header-text);
     text-decoration: none;
   }
 
@@ -298,7 +298,7 @@
   }
 
   .nav-link {
-    color: var(--header-ink-muted);
+    color: var(--color-header-text-muted);
     text-decoration: none;
     font-size: var(--font-size-2);
     font-weight: 500;
@@ -310,7 +310,7 @@
   }
 
   .nav-link:hover {
-    color: var(--header-ink);
+    color: var(--color-header-text);
   }
 
   .nav-link.active {
@@ -325,7 +325,7 @@
   }
 
   .search-link {
-    color: var(--header-ink-muted);
+    color: var(--color-header-text-muted);
     padding: var(--size-1);
     display: flex;
     align-items: center;
@@ -333,7 +333,7 @@
   }
 
   .search-link:hover {
-    color: var(--header-ink);
+    color: var(--color-header-text);
   }
 
   .search-link.active {
@@ -342,14 +342,14 @@
 
   .auth-link {
     font-size: var(--font-size-2);
-    color: var(--header-ink-muted);
+    color: var(--color-header-text-muted);
     text-decoration: none;
     font-weight: 500;
     transition: color 0.15s var(--ease-2);
   }
 
   .auth-link:hover {
-    color: var(--header-ink);
+    color: var(--color-header-text);
   }
 
   /* Hamburger / desktop-account wrappers: ActionMenu's `bare` trigger inherits
@@ -364,13 +364,13 @@
     --menu-section-header-font-size: 0.875rem;
     display: flex;
     align-items: center;
-    color: var(--header-ink-muted);
+    color: var(--color-header-text-muted);
     transition: color 0.15s var(--ease-2);
   }
 
   .hamburger:hover,
   .desktop-account:hover {
-    color: var(--header-ink);
+    color: var(--color-header-text);
   }
 
   /* ── Three responsive tiers ──
@@ -421,12 +421,8 @@
 
   /* ---- Dark mode ---- */
   @media (prefers-color-scheme: dark) {
-    .site-header {
-      --header-bg: #26221d;
-      --header-ink: var(--color-text);
-      --header-ink-muted: var(--color-text-muted);
-    }
-
+    /* Paper grain is a light-mode-only flourish; in dark mode the
+       low-contrast stops vanish into the bg anyway, so skip the layer. */
     .site-header::before {
       background: none;
     }

--- a/frontend/src/lib/components/cards/Card.svelte
+++ b/frontend/src/lib/components/cards/Card.svelte
@@ -135,15 +135,10 @@
   }
 
   .card {
-    /* Color tokens — overridden in dark mode */
-    --polaroid-paper: #faf6f0;
-    --polaroid-paper-dim: #e8e0d4;
-    --polaroid-ink: #3d3529;
-
     position: relative;
     display: flex;
     flex-direction: column;
-    background-color: var(--polaroid-paper);
+    background-color: var(--color-card-bg);
     border: none;
     border-radius: 2px;
     overflow: hidden;
@@ -157,12 +152,18 @@
       box-shadow 0.2s ease;
   }
 
-  /* Yellowed paper tint overlay */
+  /* Yellowed paper tint overlay. Hue is the themed --color-card-tint
+     (dimmer in dark mode); alpha is randomized per-card via --paper-yellow
+     so individual cards age unevenly. */
   .card::before {
     content: '';
     position: absolute;
     inset: 0;
-    background: rgba(180, 150, 80, var(--paper-yellow, 0.05));
+    background: color-mix(
+      in srgb,
+      var(--color-card-tint) calc(var(--paper-yellow, 0.05) * 100%),
+      transparent
+    );
     pointer-events: none;
     border-radius: 2px;
     z-index: 2;
@@ -191,7 +192,7 @@
   .card-img-placeholder {
     width: 100%;
     height: 8rem;
-    background-color: var(--polaroid-paper-dim);
+    background-color: var(--color-card-bg-dim);
   }
 
   .card-body {
@@ -201,22 +202,12 @@
   .card-title {
     font-size: var(--font-size-2);
     font-weight: 600;
-    color: var(--polaroid-ink);
+    color: var(--color-card-text);
     margin-bottom: var(--size-1);
   }
 
   /* ---- Dark mode ---- */
   @media (prefers-color-scheme: dark) {
-    .card {
-      --polaroid-paper: #2e2a24;
-      --polaroid-paper-dim: #3a342b;
-      --polaroid-ink: #c8bfb0;
-    }
-
-    .card::before {
-      background: rgba(140, 110, 60, var(--paper-yellow, 0.05));
-    }
-
     .card-img {
       filter: var(--grain-url) sepia(var(--sepia, 0.5))
         brightness(calc(var(--brightness, 0.95) * 0.85)) contrast(var(--contrast, 0.9))

--- a/frontend/src/lib/components/cards/WearEffect.svelte
+++ b/frontend/src/lib/components/cards/WearEffect.svelte
@@ -48,8 +48,8 @@
       135deg,
       rgba(0, 0, 0, 0.06) 0%,
       rgba(0, 0, 0, 0.02) 50%,
-      var(--polaroid-fold-light, #e8e0d0) 50%,
-      var(--polaroid-fold-dark, #ded5c4) 100%
+      var(--color-card-fold-light) 50%,
+      var(--color-card-fold-dark) 100%
     );
   }
 
@@ -71,8 +71,8 @@
       225deg,
       rgba(0, 0, 0, 0.06) 0%,
       rgba(0, 0, 0, 0.02) 50%,
-      var(--polaroid-fold-light, #e8e0d0) 50%,
-      var(--polaroid-fold-dark, #ded5c4) 100%
+      var(--color-card-fold-light) 50%,
+      var(--color-card-fold-dark) 100%
     );
   }
   .dog-ear--tr::after {
@@ -89,8 +89,8 @@
       315deg,
       rgba(0, 0, 0, 0.06) 0%,
       rgba(0, 0, 0, 0.02) 50%,
-      var(--polaroid-fold-light, #e8e0d0) 50%,
-      var(--polaroid-fold-dark, #ded5c4) 100%
+      var(--color-card-fold-light) 50%,
+      var(--color-card-fold-dark) 100%
     );
   }
   .dog-ear--tl::after {
@@ -105,8 +105,8 @@
   .dog-ear--br::before {
     background: linear-gradient(
       135deg,
-      var(--polaroid-fold-light, #e8e0d0) 0%,
-      var(--polaroid-fold-dark, #ded5c4) 50%,
+      var(--color-card-fold-light) 0%,
+      var(--color-card-fold-dark) 50%,
       rgba(0, 0, 0, 0.02) 50%,
       rgba(0, 0, 0, 0.06) 100%
     );
@@ -125,8 +125,8 @@
       45deg,
       rgba(0, 0, 0, 0.06) 0%,
       rgba(0, 0, 0, 0.02) 50%,
-      var(--polaroid-fold-light, #e8e0d0) 50%,
-      var(--polaroid-fold-dark, #ded5c4) 100%
+      var(--color-card-fold-light) 50%,
+      var(--color-card-fold-dark) 100%
     );
   }
   .dog-ear--bl::after {

--- a/frontend/src/lib/components/media/MediaCard.svelte
+++ b/frontend/src/lib/components/media/MediaCard.svelte
@@ -135,8 +135,12 @@
     position: absolute;
     bottom: var(--size-1);
     left: var(--size-1);
+    /* Badge scrim is intentionally more opaque than --color-scrim (0.5):
+       it sits over arbitrary photo content and needs to guarantee legibility
+       of the small label, not just dim the layer below. */
+    /* stylelint-disable-next-line function-disallowed-list */
     background: rgba(0, 0, 0, 0.65);
-    color: #fff;
+    color: var(--color-text-inverse);
     font-size: var(--font-size-0);
     padding: 0.1em 0.4em;
     border-radius: var(--radius-1);
@@ -153,9 +157,12 @@
     position: absolute;
     top: var(--size-1);
     right: var(--size-1);
-    color: #f5c518;
+    color: var(--color-featured);
     font-size: 1.25rem;
     line-height: 1;
+    /* Drop-shadow color is a filter primitive, not a themed surface color —
+       a literal black w/ alpha is the right tool here. */
+    /* stylelint-disable-next-line function-disallowed-list */
     filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
   }
 


### PR DESCRIPTION
## Summary

- Promote header- and card-scoped warm-paper colors to semantic `--color-*` tokens in [app.css](frontend/src/app.css) so the polaroid/brand palette can be retuned from one place. Prep for an upcoming designer iteration pass — all the knobs are now in one file.
- New token families: `--color-featured` (MediaCard star badge, replacing IMDb-yellow `#f5c518` with a deliberately picked warm gold), `--color-header-bg/-text/-text-muted`, `--color-card-bg/-bg-dim/-text/-tint/-fold-light/-fold-dark`.
- Card's per-card randomized paper-yellow tint is now `color-mix(in srgb, var(--color-card-tint) calc(var(--paper-yellow) * 100%), transparent)` so the alpha randomization still works while the hue is theme-aware via tokens.
- Decorative texture (Nav paper grain, MediaCard badge scrim + drop-shadow, WearEffect rgba shadow/highlight gradient stops) stays as raw rgba with inline stylelint-disable comments explaining why — these are filter/texture internals, not theming knobs.
- Stylelint cleanup baseline is now empty. WearEffect moved out of the cleanup baseline into a new "intentional exception" override narrowed to `function-disallowed-list`, paralleling the existing Markdown.svelte `:global` exception.

Closes #348.

## Test plan

- [ ] Card grid renders with the polaroid look in light mode (warm cream paper, warm brown text, random per-card yellow tint, random wear effects)
- [ ] Card grid renders in dark mode (deep warm brown bg, dimmer paper tint, dark-mode brightness filter on dog-ear folds)
- [ ] Sticky nav header is warm cream w/ warm brown text in light mode, deep warm brown w/ default page text colors in dark mode
- [ ] MediaCard "primary image" star renders in the new warm gold (not IMDb yellow) over photo thumbnails
- [ ] `make lint` passes
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)