### PR TITLE
fix(frontend): close ActionMenu when trigger hidden by responsive swap

### DIFF
--- a/frontend/src/lib/components/ActionMenu.svelte
+++ b/frontend/src/lib/components/ActionMenu.svelte
@@ -206,6 +206,22 @@
       document.removeEventListener('focusin', handleFocusIn);
     };
   });
+
+  // Close if the trigger is hidden out from under us (e.g. a responsive
+  // breakpoint swaps which trigger is rendered). The menu is portaled to
+  // <body>, so it would otherwise stay visible and get repositioned against
+  // a zero-sized anchor.
+  $effect(() => {
+    if (!open || !triggerEl) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0]?.contentRect;
+      if (rect && rect.width === 0 && rect.height === 0) closeMenu();
+    });
+    observer.observe(triggerEl);
+
+    return () => observer.disconnect();
+  });
 </script>
 
 <button

--- a/frontend/src/tests/setup-dom.ts
+++ b/frontend/src/tests/setup-dom.ts
@@ -9,6 +9,13 @@ Element.prototype.scrollIntoView ??= function () {};
 // to return false, which triggers MarkdownTextArea's manual fallback path.
 document.execCommand = () => false;
 
+// jsdom doesn't implement ResizeObserver.
+window.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof window.ResizeObserver;
+
 // jsdom doesn't implement matchMedia. `createBelowBreakpointFlag` reads it at
 // module-eval time for a correct first-paint value, so any test that
 // touches a detail layout needs it defined.


### PR DESCRIPTION
## Summary

When the avatar menu was open on desktop and the user resized to mobile width, the menu stayed visible and jumped to the opposite corner of the screen.

The menu is portaled to `<body>` by the `floating` action, so hiding its trigger via `display: none` (the breakpoint swap in `Nav.svelte`) leaves the menu orphaned. Floating UI then recomputes against a zero-sized anchor, and `flip`/`shift` punt it to the opposite corner.

Fix: when open, `ActionMenu` observes its trigger via `ResizeObserver` and closes itself if the trigger collapses to 0×0. General behavior — any responsive layout that swaps which trigger is rendered now just works.

- Added a `ResizeObserver` jsdom shim in `setup-dom.ts` alongside the existing shims.

## Test plan

- [ ] Sign in, narrow the viewport just past the desktop breakpoint with the avatar menu open — menu closes cleanly instead of teleporting.
- [ ] Open the hamburger menu at mobile width, widen past the wide breakpoint — menu closes cleanly.
- [ ] Other ActionMenu callers (image-category picker, etc.) still open/close normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)