### PR TITLE
feat(frontend): new styling for site, improved admin-only theme visualizer

### DIFF
--- a/frontend/.stylelintrc.cjs
+++ b/frontend/.stylelintrc.cjs
@@ -122,10 +122,11 @@ module.exports = {
       customSyntax: 'postcss-html',
     },
     // ---- Baseline ----
-    // app.css defines the design tokens; raw hex/rgba inside :root blocks is
-    // the source of truth and exempt from the no-color rules.
+    // app.css and lib/themes/*.css define the design tokens; raw hex/rgba
+    // inside :root[data-theme] blocks is the source of truth and exempt
+    // from the no-color rules.
     {
-      files: ['src/app.css'],
+      files: ['src/app.css', 'src/lib/themes/*.css'],
       rules: {
         'color-no-hex': null,
         'function-disallowed-list': null,

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -24,9 +24,10 @@
    ======================================== */
 
 /* ========================================
-   SEMANTIC DESIGN TOKENS — Light Theme
-   Warm off-white palette (from flipfix). Dark theme is based on VS Code's
-   "Dark Modern": https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_modern.json
+   SEMANTIC DESIGN TOKENS — Default Light + Dark
+   Warm cream paper in light mode, warm dark brown in dark mode, with a
+   subtle score-reel grid pattern on the page background. Navy accent
+   (#2f4f73) carries CTAs and selection in both modes.
 
    What lives where:
      - Spacing, type, radius, motion, easing — Open Props (loaded above
@@ -44,21 +45,26 @@
    ======================================== */
 :root {
   color-scheme: light;
+  --header-stains-display: none;
+  --theme-bg-pattern:
+    linear-gradient(rgb(36 31 25 / 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(36 31 25 / 0.04) 1px, transparent 1px);
+  --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
 
   /* ---- Typography ---- */
   --font-body: 'Lora', serif;
   --font-mono: var(--font-monospace-code, monospace);
 
   /* ---- Surfaces ---- */
-  --color-bg: #fbf7f0; /* page background */
-  --color-surface: #ffffff; /* cards, panels */
-  --color-surface-elevated: #ffffff; /* menus, tooltips, toasts (raised) */
-  --color-surface-muted: #f3efe8; /* recessed bg: kiosk panels, alt rows */
-  --color-surface-inverse: #1f1f1f; /* always-dark: lightbox bg, dense overlays */
+  --color-bg: #f9f1df; /* page background */
+  --color-surface: #fffaf0; /* cards, panels */
+  --color-surface-elevated: #fffdf6; /* menus, tooltips, toasts (raised) */
+  --color-surface-muted: #eadcc4; /* recessed bg: kiosk panels, alt rows */
+  --color-surface-inverse: #241f19; /* always-dark: lightbox bg, dense overlays */
 
   /* ---- Text ---- */
-  --color-text: #333333; /* primary */
-  --color-text-muted: #6b7280; /* secondary */
+  --color-text: #241f19; /* primary */
+  --color-text-muted: #665947; /* secondary */
   /* Inverse text: white text used on any saturated/dark surface
      (surface-inverse, accent buttons, danger buttons, etc.). Theme-
      invariant. Split into per-surface tokens (--color-text-on-accent,
@@ -69,68 +75,70 @@
   --color-text-inverse-muted: rgb(255 255 255 / 0.7);
 
   /* ---- Borders ---- */
-  --color-border: #d1d5db;
-  --color-border-soft: #e7e5e4;
+  --color-border: #b9a382;
+  --color-border-soft: #d8c6a8;
 
   /* ---- Action (accent: solid CTA-bg / borders / icons; link: text) ---- */
-  --color-accent: #0078d4; /* CTA bg, borders, icons — sized for white text on top */
-  --color-accent-hover: #026ec1;
-  --color-accent-soft: rgb(0 120 212 / 0.1); /* selected rows, active filter pills */
-  --color-accent-border: rgb(0 120 212 / 0.4);
+  --color-accent: #2f4f73; /* CTA bg, borders, icons — sized for white text on top */
+  --color-accent-hover: #243d59;
+  --color-accent-soft: rgb(47 79 115 / 0.12); /* selected rows, active filter pills */
+  --color-accent-border: rgb(47 79 115 / 0.44);
   /* No --color-accent-active (pressed): we intentionally collapse pressed
      into hover. Add only if a component needs to distinguish the two. */
-  /* `--color-link` is the *text* form of accent — same hue in light mode,
-     but lighter in dark mode for AA contrast on dark backgrounds. Use
-     this for any inline interactive text (links, sidebar items, tappable
+  /* `--color-link` is the *text* form of accent — a related but lighter
+     navy that reads well as inline text on the cream page bg, while
+     accent stays dark enough to host white text on solid CTA surfaces.
+     In dark mode the link lightens further for AA contrast. Use this
+     for any inline interactive text (links, sidebar items, tappable
      list rows, accordion toggles); use --color-accent for surfaces. */
-  --color-link: var(--color-accent);
+  --color-link: #37628f;
 
   /* ---- Focus ring (used by all interactive elements) ---- */
-  --color-focus-ring: rgb(0 120 212 / 0.4);
+  --color-focus-ring: rgb(47 79 115 / 0.38);
 
   /* ---- Disabled (cross-cutting state for any interactive element) ---- */
-  --color-text-disabled: #9ca3af;
-  --color-bg-disabled: #f3f4f6;
-  --color-border-disabled: #e5e7eb;
+  --color-text-disabled: #9f927f;
+  --color-bg-disabled: #eee3d1;
+  --color-border-disabled: #d8c8ad;
 
   /* ---- Status (triplets: bg / border / text) ---- */
-  --color-success-bg: #f0fdf4;
-  --color-success-border: #86efac;
-  --color-success-text: #16a34a;
+  --color-success-bg: #edf7df;
+  --color-success-border: #a2ca67;
+  --color-success-text: #4f781e;
 
-  --color-warning-bg: #fefce8;
-  --color-warning-border: #fde68a;
-  --color-warning-text: #b45309;
+  --color-warning-bg: #fff4c9;
+  --color-warning-border: #dab54a;
+  --color-warning-text: #7d5900;
 
-  --color-error-bg: #fef2f2;
-  --color-error-border: #fecaca;
-  --color-error-text: #dc2626;
+  --color-error-bg: #ffece9;
+  --color-error-border: #eaa49d;
+  --color-error-text: #a22a22;
 
-  --color-info-bg: #eff6ff;
-  --color-info-border: #bfdbfe;
-  --color-info-text: #1d4ed8;
+  --color-info-bg: #e8f4f1;
+  --color-info-border: #8ac5ba;
+  --color-info-text: #237d76;
 
   /* ---- Inputs ---- */
-  --color-input-bg: #ffffff;
-  --color-input-border: #d1d5db;
-  --color-input-focus: #0078d4;
+  --color-input-bg: #fffaf0;
+  --color-input-border: #ad9878;
+  --color-input-focus: #2f4f73;
   --color-input-focus-ring: var(--color-focus-ring);
 
   /* ---- Header chrome (warm paper tones, intentionally distinct from
      --color-bg / --color-text to make the sticky nav read as its own
      surface). Dark mode flips bg to a deep warm brown and lets text
      fall back to the page text tokens. */
-  --color-header-bg: #efe8dc;
-  --color-header-text: #3d3529;
-  --color-header-text-muted: #6b5d4d;
+  --color-header-bg: #ece0ca;
+  --color-header-text: #241f19;
+  --color-header-text-muted: #665947;
 
   /* ---- Card (polaroid-style listing cards: Card.svelte and friends).
      Distinct from the white `--color-surface` family used by tooltips,
      drawers, MediaCard, etc. `-bg-dim` is a recessed/placeholder
      variant within the card body. */
-  --color-card-bg: #faf6f0;
-  --color-card-bg-dim: #e8e0d4;
-  --color-card-text: #3d3529;
+  --color-card-bg: #fff3d8;
+  --color-card-bg-dim: #ddc59a;
+  --color-card-text: #241f19;
   /* Folded-corner variants: the lit and shadowed sides of a creased/
      dog-eared card edge. WearEffect.svelte dims these via filter in
      dark mode rather than redefining them, so no dark-mode override. */
@@ -140,19 +148,19 @@
      mix this token with `transparent` at a randomized per-card alpha
      (see Card.svelte `--paper-yellow`) so the strength varies but the
      hue is a single brand decision. */
-  --color-card-tint: #b49650;
+  --color-card-tint: #b88b34;
 
   /* ---- Highlight ---- */
-  --color-highlight-bg: #fff3cd; /* inline marks / search hits */
+  --color-highlight-bg: #ffe7a3; /* inline marks / search hits */
 
   /* ---- Featured (theme-INVARIANT — accents a "chosen one" affordance,
      e.g. the star on a primary image badge). Warm gold; sits over
      arbitrary photo content, not a themed surface. */
-  --color-featured: #e8b923;
+  --color-featured: #c69325;
 
   /* ---- Diff (special-purpose) ---- */
-  --color-diff-ins-bg: rgb(22 163 74 / 0.15);
-  --color-diff-del-bg: rgb(220 38 38 / 0.15);
+  --color-diff-ins-bg: rgb(79 120 30 / 0.16);
+  --color-diff-del-bg: rgb(162 42 34 / 0.16);
 
   /* ---- Scrims (theme-INVARIANT — black overlays in both modes) ---- */
   --color-scrim: rgb(0 0 0 / 0.5); /* modals, action menus */
@@ -176,8 +184,8 @@
                          hover-lift state of cards (a card on hover
                          steps up from -card to -popover)
        --shadow-modal    overlay layer — modals, toasts, lightbox */
-  --shadow-color: 220 3% 15%;
-  --shadow-strength: 1%;
+  --shadow-color: 33 34% 18%;
+  --shadow-strength: 4%;
   --shadow-card:
     0 1px 3px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 7%)),
     0 1px 2px hsl(var(--shadow-color) / calc(var(--shadow-strength) + 3%));
@@ -207,82 +215,86 @@
 @media (prefers-color-scheme: dark) {
   :root {
     color-scheme: dark;
+    --theme-bg-pattern:
+      linear-gradient(rgb(234 223 203 / 0.045) 1px, transparent 1px),
+      linear-gradient(90deg, rgb(234 223 203 / 0.035) 1px, transparent 1px);
+    --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
 
     /* ---- Surfaces ---- */
-    --color-bg: #1f1f1f;
-    --color-surface: #252525;
-    --color-surface-elevated: #2d2d2d;
-    --color-surface-muted: #1a1a1a;
-    --color-surface-inverse: #0a0a0a;
+    --color-bg: #211d18;
+    --color-surface: #2c261f;
+    --color-surface-elevated: #362f26;
+    --color-surface-muted: #17130f;
+    --color-surface-inverse: #060504;
     /* --color-text-inverse{,-muted} stay white — they're for
        saturated/dark surfaces that don't flip with theme. */
 
     /* ---- Text ---- */
-    --color-text: #cccccc;
-    --color-text-muted: #9ca3af;
+    --color-text: #eadfcb;
+    --color-text-muted: #b9a891;
 
     /* ---- Borders ---- */
-    --color-border: #616161;
-    --color-border-soft: #3a3a3a; /* soft but discernible against #1f1f1f bg */
+    --color-border: #75624b;
+    --color-border-soft: #463929; /* soft but discernible against the page bg */
 
     /* ---- Action ---- */
-    --color-accent: #0078d4; /* unchanged — sized for white-on-accent buttons */
-    --color-accent-hover: #026ec1;
-    --color-accent-soft: rgb(0 120 212 / 0.18);
-    --color-accent-border: rgb(0 120 212 / 0.5);
-    /* Link diverges from accent in dark mode: #0078d4 on dark bg fails
-       WCAG AA (~3.6:1); #4daafc passes (~6.6:1). White-on-accent buttons
-       still pass because their bg is the dark accent, not the light link. */
-    --color-link: #4daafc;
+    --color-accent: #2f4f73; /* sized for white-on-accent buttons */
+    --color-accent-hover: #243d59;
+    --color-accent-soft: rgb(47 79 115 / 0.16);
+    --color-accent-border: rgb(47 79 115 / 0.48);
+    /* Link lightens further in dark mode for AA contrast on the warm
+       dark bg. White-on-accent buttons still pass because their bg is
+       the dark accent, not the lighter link color. */
+    --color-link: #7faedf;
 
     /* ---- Focus ring ---- */
-    --color-focus-ring: rgb(0 120 212 / 0.5);
+    --color-focus-ring: rgb(127 174 223 / 0.36);
 
     /* ---- Disabled ---- */
-    --color-text-disabled: #6b6b6b;
-    --color-bg-disabled: #2a2a2a;
-    --color-border-disabled: #3a3a3a;
+    --color-text-disabled: #827566;
+    --color-bg-disabled: #312b24;
+    --color-border-disabled: #4c4033;
 
     /* ---- Status ---- */
-    --color-success-bg: rgb(46 160 67 / 0.15);
-    --color-success-border: #1f5132;
-    --color-success-text: #2ea043;
+    --color-success-bg: rgb(133 184 69 / 0.16);
+    --color-success-border: #5d7931;
+    --color-success-text: #a8d86b;
 
-    --color-warning-bg: rgb(251 191 36 / 0.15);
-    --color-warning-border: #5a4c1a;
-    --color-warning-text: #fbbf24;
+    --color-warning-bg: rgb(255 209 91 / 0.16);
+    --color-warning-border: #7c6423;
+    --color-warning-text: #ffd15b;
 
-    --color-error-bg: rgb(248 81 73 / 0.15);
-    --color-error-border: #671e1e;
-    --color-error-text: #f85149;
+    --color-error-bg: rgb(207 74 63 / 0.16);
+    --color-error-border: #7b3832;
+    --color-error-text: #ff8a7e;
 
-    --color-info-bg: rgb(77 170 252 / 0.12);
-    --color-info-border: #1e3a5f;
-    --color-info-text: #4daafc;
+    --color-info-bg: rgb(74 188 176 / 0.13);
+    --color-info-border: #326c67;
+    --color-info-text: #7adbd2;
 
     /* ---- Inputs ---- */
-    --color-input-bg: #2b2b2b;
-    --color-input-border: #404040;
-    --color-input-focus: #0078d4;
-    --color-input-focus-ring: rgb(0 120 212 / 0.25);
+    --color-input-bg: #2a241d;
+    --color-input-border: #65543f;
+    --color-input-focus: #2f4f73;
+    --color-input-focus-ring: var(--color-focus-ring);
 
     /* ---- Header chrome ---- */
-    --color-header-bg: #26221d;
-    --color-header-text: var(--color-text);
-    --color-header-text-muted: var(--color-text-muted);
+    --color-header-bg: #181411;
+    --color-header-text: #eadfcb;
+    --color-header-text-muted: #c7b69d;
 
     /* ---- Card ---- */
-    --color-card-bg: #2e2a24;
-    --color-card-bg-dim: #3a342b;
-    --color-card-text: #c8bfb0;
-    --color-card-tint: #8c6e3c;
+    --color-card-bg: #372c20;
+    --color-card-bg-dim: #4b3a28;
+    --color-card-text: #ffe2ae;
+    --color-card-tint: #b88b34;
 
     /* ---- Highlight ---- */
-    --color-highlight-bg: rgb(251 191 36 / 0.2);
+    --color-highlight-bg: rgb(255 209 91 / 0.23);
 
     /* ---- Diff ---- */
-    --color-diff-ins-bg: rgb(46 160 67 / 0.25);
-    --color-diff-del-bg: rgb(248 81 73 / 0.25);
+    --color-diff-ins-bg: rgb(168 216 107 / 0.24);
+    --color-diff-del-bg: rgb(255 138 126 / 0.24);
 
     /* Shadows: bump strength + saturate the shadow color for dark mode.
        Both must be set here explicitly — our :root values above are
@@ -296,608 +308,13 @@
        project had pre-refactor (e.g. modal: 24%/17% vs old 50%/30%).
        25% matches Open Props's *omnibus* default and lands close to the
        previous visual weight. */
-    --shadow-color: 220 40% 2%;
-    --shadow-strength: 25%;
-  }
-}
-
-/* ========================================
-   MANUAL THEME PRESETS
-   Set by ThemeSwitcher.svelte via <html data-theme="...">.
-   Keep these blocks limited to token overrides so components remain
-   palette-agnostic.
-   ======================================== */
-
-:root[data-theme='current-v2'] {
-  color-scheme: light;
-
-  --color-bg: #fcfaf6;
-  --color-surface: #ffffff;
-  --color-surface-elevated: #ffffff;
-  --color-surface-muted: #f4f1eb;
-  --color-surface-inverse: #1d1d1d;
-
-  --color-text: #282828;
-  --color-text-muted: #59616d;
-
-  --color-border: #bdc4ce;
-  --color-border-soft: #ddd8cf;
-
-  --color-accent: #075fb8;
-  --color-accent-hover: #034f9c;
-  --color-accent-soft: rgb(7 95 184 / 0.1);
-  --color-accent-border: rgb(7 95 184 / 0.38);
-  --color-link: #075fb8;
-  --color-focus-ring: rgb(7 95 184 / 0.36);
-
-  --color-text-disabled: #8e98a5;
-  --color-bg-disabled: #eef1f4;
-  --color-border-disabled: #d9dee5;
-
-  --color-success-bg: #edf9f1;
-  --color-success-border: #8bd5a4;
-  --color-success-text: #147c43;
-  --color-warning-bg: #fff8df;
-  --color-warning-border: #f0cf78;
-  --color-warning-text: #8a5b00;
-  --color-error-bg: #fff1f1;
-  --color-error-border: #efb5b5;
-  --color-error-text: #bf2f2f;
-  --color-info-bg: #eef6ff;
-  --color-info-border: #b8d6f6;
-  --color-info-text: #075fb8;
-
-  --color-input-bg: #ffffff;
-  --color-input-border: #b7c0cc;
-  --color-input-focus: #075fb8;
-  --color-input-focus-ring: var(--color-focus-ring);
-
-  --color-header-bg: #eee8dd;
-  --color-header-text: #2f2c27;
-  --color-header-text-muted: #5f5a51;
-
-  --color-card-bg: #fbf7f0;
-  --color-card-bg-dim: #e7dfd2;
-  --color-card-text: #302d28;
-  --color-card-tint: #a98532;
-  --color-highlight-bg: #fff1b8;
-
-  --color-featured: #dca817;
-  --color-diff-ins-bg: rgb(20 124 67 / 0.15);
-  --color-diff-del-bg: rgb(191 47 47 / 0.15);
-
-  --shadow-color: 220 14% 22%;
-  --shadow-strength: 4%;
-}
-
-:root[data-theme='flyer-archive'] {
-  color-scheme: light;
-  --header-stains-display: none;
-  --theme-bg-pattern:
-    radial-gradient(circle at 1px 1px, rgb(33 25 20 / 0.16) 1px, transparent 0),
-    linear-gradient(135deg, rgb(232 56 37 / 0.1), transparent 32%),
-    linear-gradient(315deg, rgb(0 134 164 / 0.09), transparent 36%);
-  --theme-bg-pattern-size: 9px 9px, 100% 100%, 100% 100%;
-
-  --color-bg: #fff2d7;
-  --color-surface: #fffaf0;
-  --color-surface-elevated: #fffdf7;
-  --color-surface-muted: #f1dfbc;
-  --color-surface-inverse: #211914;
-
-  --color-text: #211914;
-  --color-text-muted: #694f3d;
-
-  --color-border: #9f744c;
-  --color-border-soft: #d9b985;
-
-  --color-accent: #007a96;
-  --color-accent-hover: #005f75;
-  --color-accent-soft: rgb(0 122 150 / 0.13);
-  --color-accent-border: rgb(0 122 150 / 0.46);
-  --color-link: #006b83;
-  --color-focus-ring: rgb(0 122 150 / 0.38);
-
-  --color-text-disabled: #9e8772;
-  --color-bg-disabled: #f2e2c4;
-  --color-border-disabled: #d9c29d;
-
-  --color-success-bg: #ecf8dc;
-  --color-success-border: #a7cf66;
-  --color-success-text: #4c7e18;
-  --color-warning-bg: #fff3bf;
-  --color-warning-border: #dfb52d;
-  --color-warning-text: #805600;
-  --color-error-bg: #ffe8df;
-  --color-error-border: #f0967b;
-  --color-error-text: #b73422;
-  --color-info-bg: #e5f7fa;
-  --color-info-border: #83cedb;
-  --color-info-text: #006b83;
-
-  --color-input-bg: #fffaf0;
-  --color-input-border: #b88e5e;
-  --color-input-focus: #007a96;
-  --color-input-focus-ring: var(--color-focus-ring);
-
-  --color-header-bg: #211914;
-  --color-header-text: #ffd644;
-  --color-header-text-muted: #f5c58d;
-
-  --color-card-bg: #ffe8b0;
-  --color-card-bg-dim: #e0b869;
-  --color-card-text: #211914;
-  --color-card-tint: #e83825;
-  --color-highlight-bg: rgb(255 214 68 / 0.55);
-
-  --color-featured: #ffd644;
-  --color-diff-ins-bg: rgb(76 126 24 / 0.16);
-  --color-diff-del-bg: rgb(183 52 34 / 0.16);
-
-  --shadow-color: 24 55% 18%;
-  --shadow-strength: 6%;
-}
-
-:root[data-theme='score-reel'] {
-  color-scheme: light;
-  --header-stains-display: none;
-  --theme-bg-pattern:
-    linear-gradient(rgb(36 31 25 / 0.055) 1px, transparent 1px),
-    linear-gradient(90deg, rgb(36 31 25 / 0.04) 1px, transparent 1px);
-  --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
-
-  --color-bg: #f9f1df;
-  --color-surface: #fffaf0;
-  --color-surface-elevated: #fffdf6;
-  --color-surface-muted: #eadcc4;
-  --color-surface-inverse: #241f19;
-
-  --color-text: #241f19;
-  --color-text-muted: #665947;
-
-  --color-border: #b9a382;
-  --color-border-soft: #d8c6a8;
-
-  --color-accent: #b83228;
-  --color-accent-hover: #94251f;
-  --color-accent-soft: rgb(184 50 40 / 0.11);
-  --color-accent-border: rgb(184 50 40 / 0.42);
-  --color-link: #a22a22;
-  --color-focus-ring: rgb(184 50 40 / 0.36);
-
-  --color-text-disabled: #9f927f;
-  --color-bg-disabled: #eee3d1;
-  --color-border-disabled: #d8c8ad;
-
-  --color-success-bg: #edf7df;
-  --color-success-border: #a2ca67;
-  --color-success-text: #4f781e;
-  --color-warning-bg: #fff4c9;
-  --color-warning-border: #dab54a;
-  --color-warning-text: #7d5900;
-  --color-error-bg: #ffece9;
-  --color-error-border: #eaa49d;
-  --color-error-text: #a22a22;
-  --color-info-bg: #e8f4f1;
-  --color-info-border: #8ac5ba;
-  --color-info-text: #237d76;
-
-  --color-input-bg: #fffaf0;
-  --color-input-border: #ad9878;
-  --color-input-focus: #b83228;
-  --color-input-focus-ring: var(--color-focus-ring);
-
-  --color-header-bg: #ece0ca;
-  --color-header-text: #241f19;
-  --color-header-text-muted: #665947;
-
-  --color-card-bg: #fff3d8;
-  --color-card-bg-dim: #ddc59a;
-  --color-card-text: #241f19;
-  --color-card-tint: #b88b34;
-  --color-highlight-bg: #ffe7a3;
-
-  --color-featured: #c69325;
-  --color-diff-ins-bg: rgb(79 120 30 / 0.16);
-  --color-diff-del-bg: rgb(162 42 34 / 0.16);
-
-  --shadow-color: 33 34% 18%;
-  --shadow-strength: 4%;
-}
-
-:root[data-theme='operators-log'] {
-  color-scheme: light;
-  --header-stains-display: none;
-  --theme-bg-pattern:
-    linear-gradient(90deg, rgb(46 65 55 / 0.08) 1px, transparent 1px),
-    linear-gradient(rgb(46 65 55 / 0.05) 1px, transparent 1px);
-  --theme-bg-pattern-size: 2rem 100%, 100% 2rem;
-
-  --color-bg: #f2f1e9;
-  --color-surface: #fbfaf3;
-  --color-surface-elevated: #fffef7;
-  --color-surface-muted: #e2e4d8;
-  --color-surface-inverse: #252b27;
-
-  --color-text: #252b27;
-  --color-text-muted: #5b675f;
-
-  --color-border: #aab5aa;
-  --color-border-soft: #cfd6cc;
-
-  --color-accent: #2f6f52;
-  --color-accent-hover: #255940;
-  --color-accent-soft: rgb(47 111 82 / 0.12);
-  --color-accent-border: rgb(47 111 82 / 0.42);
-  --color-link: #285f46;
-  --color-focus-ring: rgb(47 111 82 / 0.35);
-
-  --color-text-disabled: #8c978f;
-  --color-bg-disabled: #e6e8df;
-  --color-border-disabled: #cbd3ca;
-
-  --color-success-bg: #eaf7ee;
-  --color-success-border: #91cf9f;
-  --color-success-text: #2f6f40;
-  --color-warning-bg: #fff7d8;
-  --color-warning-border: #dec86a;
-  --color-warning-text: #776000;
-  --color-error-bg: #fff0eb;
-  --color-error-border: #e5aa9b;
-  --color-error-text: #a83a25;
-  --color-info-bg: #e8f2ed;
-  --color-info-border: #99beb0;
-  --color-info-text: #2f6f52;
-
-  --color-input-bg: #fffef7;
-  --color-input-border: #9caa9f;
-  --color-input-focus: #2f6f52;
-  --color-input-focus-ring: var(--color-focus-ring);
-
-  --color-header-bg: #dce2d8;
-  --color-header-text: #252b27;
-  --color-header-text-muted: #59665d;
-
-  --color-card-bg: #f8f2df;
-  --color-card-bg-dim: #d7d0b8;
-  --color-card-text: #252b27;
-  --color-card-tint: #d0a540;
-  --color-highlight-bg: #fff0b8;
-
-  --color-featured: #c79a1e;
-  --color-diff-ins-bg: rgb(47 111 64 / 0.16);
-  --color-diff-del-bg: rgb(168 58 37 / 0.16);
-
-  --shadow-color: 142 18% 18%;
-  --shadow-strength: 4%;
-}
-
-:root[data-theme='backglass-glow'] {
-  color-scheme: dark;
-  --header-stains-display: none;
-  --theme-bg-pattern:
-    radial-gradient(circle at 18% 12%, rgb(255 193 86 / 0.14), transparent 22rem),
-    radial-gradient(circle at 82% 18%, rgb(0 210 255 / 0.12), transparent 24rem),
-    radial-gradient(circle at 50% 92%, rgb(218 70 255 / 0.1), transparent 24rem);
-  --theme-bg-pattern-size: 100% 100%, 100% 100%, 100% 100%;
-
-  --color-bg: #151923;
-  --color-surface: #1f2531;
-  --color-surface-elevated: #2a3140;
-  --color-surface-muted: #10141d;
-  --color-surface-inverse: #05070c;
-
-  --color-text: #f3efe7;
-  --color-text-muted: #b9b8c6;
-
-  --color-border: #596274;
-  --color-border-soft: #343d4f;
-
-  --color-accent: #00b7d7;
-  --color-accent-hover: #35d4eb;
-  --color-accent-soft: rgb(0 183 215 / 0.16);
-  --color-accent-border: rgb(0 183 215 / 0.48);
-  --color-link: #55dff2;
-  --color-focus-ring: rgb(85 223 242 / 0.38);
-
-  --color-text-disabled: #767c8b;
-  --color-bg-disabled: #252b36;
-  --color-border-disabled: #3d4658;
-
-  --color-success-bg: rgb(58 205 132 / 0.15);
-  --color-success-border: #34764f;
-  --color-success-text: #6ee7a1;
-  --color-warning-bg: rgb(255 193 86 / 0.16);
-  --color-warning-border: #83622a;
-  --color-warning-text: #ffc156;
-  --color-error-bg: rgb(255 83 105 / 0.16);
-  --color-error-border: #833541;
-  --color-error-text: #ff7e91;
-  --color-info-bg: rgb(85 223 242 / 0.13);
-  --color-info-border: #2b6874;
-  --color-info-text: #55dff2;
-
-  --color-input-bg: #1b212d;
-  --color-input-border: #4b566a;
-  --color-input-focus: #00b7d7;
-  --color-input-focus-ring: var(--color-focus-ring);
-
-  --color-header-bg: #0b0f19;
-  --color-header-text: #ffc156;
-  --color-header-text-muted: #c8cad6;
-
-  --color-card-bg: #252638;
-  --color-card-bg-dim: #34364b;
-  --color-card-text: #fff0c9;
-  --color-card-tint: #b338d4;
-  --color-highlight-bg: rgb(255 193 86 / 0.23);
-
-  --color-featured: #ffc156;
-  --color-diff-ins-bg: rgb(110 231 161 / 0.24);
-  --color-diff-del-bg: rgb(255 126 145 / 0.24);
-
-  --shadow-color: 225 58% 3%;
-  --shadow-strength: 30%;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root[data-theme='current-v2'] {
-    color-scheme: dark;
-
-    --color-bg: #1d1d1d;
-    --color-surface: #252525;
-    --color-surface-elevated: #2d2d2d;
-    --color-surface-muted: #171717;
-    --color-surface-inverse: #080808;
-
-    --color-text: #dfdfdf;
-    --color-text-muted: #a7adb6;
-
-    --color-border: #6d747d;
-    --color-border-soft: #3f454d;
-
-    --color-accent: #147bd1;
-    --color-accent-hover: #3c99e8;
-    --color-accent-soft: rgb(20 123 209 / 0.18);
-    --color-accent-border: rgb(20 123 209 / 0.5);
-    --color-link: #78bfff;
-    --color-focus-ring: rgb(120 191 255 / 0.42);
-
-    --color-text-disabled: #6f7782;
-    --color-bg-disabled: #2b2d30;
-    --color-border-disabled: #3f454d;
-
-    --color-success-bg: rgb(48 169 90 / 0.16);
-    --color-success-border: #2f6f45;
-    --color-success-text: #51c77b;
-    --color-warning-bg: rgb(255 213 79 / 0.15);
-    --color-warning-border: #6b571a;
-    --color-warning-text: #ffd54f;
-    --color-error-bg: rgb(248 81 73 / 0.16);
-    --color-error-border: #743030;
-    --color-error-text: #ff7b72;
-    --color-info-bg: rgb(120 191 255 / 0.13);
-    --color-info-border: #2f557b;
-    --color-info-text: #78bfff;
-
-    --color-input-bg: #2a2a2a;
-    --color-input-border: #4c545e;
-    --color-input-focus: #147bd1;
-    --color-input-focus-ring: var(--color-focus-ring);
-
-    --color-header-bg: #242424;
-    --color-header-text: #e5e5e5;
-    --color-header-text-muted: #adb3bc;
-
-    --color-card-bg: #2b2925;
-    --color-card-bg-dim: #39352e;
-    --color-card-text: #d9d1c4;
-    --color-card-tint: #8f713d;
-    --color-highlight-bg: rgb(255 213 79 / 0.2);
-
-    --color-diff-ins-bg: rgb(81 199 123 / 0.24);
-    --color-diff-del-bg: rgb(255 123 114 / 0.24);
-
-    --shadow-color: 220 28% 3%;
-    --shadow-strength: 25%;
-  }
-
-  :root[data-theme='flyer-archive'] {
-    color-scheme: dark;
-    --theme-bg-pattern:
-      radial-gradient(circle at 1px 1px, rgb(255 214 68 / 0.11) 1px, transparent 0),
-      linear-gradient(135deg, rgb(232 56 37 / 0.12), transparent 30%),
-      linear-gradient(315deg, rgb(0 165 190 / 0.1), transparent 36%);
-    --theme-bg-pattern-size: 9px 9px, 100% 100%, 100% 100%;
-
-    --color-bg: #1d1713;
-    --color-surface: #2a211a;
-    --color-surface-elevated: #34281f;
-    --color-surface-muted: #17110e;
-    --color-surface-inverse: #070504;
-
-    --color-text: #f6e7c6;
-    --color-text-muted: #c9a981;
-
-    --color-border: #7b5f45;
-    --color-border-soft: #4a382a;
-
-    --color-accent: #00a5be;
-    --color-accent-hover: #31c7dc;
-    --color-accent-soft: rgb(0 165 190 / 0.16);
-    --color-accent-border: rgb(0 165 190 / 0.48);
-    --color-link: #45d6e8;
-    --color-focus-ring: rgb(69 214 232 / 0.38);
-
-    --color-text-disabled: #8f765c;
-    --color-bg-disabled: #2e251d;
-    --color-border-disabled: #493727;
-
-    --color-success-bg: rgb(126 188 65 / 0.16);
-    --color-success-border: #587b30;
-    --color-success-text: #a8e063;
-    --color-warning-bg: rgb(255 214 68 / 0.16);
-    --color-warning-border: #84681d;
-    --color-warning-text: #ffd644;
-    --color-error-bg: rgb(232 56 37 / 0.16);
-    --color-error-border: #84382d;
-    --color-error-text: #ff7b5f;
-    --color-info-bg: rgb(69 214 232 / 0.12);
-    --color-info-border: #23616c;
-    --color-info-text: #45d6e8;
-
-    --color-input-bg: #241c16;
-    --color-input-border: #6d533a;
-    --color-input-focus: #00a5be;
-    --color-input-focus-ring: var(--color-focus-ring);
-
-    --color-header-bg: #0e0a08;
-    --color-header-text: #ffd644;
-    --color-header-text-muted: #e7b776;
-
-    --color-card-bg: #342819;
-    --color-card-bg-dim: #49351f;
-    --color-card-text: #ffe6ac;
-    --color-card-tint: #e83825;
-    --color-highlight-bg: rgb(255 214 68 / 0.24);
-
-    --color-diff-ins-bg: rgb(168 224 99 / 0.24);
-    --color-diff-del-bg: rgb(255 123 95 / 0.24);
-
-    --shadow-color: 24 60% 2%;
-    --shadow-strength: 30%;
-  }
-
-  :root[data-theme='score-reel'] {
-    color-scheme: dark;
-    --theme-bg-pattern:
-      linear-gradient(rgb(234 223 203 / 0.045) 1px, transparent 1px),
-      linear-gradient(90deg, rgb(234 223 203 / 0.035) 1px, transparent 1px);
-    --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
-
-    --color-bg: #211d18;
-    --color-surface: #2c261f;
-    --color-surface-elevated: #362f26;
-    --color-surface-muted: #17130f;
-    --color-surface-inverse: #060504;
-
-    --color-text: #eadfcb;
-    --color-text-muted: #b9a891;
-
-    --color-border: #75624b;
-    --color-border-soft: #463929;
-
-    --color-accent: #cf4a3f;
-    --color-accent-hover: #ea675b;
-    --color-accent-soft: rgb(207 74 63 / 0.16);
-    --color-accent-border: rgb(207 74 63 / 0.48);
-    --color-link: #ff8a7e;
-    --color-focus-ring: rgb(255 138 126 / 0.36);
-
-    --color-text-disabled: #827566;
-    --color-bg-disabled: #312b24;
-    --color-border-disabled: #4c4033;
-
-    --color-success-bg: rgb(133 184 69 / 0.16);
-    --color-success-border: #5d7931;
-    --color-success-text: #a8d86b;
-    --color-warning-bg: rgb(255 209 91 / 0.16);
-    --color-warning-border: #7c6423;
-    --color-warning-text: #ffd15b;
-    --color-error-bg: rgb(207 74 63 / 0.16);
-    --color-error-border: #7b3832;
-    --color-error-text: #ff8a7e;
-    --color-info-bg: rgb(74 188 176 / 0.13);
-    --color-info-border: #326c67;
-    --color-info-text: #7adbd2;
-
-    --color-input-bg: #2a241d;
-    --color-input-border: #65543f;
-    --color-input-focus: #cf4a3f;
-    --color-input-focus-ring: var(--color-focus-ring);
-
-    --color-header-bg: #181411;
-    --color-header-text: #ffd15b;
-    --color-header-text-muted: #c7b69d;
-
-    --color-card-bg: #372c20;
-    --color-card-bg-dim: #4b3a28;
-    --color-card-text: #ffe2ae;
-    --color-card-tint: #b88b34;
-    --color-highlight-bg: rgb(255 209 91 / 0.23);
-
-    --color-diff-ins-bg: rgb(168 216 107 / 0.24);
-    --color-diff-del-bg: rgb(255 138 126 / 0.24);
-
     --shadow-color: 30 50% 2%;
     --shadow-strength: 28%;
   }
-
-  :root[data-theme='operators-log'] {
-    color-scheme: dark;
-    --theme-bg-pattern:
-      linear-gradient(90deg, rgb(207 220 210 / 0.04) 1px, transparent 1px),
-      linear-gradient(rgb(207 220 210 / 0.035) 1px, transparent 1px);
-    --theme-bg-pattern-size: 2rem 100%, 100% 2rem;
-
-    --color-bg: #1b211e;
-    --color-surface: #242b27;
-    --color-surface-elevated: #2d3630;
-    --color-surface-muted: #121714;
-    --color-surface-inverse: #050806;
-
-    --color-text: #e4e9df;
-    --color-text-muted: #aebcae;
-
-    --color-border: #5d6b60;
-    --color-border-soft: #39433c;
-
-    --color-accent: #5fb284;
-    --color-accent-hover: #7bd09e;
-    --color-accent-soft: rgb(95 178 132 / 0.15);
-    --color-accent-border: rgb(95 178 132 / 0.46);
-    --color-link: #8bd8aa;
-    --color-focus-ring: rgb(139 216 170 / 0.36);
-
-    --color-text-disabled: #78867b;
-    --color-bg-disabled: #2a312c;
-    --color-border-disabled: #404b43;
-
-    --color-success-bg: rgb(95 178 90 / 0.16);
-    --color-success-border: #3e7344;
-    --color-success-text: #8bd88d;
-    --color-warning-bg: rgb(226 195 88 / 0.15);
-    --color-warning-border: #756422;
-    --color-warning-text: #f0d56f;
-    --color-error-bg: rgb(221 91 65 / 0.15);
-    --color-error-border: #7c3e32;
-    --color-error-text: #ff9276;
-    --color-info-bg: rgb(139 216 170 / 0.12);
-    --color-info-border: #3b6850;
-    --color-info-text: #8bd8aa;
-
-    --color-input-bg: #202722;
-    --color-input-border: #536258;
-    --color-input-focus: #5fb284;
-    --color-input-focus-ring: var(--color-focus-ring);
-
-    --color-header-bg: #131915;
-    --color-header-text: #d6e1d6;
-    --color-header-text-muted: #aebcae;
-
-    --color-card-bg: #2d2d25;
-    --color-card-bg-dim: #3e3e32;
-    --color-card-text: #f0e4c8;
-    --color-card-tint: #d0a540;
-    --color-highlight-bg: rgb(240 213 111 / 0.2);
-
-    --color-diff-ins-bg: rgb(139 216 141 / 0.24);
-    --color-diff-del-bg: rgb(255 146 118 / 0.24);
-
-    --shadow-color: 142 42% 3%;
-    --shadow-strength: 27%;
-  }
 }
+
+/* Manual theme presets live in lib/themes/*.css and are lazy-loaded by
+   ThemeSwitcher.svelte. Only the default light/dark contract is here. */
 
 /* ========================================
    BASE OVERRIDES

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -403,8 +403,19 @@ a:hover {
   color: var(--color-text-muted);
 }
 
+/* Invalid: red border, plus an inset 1px shadow on unfocused inputs to
+   thicken the border to 2px-effective without layout shift. In light
+   mode of the default theme the error red and tan input border read as
+   similar warm strokes at 1px; doubling the weight keeps "invalid" loud
+   across every theme without a per-theme `--color-input-invalid` token.
+   The `:not(:focus)` carve-out lets the focus ring above show through
+   on focused-invalid — the red border still signals the invalid state. */
 :where(input, textarea, select)[aria-invalid='true'] {
   border-color: var(--color-error-text);
+}
+
+:where(input, textarea, select)[aria-invalid='true']:not(:focus) {
+  box-shadow: inset 0 0 0 1px var(--color-error-text);
 }
 
 /* ========================================

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -10,78 +10,24 @@
       href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&display=swap"
       rel="stylesheet"
     />
-    <script>
-      try {
-        const theme = localStorage.getItem('flipcommons-theme');
-        if (
-          theme === 'current-v2' ||
-          theme === 'flyer-archive' ||
-          theme === 'score-reel' ||
-          theme === 'operators-log' ||
-          theme === 'backglass-glow'
-        ) {
-          document.documentElement.dataset.theme = theme;
-        }
-      } catch {
-        // Ignore storage failures; the app will fall back to system theme.
-      }
-    </script>
     <style>
-      /* Critical dark-mode background inlined to prevent flash on pre-rendered pages.
-			   Values must stay in sync with app.css. */
+      /* Critical default-theme background inlined to prevent flash on
+         pre-rendered pages. Values must stay in sync with app.css.
+         Manual themes (set by ThemeSwitcher) are test-only and tolerate
+         a brief flash while their CSS chunk loads; no FOUC wiring here. */
       html {
-        background-color: #fbf7f0;
-        color: #333333;
-      }
-      html[data-theme='current-v2'] {
-        background-color: #fcfaf6;
-        color: #282828;
-      }
-      html[data-theme='flyer-archive'] {
-        background-color: #fff2d7;
-        color: #211914;
-      }
-      html[data-theme='score-reel'] {
         background-color: #f9f1df;
         color: #241f19;
       }
-      html[data-theme='operators-log'] {
-        background-color: #f2f1e9;
-        color: #252b27;
-      }
-      html[data-theme='backglass-glow'] {
-        background-color: #151923;
-        color: #f3efe7;
-      }
       @media (prefers-color-scheme: dark) {
         html:not([data-theme]) {
-          background-color: #1f1f1f;
-          color: #cccccc;
-        }
-        html[data-theme='current-v2'] {
-          background-color: #1d1d1d;
-          color: #dfdfdf;
-        }
-        html[data-theme='flyer-archive'] {
-          background-color: #1d1713;
-          color: #f6e7c6;
-        }
-        html[data-theme='score-reel'] {
           background-color: #211d18;
           color: #eadfcb;
         }
-        html[data-theme='operators-log'] {
-          background-color: #1b211e;
-          color: #e4e9df;
-        }
-        html[data-theme='backglass-glow'] {
-          background-color: #0b0f19;
-          color: #f3efe7;
-        }
       }
     </style>
-    <meta name="theme-color" content="#fbf7f0" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#1f1f1f" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#f9f1df" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#211d18" media="(prefers-color-scheme: dark)" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/frontend/src/lib/components/ActiveFilterChips.svelte
+++ b/frontend/src/lib/components/ActiveFilterChips.svelte
@@ -64,7 +64,7 @@
     gap: var(--size-1);
     padding: var(--size-1) var(--size-2);
     font-size: var(--font-size-0);
-    background-color: var(--color-link);
+    background-color: var(--color-accent);
     color: var(--color-text-inverse);
     border-radius: var(--radius-2);
   }

--- a/frontend/src/lib/components/ManufacturerActiveFilterChips.svelte
+++ b/frontend/src/lib/components/ManufacturerActiveFilterChips.svelte
@@ -57,7 +57,7 @@
     gap: var(--size-1);
     padding: var(--size-1) var(--size-2);
     font-size: var(--font-size-0);
-    background-color: var(--color-link);
+    background-color: var(--color-accent);
     color: var(--color-text-inverse);
     border-radius: var(--radius-2);
   }

--- a/frontend/src/lib/components/ThemeSwitcher.svelte
+++ b/frontend/src/lib/components/ThemeSwitcher.svelte
@@ -1,50 +1,54 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import {
+    THEMES,
+    THEME_STORAGE_KEY,
+    isThemeId,
+    getTheme,
+    normalizeThemeId,
+    type ThemeId,
+  } from '$lib/themes';
 
-  const STORAGE_KEY = 'flipcommons-theme';
-
-  const themes = [
-    { id: 'system', label: 'Current' },
-    { id: 'current-v2', label: 'Current v2' },
-    { id: 'flyer-archive', label: 'Pinball Flyer Archive' },
-    { id: 'score-reel', label: 'Score Reel' },
-    { id: 'operators-log', label: "Operator's Log" },
-    { id: 'backglass-glow', label: 'Backglass Glow' },
-  ] as const;
-
-  type ThemeId = (typeof themes)[number]['id'];
+  // /style-lab-only component: deliberately NOT hardened against
+  // localStorage / dynamic-import failures. If something here breaks, a
+  // dev sees it loudly and fixes it. End users never reach this code.
+  // The page-load bootstrap in lib/themes/index.ts IS hardened — that's
+  // the path that runs for every visitor on every page.
 
   let selectedTheme = $state<ThemeId>('system');
+  // Monotonic token so a slow CSS chunk from a previous selection can't
+  // overwrite the DOM/storage after the user has moved on to another theme.
+  let applyToken = 0;
 
-  function isThemeId(value: string): value is ThemeId {
-    return themes.some((theme) => theme.id === value);
-  }
-
-  function applyTheme(theme: ThemeId) {
+  async function applyTheme(theme: ThemeId) {
     selectedTheme = theme;
+    const token = ++applyToken;
 
     if (theme === 'system') {
       delete document.documentElement.dataset.theme;
-      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(THEME_STORAGE_KEY);
       return;
     }
 
+    await getTheme(theme).load();
+    if (token !== applyToken) return;
     document.documentElement.dataset.theme = theme;
-    localStorage.setItem(STORAGE_KEY, theme);
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
   }
 
   function handleChange(event: Event) {
     const target = event.currentTarget;
     if (!(target instanceof HTMLSelectElement)) return;
-    if (isThemeId(target.value)) applyTheme(target.value);
+    if (isThemeId(target.value)) void applyTheme(target.value);
   }
 
   onMount(() => {
-    const storedTheme = localStorage.getItem(STORAGE_KEY);
-    if (storedTheme && isThemeId(storedTheme)) {
-      applyTheme(storedTheme);
+    const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    const theme = storedTheme ? normalizeThemeId(storedTheme) : null;
+    if (theme) {
+      void applyTheme(theme);
     } else if (storedTheme) {
-      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(THEME_STORAGE_KEY);
     }
   });
 </script>
@@ -52,7 +56,7 @@
 <div class="theme-switcher">
   <label for="theme-select">Theme</label>
   <select id="theme-select" value={selectedTheme} onchange={handleChange}>
-    {#each themes as theme (theme.id)}
+    {#each THEMES as theme (theme.id)}
       <option value={theme.id}>{theme.label}</option>
     {/each}
   </select>

--- a/frontend/src/lib/themes/backglass-glow-dark.css
+++ b/frontend/src/lib/themes/backglass-glow-dark.css
@@ -1,0 +1,67 @@
+:root[data-theme='backglass-glow-dark'] {
+  color-scheme: dark;
+  --header-stains-display: none;
+  --theme-bg-pattern:
+    radial-gradient(circle at 18% 12%, rgb(255 193 86 / 0.14), transparent 22rem),
+    radial-gradient(circle at 82% 18%, rgb(0 210 255 / 0.12), transparent 24rem),
+    radial-gradient(circle at 50% 92%, rgb(218 70 255 / 0.1), transparent 24rem);
+  --theme-bg-pattern-size: 100% 100%, 100% 100%, 100% 100%;
+
+  --color-bg: #151923;
+  --color-surface: #1f2531;
+  --color-surface-elevated: #2a3140;
+  --color-surface-muted: #10141d;
+  --color-surface-inverse: #05070c;
+
+  --color-text: #f3efe7;
+  --color-text-muted: #b9b8c6;
+
+  --color-border: #596274;
+  --color-border-soft: #343d4f;
+
+  --color-accent: #00b7d7;
+  --color-accent-hover: #35d4eb;
+  --color-accent-soft: rgb(0 183 215 / 0.16);
+  --color-accent-border: rgb(0 183 215 / 0.48);
+  --color-link: #55dff2;
+  --color-focus-ring: rgb(85 223 242 / 0.38);
+
+  --color-text-disabled: #767c8b;
+  --color-bg-disabled: #252b36;
+  --color-border-disabled: #3d4658;
+
+  --color-success-bg: rgb(58 205 132 / 0.15);
+  --color-success-border: #34764f;
+  --color-success-text: #6ee7a1;
+  --color-warning-bg: rgb(255 193 86 / 0.16);
+  --color-warning-border: #83622a;
+  --color-warning-text: #ffc156;
+  --color-error-bg: rgb(255 83 105 / 0.16);
+  --color-error-border: #833541;
+  --color-error-text: #ff7e91;
+  --color-info-bg: rgb(85 223 242 / 0.13);
+  --color-info-border: #2b6874;
+  --color-info-text: #55dff2;
+
+  --color-input-bg: #1b212d;
+  --color-input-border: #4b566a;
+  --color-input-focus: #00b7d7;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #0b0f19;
+  --color-header-text: #ffc156;
+  --color-header-text-muted: #c8cad6;
+
+  --color-card-bg: #252638;
+  --color-card-bg-dim: #34364b;
+  --color-card-text: #fff0c9;
+  --color-card-tint: #b338d4;
+  --color-highlight-bg: rgb(255 193 86 / 0.23);
+
+  --color-featured: #ffc156;
+  --color-diff-ins-bg: rgb(110 231 161 / 0.24);
+  --color-diff-del-bg: rgb(255 126 145 / 0.24);
+
+  --shadow-color: 225 58% 3%;
+  --shadow-strength: 30%;
+}

--- a/frontend/src/lib/themes/flyer-archive-dark.css
+++ b/frontend/src/lib/themes/flyer-archive-dark.css
@@ -1,0 +1,65 @@
+:root[data-theme='flyer-archive-dark'] {
+  color-scheme: dark;
+  --theme-bg-pattern:
+    radial-gradient(circle at 1px 1px, rgb(255 214 68 / 0.11) 1px, transparent 0),
+    linear-gradient(135deg, rgb(232 56 37 / 0.12), transparent 30%),
+    linear-gradient(315deg, rgb(0 165 190 / 0.1), transparent 36%);
+  --theme-bg-pattern-size: 9px 9px, 100% 100%, 100% 100%;
+
+  --color-bg: #1d1713;
+  --color-surface: #2a211a;
+  --color-surface-elevated: #34281f;
+  --color-surface-muted: #17110e;
+  --color-surface-inverse: #070504;
+
+  --color-text: #f6e7c6;
+  --color-text-muted: #c9a981;
+
+  --color-border: #7b5f45;
+  --color-border-soft: #4a382a;
+
+  --color-accent: #00a5be;
+  --color-accent-hover: #31c7dc;
+  --color-accent-soft: rgb(0 165 190 / 0.16);
+  --color-accent-border: rgb(0 165 190 / 0.48);
+  --color-link: #45d6e8;
+  --color-focus-ring: rgb(69 214 232 / 0.38);
+
+  --color-text-disabled: #8f765c;
+  --color-bg-disabled: #2e251d;
+  --color-border-disabled: #493727;
+
+  --color-success-bg: rgb(126 188 65 / 0.16);
+  --color-success-border: #587b30;
+  --color-success-text: #a8e063;
+  --color-warning-bg: rgb(255 214 68 / 0.16);
+  --color-warning-border: #84681d;
+  --color-warning-text: #ffd644;
+  --color-error-bg: rgb(232 56 37 / 0.16);
+  --color-error-border: #84382d;
+  --color-error-text: #ff7b5f;
+  --color-info-bg: rgb(69 214 232 / 0.12);
+  --color-info-border: #23616c;
+  --color-info-text: #45d6e8;
+
+  --color-input-bg: #241c16;
+  --color-input-border: #6d533a;
+  --color-input-focus: #00a5be;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #0e0a08;
+  --color-header-text: #ffd644;
+  --color-header-text-muted: #e7b776;
+
+  --color-card-bg: #342819;
+  --color-card-bg-dim: #49351f;
+  --color-card-text: #ffe6ac;
+  --color-card-tint: #e83825;
+  --color-highlight-bg: rgb(255 214 68 / 0.24);
+
+  --color-diff-ins-bg: rgb(168 224 99 / 0.24);
+  --color-diff-del-bg: rgb(255 123 95 / 0.24);
+
+  --shadow-color: 24 60% 2%;
+  --shadow-strength: 30%;
+}

--- a/frontend/src/lib/themes/flyer-archive-light.css
+++ b/frontend/src/lib/themes/flyer-archive-light.css
@@ -1,0 +1,67 @@
+:root[data-theme='flyer-archive-light'] {
+  color-scheme: light;
+  --header-stains-display: none;
+  --theme-bg-pattern:
+    radial-gradient(circle at 1px 1px, rgb(33 25 20 / 0.16) 1px, transparent 0),
+    linear-gradient(135deg, rgb(232 56 37 / 0.1), transparent 32%),
+    linear-gradient(315deg, rgb(0 134 164 / 0.09), transparent 36%);
+  --theme-bg-pattern-size: 9px 9px, 100% 100%, 100% 100%;
+
+  --color-bg: #fff2d7;
+  --color-surface: #fffaf0;
+  --color-surface-elevated: #fffdf7;
+  --color-surface-muted: #f1dfbc;
+  --color-surface-inverse: #211914;
+
+  --color-text: #211914;
+  --color-text-muted: #694f3d;
+
+  --color-border: #9f744c;
+  --color-border-soft: #d9b985;
+
+  --color-accent: #007a96;
+  --color-accent-hover: #005f75;
+  --color-accent-soft: rgb(0 122 150 / 0.13);
+  --color-accent-border: rgb(0 122 150 / 0.46);
+  --color-link: #006b83;
+  --color-focus-ring: rgb(0 122 150 / 0.38);
+
+  --color-text-disabled: #9e8772;
+  --color-bg-disabled: #f2e2c4;
+  --color-border-disabled: #d9c29d;
+
+  --color-success-bg: #ecf8dc;
+  --color-success-border: #a7cf66;
+  --color-success-text: #4c7e18;
+  --color-warning-bg: #fff3bf;
+  --color-warning-border: #dfb52d;
+  --color-warning-text: #805600;
+  --color-error-bg: #ffe8df;
+  --color-error-border: #f0967b;
+  --color-error-text: #b73422;
+  --color-info-bg: #e5f7fa;
+  --color-info-border: #83cedb;
+  --color-info-text: #006b83;
+
+  --color-input-bg: #fffaf0;
+  --color-input-border: #b88e5e;
+  --color-input-focus: #007a96;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #211914;
+  --color-header-text: #ffd644;
+  --color-header-text-muted: #f5c58d;
+
+  --color-card-bg: #ffe8b0;
+  --color-card-bg-dim: #e0b869;
+  --color-card-text: #211914;
+  --color-card-tint: #e83825;
+  --color-highlight-bg: rgb(255 214 68 / 0.55);
+
+  --color-featured: #ffd644;
+  --color-diff-ins-bg: rgb(76 126 24 / 0.16);
+  --color-diff-del-bg: rgb(183 52 34 / 0.16);
+
+  --shadow-color: 24 55% 18%;
+  --shadow-strength: 6%;
+}

--- a/frontend/src/lib/themes/index.ts
+++ b/frontend/src/lib/themes/index.ts
@@ -1,0 +1,179 @@
+/**
+ * Theme registry. Each non-default theme's tokens live in its own CSS file
+ * and are loaded on demand via a dynamic import — Vite code-splits each
+ * file into its own asset, so unused themes cost nothing on first paint.
+ *
+ * `system` means "no override": delete the `data-theme` attribute and the
+ * default light/dark tokens in app.css take over via `prefers-color-scheme`.
+ */
+export interface Theme {
+  id: string;
+  label: string;
+  /** Dynamic import of the theme's CSS (no-op for `system`). */
+  load: () => Promise<unknown>;
+}
+
+const noop = () => Promise.resolve();
+
+export const THEMES = [
+  { id: 'system', label: 'Current', load: noop },
+  {
+    id: 'original-light',
+    label: 'Original - Light',
+    load: () => import('./original-light.css'),
+  },
+  {
+    id: 'original-dark',
+    label: 'Original - Dark',
+    load: () => import('./original-dark.css'),
+  },
+  {
+    id: 'original-v2-light',
+    label: 'Original v2 - Light',
+    load: () => import('./original-v2-light.css'),
+  },
+  {
+    id: 'original-v2-dark',
+    label: 'Original v2 - Dark',
+    load: () => import('./original-v2-dark.css'),
+  },
+  {
+    id: 'flyer-archive-light',
+    label: 'Pinball Flyer Archive - Light',
+    load: () => import('./flyer-archive-light.css'),
+  },
+  {
+    id: 'flyer-archive-dark',
+    label: 'Pinball Flyer Archive - Dark',
+    load: () => import('./flyer-archive-dark.css'),
+  },
+  {
+    id: 'score-reel-light',
+    label: 'Score Reel - Light',
+    load: () => import('./score-reel-light.css'),
+  },
+  {
+    id: 'score-reel-dark',
+    label: 'Score Reel - Dark',
+    load: () => import('./score-reel-dark.css'),
+  },
+  {
+    id: 'score-reel-2-light',
+    label: 'Score Reel 2 - Light',
+    load: () => import('./score-reel-2-light.css'),
+  },
+  {
+    id: 'score-reel-2-dark',
+    label: 'Score Reel 2 - Dark',
+    load: () => import('./score-reel-2-dark.css'),
+  },
+  {
+    id: 'score-reel-3-light',
+    label: 'Score Reel 3 - Light',
+    load: () => import('./score-reel-3-light.css'),
+  },
+  {
+    id: 'score-reel-3-dark',
+    label: 'Score Reel 3 - Dark',
+    load: () => import('./score-reel-3-dark.css'),
+  },
+  {
+    id: 'operators-log-light',
+    label: "Operator's Log - Light",
+    load: () => import('./operators-log-light.css'),
+  },
+  {
+    id: 'operators-log-dark',
+    label: "Operator's Log - Dark",
+    load: () => import('./operators-log-dark.css'),
+  },
+  {
+    id: 'backglass-glow-dark',
+    label: 'Backglass Glow - Dark',
+    load: () => import('./backglass-glow-dark.css'),
+  },
+] as const satisfies readonly Theme[];
+
+// Fail fast at module load if a copy-paste leaves two entries with the
+// same id — TS's `as const satisfies` can't catch this.
+{
+  const ids = THEMES.map((t) => t.id);
+  if (new Set(ids).size !== ids.length) {
+    throw new Error(`Duplicate theme id in THEMES: ${ids.join(', ')}`);
+  }
+}
+
+export type ThemeId = (typeof THEMES)[number]['id'];
+
+const LEGACY_THEME_IDS: Record<string, ThemeId> = {
+  'current-v2-light': 'original-v2-light',
+  'current-v2-dark': 'original-v2-dark',
+};
+
+export function isThemeId(value: string): value is ThemeId {
+  return THEMES.some((t) => t.id === value);
+}
+
+export function normalizeThemeId(value: string): ThemeId | null {
+  if (isThemeId(value)) return value;
+  return LEGACY_THEME_IDS[value] ?? null;
+}
+
+export function getTheme(id: ThemeId): Theme {
+  const theme = THEMES.find((t) => t.id === id);
+  if (!theme) throw new Error(`Unknown theme: ${id}`);
+  return theme;
+}
+
+export const THEME_STORAGE_KEY = 'flipcommons-theme';
+
+/**
+ * Apply a persisted theme on app boot. Themes are a dev/UX playground —
+ * any failure here (localStorage blocked, CSS chunk 404, unknown id) MUST
+ * leave the site rendering the default palette rather than break the page.
+ * Catches everything and swallows it. A brief flash before the chunk loads
+ * is acceptable since themes are test-only.
+ */
+export async function bootstrapTheme(): Promise<void> {
+  try {
+    const stored = safeGetItem(THEME_STORAGE_KEY);
+    if (!stored) return;
+    const theme = normalizeThemeId(stored);
+    if (!theme || theme === 'system') {
+      safeRemoveItem(THEME_STORAGE_KEY);
+      return;
+    }
+    await getTheme(theme).load();
+    document.documentElement.dataset.theme = theme;
+    if (theme !== stored) safeSetItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Default palette is already rendering; nothing to undo.
+  }
+}
+
+/* localStorage wrappers: access can throw (Safari "Block All Cookies",
+   sandboxed iframes, quota exhaustion). Callers treat failure as "no
+   stored theme" and continue with the default. */
+function safeGetItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* ignore */
+  }
+}
+
+function safeRemoveItem(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/lib/themes/operators-log-dark.css
+++ b/frontend/src/lib/themes/operators-log-dark.css
@@ -1,0 +1,64 @@
+:root[data-theme='operators-log-dark'] {
+  color-scheme: dark;
+  --theme-bg-pattern:
+    linear-gradient(90deg, rgb(207 220 210 / 0.04) 1px, transparent 1px),
+    linear-gradient(rgb(207 220 210 / 0.035) 1px, transparent 1px);
+  --theme-bg-pattern-size: 2rem 100%, 100% 2rem;
+
+  --color-bg: #1b211e;
+  --color-surface: #242b27;
+  --color-surface-elevated: #2d3630;
+  --color-surface-muted: #121714;
+  --color-surface-inverse: #050806;
+
+  --color-text: #e4e9df;
+  --color-text-muted: #aebcae;
+
+  --color-border: #5d6b60;
+  --color-border-soft: #39433c;
+
+  --color-accent: #5fb284;
+  --color-accent-hover: #7bd09e;
+  --color-accent-soft: rgb(95 178 132 / 0.15);
+  --color-accent-border: rgb(95 178 132 / 0.46);
+  --color-link: #8bd8aa;
+  --color-focus-ring: rgb(139 216 170 / 0.36);
+
+  --color-text-disabled: #78867b;
+  --color-bg-disabled: #2a312c;
+  --color-border-disabled: #404b43;
+
+  --color-success-bg: rgb(95 178 90 / 0.16);
+  --color-success-border: #3e7344;
+  --color-success-text: #8bd88d;
+  --color-warning-bg: rgb(226 195 88 / 0.15);
+  --color-warning-border: #756422;
+  --color-warning-text: #f0d56f;
+  --color-error-bg: rgb(221 91 65 / 0.15);
+  --color-error-border: #7c3e32;
+  --color-error-text: #ff9276;
+  --color-info-bg: rgb(139 216 170 / 0.12);
+  --color-info-border: #3b6850;
+  --color-info-text: #8bd8aa;
+
+  --color-input-bg: #202722;
+  --color-input-border: #536258;
+  --color-input-focus: #5fb284;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #131915;
+  --color-header-text: #d6e1d6;
+  --color-header-text-muted: #aebcae;
+
+  --color-card-bg: #2d2d25;
+  --color-card-bg-dim: #3e3e32;
+  --color-card-text: #f0e4c8;
+  --color-card-tint: #d0a540;
+  --color-highlight-bg: rgb(240 213 111 / 0.2);
+
+  --color-diff-ins-bg: rgb(139 216 141 / 0.24);
+  --color-diff-del-bg: rgb(255 146 118 / 0.24);
+
+  --shadow-color: 142 42% 3%;
+  --shadow-strength: 27%;
+}

--- a/frontend/src/lib/themes/operators-log-light.css
+++ b/frontend/src/lib/themes/operators-log-light.css
@@ -1,0 +1,66 @@
+:root[data-theme='operators-log-light'] {
+  color-scheme: light;
+  --header-stains-display: none;
+  --theme-bg-pattern:
+    linear-gradient(90deg, rgb(46 65 55 / 0.08) 1px, transparent 1px),
+    linear-gradient(rgb(46 65 55 / 0.05) 1px, transparent 1px);
+  --theme-bg-pattern-size: 2rem 100%, 100% 2rem;
+
+  --color-bg: #f2f1e9;
+  --color-surface: #fbfaf3;
+  --color-surface-elevated: #fffef7;
+  --color-surface-muted: #e2e4d8;
+  --color-surface-inverse: #252b27;
+
+  --color-text: #252b27;
+  --color-text-muted: #5b675f;
+
+  --color-border: #aab5aa;
+  --color-border-soft: #cfd6cc;
+
+  --color-accent: #2f6f52;
+  --color-accent-hover: #255940;
+  --color-accent-soft: rgb(47 111 82 / 0.12);
+  --color-accent-border: rgb(47 111 82 / 0.42);
+  --color-link: #285f46;
+  --color-focus-ring: rgb(47 111 82 / 0.35);
+
+  --color-text-disabled: #8c978f;
+  --color-bg-disabled: #e6e8df;
+  --color-border-disabled: #cbd3ca;
+
+  --color-success-bg: #eaf7ee;
+  --color-success-border: #91cf9f;
+  --color-success-text: #2f6f40;
+  --color-warning-bg: #fff7d8;
+  --color-warning-border: #dec86a;
+  --color-warning-text: #776000;
+  --color-error-bg: #fff0eb;
+  --color-error-border: #e5aa9b;
+  --color-error-text: #a83a25;
+  --color-info-bg: #e8f2ed;
+  --color-info-border: #99beb0;
+  --color-info-text: #2f6f52;
+
+  --color-input-bg: #fffef7;
+  --color-input-border: #9caa9f;
+  --color-input-focus: #2f6f52;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #dce2d8;
+  --color-header-text: #252b27;
+  --color-header-text-muted: #59665d;
+
+  --color-card-bg: #f8f2df;
+  --color-card-bg-dim: #d7d0b8;
+  --color-card-text: #252b27;
+  --color-card-tint: #d0a540;
+  --color-highlight-bg: #fff0b8;
+
+  --color-featured: #c79a1e;
+  --color-diff-ins-bg: rgb(47 111 64 / 0.16);
+  --color-diff-del-bg: rgb(168 58 37 / 0.16);
+
+  --shadow-color: 142 18% 18%;
+  --shadow-strength: 4%;
+}

--- a/frontend/src/lib/themes/original-dark.css
+++ b/frontend/src/lib/themes/original-dark.css
@@ -1,0 +1,66 @@
+/* Based on VS Code's "Dark Modern":
+   https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_modern.json */
+:root[data-theme='original-dark'] {
+  color-scheme: dark;
+  --header-stains-display: none;
+  --theme-bg-pattern: none;
+  --theme-bg-pattern-size: auto;
+
+  --color-bg: #1f1f1f;
+  --color-surface: #252525;
+  --color-surface-elevated: #2d2d2d;
+  --color-surface-muted: #1a1a1a;
+  --color-surface-inverse: #0a0a0a;
+
+  --color-text: #cccccc;
+  --color-text-muted: #9ca3af;
+
+  --color-border: #616161;
+  --color-border-soft: #3a3a3a;
+
+  --color-accent: #0078d4;
+  --color-accent-hover: #026ec1;
+  --color-accent-soft: rgb(0 120 212 / 0.18);
+  --color-accent-border: rgb(0 120 212 / 0.5);
+  --color-link: #4daafc;
+  --color-focus-ring: rgb(0 120 212 / 0.5);
+
+  --color-text-disabled: #6b6b6b;
+  --color-bg-disabled: #2a2a2a;
+  --color-border-disabled: #3a3a3a;
+
+  --color-success-bg: rgb(46 160 67 / 0.15);
+  --color-success-border: #1f5132;
+  --color-success-text: #2ea043;
+  --color-warning-bg: rgb(251 191 36 / 0.15);
+  --color-warning-border: #5a4c1a;
+  --color-warning-text: #fbbf24;
+  --color-error-bg: rgb(248 81 73 / 0.15);
+  --color-error-border: #671e1e;
+  --color-error-text: #f85149;
+  --color-info-bg: rgb(77 170 252 / 0.12);
+  --color-info-border: #1e3a5f;
+  --color-info-text: #4daafc;
+
+  --color-input-bg: #2b2b2b;
+  --color-input-border: #404040;
+  --color-input-focus: #0078d4;
+  --color-input-focus-ring: rgb(0 120 212 / 0.25);
+
+  --color-header-bg: #26221d;
+  --color-header-text: var(--color-text);
+  --color-header-text-muted: var(--color-text-muted);
+
+  --color-card-bg: #2e2a24;
+  --color-card-bg-dim: #3a342b;
+  --color-card-text: #c8bfb0;
+  --color-card-tint: #8c6e3c;
+  --color-highlight-bg: rgb(251 191 36 / 0.2);
+
+  --color-featured: #e8b923;
+  --color-diff-ins-bg: rgb(46 160 67 / 0.25);
+  --color-diff-del-bg: rgb(248 81 73 / 0.25);
+
+  --shadow-color: 220 40% 2%;
+  --shadow-strength: 25%;
+}

--- a/frontend/src/lib/themes/original-light.css
+++ b/frontend/src/lib/themes/original-light.css
@@ -1,0 +1,64 @@
+:root[data-theme='original-light'] {
+  color-scheme: light;
+  --header-stains-display: block;
+  --theme-bg-pattern: none;
+  --theme-bg-pattern-size: auto;
+
+  --color-bg: #fbf7f0;
+  --color-surface: #ffffff;
+  --color-surface-elevated: #ffffff;
+  --color-surface-muted: #f3efe8;
+  --color-surface-inverse: #1f1f1f;
+
+  --color-text: #333333;
+  --color-text-muted: #6b7280;
+
+  --color-border: #d1d5db;
+  --color-border-soft: #e7e5e4;
+
+  --color-accent: #0078d4;
+  --color-accent-hover: #026ec1;
+  --color-accent-soft: rgb(0 120 212 / 0.1);
+  --color-accent-border: rgb(0 120 212 / 0.4);
+  --color-link: var(--color-accent);
+  --color-focus-ring: rgb(0 120 212 / 0.4);
+
+  --color-text-disabled: #9ca3af;
+  --color-bg-disabled: #f3f4f6;
+  --color-border-disabled: #e5e7eb;
+
+  --color-success-bg: #f0fdf4;
+  --color-success-border: #86efac;
+  --color-success-text: #16a34a;
+  --color-warning-bg: #fefce8;
+  --color-warning-border: #fde68a;
+  --color-warning-text: #b45309;
+  --color-error-bg: #fef2f2;
+  --color-error-border: #fecaca;
+  --color-error-text: #dc2626;
+  --color-info-bg: #eff6ff;
+  --color-info-border: #bfdbfe;
+  --color-info-text: #1d4ed8;
+
+  --color-input-bg: #ffffff;
+  --color-input-border: #d1d5db;
+  --color-input-focus: #0078d4;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #efe8dc;
+  --color-header-text: #3d3529;
+  --color-header-text-muted: #6b5d4d;
+
+  --color-card-bg: #faf6f0;
+  --color-card-bg-dim: #e8e0d4;
+  --color-card-text: #3d3529;
+  --color-card-tint: #b49650;
+  --color-highlight-bg: #fff3cd;
+
+  --color-featured: #e8b923;
+  --color-diff-ins-bg: rgb(22 163 74 / 0.15);
+  --color-diff-del-bg: rgb(220 38 38 / 0.15);
+
+  --shadow-color: 220 3% 15%;
+  --shadow-strength: 1%;
+}

--- a/frontend/src/lib/themes/original-v2-dark.css
+++ b/frontend/src/lib/themes/original-v2-dark.css
@@ -1,0 +1,64 @@
+:root[data-theme='original-v2-dark'] {
+  color-scheme: dark;
+  --header-stains-display: none;
+  --theme-bg-pattern: none;
+  --theme-bg-pattern-size: auto;
+
+  --color-bg: #1d1d1d;
+  --color-surface: #252525;
+  --color-surface-elevated: #2d2d2d;
+  --color-surface-muted: #171717;
+  --color-surface-inverse: #080808;
+
+  --color-text: #dfdfdf;
+  --color-text-muted: #a7adb6;
+
+  --color-border: #6d747d;
+  --color-border-soft: #3f454d;
+
+  --color-accent: #147bd1;
+  --color-accent-hover: #3c99e8;
+  --color-accent-soft: rgb(20 123 209 / 0.18);
+  --color-accent-border: rgb(20 123 209 / 0.5);
+  --color-link: #78bfff;
+  --color-focus-ring: rgb(120 191 255 / 0.42);
+
+  --color-text-disabled: #6f7782;
+  --color-bg-disabled: #2b2d30;
+  --color-border-disabled: #3f454d;
+
+  --color-success-bg: rgb(48 169 90 / 0.16);
+  --color-success-border: #2f6f45;
+  --color-success-text: #51c77b;
+  --color-warning-bg: rgb(255 213 79 / 0.15);
+  --color-warning-border: #6b571a;
+  --color-warning-text: #ffd54f;
+  --color-error-bg: rgb(248 81 73 / 0.16);
+  --color-error-border: #743030;
+  --color-error-text: #ff7b72;
+  --color-info-bg: rgb(120 191 255 / 0.13);
+  --color-info-border: #2f557b;
+  --color-info-text: #78bfff;
+
+  --color-input-bg: #2a2a2a;
+  --color-input-border: #4c545e;
+  --color-input-focus: #147bd1;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #242424;
+  --color-header-text: #e5e5e5;
+  --color-header-text-muted: #adb3bc;
+
+  --color-card-bg: #2b2925;
+  --color-card-bg-dim: #39352e;
+  --color-card-text: #d9d1c4;
+  --color-card-tint: #8f713d;
+  --color-highlight-bg: rgb(255 213 79 / 0.2);
+
+  --color-featured: #dca817;
+  --color-diff-ins-bg: rgb(81 199 123 / 0.24);
+  --color-diff-del-bg: rgb(255 123 114 / 0.24);
+
+  --shadow-color: 220 28% 3%;
+  --shadow-strength: 25%;
+}

--- a/frontend/src/lib/themes/original-v2-light.css
+++ b/frontend/src/lib/themes/original-v2-light.css
@@ -1,0 +1,64 @@
+:root[data-theme='original-v2-light'] {
+  color-scheme: light;
+  --header-stains-display: block;
+  --theme-bg-pattern: none;
+  --theme-bg-pattern-size: auto;
+
+  --color-bg: #fcfaf6;
+  --color-surface: #ffffff;
+  --color-surface-elevated: #ffffff;
+  --color-surface-muted: #f4f1eb;
+  --color-surface-inverse: #1d1d1d;
+
+  --color-text: #282828;
+  --color-text-muted: #59616d;
+
+  --color-border: #bdc4ce;
+  --color-border-soft: #ddd8cf;
+
+  --color-accent: #075fb8;
+  --color-accent-hover: #034f9c;
+  --color-accent-soft: rgb(7 95 184 / 0.1);
+  --color-accent-border: rgb(7 95 184 / 0.38);
+  --color-link: #075fb8;
+  --color-focus-ring: rgb(7 95 184 / 0.36);
+
+  --color-text-disabled: #8e98a5;
+  --color-bg-disabled: #eef1f4;
+  --color-border-disabled: #d9dee5;
+
+  --color-success-bg: #edf9f1;
+  --color-success-border: #8bd5a4;
+  --color-success-text: #147c43;
+  --color-warning-bg: #fff8df;
+  --color-warning-border: #f0cf78;
+  --color-warning-text: #8a5b00;
+  --color-error-bg: #fff1f1;
+  --color-error-border: #efb5b5;
+  --color-error-text: #bf2f2f;
+  --color-info-bg: #eef6ff;
+  --color-info-border: #b8d6f6;
+  --color-info-text: #075fb8;
+
+  --color-input-bg: #ffffff;
+  --color-input-border: #b7c0cc;
+  --color-input-focus: #075fb8;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #eee8dd;
+  --color-header-text: #2f2c27;
+  --color-header-text-muted: #5f5a51;
+
+  --color-card-bg: #fbf7f0;
+  --color-card-bg-dim: #e7dfd2;
+  --color-card-text: #302d28;
+  --color-card-tint: #a98532;
+  --color-highlight-bg: #fff1b8;
+
+  --color-featured: #dca817;
+  --color-diff-ins-bg: rgb(20 124 67 / 0.15);
+  --color-diff-del-bg: rgb(191 47 47 / 0.15);
+
+  --shadow-color: 220 14% 22%;
+  --shadow-strength: 4%;
+}

--- a/frontend/src/lib/themes/score-reel-2-dark.css
+++ b/frontend/src/lib/themes/score-reel-2-dark.css
@@ -1,0 +1,64 @@
+:root[data-theme='score-reel-2-dark'] {
+  color-scheme: dark;
+  --theme-bg-pattern:
+    linear-gradient(rgb(234 223 203 / 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(234 223 203 / 0.035) 1px, transparent 1px);
+  --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
+
+  --color-bg: #211d18;
+  --color-surface: #2c261f;
+  --color-surface-elevated: #362f26;
+  --color-surface-muted: #17130f;
+  --color-surface-inverse: #060504;
+
+  --color-text: #eadfcb;
+  --color-text-muted: #b9a891;
+
+  --color-border: #75624b;
+  --color-border-soft: #463929;
+
+  --color-accent: #176f72;
+  --color-accent-hover: #11575a;
+  --color-accent-soft: rgb(23 111 114 / 0.16);
+  --color-accent-border: rgb(23 111 114 / 0.48);
+  --color-link: #66c2b8;
+  --color-focus-ring: rgb(102 194 184 / 0.36);
+
+  --color-text-disabled: #827566;
+  --color-bg-disabled: #312b24;
+  --color-border-disabled: #4c4033;
+
+  --color-success-bg: rgb(133 184 69 / 0.16);
+  --color-success-border: #5d7931;
+  --color-success-text: #a8d86b;
+  --color-warning-bg: rgb(255 209 91 / 0.16);
+  --color-warning-border: #7c6423;
+  --color-warning-text: #ffd15b;
+  --color-error-bg: rgb(207 74 63 / 0.16);
+  --color-error-border: #7b3832;
+  --color-error-text: #ff8a7e;
+  --color-info-bg: rgb(74 188 176 / 0.13);
+  --color-info-border: #326c67;
+  --color-info-text: #7adbd2;
+
+  --color-input-bg: #2a241d;
+  --color-input-border: #65543f;
+  --color-input-focus: #176f72;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #181411;
+  --color-header-text: #c7a55f;
+  --color-header-text-muted: #c7b69d;
+
+  --color-card-bg: #372c20;
+  --color-card-bg-dim: #4b3a28;
+  --color-card-text: #ffe2ae;
+  --color-card-tint: #b88b34;
+  --color-highlight-bg: rgb(255 209 91 / 0.23);
+
+  --color-diff-ins-bg: rgb(168 216 107 / 0.24);
+  --color-diff-del-bg: rgb(255 138 126 / 0.24);
+
+  --shadow-color: 30 50% 2%;
+  --shadow-strength: 28%;
+}

--- a/frontend/src/lib/themes/score-reel-2-light.css
+++ b/frontend/src/lib/themes/score-reel-2-light.css
@@ -1,0 +1,66 @@
+:root[data-theme='score-reel-2-light'] {
+  color-scheme: light;
+  --header-stains-display: none;
+  --theme-bg-pattern:
+    linear-gradient(rgb(36 31 25 / 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(36 31 25 / 0.04) 1px, transparent 1px);
+  --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
+
+  --color-bg: #f9f1df;
+  --color-surface: #fffaf0;
+  --color-surface-elevated: #fffdf6;
+  --color-surface-muted: #eadcc4;
+  --color-surface-inverse: #241f19;
+
+  --color-text: #241f19;
+  --color-text-muted: #665947;
+
+  --color-border: #b9a382;
+  --color-border-soft: #d8c6a8;
+
+  --color-accent: #176f72;
+  --color-accent-hover: #11575a;
+  --color-accent-soft: rgb(23 111 114 / 0.12);
+  --color-accent-border: rgb(23 111 114 / 0.44);
+  --color-link: #24736d;
+  --color-focus-ring: rgb(23 111 114 / 0.38);
+
+  --color-text-disabled: #9f927f;
+  --color-bg-disabled: #eee3d1;
+  --color-border-disabled: #d8c8ad;
+
+  --color-success-bg: #edf7df;
+  --color-success-border: #a2ca67;
+  --color-success-text: #4f781e;
+  --color-warning-bg: #fff4c9;
+  --color-warning-border: #dab54a;
+  --color-warning-text: #7d5900;
+  --color-error-bg: #ffece9;
+  --color-error-border: #eaa49d;
+  --color-error-text: #a22a22;
+  --color-info-bg: #e8f4f1;
+  --color-info-border: #8ac5ba;
+  --color-info-text: #237d76;
+
+  --color-input-bg: #fffaf0;
+  --color-input-border: #ad9878;
+  --color-input-focus: #176f72;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #ece0ca;
+  --color-header-text: #241f19;
+  --color-header-text-muted: #665947;
+
+  --color-card-bg: #fff3d8;
+  --color-card-bg-dim: #ddc59a;
+  --color-card-text: #241f19;
+  --color-card-tint: #b88b34;
+  --color-highlight-bg: #ffe7a3;
+
+  --color-featured: #c69325;
+  --color-diff-ins-bg: rgb(79 120 30 / 0.16);
+  --color-diff-del-bg: rgb(162 42 34 / 0.16);
+
+  --shadow-color: 33 34% 18%;
+  --shadow-strength: 4%;
+}

--- a/frontend/src/lib/themes/score-reel-3-dark.css
+++ b/frontend/src/lib/themes/score-reel-3-dark.css
@@ -1,0 +1,64 @@
+:root[data-theme='score-reel-3-dark'] {
+  color-scheme: dark;
+  --theme-bg-pattern:
+    linear-gradient(rgb(234 223 203 / 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(234 223 203 / 0.035) 1px, transparent 1px);
+  --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
+
+  --color-bg: #211d18;
+  --color-surface: #2c261f;
+  --color-surface-elevated: #362f26;
+  --color-surface-muted: #17130f;
+  --color-surface-inverse: #060504;
+
+  --color-text: #eadfcb;
+  --color-text-muted: #b9a891;
+
+  --color-border: #75624b;
+  --color-border-soft: #463929;
+
+  --color-accent: #2f4f73;
+  --color-accent-hover: #243d59;
+  --color-accent-soft: rgb(47 79 115 / 0.16);
+  --color-accent-border: rgb(47 79 115 / 0.48);
+  --color-link: #7faedf;
+  --color-focus-ring: rgb(127 174 223 / 0.36);
+
+  --color-text-disabled: #827566;
+  --color-bg-disabled: #312b24;
+  --color-border-disabled: #4c4033;
+
+  --color-success-bg: rgb(133 184 69 / 0.16);
+  --color-success-border: #5d7931;
+  --color-success-text: #a8d86b;
+  --color-warning-bg: rgb(255 209 91 / 0.16);
+  --color-warning-border: #7c6423;
+  --color-warning-text: #ffd15b;
+  --color-error-bg: rgb(207 74 63 / 0.16);
+  --color-error-border: #7b3832;
+  --color-error-text: #ff8a7e;
+  --color-info-bg: rgb(74 188 176 / 0.13);
+  --color-info-border: #326c67;
+  --color-info-text: #7adbd2;
+
+  --color-input-bg: #2a241d;
+  --color-input-border: #65543f;
+  --color-input-focus: #2f4f73;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #181411;
+  --color-header-text: #eadfcb;
+  --color-header-text-muted: #c7b69d;
+
+  --color-card-bg: #372c20;
+  --color-card-bg-dim: #4b3a28;
+  --color-card-text: #ffe2ae;
+  --color-card-tint: #b88b34;
+  --color-highlight-bg: rgb(255 209 91 / 0.23);
+
+  --color-diff-ins-bg: rgb(168 216 107 / 0.24);
+  --color-diff-del-bg: rgb(255 138 126 / 0.24);
+
+  --shadow-color: 30 50% 2%;
+  --shadow-strength: 28%;
+}

--- a/frontend/src/lib/themes/score-reel-3-light.css
+++ b/frontend/src/lib/themes/score-reel-3-light.css
@@ -1,0 +1,66 @@
+:root[data-theme='score-reel-3-light'] {
+  color-scheme: light;
+  --header-stains-display: none;
+  --theme-bg-pattern:
+    linear-gradient(rgb(36 31 25 / 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(36 31 25 / 0.04) 1px, transparent 1px);
+  --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
+
+  --color-bg: #f9f1df;
+  --color-surface: #fffaf0;
+  --color-surface-elevated: #fffdf6;
+  --color-surface-muted: #eadcc4;
+  --color-surface-inverse: #241f19;
+
+  --color-text: #241f19;
+  --color-text-muted: #665947;
+
+  --color-border: #b9a382;
+  --color-border-soft: #d8c6a8;
+
+  --color-accent: #2f4f73;
+  --color-accent-hover: #243d59;
+  --color-accent-soft: rgb(47 79 115 / 0.12);
+  --color-accent-border: rgb(47 79 115 / 0.44);
+  --color-link: #37628f;
+  --color-focus-ring: rgb(47 79 115 / 0.38);
+
+  --color-text-disabled: #9f927f;
+  --color-bg-disabled: #eee3d1;
+  --color-border-disabled: #d8c8ad;
+
+  --color-success-bg: #edf7df;
+  --color-success-border: #a2ca67;
+  --color-success-text: #4f781e;
+  --color-warning-bg: #fff4c9;
+  --color-warning-border: #dab54a;
+  --color-warning-text: #7d5900;
+  --color-error-bg: #ffece9;
+  --color-error-border: #eaa49d;
+  --color-error-text: #a22a22;
+  --color-info-bg: #e8f4f1;
+  --color-info-border: #8ac5ba;
+  --color-info-text: #237d76;
+
+  --color-input-bg: #fffaf0;
+  --color-input-border: #ad9878;
+  --color-input-focus: #2f4f73;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #ece0ca;
+  --color-header-text: #241f19;
+  --color-header-text-muted: #665947;
+
+  --color-card-bg: #fff3d8;
+  --color-card-bg-dim: #ddc59a;
+  --color-card-text: #241f19;
+  --color-card-tint: #b88b34;
+  --color-highlight-bg: #ffe7a3;
+
+  --color-featured: #c69325;
+  --color-diff-ins-bg: rgb(79 120 30 / 0.16);
+  --color-diff-del-bg: rgb(162 42 34 / 0.16);
+
+  --shadow-color: 33 34% 18%;
+  --shadow-strength: 4%;
+}

--- a/frontend/src/lib/themes/score-reel-dark.css
+++ b/frontend/src/lib/themes/score-reel-dark.css
@@ -1,0 +1,64 @@
+:root[data-theme='score-reel-dark'] {
+  color-scheme: dark;
+  --theme-bg-pattern:
+    linear-gradient(rgb(234 223 203 / 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(234 223 203 / 0.035) 1px, transparent 1px);
+  --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
+
+  --color-bg: #211d18;
+  --color-surface: #2c261f;
+  --color-surface-elevated: #362f26;
+  --color-surface-muted: #17130f;
+  --color-surface-inverse: #060504;
+
+  --color-text: #eadfcb;
+  --color-text-muted: #b9a891;
+
+  --color-border: #75624b;
+  --color-border-soft: #463929;
+
+  --color-accent: #cf4a3f;
+  --color-accent-hover: #ea675b;
+  --color-accent-soft: rgb(207 74 63 / 0.16);
+  --color-accent-border: rgb(207 74 63 / 0.48);
+  --color-link: #66c2b8;
+  --color-focus-ring: rgb(255 138 126 / 0.36);
+
+  --color-text-disabled: #827566;
+  --color-bg-disabled: #312b24;
+  --color-border-disabled: #4c4033;
+
+  --color-success-bg: rgb(133 184 69 / 0.16);
+  --color-success-border: #5d7931;
+  --color-success-text: #a8d86b;
+  --color-warning-bg: rgb(255 209 91 / 0.16);
+  --color-warning-border: #7c6423;
+  --color-warning-text: #ffd15b;
+  --color-error-bg: rgb(207 74 63 / 0.16);
+  --color-error-border: #7b3832;
+  --color-error-text: #ff8a7e;
+  --color-info-bg: rgb(74 188 176 / 0.13);
+  --color-info-border: #326c67;
+  --color-info-text: #7adbd2;
+
+  --color-input-bg: #2a241d;
+  --color-input-border: #65543f;
+  --color-input-focus: #cf4a3f;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #181411;
+  --color-header-text: #ffd15b;
+  --color-header-text-muted: #c7b69d;
+
+  --color-card-bg: #372c20;
+  --color-card-bg-dim: #4b3a28;
+  --color-card-text: #ffe2ae;
+  --color-card-tint: #b88b34;
+  --color-highlight-bg: rgb(255 209 91 / 0.23);
+
+  --color-diff-ins-bg: rgb(168 216 107 / 0.24);
+  --color-diff-del-bg: rgb(255 138 126 / 0.24);
+
+  --shadow-color: 30 50% 2%;
+  --shadow-strength: 28%;
+}

--- a/frontend/src/lib/themes/score-reel-light.css
+++ b/frontend/src/lib/themes/score-reel-light.css
@@ -1,0 +1,66 @@
+:root[data-theme='score-reel-light'] {
+  color-scheme: light;
+  --header-stains-display: none;
+  --theme-bg-pattern:
+    linear-gradient(rgb(36 31 25 / 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(36 31 25 / 0.04) 1px, transparent 1px);
+  --theme-bg-pattern-size: 100% 2.25rem, 2.25rem 100%;
+
+  --color-bg: #f9f1df;
+  --color-surface: #fffaf0;
+  --color-surface-elevated: #fffdf6;
+  --color-surface-muted: #eadcc4;
+  --color-surface-inverse: #241f19;
+
+  --color-text: #241f19;
+  --color-text-muted: #665947;
+
+  --color-border: #b9a382;
+  --color-border-soft: #d8c6a8;
+
+  --color-accent: #b83228;
+  --color-accent-hover: #94251f;
+  --color-accent-soft: rgb(184 50 40 / 0.11);
+  --color-accent-border: rgb(184 50 40 / 0.42);
+  --color-link: #24736d;
+  --color-focus-ring: rgb(184 50 40 / 0.36);
+
+  --color-text-disabled: #9f927f;
+  --color-bg-disabled: #eee3d1;
+  --color-border-disabled: #d8c8ad;
+
+  --color-success-bg: #edf7df;
+  --color-success-border: #a2ca67;
+  --color-success-text: #4f781e;
+  --color-warning-bg: #fff4c9;
+  --color-warning-border: #dab54a;
+  --color-warning-text: #7d5900;
+  --color-error-bg: #ffece9;
+  --color-error-border: #eaa49d;
+  --color-error-text: #a22a22;
+  --color-info-bg: #e8f4f1;
+  --color-info-border: #8ac5ba;
+  --color-info-text: #237d76;
+
+  --color-input-bg: #fffaf0;
+  --color-input-border: #ad9878;
+  --color-input-focus: #b83228;
+  --color-input-focus-ring: var(--color-focus-ring);
+
+  --color-header-bg: #ece0ca;
+  --color-header-text: #241f19;
+  --color-header-text-muted: #665947;
+
+  --color-card-bg: #fff3d8;
+  --color-card-bg-dim: #ddc59a;
+  --color-card-text: #241f19;
+  --color-card-tint: #b88b34;
+  --color-highlight-bg: #ffe7a3;
+
+  --color-featured: #c69325;
+  --color-diff-ins-bg: rgb(79 120 30 / 0.16);
+  --color-diff-del-bg: rgb(162 42 34 / 0.16);
+
+  --shadow-color: 33 34% 18%;
+  --shadow-strength: 4%;
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import ToastHost from '$lib/toast/ToastHost.svelte';
   import { isFocusModePath } from '$lib/focus-mode';
   import { isKioskCookieSet } from '$lib/kiosk/config';
+  import { bootstrapTheme } from '$lib/themes';
   import { onMount } from 'svelte';
 
   // When SvelteKit's version.json poll detects a new deploy, swap the next
@@ -27,6 +28,7 @@
   let isKiosk = $state(false);
   onMount(() => {
     isKiosk = isKioskCookieSet();
+    void bootstrapTheme();
   });
 </script>
 

--- a/frontend/src/routes/style-lab/+page.svelte
+++ b/frontend/src/routes/style-lab/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ActiveFilterChips from '$lib/components/ActiveFilterChips.svelte';
   import ActionMenu from '$lib/components/ActionMenu.svelte';
   import Button from '$lib/components/Button.svelte';
   import MenuDivider from '$lib/components/MenuDivider.svelte';
@@ -11,6 +12,7 @@
     type CardDistressType,
   } from '$lib/components/cards/Card.svelte';
   import MachineCard from '$lib/components/cards/MachineCard.svelte';
+  import { emptyFilterState, type FacetedTitle, type FilterState } from '$lib/facet-engine';
 
   const distressCases: {
     label: string;
@@ -26,6 +28,39 @@
     { label: 'Dog ear bottom left', type: 'dog-ear', corner: 'bl' },
     { label: 'Dog ear bottom right', type: 'dog-ear', corner: 'br' },
   ];
+
+  const filterTitles: FacetedTitle[] = [
+    {
+      name: 'Attack from Mars',
+      slug: 'attack-from-mars',
+      abbreviations: ['AFM'],
+      model_count: 1,
+      manufacturer: { slug: 'williams', name: 'Williams' },
+      year: 1995,
+      thumbnail_url: null,
+      tech_generations: [{ slug: 'solid-state', name: 'Solid state' }],
+      display_types: [{ slug: 'dot-matrix-display', name: 'Dot matrix display' }],
+      player_counts: [4],
+      systems: [{ slug: 'wpc-95', name: 'WPC-95' }],
+      themes: [{ slug: 'sci-fi', name: 'Science fiction' }],
+      gameplay_features: [{ slug: 'multiball', name: 'Multiball' }],
+      reward_types: [],
+      persons: [],
+      franchise: null,
+      series: null,
+      year_min: 1995,
+      year_max: 1995,
+      ipdb_rating_max: 8.4,
+    },
+  ];
+
+  let activeFilters = $state<FilterState>({
+    ...emptyFilterState(),
+    manufacturer: 'williams',
+    themes: ['sci-fi'],
+    yearMin: 1980,
+    yearMax: 1995,
+  });
 </script>
 
 <div class="lab-header">
@@ -105,6 +140,10 @@
       <div class="status-card success">Saved changes to manufacturer claims.</div>
       <div class="status-card warning">Three citations need locator details.</div>
       <div class="status-card error">Slug conflicts with an existing record.</div>
+      <div class="filter-state-card">
+        <div class="state-label">Active filters</div>
+        <ActiveFilterChips bind:filters={activeFilters} allTitles={filterTitles} />
+      </div>
       <div class="action-cluster">
         <Button variant="secondary">Cancel</Button>
         <Button>Save changes</Button>
@@ -226,6 +265,7 @@
   .search-panel,
   .record-panel,
   .sidebar-panel,
+  .filter-state-card,
   .status-card {
     background: var(--color-surface);
     border: 1px solid var(--color-border-soft);
@@ -301,10 +341,10 @@
   }
 
   .chip-row span {
-    background: var(--color-accent-soft);
-    border: 1px solid var(--color-accent-border);
+    background: var(--color-surface-muted);
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-2);
-    color: var(--color-link);
+    color: var(--color-text);
     font-size: var(--font-size-0);
     font-weight: 600;
     padding: var(--size-1) var(--size-2);
@@ -339,6 +379,20 @@
   .status-card {
     padding: var(--size-4);
     font-weight: 600;
+  }
+
+  .filter-state-card {
+    display: grid;
+    gap: var(--size-2);
+    grid-column: 1 / -1;
+    padding: var(--size-4);
+  }
+
+  .state-label {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-0);
+    font-weight: 700;
+    text-transform: uppercase;
   }
 
   .success {

--- a/frontend/src/routes/style-lab/+page.svelte
+++ b/frontend/src/routes/style-lab/+page.svelte
@@ -64,15 +64,11 @@
 </script>
 
 <div class="lab-header">
-  <PageHeader
-    title="Style Lab"
-    subtitle="Representative UI specimens for judging palette and texture changes."
-  />
+  <PageHeader title="Style Lab" subtitle="UI samples for judging palette and texture changes." />
   <div class="theme-control">
     <ThemeSwitcher />
   </div>
 </div>
-
 <div class="style-lab">
   <section class="specimen">
     <div class="section-heading">
@@ -159,6 +155,137 @@
   </section>
   <section class="specimen">
     <div class="section-heading">
+      <h2>Form Controls</h2>
+      <p>
+        Input surfaces, focus rings, validation feedback, disabled states, and button variants.
+        Click any control to verify the focus ring against the page background.
+      </p>
+    </div>
+
+    <div class="form-grid">
+      <div class="form-row">
+        <label for="lab-text">Text</label>
+        <input id="lab-text" type="text" value="Williams" />
+      </div>
+      <div class="form-row">
+        <label for="lab-email">Email</label>
+        <input id="lab-email" type="email" placeholder="curator@flipcommons.org" />
+      </div>
+      <div class="form-row">
+        <label for="lab-number">Year</label>
+        <input id="lab-number" type="number" value="1995" />
+      </div>
+      <div class="form-row">
+        <label for="lab-select">Manufacturer</label>
+        <select id="lab-select">
+          <option>Williams</option>
+          <option>Bally</option>
+          <option>Stern</option>
+        </select>
+      </div>
+      <div class="form-row form-row--wide">
+        <label for="lab-textarea">Notes</label>
+        <textarea id="lab-textarea" rows="3"
+          >Citation pending operator manual confirmation.</textarea
+        >
+      </div>
+      <div class="form-row">
+        <label for="lab-invalid">Invalid</label>
+        <input id="lab-invalid" type="text" value="not-a-valid-slug!" aria-invalid="true" />
+      </div>
+      <div class="form-row">
+        <label for="lab-disabled">Disabled</label>
+        <input id="lab-disabled" type="text" value="Read-only field" disabled />
+      </div>
+
+      <fieldset class="form-row form-row--wide">
+        <legend>Choice inputs</legend>
+        <div class="choice-row">
+          <label class="choice"><input type="checkbox" checked /> Verified</label>
+          <label class="choice"><input type="checkbox" /> Featured</label>
+          <label class="choice"><input type="checkbox" disabled checked /> Locked</label>
+        </div>
+        <div class="choice-row">
+          <label class="choice"><input type="radio" name="lab-radio" checked /> Solid state</label>
+          <label class="choice"><input type="radio" name="lab-radio" /> Electromechanical</label>
+          <label class="choice"><input type="radio" name="lab-radio" disabled /> Mechanical</label>
+        </div>
+      </fieldset>
+
+      <div class="form-row form-row--wide">
+        <span class="form-label">Buttons: active • disabled</span>
+        <div class="action-cluster">
+          <Button>Save</Button>
+          <Button variant="secondary">Cancel</Button>
+          •
+          <Button disabled>Save</Button>
+          <Button variant="secondary" disabled>Cancel</Button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="specimen">
+    <div class="section-heading">
+      <h2>Editor Dialog</h2>
+      <p>Buttons are inert.</p>
+    </div>
+
+    <div class="editor-stage" aria-hidden="true">
+      <div class="stage-backdrop">
+        <h3>Attack from Mars</h3>
+        <p>
+          A widebody-feeling fan favorite with saucers, martians, stroke-heavy callouts, and
+          unusually broad collector recognition. Sourced from IPDB, flyers, and operator manuals.
+        </p>
+        <div class="chip-row">
+          <span>Williams</span>
+          <span>1995</span>
+          <span>Solid state</span>
+        </div>
+      </div>
+
+      <div class="stage-scrim">
+        <!--
+          Visually mirrors Modal.svelte's `.modal-dialog` / `-header` /
+          `-body` / `-footer`. Uses the same tokens (--color-bg,
+          --color-border, --radius-3, --shadow-modal) so theme changes
+          carry across identically. If Modal's structure or tokens
+          change, update here too — Modal.svelte is the source of truth.
+        -->
+        <div class="editor-dialog">
+          <header class="editor-header">
+            <h3>Name <span aria-hidden="true">▾</span></h3>
+            <button type="button" class="editor-close" aria-label="Close">×</button>
+          </header>
+          <div class="editor-body">
+            <div class="form-row">
+              <label for="lab-edit-name">Name</label>
+              <input id="lab-edit-name" type="text" value="Bally" />
+            </div>
+            <div class="form-row">
+              <label for="lab-edit-slug">Slug</label>
+              <input id="lab-edit-slug" type="text" value="bally" />
+            </div>
+            <details class="notes-citations">
+              <summary>Notes &amp; Citations</summary>
+              <div class="form-row">
+                <label for="lab-edit-note">Note (optional, public)</label>
+                <input id="lab-edit-note" type="text" placeholder="Why this edit?" />
+              </div>
+            </details>
+          </div>
+          <footer class="editor-footer">
+            <Button variant="secondary">Cancel</Button>
+            <Button>Save</Button>
+          </footer>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="specimen">
+    <div class="section-heading">
       <h2>Catalog Cards</h2>
       <p>Polaroid cards, muted metadata, and link contrast.</p>
     </div>
@@ -227,10 +354,13 @@
   }
 
   .lab-header {
-    display: flex;
-    justify-content: space-between;
     align-items: flex-start;
+    border-bottom: 1px solid var(--color-border-soft);
+    display: flex;
     gap: var(--size-5);
+    justify-content: space-between;
+    margin-bottom: var(--size-5);
+    padding-bottom: var(--size-4);
   }
 
   .theme-control {
@@ -421,6 +551,190 @@
     grid-column: 1 / -1;
   }
 
+  /* Editor dialog: faithful inline re-render of Modal.svelte's chrome so
+     the dialog can be judged by scrolling without trapping focus or
+     locking page scroll. Token usage mirrors Modal.svelte's styles; if
+     Modal changes, update here too. */
+  .editor-stage {
+    border-radius: var(--radius-2);
+    min-height: 38rem;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .stage-backdrop {
+    align-items: start;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-2);
+    display: grid;
+    gap: var(--size-3);
+    height: 100%;
+    padding: var(--size-5);
+  }
+
+  .stage-backdrop h3 {
+    font-size: var(--font-size-4);
+  }
+
+  .stage-scrim {
+    background: var(--color-scrim);
+    display: grid;
+    inset: 0;
+    padding: var(--size-5);
+    place-items: center;
+    position: absolute;
+  }
+
+  /* Mirrors Modal.svelte `.modal-dialog`. */
+  .editor-dialog {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-3);
+    box-shadow: var(--shadow-modal);
+    display: flex;
+    flex-direction: column;
+    max-width: 36rem;
+    overflow: hidden;
+    width: 100%;
+  }
+
+  /* Mirrors Modal.svelte `.modal-header`. */
+  .editor-header {
+    align-items: center;
+    border-bottom: 1px solid var(--color-border-soft);
+    display: flex;
+    gap: var(--size-3);
+    justify-content: space-between;
+    padding: var(--size-3) var(--size-4);
+  }
+
+  .editor-header h3 {
+    align-items: center;
+    color: var(--color-text);
+    display: inline-flex;
+    font-size: var(--font-size-3);
+    font-weight: 600;
+    gap: var(--size-1);
+    margin: 0;
+  }
+
+  .editor-close {
+    background: none;
+    border: 0;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 1.5rem;
+    line-height: 1;
+    padding: var(--size-1);
+  }
+
+  .editor-close:hover {
+    color: var(--color-text);
+  }
+
+  .editor-body {
+    display: grid;
+    gap: var(--size-4);
+    padding: var(--size-4);
+  }
+
+  /* Mirrors Modal.svelte `.modal-footer`. */
+  .editor-footer {
+    align-items: center;
+    border-top: 1px solid var(--color-border-soft);
+    display: flex;
+    gap: var(--size-2);
+    justify-content: flex-end;
+    padding: var(--size-3) var(--size-4);
+  }
+
+  /* Mirrors NotesAndCitationsDetails.svelte. `background: inherit` on
+     both the details and the summary suppresses the user agent's
+     default summary background (a subtle blue/grey tint in Chrome) so
+     the row picks up the dialog's --color-bg cleanly. */
+  .notes-citations {
+    background: inherit;
+    border-top: 1px solid var(--color-border-soft);
+    margin-top: var(--size-4);
+    padding-top: var(--size-3);
+  }
+
+  .notes-citations > summary {
+    background: inherit;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: var(--font-size-0);
+    user-select: none;
+  }
+
+  .notes-citations summary + .form-row {
+    margin-top: var(--size-3);
+  }
+
+  .form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--size-3);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-2);
+    box-shadow: var(--shadow-card);
+    padding: var(--size-5);
+  }
+
+  .form-row {
+    display: grid;
+    gap: var(--size-1);
+  }
+
+  .form-row--wide {
+    grid-column: 1 / -1;
+  }
+
+  .form-row label,
+  .form-row legend,
+  .form-label {
+    color: var(--color-text);
+    font-size: var(--font-size-1);
+    font-weight: 600;
+  }
+
+  /* Fieldset keeps its semantic grouping but loses the border — the muted
+     bg already separates it from the surrounding form-grid surface. Float
+     pulls the legend out of its default "straddle the top border"
+     rendering so it behaves like a normal block label and doesn't clash
+     with the fieldset's rounded corners or split across two surfaces. */
+  .form-grid fieldset {
+    background: var(--color-surface-muted);
+    border: 0;
+    border-radius: var(--radius-2);
+    display: grid;
+    gap: var(--size-2);
+    padding: var(--size-3) var(--size-4);
+  }
+
+  .form-grid fieldset legend {
+    float: left;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+  }
+
+  .choice-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--size-4);
+  }
+
+  .choice {
+    align-items: center;
+    display: inline-flex;
+    font-size: var(--font-size-1);
+    font-weight: 400;
+    gap: var(--size-1);
+  }
+
   @media (--breakpoint-narrow) {
     .lab-header {
       display: grid;
@@ -431,7 +745,8 @@
     .card-grid,
     .distress-grid,
     .detail-shell,
-    .states-grid {
+    .states-grid,
+    .form-grid {
       grid-template-columns: 1fr;
     }
   }


### PR DESCRIPTION
## Summary

Restyles the site in both light and dark mode.  Also, refactors the admin-only theme evaluation system to make themes easier to maintain and compare.

### Site restyle

- New light and dark mode looks across the site
- Updated typography, color tokens, and component styling flow through every page

### Theme visualizer improvements (admin-only)

- `/style-lab` expanded to cover form controls, editor dialog, and header rule, so themes can be judged side-by-side
- Each theme now lives in its own lazy-loaded CSS file under `frontend/src/lib/themes/`, with a central `index.ts` registry
- `app.css` slimmed down by ~800 lines as theme-specific tokens moved into per-theme files
- `ThemeSwitcher` updated to drive the new registry

## Test plan

- [ ] `make dev` and verify the new light and dark mode look across home, catalog, and detail pages
- [ ] Visit `/style-lab` (admin) and confirm form controls, editor dialog, and header rule render across all themes
- [ ] Switch themes via `ThemeSwitcher` and confirm lazy-loaded CSS applies cleanly with no FOUC
- [ ] `make lint` and `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)