### PR TITLE
fix(frontend): provide access to Model Edit History and Sources on single-Model Titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,8 @@ Prefer NamedTuple, dataclass, or TypedDict. For the full catalogue and legitimat
 
 See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
 
+See [SingleModelTitles.md](SingleModelTitles.md) for how the catalog handles Titles with exactly one Model — the UI collapse rule, the asymmetric Title/Model info split, and the description forward-compat rule.
+
 See [docs/DataModeling.md](DataModeling.md) for modeling principles, Django pitfalls, and constraint testing patterns. Key rules:
 
 - **Validate strictly** — start with the tightest constraint you can defend. Relaxing is a one-line migration; tightening requires auditing every row.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,8 @@ Prefer NamedTuple, dataclass, or TypedDict. For the full catalogue and legitimat
 
 See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
 
+See [SingleModelTitles.md](SingleModelTitles.md) for how the catalog handles Titles with exactly one Model — the UI collapse rule, the asymmetric Title/Model info split, and the description forward-compat rule.
+
 See [docs/DataModeling.md](DataModeling.md) for modeling principles, Django pitfalls, and constraint testing patterns. Key rules:
 
 - **Validate strictly** — start with the tightest constraint you can defend. Relaxing is a one-line migration; tightening requires auditing every row.

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -267,6 +267,8 @@ Prefer NamedTuple, dataclass, or TypedDict. For the full catalogue and legitimat
 
 See [DomainModel.md](DomainModel.md) for the catalog entity hierarchy (Title → Model, variants, remakes, manufacturers, taxonomy, etc.).
 
+See [SingleModelTitles.md](SingleModelTitles.md) for how the catalog handles Titles with exactly one Model — the UI collapse rule, the asymmetric Title/Model info split, and the description forward-compat rule.
+
 See [docs/DataModeling.md](DataModeling.md) for modeling principles, Django pitfalls, and constraint testing patterns. Key rules:
 
 - **Validate strictly** — start with the tightest constraint you can defend. Relaxing is a one-line migration; tightening requires auditing every row.

--- a/docs/DomainModel.md
+++ b/docs/DomainModel.md
@@ -45,7 +45,7 @@ The _Godzilla_ `Title` has four `Model`s:
 - **`Model`**: a distinct, buyable machine — an actual SKU. The _Medieval Madness_ Title contains six Models: the Williams original (1997), and five Chicago Gaming remakes (2015–2025).
 - **`Variants`**: a Model that shares the same gameplay as another Model, differing only in cosmetics (cabinet art, numbered plaques, toppers, colored plastics). Variants are linked via `variant_of`. Godzilla Pro and Premium are separate canonical Models because they have different gameplay and hardware. The LE and 70th Anniversary models are variants of Premium: same gameplay, different dress.
 
-A standalone game that has never been remade — like Gottlieb's 1965 _Buckaroo_ — has one `Title` and one `Model`.
+A standalone game that has never been remade — like Gottlieb's 1965 _Buckaroo_ — has one `Title` and one `Model`. See [SingleModelTitles.md](SingleModelTitles.md) for how this case is handled in the UI.
 
 ### Remakes
 

--- a/docs/SingleModelTitles.md
+++ b/docs/SingleModelTitles.md
@@ -1,0 +1,72 @@
+# Single-Model Titles
+
+This doc describes how the system handles **single-Model Titles** -- that is, Titles that contain exactly one Model with no variants.
+
+## The Background
+
+Most pinball sites don't have the concept of Title; instead, they only have Models (like Godzilla Pro & Godzilla Premium are separate models). This is because most pinball sites are developed by and for enthusiasts and collectors who think in those terms. This site, however, is run by a museum and aims to be inclusive of the broader public, who doesn't think at that level of detail. To the public, the machine is simply "Godzilla".
+
+This creates a UX problem: most older machines only have one single model. For single-Model Titles, we don't want to force the user to click on the Title, then click on the Model to see all the info. So the title route ( /titles/doctor-who ) shows all the information, and we don't link to the model route.
+
+Editor users are different; we can reasonably expect them to think in terms of distinct models. Regardless, for ease of editing, we made the decision to collapse the edit UX of single-Model Titles as well: you edit them from the Title page. However, each individual Editor dialog only edits Title info or Model info -- we never create a ChangeSet that changes multiple records.
+
+## Information asymmetry
+
+Almost all editable content lives on the Model. The Title row carries only identity-and-grouping fields:
+
+- `name`, abbreviations, `franchise`, `series`, `description` (dormant when single-Model — see below)
+
+Everything else — manufacturer, year, technology, features, people, media,
+related models, external IDs — lives on the Model.
+
+A single-Model Title's Model therefore carries the large majority of the
+catalog content and edit history. The Title row is a thin shell.
+
+## Single-to-Multi-Model Titles
+
+Single-Model Titles _can_ and _do_ become multi-Model:
+
+- Every new multi-Model Title passes through single-Model during creation, because an editor must create the Title first with no Models, then add Models one at a time.
+- Remakes (e.g. Medieval Madness 2025) with many years of edit history promote established single-Model Titles into multi-Model ones.
+
+## Collapse rule
+
+When `len(active_models) == 1` and that Model has no variants, the UI
+**collapses** the Title and Model into one page. This rule fires in three
+places and must stay consistent across them:
+
+- API: `TitleDetailSchema.model_detail` is populated inline — see
+  [titles.py:609-613](../backend/apps/catalog/api/titles.py#L609-L613).
+- Read view: the Title page renders the Model's content inline — see
+  [+page.svelte](../frontend/src/routes/titles/[slug]/+page.svelte).
+- Edit view: the section-edit menu interleaves Title-tier and Model-tier
+  sections via `combinedSectionsFor(isSingleModel)` —
+  see [combined-edit-sections.ts](../frontend/src/lib/components/editors/combined-edit-sections.ts).
+
+The collapse is UI-only. The data model is unchanged: two entities, two sets
+of claims, two ChangeSet histories.
+
+## Description: the one field overlap
+
+Both `Title` and `MachineModel` have a `description` field. No other catalog field exists on both entities.
+
+For single-Model Titles, we use the **Model's** description; the read view shows the **Model's** description and the edit menu's Overview section edits the **Model's** description. The Title's
+description is dormant.
+
+We use the Model's description for single-Model Titles because it stays correct after
+promotion to multi-Model; it still describes that Model. The Title's description is expected to be used for copy about the collection of Models that only makes sense once multiple Models exist.
+
+## Which entity each editor section targets
+
+In the single-Model Title edit menu, each section targets exactly one entity. Which entity
+is encoded in the URL key (`edit=title:...` vs `edit=model:...`) but is not
+shown in menu labels, except where a section-key collision forces it (today:
+`External Data - Title` vs `External Data`).
+
+Every section save is single-entity. No ChangeSet ever spans both Title and Model.
+
+## Edit history and sources
+
+The Edit History and Sources pages are unaware of single-Model Titles; their job is to display the edit history / sources of a single catalog record. Each ChangeSet targets exactly one entity, so `/edit-history` and `/sources` filter strictly by entity.
+
+The single-Model Title page surfaces links to both the title _AND_ model Edit History and Sources routes.

--- a/frontend/src/lib/components/PageActionBar.svelte
+++ b/frontend/src/lib/components/PageActionBar.svelte
@@ -11,6 +11,10 @@
     editDropdowns?: EditSectionDropdown[];
     historyHref?: string;
     sourcesHref?: string;
+    /** When set, renders History as a dropdown (e.g. single-model title: "Title History" + "Model History") instead of historyHref. */
+    historyMenu?: EditSectionMenuItem[];
+    /** When set, renders Sources as a dropdown instead of sourcesHref. */
+    sourcesMenu?: EditSectionMenuItem[];
   };
 
   let {
@@ -20,6 +24,8 @@
     editDropdowns,
     historyHref,
     sourcesHref,
+    historyMenu,
+    sourcesMenu,
   }: Props = $props();
 </script>
 
@@ -37,10 +43,14 @@
     {:else if editHref}
       <a href={editHref}>Edit</a>
     {/if}
-    {#if historyHref}
+    {#if historyMenu && historyMenu.length > 0}
+      <EditSectionMenu label="History" items={historyMenu} />
+    {:else if historyHref}
       <a href={historyHref}>History</a>
     {/if}
-    {#if sourcesHref}
+    {#if sourcesMenu && sourcesMenu.length > 0}
+      <EditSectionMenu label="Sources" items={sourcesMenu} />
+    {:else if sourcesHref}
       <ActionMenu label="Tools">
         <a class="tools-item" href={sourcesHref} role="menuitem">Sources</a>
       </ActionMenu>

--- a/frontend/src/routes/titles/[slug]/+layout.svelte
+++ b/frontend/src/routes/titles/[slug]/+layout.svelte
@@ -172,6 +172,42 @@
 
   let editSectionsForBar = $derived(auth.isAuthenticated ? switcherItems : undefined);
 
+  // On single-Model Titles the Model's detail URL redirects to the Title,
+  // so the Model's audit subroutes are otherwise unreachable from the UI —
+  // surface them here alongside the Title's. See docs/SingleModelTitles.md.
+  let historyMenu: EditSectionMenuItem[] | undefined = $derived(
+    md
+      ? [
+          {
+            key: 'title',
+            label: 'Title History',
+            href: resolve(`/titles/${slug}/edit-history`),
+          },
+          {
+            key: 'model',
+            label: 'Model History',
+            href: resolve(`/models/${md.slug}/edit-history`),
+          },
+        ]
+      : undefined,
+  );
+  let sourcesMenu: EditSectionMenuItem[] | undefined = $derived(
+    md
+      ? [
+          {
+            key: 'title',
+            label: 'Title Sources',
+            href: resolve(`/titles/${slug}/sources`),
+          },
+          {
+            key: 'model',
+            label: 'Model Sources',
+            href: resolve(`/models/${md.slug}/sources`),
+          },
+        ]
+      : undefined,
+  );
+
   function editAction(key: CombinedSectionKey): (() => void) | undefined {
     if (!auth.isAuthenticated) return undefined;
     return getMenuItemAction(switcherItems, key, (href) => goto(href));
@@ -201,6 +237,8 @@
       editSections={editSectionsForBar}
       historyHref={resolve(`/titles/${slug}/edit-history`)}
       sourcesHref={resolve(`/titles/${slug}/sources`)}
+      {historyMenu}
+      {sourcesMenu}
     />
   {/snippet}
 

--- a/frontend/src/routes/titles/[slug]/title-layout.test.ts
+++ b/frontend/src/routes/titles/[slug]/title-layout.test.ts
@@ -97,6 +97,58 @@ describe('title layout', () => {
     expect(body).not.toContain('History');
   });
 
+  it('renders History and Sources as menu triggers on single-Model titles', () => {
+    // On single-Model titles the action bar swaps the plain History link and
+    // the existing "Tools" Sources menu for two-item dropdowns that surface
+    // the Model's audit pages alongside the Title's. Menu items themselves
+    // render in a portal on click and aren't observable via SSR — those are
+    // covered by EditSectionMenu.dom.test.ts. Here we verify the layout
+    // selects the menu shape instead of the plain link when model_detail is
+    // populated.
+    pageState.params.slug = 'doctor-who';
+    pageState.url = new URL('http://localhost:5173/titles/doctor-who');
+
+    const singleModelTitle = {
+      ...MOCK_TITLE,
+      name: 'Doctor Who',
+      slug: 'doctor-who',
+      model_detail: {
+        name: 'Doctor Who',
+        slug: 'doctor-who-1992',
+        description: { text: '', html: '', citations: [], attribution: null },
+        abbreviations: [],
+        extra_data: {},
+        credits: [],
+        sources: [],
+        uploaded_media: [],
+        variant_features: [],
+        variants: [],
+        themes: [],
+        gameplay_features: [],
+        tags: [],
+        reward_types: [],
+        variant_siblings: [],
+        conversions: [],
+        remakes: [],
+        title_models: [],
+        production_quantity: '',
+      },
+    };
+
+    const { body } = render(Harness, {
+      props: { data: { title: singleModelTitle } } as never,
+    });
+
+    // Two ActionMenu triggers: History and Sources. (Multi-Model titles have
+    // just one — the Sources/Tools menu.)
+    const triggerCount = (body.match(/aria-haspopup="menu"/g) ?? []).length;
+    expect(triggerCount).toBe(2);
+
+    // The plain "<a href=…/edit-history>History" link from the multi-Model
+    // shape is suppressed when the menu takes over.
+    expect(body).not.toMatch(/<a[^>]+href="[^"]*\/edit-history"[^>]*>\s*History/);
+  });
+
   it('renders direct edit links on editable title sidebar sections when authenticated', () => {
     authState.isAuthenticated = true;
 


### PR DESCRIPTION
## Summary

For single-Model Titles the Model carries the bulk of the catalog's edit history and sources, but its detail URL redirects to the Title so editors had no UI path to the Model's audit subroutes. The Title page action bar now renders **History** and **Sources** as two-item dropdowns ("Title …" + "Model …") on single-Model Titles, exposing both entities' audit pages; multi-Model Titles are unchanged.

- Adds `historyMenu` / `sourcesMenu` props to `PageActionBar`, reusing the existing `EditSectionMenu` primitive.
- Title layout derives the menu arrays from `title.model_detail.slug` when the collapse rule fires; passes plain `historyHref` / `sourcesHref` as a fallback for the multi-Model case.
- Adds [docs/SingleModelTitles.md](docs/SingleModelTitles.md) describing the museum-vs-enthusiast rationale for the collapse, the Title/Model information asymmetry, the description forward-compat rule, and the audit-access pattern. Cross-linked from `DomainModel.md` and `AGENTS.src.md`.

Closes #388.

## Test plan

- [ ] `make dev`, open a single-Model Title (e.g. `/titles/doctor-who/`). The action bar shows **History** and **Sources** as dropdown triggers (not plain links).
- [ ] Click "Model History" — lands on `/models/{model-slug}/edit-history` (no redirect) and shows the bulk of the title's edit history.
- [ ] Click "Title History" — lands on `/titles/{slug}/edit-history` showing the thin Title slice (name, franchise, abbreviations only).
- [ ] Repeat for Sources.
- [ ] Open a multi-Model Title — confirm History is still a plain link and Sources still uses its existing single-item "Tools" menu (no regression).
- [ ] `pnpm -C frontend test` — 1125/1125 passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)