### PR TITLE
feat(frontend): improvements to edit history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,9 +232,9 @@ Code MUST be as strongly typed as possible.
 The following smells are _sometimes_ legitimate, but are usually a sign the type can be tightened:
 
 - Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING`, `# type: ignore`, `# noqa`
-- `tuple[...]` with 3+ positional fields, or the same tuple shape repeated across modules
+- Compound types in signatures whose meaning isn't obvious from the types alone — `tuple[...]`, nested dicts (`dict[X, dict[Y, Z]]`), `Callable[[A, B, C], R]`. **Heuristic**: if a reader would need a comment to know what each position/key means, name it. Applies to 2-tuples that cross a module boundary or appear in a public signature; locally unpacked pairs (`found, value = _lookup(key)`) are fine as plain tuples.
 
-Prefer NamedTuple, dataclass, or TypedDict. For the full catalogue and legitimate exceptions, see [docs/Python.md](Python.md).
+Prefer NamedTuple, dataclass, or TypedDict. For worked examples (including the no-op decorator pattern that pins `Callable` implementations to a typed contract) and the full catalogue of exceptions, see [docs/Python.md](Python.md).
 
 ## Data Modeling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,9 +226,9 @@ Code MUST be as strongly typed as possible.
 The following smells are _sometimes_ legitimate, but are usually a sign the type can be tightened:
 
 - Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING`, `# type: ignore`, `# noqa`
-- `tuple[...]` with 3+ positional fields, or the same tuple shape repeated across modules
+- Compound types in signatures whose meaning isn't obvious from the types alone — `tuple[...]`, nested dicts (`dict[X, dict[Y, Z]]`), `Callable[[A, B, C], R]`. **Heuristic**: if a reader would need a comment to know what each position/key means, name it. Applies to 2-tuples that cross a module boundary or appear in a public signature; locally unpacked pairs (`found, value = _lookup(key)`) are fine as plain tuples.
 
-Prefer NamedTuple, dataclass, or TypedDict. For the full catalogue and legitimate exceptions, see [docs/Python.md](Python.md).
+Prefer NamedTuple, dataclass, or TypedDict. For worked examples (including the no-op decorator pattern that pins `Callable` implementations to a typed contract) and the full catalogue of exceptions, see [docs/Python.md](Python.md).
 
 ## Data Modeling
 

--- a/backend/apps/catalog/claims.py
+++ b/backend/apps/catalog/claims.py
@@ -214,6 +214,7 @@ def register_catalog_relationship_schemas() -> None:
                     scalar_type=str,
                     required=True,
                     identity="alias",
+                    display_key="alias_display",
                 ),
                 ValueKeySpec(
                     name="alias_display",

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -14,6 +14,10 @@ from typing import NamedTuple, cast
 from django.db.models import Model
 
 from apps.provenance.models import Claim, ClaimControlledModel
+from apps.provenance.validation import (
+    get_display_override,
+    get_relationship_schema,
+)
 
 from .._alias_registry import AliasType, discover_alias_types
 from ..models import (
@@ -676,7 +680,12 @@ def _resolve_aliases(
             winners_by_parent.setdefault(claim.object_id, []).append(claim)
 
     # Build desired aliases per parent: {lower_val → display_val}.
-    # alias_display (original case) is preferred; falls back to alias_value.
+    # alias_display (original case) is preferred via the schema's
+    # display_key declaration; falls back to alias_value when absent/empty.
+    schema = get_relationship_schema(claim_field_name)
+    assert schema is not None, (
+        f"alias namespace {claim_field_name!r} has no registered relationship schema"
+    )
     desired_by_parent: dict[int, dict[str, str]] = {}
     for parent_id, claims_list in winners_by_parent.items():
         desired: dict[str, str] = {}
@@ -686,7 +695,11 @@ def _resolve_aliases(
                 continue
             alias_val = val.get("alias_value", "")
             if alias_val:
-                display = val.get("alias_display") or alias_val
+                override = get_display_override(val, schema, "alias_value")
+                # Schema registration pins ``alias_display.scalar_type`` to
+                # ``str``, so the override (when present) is always a str at
+                # runtime. ``str(...)`` keeps mypy happy without coercing.
+                display = str(override) if override is not None else alias_val
                 desired[alias_val] = display  # alias_val is already lowercase
         desired_by_parent[parent_id] = desired
 

--- a/backend/apps/provenance/display.py
+++ b/backend/apps/provenance/display.py
@@ -1,0 +1,313 @@
+"""Build display labels for relationship-claim values in edit history.
+
+A relationship claim's stored value is a dict like
+``{"person": 13, "role": 9, "exists": true}`` — fine for the data model,
+unfriendly for users. This module turns those into strings like
+``"Pat Lawlor — Art"`` by resolving FK references via a pre-built label
+lookup.
+
+Usage::
+
+    labels = resolve_labels([FieldValue(field_name, value), ...])
+    display = build_display_label(field_name, value, labels)
+
+``resolve_labels`` queries one row per FK target model (no per-row N+1).
+Bare scalars (direct-field claims like ``technology_generation``) are not
+formatted here — they render as-is. ``None`` is returned for any value the
+formatter doesn't recognise (non-dict, unknown namespace, no registered
+formatter).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from typing import NamedTuple
+
+from django.db.models import Model
+
+from .validation import (
+    RelationshipSchema,
+    ValueKeySpec,
+    get_relationship_schema,
+)
+
+# A relationship claim's value payload: a dict with ``exists: bool`` plus
+# the namespace-specific keys declared in :class:`ValueKeySpec`. Per-key
+# types vary by namespace (int pks, optional counts, str literals), so the
+# value type is ``object`` and formatters narrow with ``isinstance`` at the
+# few sites that read non-pk fields. Schema validation enforces shape at
+# the data-layer boundary; this alias just names the concept.
+RelationshipClaimValue = dict[str, object]
+
+
+class FieldValue(NamedTuple):
+    """A claim value paired with the field name that interprets it.
+
+    The field name picks which relationship schema (and therefore which
+    formatter) applies; the value is the raw payload. Callers feed
+    :func:`resolve_labels` with these so FK pks can be collected for
+    batched resolution before per-row formatting.
+    """
+
+    field_name: str
+    value: object
+
+
+class FkRef(NamedTuple):
+    """A reference to a specific row in an FK target model.
+
+    ``model`` is the target class (e.g. ``Person``); ``pk`` identifies the
+    row. Used as the lookup key in :class:`LabelLookup` so the keying is
+    a single named concept rather than an opaque ``(model, pk)`` tuple.
+    """
+
+    model: type[Model]
+    pk: int
+
+
+class LabelLookup:
+    """Display labels resolved from :class:`FkRef`\\ s.
+
+    Built once per response by :func:`resolve_labels`; consulted by the
+    per-namespace formatters when they need to turn a pk into a name.
+    """
+
+    __slots__ = ("_labels",)
+
+    def __init__(self) -> None:
+        self._labels: dict[FkRef, str] = {}
+
+    def add(self, ref: FkRef, label: str) -> None:
+        self._labels[ref] = label
+
+    def get(self, ref: FkRef) -> str | None:
+        return self._labels.get(ref)
+
+
+# A formatter receives the value dict, its registered schema, and the
+# pre-built label lookup. Returning ``None`` signals the value isn't
+# formatable (callers fall back to raw rendering).
+ValueFormatter = Callable[
+    [RelationshipClaimValue, RelationshipSchema, LabelLookup], str | None
+]
+
+
+def value_formatter(fn: ValueFormatter) -> ValueFormatter:
+    """No-op decorator that pins a function to the :data:`ValueFormatter` shape.
+
+    Apply to each formatter so signature drift is caught at the function
+    definition rather than at the ``_FORMATTERS`` registry assignment.
+    Returns the input unchanged — no runtime overhead.
+    """
+    return fn
+
+
+def _spec(schema: RelationshipSchema, name: str) -> ValueKeySpec:
+    for s in schema.value_keys:
+        if s.name == name:
+            return s
+    raise KeyError(f"value key {name!r} not found in namespace {schema.namespace!r}")
+
+
+def _fk_label(
+    value: RelationshipClaimValue,
+    schema: RelationshipSchema,
+    key_name: str,
+    labels: LabelLookup,
+) -> str:
+    spec = _spec(schema, key_name)
+    assert spec.fk_target is not None, (
+        f"{schema.namespace!r}.{key_name!r} is not declared as an FK"
+    )
+    # Display assumes pk lookups. Validation honours ``lookup_field``, so a
+    # future ``FkTarget(Model, "slug")`` registration would silently miss
+    # labels here. Fail loud until that case is actually needed.
+    assert spec.fk_target.lookup_field == "pk", (
+        f"{schema.namespace!r}.{key_name!r} uses non-pk lookup "
+        f"{spec.fk_target.lookup_field!r}; build_display_label only supports pk"
+    )
+    pk = value.get(key_name)
+    if pk is None:
+        return "?"
+    # ``type(pk) is int`` (not ``isinstance``): ``isinstance(True, int)`` is
+    # ``True`` and would let a stray bool slip through as a pk.
+    assert type(pk) is int, (
+        f"expected int pk for {schema.namespace}.{key_name}, got {type(pk).__name__}"
+    )
+    label = labels.get(FkRef(spec.fk_target.model, pk))
+    # Reference points to a row that no longer exists — fall back to the pk
+    # so the row is still identifiable, and prefix `?#` to flag the miss.
+    return label if label is not None else f"?#{pk}"
+
+
+@value_formatter
+def _format_credit(
+    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
+) -> str:
+    person = _fk_label(value, schema, "person", labels)
+    role = _fk_label(value, schema, "role", labels)
+    return f"{person} — {role}"
+
+
+@value_formatter
+def _format_gameplay_feature(
+    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
+) -> str:
+    feat = _fk_label(value, schema, "gameplay_feature", labels)
+    count = value.get("count")
+    if isinstance(count, int) and count > 1:
+        return f"{feat} ×{count}"
+    return feat
+
+
+def _single_fk_formatter(key_name: str) -> ValueFormatter:
+    @value_formatter
+    def fmt(
+        value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
+    ) -> str:
+        return _fk_label(value, schema, key_name, labels)
+
+    return fmt
+
+
+@value_formatter
+def _format_alias(
+    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
+) -> str:
+    # ``alias_value`` is the required identity key; ``alias_display`` is an
+    # optional friendlier label that ingest sources may attach. ``.get`` with
+    # a ``?`` fallback matches the contract used by ``_fk_label`` so a
+    # malformed shape (e.g. ``{"exists": false}``) renders visibly instead
+    # of raising mid-response.
+    display = value.get("alias_display")
+    raw = value.get("alias_value")
+    if display:
+        return str(display)
+    if raw:
+        return str(raw)
+    return "?"
+
+
+@value_formatter
+def _format_abbreviation(
+    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
+) -> str:
+    raw = value.get("value")
+    return str(raw) if raw is not None else "?"
+
+
+@value_formatter
+def _format_media_attachment(
+    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
+) -> str:
+    media = _fk_label(value, schema, "media_asset", labels)
+    parts = [media]
+    category = value.get("category")
+    if category:
+        parts.append(f"({category})")
+    if value.get("is_primary"):
+        parts.append("[primary]")
+    return " ".join(parts)
+
+
+# Per-namespace explicit formatters. Aliases are dispatched dynamically below
+# (one namespace per AliasModel subclass, all sharing the alias_value shape).
+_FORMATTERS: dict[str, ValueFormatter] = {
+    "credit": _format_credit,
+    "gameplay_feature": _format_gameplay_feature,
+    "theme": _single_fk_formatter("theme"),
+    "tag": _single_fk_formatter("tag"),
+    "reward_type": _single_fk_formatter("reward_type"),
+    "location": _single_fk_formatter("location"),
+    "theme_parent": _single_fk_formatter("parent"),
+    "gameplay_feature_parent": _single_fk_formatter("parent"),
+    "media_attachment": _format_media_attachment,
+    "abbreviation": _format_abbreviation,
+}
+
+
+def _formatter_for(schema: RelationshipSchema) -> ValueFormatter | None:
+    explicit = _FORMATTERS.get(schema.namespace)
+    if explicit is not None:
+        return explicit
+    # Aliases register one namespace per AliasModel subclass. They all carry
+    # an "alias_value" key, which is the discriminator we use here so we
+    # don't have to enumerate them.
+    if any(s.name == "alias_value" for s in schema.value_keys):
+        return _format_alias
+    return None
+
+
+def _collect_refs(items: Iterable[FieldValue]) -> set[FkRef]:
+    """Walk :class:`FieldValue`\\ s and gather every FK reference.
+
+    Non-dict values and direct-field claims (unregistered namespaces) are
+    skipped — they have no FKs to resolve.
+    """
+    refs: set[FkRef] = set()
+    for field_name, value in items:
+        if not isinstance(value, dict):
+            continue
+        schema = get_relationship_schema(field_name)
+        if schema is None:
+            continue
+        for spec in schema.value_keys:
+            if spec.fk_target is None:
+                continue
+            # Mirror the assertion in ``_fk_label``: pk-only for now. See
+            # the comment there for context.
+            assert spec.fk_target.lookup_field == "pk", (
+                f"{field_name!r}.{spec.name!r} uses non-pk lookup "
+                f"{spec.fk_target.lookup_field!r}; build_display_label only supports pk"
+            )
+            pk = value.get(spec.name)
+            if pk is None:
+                continue
+            # See ``_fk_label`` for why this isn't ``isinstance``.
+            assert type(pk) is int, (
+                f"expected int pk for {field_name}.{spec.name}, got {type(pk).__name__}"
+            )
+            refs.add(FkRef(spec.fk_target.model, pk))
+    return refs
+
+
+def resolve_labels(items: Iterable[FieldValue]) -> LabelLookup:
+    """Build a :class:`LabelLookup` for all relationship claims in ``items``.
+
+    One query per FK target model. Resolved labels are ``str(instance)``,
+    so each FK target model is expected to define a meaningful ``__str__``
+    — registering a relationship whose target falls back to Django's
+    default ``"Foo object (13)"`` would leak through to edit history.
+    Missing rows (referent deleted) simply don't appear in the result;
+    callers render them as ``?#<pk>``.
+    """
+    pks_by_model: dict[type[Model], set[int]] = defaultdict(set)
+    for ref in _collect_refs(items):
+        pks_by_model[ref.model].add(ref.pk)
+
+    lookup = LabelLookup()
+    for model, pks in pks_by_model.items():
+        for inst in model._default_manager.filter(pk__in=pks):
+            lookup.add(FkRef(model, inst.pk), str(inst))
+    return lookup
+
+
+def build_display_label(
+    field_name: str, value: object, labels: LabelLookup
+) -> str | None:
+    """Return a friendly display string for a relationship-claim value.
+
+    Returns ``None`` when ``value`` isn't a formatable relationship-claim
+    dict — direct-field scalars, unknown namespaces, and namespaces without
+    a registered formatter all fall through.
+    """
+    if not isinstance(value, dict):
+        return None
+    schema = get_relationship_schema(field_name)
+    if schema is None:
+        return None
+    formatter = _formatter_for(schema)
+    if formatter is None:
+        return None
+    return formatter(value, schema, labels)

--- a/backend/apps/provenance/display.py
+++ b/backend/apps/provenance/display.py
@@ -1,53 +1,76 @@
-"""Build display labels for relationship-claim values in edit history.
+"""Build structured display values for relationship-claim values in edit history.
 
 A relationship claim's stored value is a dict like
 ``{"person": 13, "role": 9, "exists": true}`` — fine for the data model,
-unfriendly for users. This module turns those into strings like
-``"Pat Lawlor — Art"`` by resolving FK references via a pre-built label
-lookup.
+unfriendly for users. This module turns those into a
+:class:`~apps.provenance.schemas.ClaimDisplayValueSchema` — an ordered list of
+identity parts (each resolved to a user-facing label) and qualifier parts
+(scalars left as-is for the frontend to render). Layout decisions
+(separators, ``×N`` count suffixes, parentheses around categories) live on
+the frontend; the backend's job is FK-pk-to-label resolution.
 
 Usage::
 
     labels = resolve_labels([FieldValue(field_name, value), ...])
-    display = build_display_label(field_name, value, labels)
+    display = build_display_value(field_name, value, labels)
 
 ``resolve_labels`` queries one row per FK target model (no per-row N+1).
-Bare scalars (direct-field claims like ``technology_generation``) are not
-formatted here — they render as-is. ``None`` is returned for any value the
-formatter doesn't recognise (non-dict, unknown namespace, no registered
-formatter).
+Bare scalars (direct-field claims like ``technology_generation``) and
+unregistered namespaces return ``None`` — clients fall back to the raw
+value in that case.
 """
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable, Mapping
 from typing import NamedTuple
 
 from django.db.models import Model
 
+from .schemas import (
+    ClaimDisplayIdentityPartSchema,
+    ClaimDisplayIdentityState,
+    ClaimDisplayQualifierPartSchema,
+    ClaimDisplayValueSchema,
+)
 from .validation import (
     RelationshipSchema,
     ValueKeySpec,
+    get_display_override,
     get_relationship_schema,
 )
 
+logger = logging.getLogger(__name__)
+
+
+class _LabelResult(NamedTuple):
+    """A resolved identity label plus its state discriminant.
+
+    Two-return-value plumbing for the engine: ``state`` says which case
+    we're in, ``label`` carries the resolved string when ``state ==
+    "resolved"`` and is None otherwise. The Schema mirrors this shape;
+    rendering decisions for the non-resolved states are the frontend's.
+    """
+
+    label: str | None
+    state: ClaimDisplayIdentityState
+
+
 # A relationship claim's value payload: a dict with ``exists: bool`` plus
 # the namespace-specific keys declared in :class:`ValueKeySpec`. Per-key
-# types vary by namespace (int pks, optional counts, str literals), so the
-# value type is ``object`` and formatters narrow with ``isinstance`` at the
-# few sites that read non-pk fields. Schema validation enforces shape at
-# the data-layer boundary; this alias just names the concept.
-RelationshipClaimValue = dict[str, object]
+# types vary by namespace (int pks, optional counts, str literals); schema
+# validation enforces shape at the data-layer boundary.
+RelationshipClaimValue = Mapping[str, object]
 
 
 class FieldValue(NamedTuple):
     """A claim value paired with the field name that interprets it.
 
-    The field name picks which relationship schema (and therefore which
-    formatter) applies; the value is the raw payload. Callers feed
-    :func:`resolve_labels` with these so FK pks can be collected for
-    batched resolution before per-row formatting.
+    The field name picks which relationship schema applies; the value is the
+    raw payload. Callers feed :func:`resolve_labels` with these so FK pks
+    can be collected for batched resolution.
     """
 
     field_name: str
@@ -55,12 +78,7 @@ class FieldValue(NamedTuple):
 
 
 class FkRef(NamedTuple):
-    """A reference to a specific row in an FK target model.
-
-    ``model`` is the target class (e.g. ``Person``); ``pk`` identifies the
-    row. Used as the lookup key in :class:`LabelLookup` so the keying is
-    a single named concept rather than an opaque ``(model, pk)`` tuple.
-    """
+    """A reference to a specific row in an FK target model."""
 
     model: type[Model]
     pk: int
@@ -70,7 +88,7 @@ class LabelLookup:
     """Display labels resolved from :class:`FkRef`\\ s.
 
     Built once per response by :func:`resolve_labels`; consulted by the
-    per-namespace formatters when they need to turn a pk into a name.
+    display engine when it needs to turn a pk into a name.
     """
 
     __slots__ = ("_labels",)
@@ -85,165 +103,116 @@ class LabelLookup:
         return self._labels.get(ref)
 
 
-# A formatter receives the value dict, its registered schema, and the
-# pre-built label lookup. Returning ``None`` signals the value isn't
-# formatable (callers fall back to raw rendering).
-ValueFormatter = Callable[
-    [RelationshipClaimValue, RelationshipSchema, LabelLookup], str | None
-]
-
-
-def value_formatter(fn: ValueFormatter) -> ValueFormatter:
-    """No-op decorator that pins a function to the :data:`ValueFormatter` shape.
-
-    Apply to each formatter so signature drift is caught at the function
-    definition rather than at the ``_FORMATTERS`` registry assignment.
-    Returns the input unchanged — no runtime overhead.
-    """
-    return fn
-
-
-def _spec(schema: RelationshipSchema, name: str) -> ValueKeySpec:
-    for s in schema.value_keys:
-        if s.name == name:
-            return s
-    raise KeyError(f"value key {name!r} not found in namespace {schema.namespace!r}")
-
-
 def _fk_label(
     value: RelationshipClaimValue,
     schema: RelationshipSchema,
-    key_name: str,
+    spec: ValueKeySpec,
     labels: LabelLookup,
-) -> str:
-    spec = _spec(schema, key_name)
+) -> _LabelResult:
+    """Resolve a spec's FK value into a ``_LabelResult``.
+
+    Returns ``(None, "missing")`` when the claim dict carries no value
+    for the key — an invariant violation that validation rule 4 should
+    prevent (logged loudly so it's observable). Returns ``(None,
+    "deleted")`` when the pk is present but the target row no longer
+    exists — a legitimate runtime condition. Otherwise returns the
+    resolved label with ``state="resolved"``.
+    """
     assert spec.fk_target is not None, (
-        f"{schema.namespace!r}.{key_name!r} is not declared as an FK"
+        f"{schema.namespace!r}.{spec.name!r} is not declared as an FK"
     )
     # Display assumes pk lookups. Validation honours ``lookup_field``, so a
     # future ``FkTarget(Model, "slug")`` registration would silently miss
     # labels here. Fail loud until that case is actually needed.
     assert spec.fk_target.lookup_field == "pk", (
-        f"{schema.namespace!r}.{key_name!r} uses non-pk lookup "
-        f"{spec.fk_target.lookup_field!r}; build_display_label only supports pk"
+        f"{schema.namespace!r}.{spec.name!r} uses non-pk lookup "
+        f"{spec.fk_target.lookup_field!r}; display only supports pk"
     )
-    pk = value.get(key_name)
+    pk = value.get(spec.name)
     if pk is None:
-        return "?"
+        # Invariant violation: validation rule 4 (required identity keys)
+        # should prevent this. If we got here, something bypassed the
+        # write-time validator — pre-validation data, an ingest source
+        # that skipped validation, or a future bug. Log loudly so it's
+        # observable in monitoring; emit state="missing" so the frontend
+        # can render a placeholder without crashing the page.
+        logger.error(
+            "display: missing identity key %r in namespace %r — validation "
+            "rule 4 should prevent this; value=%r",
+            spec.name,
+            schema.namespace,
+            dict(value),
+        )
+        return _LabelResult(label=None, state="missing")
     # ``type(pk) is int`` (not ``isinstance``): ``isinstance(True, int)`` is
-    # ``True`` and would let a stray bool slip through as a pk.
-    assert type(pk) is int, (
-        f"expected int pk for {schema.namespace}.{key_name}, got {type(pk).__name__}"
-    )
+    # ``True`` and would let a stray bool slip through as a pk. Schema
+    # validation rule 5 rejects wrong-type values at write time, so reaching
+    # here means the same kind of integrity breach as ``pk is None``: log
+    # and degrade, don't 500 the whole edit-history page.
+    if type(pk) is not int:
+        logger.error(
+            "display: non-int pk %r (%s) for identity key %r in namespace %r — "
+            "validation rule 5 should prevent this; value=%r",
+            pk,
+            type(pk).__name__,
+            spec.name,
+            schema.namespace,
+            dict(value),
+        )
+        return _LabelResult(label=None, state="missing")
     label = labels.get(FkRef(spec.fk_target.model, pk))
-    # Reference points to a row that no longer exists — fall back to the pk
-    # so the row is still identifiable, and prefix `?#` to flag the miss.
-    return label if label is not None else f"?#{pk}"
+    if label is None:
+        return _LabelResult(label=None, state="deleted")
+    return _LabelResult(label=label, state="resolved")
 
 
-@value_formatter
-def _format_credit(
-    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
-) -> str:
-    person = _fk_label(value, schema, "person", labels)
-    role = _fk_label(value, schema, "role", labels)
-    return f"{person} — {role}"
+def resolve_identity_label(
+    value: RelationshipClaimValue,
+    schema: RelationshipSchema,
+    spec: ValueKeySpec,
+    labels: LabelLookup,
+) -> _LabelResult:
+    """Resolve one identity slot into a ``_LabelResult``.
 
-
-@value_formatter
-def _format_gameplay_feature(
-    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
-) -> str:
-    feat = _fk_label(value, schema, "gameplay_feature", labels)
-    count = value.get("count")
-    if isinstance(count, int) and count > 1:
-        return f"{feat} ×{count}"
-    return feat
-
-
-def _single_fk_formatter(key_name: str) -> ValueFormatter:
-    @value_formatter
-    def fmt(
-        value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
-    ) -> str:
-        return _fk_label(value, schema, key_name, labels)
-
-    return fmt
-
-
-@value_formatter
-def _format_alias(
-    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
-) -> str:
-    # ``alias_value`` is the required identity key; ``alias_display`` is an
-    # optional friendlier label that ingest sources may attach. ``.get`` with
-    # a ``?`` fallback matches the contract used by ``_fk_label`` so a
-    # malformed shape (e.g. ``{"exists": false}``) renders visibly instead
-    # of raising mid-response.
-    display = value.get("alias_display")
-    raw = value.get("alias_value")
-    if display:
-        return str(display)
-    if raw:
-        return str(raw)
-    return "?"
-
-
-@value_formatter
-def _format_abbreviation(
-    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
-) -> str:
-    raw = value.get("value")
-    return str(raw) if raw is not None else "?"
-
-
-@value_formatter
-def _format_media_attachment(
-    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
-) -> str:
-    media = _fk_label(value, schema, "media_asset", labels)
-    parts = [media]
-    category = value.get("category")
-    if category:
-        parts.append(f"({category})")
-    if value.get("is_primary"):
-        parts.append("[primary]")
-    return " ".join(parts)
-
-
-# Per-namespace explicit formatters. Aliases are dispatched dynamically below
-# (one namespace per AliasModel subclass, all sharing the alias_value shape).
-_FORMATTERS: dict[str, ValueFormatter] = {
-    "credit": _format_credit,
-    "gameplay_feature": _format_gameplay_feature,
-    "theme": _single_fk_formatter("theme"),
-    "tag": _single_fk_formatter("tag"),
-    "reward_type": _single_fk_formatter("reward_type"),
-    "location": _single_fk_formatter("location"),
-    "theme_parent": _single_fk_formatter("parent"),
-    "gameplay_feature_parent": _single_fk_formatter("parent"),
-    "media_attachment": _format_media_attachment,
-    "abbreviation": _format_abbreviation,
-}
-
-
-def _formatter_for(schema: RelationshipSchema) -> ValueFormatter | None:
-    explicit = _FORMATTERS.get(schema.namespace)
-    if explicit is not None:
-        return explicit
-    # Aliases register one namespace per AliasModel subclass. They all carry
-    # an "alias_value" key, which is the discriminator we use here so we
-    # don't have to enumerate them.
-    if any(s.name == "alias_value" for s in schema.value_keys):
-        return _format_alias
-    return None
+    Composes :func:`get_display_override` (declarative display_key
+    substitution) with :func:`_fk_label` (FK pk → label) and the canonical
+    scalar fallback. The override and resolved-scalar paths always return
+    ``state="resolved"``; missing-key paths log and return
+    ``state="missing"``.
+    """
+    assert spec.identity is not None, (
+        f"resolve_identity_label called on non-identity spec {spec.name!r}"
+    )
+    override = get_display_override(value, schema, spec.name)
+    if override is not None:
+        return _LabelResult(label=str(override), state="resolved")
+    if spec.fk_target is not None:
+        return _fk_label(value, schema, spec, labels)
+    # Canonical scalar fallback. ``is not None`` (not truthy) so a
+    # deliberately empty identity renders as the empty string rather than
+    # state="missing" — matches the prior abbreviation behavior.
+    # Absent key (invariant violation) → state="missing" + loud log.
+    raw = value.get(spec.name)
+    if raw is None:
+        logger.error(
+            "display: missing scalar identity key %r in namespace %r — "
+            "validation rule 4 should prevent this; value=%r",
+            spec.name,
+            schema.namespace,
+            dict(value),
+        )
+        return _LabelResult(label=None, state="missing")
+    return _LabelResult(label=str(raw), state="resolved")
 
 
 def _collect_refs(items: Iterable[FieldValue]) -> set[FkRef]:
     """Walk :class:`FieldValue`\\ s and gather every FK reference.
 
     Non-dict values and direct-field claims (unregistered namespaces) are
-    skipped — they have no FKs to resolve.
+    skipped — they have no FKs to resolve. Corrupt pk values (None, wrong
+    type) are also skipped silently here; ``_fk_label`` is the canonical
+    log site for those violations so we don't double-log when the same
+    claim flows through both functions during a single response.
     """
     refs: set[FkRef] = set()
     for field_name, value in items:
@@ -255,19 +224,19 @@ def _collect_refs(items: Iterable[FieldValue]) -> set[FkRef]:
         for spec in schema.value_keys:
             if spec.fk_target is None:
                 continue
-            # Mirror the assertion in ``_fk_label``: pk-only for now. See
-            # the comment there for context.
+            # Display-engine limitation. Same check fires in ``_fk_label``;
+            # consider hoisting to ``register_relationship_schema`` if a
+            # second site ever needs it.
             assert spec.fk_target.lookup_field == "pk", (
                 f"{field_name!r}.{spec.name!r} uses non-pk lookup "
-                f"{spec.fk_target.lookup_field!r}; build_display_label only supports pk"
+                f"{spec.fk_target.lookup_field!r}; display only supports pk"
             )
             pk = value.get(spec.name)
-            if pk is None:
+            # Don't crash on data-integrity violations — ``_fk_label`` logs
+            # and degrades to ``state="missing"`` for the same row when it
+            # processes the value later in the request.
+            if type(pk) is not int:
                 continue
-            # See ``_fk_label`` for why this isn't ``isinstance``.
-            assert type(pk) is int, (
-                f"expected int pk for {field_name}.{spec.name}, got {type(pk).__name__}"
-            )
             refs.add(FkRef(spec.fk_target.model, pk))
     return refs
 
@@ -276,11 +245,9 @@ def resolve_labels(items: Iterable[FieldValue]) -> LabelLookup:
     """Build a :class:`LabelLookup` for all relationship claims in ``items``.
 
     One query per FK target model. Resolved labels are ``str(instance)``,
-    so each FK target model is expected to define a meaningful ``__str__``
-    — registering a relationship whose target falls back to Django's
-    default ``"Foo object (13)"`` would leak through to edit history.
+    so each FK target model is expected to define a meaningful ``__str__``.
     Missing rows (referent deleted) simply don't appear in the result;
-    callers render them as ``?#<pk>``.
+    callers (``_fk_label``) emit ``state="deleted"`` for those refs.
     """
     pks_by_model: dict[type[Model], set[int]] = defaultdict(set)
     for ref in _collect_refs(items):
@@ -293,21 +260,83 @@ def resolve_labels(items: Iterable[FieldValue]) -> LabelLookup:
     return lookup
 
 
-def build_display_label(
+def build_display_value(
     field_name: str, value: object, labels: LabelLookup
-) -> str | None:
-    """Return a friendly display string for a relationship-claim value.
+) -> ClaimDisplayValueSchema | None:
+    """Return a structured display rendering for a relationship-claim value.
 
-    Returns ``None`` when ``value`` isn't a formatable relationship-claim
-    dict — direct-field scalars, unknown namespaces, and namespaces without
-    a registered formatter all fall through.
+    Returns ``None`` when ``value`` isn't a relationship-claim dict —
+    direct-field scalars and unknown namespaces fall through, and the
+    frontend renders the raw value.
+
+    Generic engine: identity slots are emitted in declaration order via
+    :func:`resolve_identity_label`; non-identity, non-display-override
+    specs are emitted as ``ClaimDisplayQualifierPartSchema`` entries in
+    declaration order. Absent qualifier keys are skipped; present-but-
+    falsy qualifiers (``None``, ``False``, ``0``, ``""``) are emitted —
+    "should this be visible to the user" is the frontend's job.
     """
     if not isinstance(value, dict):
         return None
     schema = get_relationship_schema(field_name)
     if schema is None:
         return None
-    formatter = _formatter_for(schema)
-    if formatter is None:
-        return None
-    return formatter(value, schema, labels)
+
+    # display_key targets are consumed by their identity spec's rendering;
+    # they must not also surface as qualifiers.
+    consumed_by_display: set[str] = {
+        s.display_key for s in schema.value_keys if s.display_key is not None
+    }
+
+    identity_parts: list[ClaimDisplayIdentityPartSchema] = []
+    qualifier_parts: list[ClaimDisplayQualifierPartSchema] = []
+
+    for spec in schema.value_keys:
+        if spec.identity is not None:
+            result = resolve_identity_label(value, schema, spec, labels)
+            identity_parts.append(
+                ClaimDisplayIdentityPartSchema(
+                    key=spec.name,
+                    label=result.label,
+                    state=result.state,
+                )
+            )
+            continue
+
+        if spec.name in consumed_by_display:
+            continue
+
+        if spec.name not in value:
+            continue
+
+        raw = value[spec.name]
+        if spec.fk_target is not None:
+            # TODO(qualifier-fk): no schema has non-identity FKs today; this
+            # branch exists for symmetry with the identity FK path. The
+            # state discriminant has nowhere to surface on
+            # ``ClaimDisplayQualifierPartSchema``, so ``deleted`` and
+            # ``missing`` both silently collapse to ``value=None`` here.
+            # When the first qualifier-FK schema is registered, widen
+            # ``ClaimDisplayQualifierPartSchema`` with a ``state`` field
+            # rather than shipping with the silent collapse.
+            qualifier_parts.append(
+                ClaimDisplayQualifierPartSchema(
+                    key=spec.name,
+                    value=_fk_label(value, schema, spec, labels).label,
+                )
+            )
+            continue
+
+        # Pass the typed value through. ``bool`` stays bool through this
+        # Python-side path because ``raw`` keeps its runtime type — the
+        # Pydantic-side coercion risk (True → 1) is handled at the Schema
+        # by ordering ``bool`` before ``int`` in the union. Unexpected
+        # types get stringified (schema validation should have caught any).
+        scalar: bool | int | str | None = (
+            raw if raw is None or isinstance(raw, bool | int | str) else str(raw)
+        )
+        qualifier_parts.append(
+            ClaimDisplayQualifierPartSchema(key=spec.name, value=scalar)
+        )
+
+    return ClaimDisplayValueSchema(identity=identity_parts, qualifiers=qualifier_parts)

--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Case, F, IntegerField, Model, Prefetch, Q, Value, When
 
 from apps.core.authz import PolicyUser, compute_row_capabilities
 
+from .display import FieldValue, LabelLookup, build_display_label, resolve_labels
 from .models import ChangeSet, Claim
 from .schemas import (
     ChangeSetSchema,
@@ -16,6 +18,89 @@ from .schemas import (
     FieldChangeSchema,
     RetractionSchema,
 )
+
+
+def _prior_value(claim: Claim, chain: Sequence[Claim]) -> object | None:
+    """Return the value of the claim immediately preceding ``claim`` in ``chain``.
+
+    ``chain`` is ordered newest-first by ``(-created_at, -pk)``; the prior
+    claim is the entry immediately after ``claim`` in that ordering.
+    Returns ``None`` if ``claim`` is at the tail of the chain or absent
+    from it.
+    """
+    for i, c in enumerate(chain):
+        if c.pk == claim.pk and i + 1 < len(chain):
+            # Claim.value is a JSONField (django-stubs types it Any).
+            prior: object = chain[i + 1].value
+            return prior
+    return None
+
+
+def build_changes(
+    own_claims: Iterable[Claim],
+    retracted: Iterable[Claim],
+    history_by_key: Mapping[str, Sequence[Claim]],
+    *,
+    winning_ids: set[int] | None = None,
+    labels: LabelLookup | None = None,
+) -> tuple[list[FieldChangeSchema], list[RetractionSchema]]:
+    """Build per-field changes and retractions for a changeset.
+
+    No per-row DB lookups during display-label building: pass a pre-built ``labels``
+    when the caller already has one (e.g. a multi-changeset response that
+    resolved labels across the whole entity); otherwise this builds its
+    own from the union of values referenced here.
+
+    ``winning_ids`` is only meaningful for entity-wide history; omit it for
+    single-changeset detail views and ``is_winning`` will be left unset.
+    """
+    own = list(own_claims)
+    rets = list(retracted)
+
+    if labels is None:
+
+        def _label_refs() -> Iterable[FieldValue]:
+            for c in own:
+                yield FieldValue(c.field_name, c.value)
+            for c in rets:
+                yield FieldValue(c.field_name, c.value)
+            for chain in history_by_key.values():
+                for c in chain:
+                    yield FieldValue(c.field_name, c.value)
+
+        labels = resolve_labels(_label_refs())
+
+    changes = [
+        FieldChangeSchema(
+            field_name=claim.field_name,
+            claim_key=claim.claim_key,
+            old_value=(
+                old := _prior_value(claim, history_by_key.get(claim.claim_key, []))
+            ),
+            new_value=claim.value,
+            old_display=build_display_label(claim.field_name, old, labels),
+            new_display=build_display_label(claim.field_name, claim.value, labels),
+            claim_id=claim.pk,
+            claim_user_id=claim.user_id,
+            is_active=claim.is_active,
+            is_winning=(claim.pk in winning_ids) if winning_ids is not None else None,
+            is_retracted=claim.retracted_by_changeset_id is not None,
+        )
+        for claim in own
+    ]
+
+    retractions = [
+        RetractionSchema(
+            claim_id=c.pk,
+            field_name=c.field_name,
+            claim_key=c.claim_key,
+            old_value=c.value,
+            old_display=build_display_label(c.field_name, c.value, labels),
+        )
+        for c in rets
+    ]
+
+    return changes, retractions
 
 
 def _compute_winning_claim_ids(ct: ContentType, entity_pk: int) -> set[int]:
@@ -55,9 +140,10 @@ def _compute_winning_claim_ids(ct: ContentType, entity_pk: int) -> set[int]:
 def build_edit_history(entity: Model, user: PolicyUser) -> list[ChangeSetSchema]:
     """Build changeset-grouped edit history with old→new diffs for an entity.
 
-    Returns ChangeSetSchema rows newest first. Uses two queries to avoid N+1:
-    one for changesets with their claims, one for all inactive user claims
-    (to look up previous values).
+    Returns ChangeSetSchema rows newest first. Query count is bounded
+    independent of changeset count: changesets+prefetches, all claims for
+    the entity (for old-value lookup), winning-claim computation, and one
+    query per distinct FK target model build_display_label needs to resolve.
 
     ``user`` is the caller (boundary-cast via ``policy_user``) and is
     used to populate the per-row ``capabilities`` map.
@@ -111,41 +197,21 @@ def build_edit_history(entity: Model, user: PolicyUser) -> list[ChangeSetSchema]
     # 3. Compute winning claims for is_winning.
     winning_ids = _compute_winning_claim_ids(ct, entity.pk)
 
-    # 4. Build response.
+    # 4. Resolve FK labels once across every value any changeset will
+    #    render. ``all_claims`` is the superset (current claims, retracted
+    #    claims, and history chains all draw from it), so one pass suffices.
+    labels = resolve_labels(FieldValue(c.field_name, c.value) for c in all_claims)
+
+    # 5. Build response.
     result: list[ChangeSetSchema] = []
     for cs in changesets:
-        changes: list[FieldChangeSchema] = []
-        for claim in cs.claims.all():
-            chain = history.get(claim.claim_key, [])
-            old_value = None
-            for i, c in enumerate(chain):
-                if c.pk == claim.pk and i + 1 < len(chain):
-                    old_value = chain[i + 1].value
-                    break
-            changes.append(
-                FieldChangeSchema(
-                    field_name=claim.field_name,
-                    claim_key=claim.claim_key,
-                    old_value=old_value,
-                    new_value=claim.value,
-                    claim_id=claim.pk,
-                    claim_user_id=claim.user_id,
-                    is_active=claim.is_active,
-                    is_winning=claim.pk in winning_ids,
-                    is_retracted=claim.retracted_by_changeset_id is not None,
-                )
-            )
-
-        retractions: list[RetractionSchema] = [
-            RetractionSchema(
-                claim_id=c.pk,
-                field_name=c.field_name,
-                claim_key=c.claim_key,
-                old_value=c.value,
-            )
-            for c in cs.retracted_claims.all()
-        ]
-
+        changes, retractions = build_changes(
+            cs.claims.all(),
+            cs.retracted_claims.all(),
+            history,
+            winning_ids=winning_ids,
+            labels=labels,
+        )
         assert cs.pk is not None
         result.append(
             ChangeSetSchema(

--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -10,11 +10,12 @@ from django.db.models import Case, F, IntegerField, Model, Prefetch, Q, Value, W
 
 from apps.core.authz import PolicyUser, compute_row_capabilities
 
-from .display import FieldValue, LabelLookup, build_display_label, resolve_labels
+from .display import FieldValue, LabelLookup, build_display_value, resolve_labels
 from .models import ChangeSet, Claim
 from .schemas import (
     ChangeSetSchema,
     ClaimAttributionSchema,
+    ClaimValueSchema,
     FieldChangeSchema,
     RetractionSchema,
 )
@@ -70,32 +71,46 @@ def build_changes(
 
         labels = resolve_labels(_label_refs())
 
-    changes = [
-        FieldChangeSchema(
-            field_name=claim.field_name,
-            claim_key=claim.claim_key,
-            old_value=(
-                old := _prior_value(claim, history_by_key.get(claim.claim_key, []))
-            ),
-            new_value=claim.value,
-            old_display=build_display_label(claim.field_name, old, labels),
-            new_display=build_display_label(claim.field_name, claim.value, labels),
-            claim_id=claim.pk,
-            claim_user_id=claim.user_id,
-            is_active=claim.is_active,
-            is_winning=(claim.pk in winning_ids) if winning_ids is not None else None,
-            is_retracted=claim.retracted_by_changeset_id is not None,
+    changes: list[FieldChangeSchema] = []
+    for claim in own:
+        prior = _prior_value(claim, history_by_key.get(claim.claim_key, []))
+        old_value = (
+            ClaimValueSchema(
+                raw=prior,
+                display=build_display_value(claim.field_name, prior, labels),
+            )
+            if prior is not None
+            else None
         )
-        for claim in own
-    ]
+        new_value = ClaimValueSchema(
+            raw=claim.value,
+            display=build_display_value(claim.field_name, claim.value, labels),
+        )
+        changes.append(
+            FieldChangeSchema(
+                field_name=claim.field_name,
+                claim_key=claim.claim_key,
+                old_value=old_value,
+                new_value=new_value,
+                claim_id=claim.pk,
+                claim_user_id=claim.user_id,
+                is_active=claim.is_active,
+                is_winning=(
+                    (claim.pk in winning_ids) if winning_ids is not None else None
+                ),
+                is_retracted=claim.retracted_by_changeset_id is not None,
+            )
+        )
 
     retractions = [
         RetractionSchema(
             claim_id=c.pk,
             field_name=c.field_name,
             claim_key=c.claim_key,
-            old_value=c.value,
-            old_display=build_display_label(c.field_name, c.value, labels),
+            old_value=ClaimValueSchema(
+                raw=c.value,
+                display=build_display_value(c.field_name, c.value, labels),
+            ),
         )
         for c in rets
     ]

--- a/backend/apps/provenance/page_endpoints.py
+++ b/backend/apps/provenance/page_endpoints.py
@@ -31,7 +31,7 @@ from apps.core.types import EntityKey
 from .entity_resolution import batch_resolve_entities
 from .evidence import build_cited_changesets
 from .helpers import active_claims, build_sources, claims_prefetch
-from .history import build_edit_history
+from .history import build_changes, build_edit_history
 from .models.changeset import ChangeSet
 from .schemas import (
     ChangeSetBaseSchema,
@@ -383,35 +383,7 @@ def change_detail(
     for c in history_claims:
         by_key[c.claim_key].append(c)
 
-    changes: list[FieldChangeSchema] = []
-    for claim in claims:
-        old_value = None
-        chain = by_key.get(claim.claim_key, [])
-        for c in chain:
-            before_this = c.created_at < claim.created_at or (
-                c.created_at == claim.created_at and c.pk < claim.pk
-            )
-            if before_this:
-                old_value = c.value
-                break
-        changes.append(
-            FieldChangeSchema(
-                field_name=claim.field_name,
-                claim_key=claim.claim_key,
-                old_value=old_value,
-                new_value=claim.value,
-            )
-        )
-
-    retractions = [
-        RetractionSchema(
-            claim_id=c.pk,
-            field_name=c.field_name,
-            claim_key=c.claim_key,
-            old_value=c.value,
-        )
-        for c in retracted
-    ]
+    changes, retractions = build_changes(claims, retracted, by_key)
 
     ingest_run = cs.ingest_run
     assert cs.pk is not None

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -21,12 +21,22 @@ from .models.changeset import ChangeSet
 
 
 class FieldChangeSchema(Schema):
-    """A single field change within a ChangeSet (old -> new)."""
+    """A single field change within a ChangeSet (old -> new).
+
+    ``old_display`` / ``new_display`` are optional human-readable renderings
+    of relationship-claim values (e.g. ``"Pat Lawlor — Art"`` for a credit
+    claim whose raw ``new_value`` is ``{"person": 13, "role": 9, "exists":
+    true}``). Null when the backend can't produce a display label
+    (direct-field scalars, namespaces without a registered formatter) —
+    clients should fall back to rendering the raw value.
+    """
 
     field_name: str
     claim_key: str
     old_value: object | None = None
     new_value: object
+    old_display: str | None = None
+    new_display: str | None = None
     claim_id: int | None = None
     claim_user_id: int | None = None
     is_active: bool | None = None
@@ -39,6 +49,7 @@ class RetractionSchema(Schema):
     field_name: str
     claim_key: str
     old_value: object
+    old_display: str | None = None
 
 
 class ClaimAttributionSchema(Schema):

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -3,14 +3,16 @@
 Used by api.py and the page-oriented changes endpoints (page_endpoints.py).
 
 Claim payloads are stored as JSON (``Claim.value`` is a ``JSONField``), so
-``old_value`` / ``new_value`` / ``value`` fields are typed as ``object`` —
-they carry scalars, dicts, lists, or null depending on the claim kind, and
-the catalog-level schema is what actually constrains each field's shape.
+the ``raw`` field of :class:`ClaimValueSchema` (used wherever a claim
+value crosses the wire — ``old_value`` / ``new_value`` / ``value``) is
+typed as ``object``: it carries scalars, dicts, lists, or null depending
+on the claim kind, and the catalog-level schema is what actually
+constrains each field's shape.
 """
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from django.db.models import Model
 from ninja import Field, Schema
@@ -19,24 +21,102 @@ from apps.core.authz import Activity
 
 from .models.changeset import ChangeSet
 
+ClaimDisplayIdentityState = Literal["resolved", "deleted", "missing"]
+"""Discriminant for :class:`ClaimDisplayIdentityPartSchema`.
+
+See that schema for what each value implies about the surrounding fields.
+"""
+
+
+class ClaimDisplayIdentityPartSchema(Schema):
+    """One identity slot of a relationship claim's user-facing rendering.
+
+    ``key`` names the identity ``ValueKeySpec`` (e.g. ``"person"``,
+    ``"alias_value"``).
+
+    ``state`` (see :data:`ClaimDisplayIdentityState`) discriminates three cases that
+    frontends typically want to render differently:
+
+    - ``"resolved"``: the backend produced a real label; ``label`` is the
+      non-empty user-facing string.
+    - ``"deleted"``: the claim references an FK target row that no longer
+      exists in the catalog (e.g. a Person was removed after the claim
+      was made). Legitimate runtime condition; ``label`` is null.
+    - ``"missing"``: the claim dict didn't carry this identity key at
+      all — an invariant violation that validation should have prevented.
+      Backend logs loudly when this happens; ``label`` is null.
+
+    No default on ``state``: every construction must pick one. Defaulting
+    to ``"resolved"`` would let ``ClaimDisplayIdentityPartSchema(key=..., label=None)``
+    construct silently with an incoherent ``(resolved, null)`` pair.
+    """
+
+    key: str
+    label: str | None
+    state: ClaimDisplayIdentityState
+
+
+class ClaimDisplayQualifierPartSchema(Schema):
+    """One qualifier on a relationship claim's user-facing rendering.
+
+    ``key`` names a non-identity ``ValueKeySpec`` (e.g. ``"count"``,
+    ``"category"``, ``"is_primary"``); ``value`` is the raw scalar so the
+    frontend can apply per-key rendering rules (``count > 1``, ``is_primary
+    === true``, etc.).
+
+    Union ordering is **most specific first**: ``bool`` before ``int``
+    because ``bool`` is an ``int`` subclass and Pydantic v2's default union
+    resolution would otherwise coerce ``True`` into ``1``, silently breaking
+    frontend ``v === true`` checks.
+    """
+
+    key: str
+    value: bool | int | str | None = None
+
+
+class ClaimDisplayValueSchema(Schema):
+    """Structured user-facing rendering of a relationship-claim value.
+
+    ``identity`` and ``qualifiers`` are lists (not dicts) so declaration
+    order is part of the wire format, not an implicit dict-insertion-order
+    contract. Direct-field scalar claims and non-relationship namespaces
+    have no ``ClaimDisplayValueSchema`` — the frontend falls back to the raw
+    ``old_value`` / ``new_value`` in that case.
+    """
+
+    identity: list[ClaimDisplayIdentityPartSchema]
+    qualifiers: list[ClaimDisplayQualifierPartSchema]
+
+
+class ClaimValueSchema(Schema):
+    """A claim value paired with its structured user-facing rendering.
+
+    ``raw`` is the JSONField payload (scalar/dict/list/null). ``display`` is
+    the structured rendering for relationship claims (see
+    :class:`ClaimDisplayValueSchema`) or ``None`` when there's no
+    structured rendering — direct-field scalars, unknown namespaces,
+    non-dict values. Clients fall back to ``raw`` when ``display`` is null.
+    """
+
+    raw: object
+    display: ClaimDisplayValueSchema | None = None
+
 
 class FieldChangeSchema(Schema):
     """A single field change within a ChangeSet (old -> new).
 
-    ``old_display`` / ``new_display`` are optional human-readable renderings
-    of relationship-claim values (e.g. ``"Pat Lawlor — Art"`` for a credit
-    claim whose raw ``new_value`` is ``{"person": 13, "role": 9, "exists":
-    true}``). Null when the backend can't produce a display label
-    (direct-field scalars, namespaces without a registered formatter) —
-    clients should fall back to rendering the raw value.
+    ``old_value`` / ``new_value`` are :class:`ClaimValueSchema` — each
+    bundles the raw JSON payload with its structured display rendering.
+
+    ``old_value`` is null in two cases that this wire format does not
+    distinguish: (1) no prior claim exists in the chain, or (2) a prior
+    claim exists but its value is JSON null.
     """
 
     field_name: str
     claim_key: str
-    old_value: object | None = None
-    new_value: object
-    old_display: str | None = None
-    new_display: str | None = None
+    old_value: ClaimValueSchema | None = None
+    new_value: ClaimValueSchema
     claim_id: int | None = None
     claim_user_id: int | None = None
     is_active: bool | None = None
@@ -48,18 +128,14 @@ class RetractionSchema(Schema):
     claim_id: int
     field_name: str
     claim_key: str
-    old_value: object
-    old_display: str | None = None
+    old_value: ClaimValueSchema
 
 
 class ClaimAttributionSchema(Schema):
     """Who asserted a Claim and when.
 
-    User-attributed: ``user_username`` set, ``source_name`` null.
-    Ingest-attributed: ``source_name`` set, ``user_username`` null.
-
-    Reused for ChangeSet attribution — a ChangeSet inherits its attribution
-    from its (uniform-author) claims, so the shape is identical.
+    Exactly one of ``user_username`` / ``source_name`` is non-null — set
+    by user (``user_username``) or ingest (``source_name``), never both.
     """
 
     user_username: str | None = None
@@ -108,7 +184,14 @@ class ChangeSetSchema(ChangeSetBaseSchema):
 
 
 class ClaimSchema(Schema):
-    """A single per-field claim as surfaced to the Sources UI."""
+    """A single per-field claim as surfaced to the Sources UI.
+
+    ``value`` is the raw JSONField payload — kept flat (``object``, not
+    bundled into :class:`ClaimValueSchema`) until Sources UI display
+    rendering is actually implemented. Bundling now would require
+    rewriting the live Sources consumers (``EntitySources.svelte``,
+    ``entity-sources.ts``) — out of scope for this PR.
+    """
 
     attribution: ClaimAttributionSchema
     field_name: str
@@ -193,9 +276,9 @@ class ReviewClaimSchema(Schema):
     id: int
     source_name: str
     field_name: str
-    # ``value`` is the raw JSONField payload of a claim — scalar, dict, list,
-    # or null depending on the field — and stays ``object`` for the same
-    # reason the shared schemas above do.
+    # ``value`` is the raw JSONField payload — kept flat (``object``, not
+    # bundled into :class:`ClaimValueSchema`) until the review UI grows
+    # structured display rendering.
     value: object
     needs_review_notes: str
     created_at: str

--- a/backend/apps/provenance/tests/test_api_edit_history.py
+++ b/backend/apps/provenance/tests/test_api_edit_history.py
@@ -67,7 +67,7 @@ class TestEditHistoryBasic:
         assert cs["note"] == ""
         assert len(cs["changes"]) == 1
         assert cs["changes"][0]["field_name"] == "year"
-        assert cs["changes"][0]["new_value"] == 1998
+        assert cs["changes"][0]["new_value"]["raw"] == 1998
         # First edit — no old value
         assert cs["changes"][0]["old_value"] is None
 
@@ -92,12 +92,12 @@ class TestEditHistoryBasic:
         # Most recent first
         newest = data[0]
         assert newest["changes"][0]["field_name"] == "year"
-        assert newest["changes"][0]["old_value"] == 1998
-        assert newest["changes"][0]["new_value"] == 1999
+        assert newest["changes"][0]["old_value"]["raw"] == 1998
+        assert newest["changes"][0]["new_value"]["raw"] == 1999
 
         oldest = data[1]
         assert oldest["changes"][0]["old_value"] is None
-        assert oldest["changes"][0]["new_value"] == 1998
+        assert oldest["changes"][0]["new_value"]["raw"] == 1998
 
 
 @pytest.mark.django_db
@@ -144,13 +144,13 @@ class TestEditHistoryMultiUser:
 
         # User B's edit is newest — old value is User A's prior claim
         assert data[0]["attribution"]["user_username"] == user_b.username
-        assert data[0]["changes"][0]["old_value"] == 1998
-        assert data[0]["changes"][0]["new_value"] == 1999
+        assert data[0]["changes"][0]["old_value"]["raw"] == 1998
+        assert data[0]["changes"][0]["new_value"]["raw"] == 1999
 
         # User A's edit — no prior claim, so no old value
         assert data[1]["attribution"]["user_username"] == user.username
         assert data[1]["changes"][0]["old_value"] is None
-        assert data[1]["changes"][0]["new_value"] == 1998
+        assert data[1]["changes"][0]["new_value"]["raw"] == 1998
 
     def test_old_value_uses_source_claim(self, client, user, pm, source):
         """A user edit shows the prior source/ingest claim's value as old."""
@@ -166,8 +166,8 @@ class TestEditHistoryMultiUser:
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
         data = resp.json()
         assert len(data) == 1
-        assert data[0]["changes"][0]["old_value"] == 1997
-        assert data[0]["changes"][0]["new_value"] == 1999
+        assert data[0]["changes"][0]["old_value"]["raw"] == 1997
+        assert data[0]["changes"][0]["new_value"]["raw"] == 1999
 
 
 @pytest.mark.django_db
@@ -216,7 +216,7 @@ class TestEditHistorySoftDeleted:
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
-        assert data[0]["changes"][0]["new_value"] == 1998
+        assert data[0]["changes"][0]["new_value"]["raw"] == 1998
 
 
 @pytest.mark.django_db

--- a/backend/apps/provenance/tests/test_changes.py
+++ b/backend/apps/provenance/tests/test_changes.py
@@ -259,7 +259,7 @@ class TestChangesDetail:
         assert data["entity"]["name"] == "Medieval Madness"
         assert len(data["changes"]) >= 1
         year_change = next(c for c in data["changes"] if c["field_name"] == "year")
-        assert year_change["new_value"] == 1998
+        assert year_change["new_value"]["raw"] == 1998
 
     def test_cross_author_old_value(self, client, user, user_b, pm):
         """User B editing after User A shows A's value as old_value."""
@@ -282,8 +282,8 @@ class TestChangesDetail:
         year_change = next(
             c for c in resp.json()["changes"] if c["field_name"] == "year"
         )
-        assert year_change["old_value"] == 1998
-        assert year_change["new_value"] == 2001
+        assert year_change["old_value"]["raw"] == 1998
+        assert year_change["new_value"]["raw"] == 2001
 
     def test_nonexistent_changeset_returns_404(self, client):
         resp = client.get("/api/pages/changesets/99999/")
@@ -326,7 +326,7 @@ class TestChangesDetail:
         assert data["changes"] == []
         assert len(data["retractions"]) == 1
         assert data["retractions"][0]["field_name"] == "year"
-        assert data["retractions"][0]["old_value"] == 2000
+        assert data["retractions"][0]["old_value"]["raw"] == 2000
 
 
 @pytest.mark.django_db

--- a/backend/apps/provenance/tests/test_display.py
+++ b/backend/apps/provenance/tests/test_display.py
@@ -1,0 +1,207 @@
+"""Tests for the relationship-claim display labeler in apps.provenance.display."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from apps.accounts.test_factories import make_user
+from apps.catalog.models import (
+    CreditRole,
+    GameplayFeature,
+    Person,
+    Theme,
+)
+from apps.catalog.tests.conftest import make_machine_model
+from apps.provenance.display import (
+    FieldValue,
+    FkRef,
+    LabelLookup,
+    build_display_label,
+    resolve_labels,
+)
+from apps.provenance.models import Claim, Source
+
+
+@pytest.mark.django_db
+class TestBuildDisplayLabel:
+    def test_credit_renders_person_em_dash_role(self):
+        person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
+        role = CreditRole.objects.create(name="Art", slug="art")
+        value = {"person": person.pk, "role": role.pk, "exists": True}
+
+        labels = resolve_labels([FieldValue("credit", value)])
+        assert build_display_label("credit", value, labels) == "Pat Lawlor — Art"
+
+    def test_credit_with_missing_target_falls_back_to_pk_marker(self):
+        # Person row deleted between claim creation and history rendering.
+        value = {"person": 999, "role": 888, "exists": True}
+        labels = resolve_labels([FieldValue("credit", value)])
+        assert build_display_label("credit", value, labels) == "?#999 — ?#888"
+
+    def test_gameplay_feature_includes_count_when_greater_than_one(self):
+        feat = GameplayFeature.objects.create(name="Multiball", slug="multiball")
+        value = {"gameplay_feature": feat.pk, "count": 3, "exists": True}
+        labels = resolve_labels([FieldValue("gameplay_feature", value)])
+        assert build_display_label("gameplay_feature", value, labels) == "Multiball ×3"
+
+    def test_gameplay_feature_omits_count_when_one_or_missing(self):
+        feat = GameplayFeature.objects.create(name="Multiball", slug="multiball")
+        no_count = {"gameplay_feature": feat.pk, "exists": True}
+        count_one = {"gameplay_feature": feat.pk, "count": 1, "exists": True}
+        labels = resolve_labels(
+            [
+                FieldValue("gameplay_feature", no_count),
+                FieldValue("gameplay_feature", count_one),
+            ]
+        )
+        assert build_display_label("gameplay_feature", no_count, labels) == "Multiball"
+        assert build_display_label("gameplay_feature", count_one, labels) == "Multiball"
+
+    def test_theme_renders_single_fk_label(self):
+        theme = Theme.objects.create(name="Sci-Fi", slug="sci-fi")
+        value = {"theme": theme.pk, "exists": True}
+        labels = resolve_labels([FieldValue("theme", value)])
+        assert build_display_label("theme", value, labels) == "Sci-Fi"
+
+    def test_abbreviation_renders_scalar(self):
+        value = {"value": "DW", "exists": True}
+        labels = resolve_labels([FieldValue("abbreviation", value)])
+        assert build_display_label("abbreviation", value, labels) == "DW"
+
+    def test_bare_marker_renders_with_unresolved_placeholders(self):
+        # Validation rule 4 (required identity keys) shouldn't allow this
+        # shape to reach build_display_label. If it ever does — e.g. a stale row,
+        # a fixture, or a future validation relaxation — surface it visibly
+        # ("?") rather than swallow to None or crash. Filtering absent
+        # values is the caller's policy decision (see hasMeaningfulValue
+        # on the frontend).
+        labels = LabelLookup()
+        assert build_display_label("credit", {"exists": False}, labels) == "? — ?"
+        assert build_display_label("theme", {"exists": False}, labels) == "?"
+        # Literal-scalar namespaces have to follow the same contract — bare
+        # subscription on a missing key would tank the edit-history endpoint.
+        assert build_display_label("abbreviation", {"exists": False}, labels) == "?"
+        # An alias namespace (one is registered per AliasModel subclass).
+        assert build_display_label("person_alias", {"exists": False}, labels) == "?"
+
+    def test_unknown_namespace_returns_none(self):
+        # Direct-field claims (scalar new_value, not a registered namespace)
+        # fall through — frontend renders the raw scalar.
+        labels = LabelLookup()
+        assert build_display_label("year", 1998, labels) is None
+        assert (
+            build_display_label("technology_generation", "solid-state", labels) is None
+        )
+
+    def test_non_dict_value_returns_none(self):
+        labels = LabelLookup()
+        assert build_display_label("credit", None, labels) is None
+        assert build_display_label("credit", "string", labels) is None
+
+    def test_resolve_labels_ignores_direct_fields_and_bare_markers(self):
+        # Resolve over a mixed batch: a creditable dict, a theme dict, a
+        # direct-field scalar (year), and a bare retraction marker. The
+        # resulting lookup should only know about the FKs that were
+        # genuinely referenced.
+        person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
+        role = CreditRole.objects.create(name="Art", slug="art")
+        theme = Theme.objects.create(name="Sci-Fi", slug="sci-fi")
+        labels = resolve_labels(
+            [
+                FieldValue(
+                    "credit",
+                    {"person": person.pk, "role": role.pk, "exists": True},
+                ),
+                FieldValue("theme", {"theme": theme.pk, "exists": True}),
+                FieldValue("year", 1998),
+                FieldValue("credit", {"exists": False}),
+            ]
+        )
+        assert labels.get(FkRef(Person, person.pk)) == "Pat Lawlor"
+        assert labels.get(FkRef(CreditRole, role.pk)) == "Art"
+        assert labels.get(FkRef(Theme, theme.pk)) == "Sci-Fi"
+        # Pks that were never referenced return None.
+        assert labels.get(FkRef(Person, 999)) is None
+
+
+# ---------------------------------------------------------------------------
+# Query-count regression: FK label resolution must be batched. If a future
+# change inlines ``str(instance)`` into per-row formatting, query count
+# would scale with the number of distinct FK targets in history — this
+# test pins it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bootstrap_source(db):
+    return Source.objects.create(
+        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
+    )
+
+
+def _q(fn: Callable[[], object]) -> int:
+    with CaptureQueriesContext(connection) as ctx:
+        fn()
+    return len(ctx.captured_queries)
+
+
+@pytest.mark.django_db
+class TestQueryCountDoesNotScale:
+    def test_credits_resolved_in_batched_queries(self, client, bootstrap_source):
+        """Adding more credits must not add per-credit FK lookup queries.
+
+        Failure mode this guards against: build_display_label calling
+        ``str(instance)`` via a lazy FK fetch inside the per-row loop,
+        producing one query per credit on top of the batched baseline.
+        """
+        user = make_user()
+        pm = make_machine_model(name="MM", slug="mm-credits", year=1997)
+        Claim.objects.assert_claim(pm, "name", "MM", source=bootstrap_source)
+        CreditRole.objects.create(name="Design", slug="design")
+
+        counter = 0
+
+        def add_credits(n: int) -> None:
+            # New Person each iteration → maximises distinct FK pks
+            # build_display_label must resolve across the two measured fetches.
+            nonlocal counter
+            client.force_login(user)
+            for _ in range(n):
+                counter += 1
+                Person.objects.create(
+                    name=f"Person {counter}", slug=f"person-{counter}"
+                )
+                resp = client.patch(
+                    f"/api/models/{pm.slug}/claims/",
+                    data=json.dumps(
+                        {
+                            "credits": [
+                                {"person_slug": f"person-{counter}", "role": "design"}
+                            ]
+                        }
+                    ),
+                    content_type="application/json",
+                )
+                assert resp.status_code == 200, (
+                    f"seed PATCH failed with {resp.status_code}: {resp.content!r}"
+                )
+
+        add_credits(2)
+        client.logout()
+        url = f"/api/pages/edit-history/model/{pm.slug}/"
+        base = _q(lambda: client.get(url))
+
+        add_credits(18)
+        client.logout()
+        scaled = _q(lambda: client.get(url))
+
+        assert scaled == base, (
+            f"edit-history query count scales with credit count: {base} -> {scaled}. "
+            f"build_display_label is likely resolving FK labels per-row "
+            f"instead of via the batched resolve_labels() pass."
+        )

--- a/backend/apps/provenance/tests/test_display.py
+++ b/backend/apps/provenance/tests/test_display.py
@@ -1,4 +1,4 @@
-"""Tests for the relationship-claim display labeler in apps.provenance.display."""
+"""Tests for the relationship-claim display engine in apps.provenance.display."""
 
 from __future__ import annotations
 
@@ -21,90 +21,309 @@ from apps.provenance.display import (
     FieldValue,
     FkRef,
     LabelLookup,
-    build_display_label,
+    build_display_value,
     resolve_labels,
 )
 from apps.provenance.models import Claim, Source
+from apps.provenance.schemas import (
+    ClaimDisplayIdentityPartSchema,
+    ClaimDisplayQualifierPartSchema,
+    ClaimDisplayValueSchema,
+)
+
+
+def _identity(parts: list[tuple[str, str]]) -> list[ClaimDisplayIdentityPartSchema]:
+    # Helper for resolved-state identity parts. Failure-case tests construct
+    # ClaimDisplayIdentityPartSchema directly with state="deleted" / "missing".
+    return [
+        ClaimDisplayIdentityPartSchema(key=k, label=v, state="resolved")
+        for k, v in parts
+    ]
+
+
+def _qualifiers(
+    parts: list[tuple[str, bool | int | str | None]],
+) -> list[ClaimDisplayQualifierPartSchema]:
+    return [ClaimDisplayQualifierPartSchema(key=k, value=v) for k, v in parts]
 
 
 @pytest.mark.django_db
-class TestBuildDisplayLabel:
-    def test_credit_renders_person_em_dash_role(self):
+class TestBuildDisplayValue:
+    def test_credit_emits_two_identity_parts_in_declaration_order(self):
         person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
         role = CreditRole.objects.create(name="Art", slug="art")
         value = {"person": person.pk, "role": role.pk, "exists": True}
 
         labels = resolve_labels([FieldValue("credit", value)])
-        assert build_display_label("credit", value, labels) == "Pat Lawlor — Art"
+        assert build_display_value("credit", value, labels) == ClaimDisplayValueSchema(
+            identity=_identity([("person", "Pat Lawlor"), ("role", "Art")]),
+            qualifiers=[],
+        )
 
-    def test_credit_with_missing_target_falls_back_to_pk_marker(self):
-        # Person row deleted between claim creation and history rendering.
+    def test_credit_with_deleted_targets_emits_deleted_state(self):
+        # FK rows deleted between claim creation and history rendering —
+        # a legitimate runtime condition. ``state="deleted"`` lets the
+        # frontend render this case however it wants; ``label`` is null
+        # because the backend doesn't choose presentation.
         value = {"person": 999, "role": 888, "exists": True}
         labels = resolve_labels([FieldValue("credit", value)])
-        assert build_display_label("credit", value, labels) == "?#999 — ?#888"
+        assert build_display_value("credit", value, labels) == ClaimDisplayValueSchema(
+            identity=[
+                ClaimDisplayIdentityPartSchema(
+                    key="person", label=None, state="deleted"
+                ),
+                ClaimDisplayIdentityPartSchema(key="role", label=None, state="deleted"),
+            ],
+            qualifiers=[],
+        )
 
-    def test_gameplay_feature_includes_count_when_greater_than_one(self):
+    def test_corrupt_pk_type_degrades_to_missing_without_crashing(self):
+        # Validation rule 5 rejects wrong-type FK values at write time, so
+        # this shape shouldn't exist. If a stale row / bypassed ingest
+        # source slips one through, the display engine must not 500 the
+        # whole page — log, emit state="missing", carry on.
+        value = {"person": "not-an-int", "role": 7, "exists": True}
+        labels = resolve_labels([FieldValue("credit", value)])
+        result = build_display_value("credit", value, labels)
+        assert result is not None
+        person_part = next(p for p in result.identity if p.key == "person")
+        assert person_part.state == "missing"
+        assert person_part.label is None
+
+    def test_gameplay_feature_emits_count_qualifier_when_present(self):
         feat = GameplayFeature.objects.create(name="Multiball", slug="multiball")
         value = {"gameplay_feature": feat.pk, "count": 3, "exists": True}
         labels = resolve_labels([FieldValue("gameplay_feature", value)])
-        assert build_display_label("gameplay_feature", value, labels) == "Multiball ×3"
-
-    def test_gameplay_feature_omits_count_when_one_or_missing(self):
-        feat = GameplayFeature.objects.create(name="Multiball", slug="multiball")
-        no_count = {"gameplay_feature": feat.pk, "exists": True}
-        count_one = {"gameplay_feature": feat.pk, "count": 1, "exists": True}
-        labels = resolve_labels(
-            [
-                FieldValue("gameplay_feature", no_count),
-                FieldValue("gameplay_feature", count_one),
-            ]
+        # Backend always emits the qualifier when the key is present in the
+        # claim dict — including count==1. The frontend's per-qualifier rule
+        # decides whether to render ``×N`` (only when N > 1). Wire format
+        # stays data-faithful.
+        assert build_display_value(
+            "gameplay_feature", value, labels
+        ) == ClaimDisplayValueSchema(
+            identity=_identity([("gameplay_feature", "Multiball")]),
+            qualifiers=_qualifiers([("count", 3)]),
         )
-        assert build_display_label("gameplay_feature", no_count, labels) == "Multiball"
-        assert build_display_label("gameplay_feature", count_one, labels) == "Multiball"
 
-    def test_theme_renders_single_fk_label(self):
+    def test_gameplay_feature_count_one_still_emits_qualifier(self):
+        # Demonstrates the backend's "data-faithful" rule: the qualifier is
+        # always emitted when present, with the raw value. The decision to
+        # hide ``count == 1`` belongs on the frontend.
+        feat = GameplayFeature.objects.create(name="Multiball", slug="multiball")
+        value = {"gameplay_feature": feat.pk, "count": 1, "exists": True}
+        labels = resolve_labels([FieldValue("gameplay_feature", value)])
+        assert build_display_value(
+            "gameplay_feature", value, labels
+        ) == ClaimDisplayValueSchema(
+            identity=_identity([("gameplay_feature", "Multiball")]),
+            qualifiers=_qualifiers([("count", 1)]),
+        )
+
+    def test_gameplay_feature_omits_count_qualifier_when_missing(self):
+        feat = GameplayFeature.objects.create(name="Multiball", slug="multiball")
+        value = {"gameplay_feature": feat.pk, "exists": True}
+        labels = resolve_labels([FieldValue("gameplay_feature", value)])
+        # Absent key → no qualifier emitted. Distinct from count==0.
+        assert build_display_value(
+            "gameplay_feature", value, labels
+        ) == ClaimDisplayValueSchema(
+            identity=_identity([("gameplay_feature", "Multiball")]),
+            qualifiers=[],
+        )
+
+    def test_theme_emits_single_identity_part(self):
         theme = Theme.objects.create(name="Sci-Fi", slug="sci-fi")
         value = {"theme": theme.pk, "exists": True}
         labels = resolve_labels([FieldValue("theme", value)])
-        assert build_display_label("theme", value, labels) == "Sci-Fi"
+        assert build_display_value("theme", value, labels) == ClaimDisplayValueSchema(
+            identity=_identity([("theme", "Sci-Fi")]),
+            qualifiers=[],
+        )
 
-    def test_abbreviation_renders_scalar(self):
+    def test_abbreviation_emits_scalar_identity(self):
         value = {"value": "DW", "exists": True}
         labels = resolve_labels([FieldValue("abbreviation", value)])
-        assert build_display_label("abbreviation", value, labels) == "DW"
+        assert build_display_value(
+            "abbreviation", value, labels
+        ) == ClaimDisplayValueSchema(
+            identity=_identity([("value", "DW")]),
+            qualifiers=[],
+        )
 
-    def test_bare_marker_renders_with_unresolved_placeholders(self):
+    def test_bare_marker_emits_missing_state(self):
         # Validation rule 4 (required identity keys) shouldn't allow this
-        # shape to reach build_display_label. If it ever does — e.g. a stale row,
-        # a fixture, or a future validation relaxation — surface it visibly
-        # ("?") rather than swallow to None or crash. Filtering absent
-        # values is the caller's policy decision (see hasMeaningfulValue
-        # on the frontend).
+        # shape to reach build_display_value. If it ever does — e.g. a
+        # stale row, a fixture, or an ingest source that skipped validation
+        # — surface ``state="missing"`` so the frontend can render a
+        # placeholder, and log loudly so the integrity issue is observable.
         labels = LabelLookup()
-        assert build_display_label("credit", {"exists": False}, labels) == "? — ?"
-        assert build_display_label("theme", {"exists": False}, labels) == "?"
-        # Literal-scalar namespaces have to follow the same contract — bare
-        # subscription on a missing key would tank the edit-history endpoint.
-        assert build_display_label("abbreviation", {"exists": False}, labels) == "?"
-        # An alias namespace (one is registered per AliasModel subclass).
-        assert build_display_label("person_alias", {"exists": False}, labels) == "?"
+        assert build_display_value("credit", {"exists": False}, labels) == (
+            ClaimDisplayValueSchema(
+                identity=[
+                    ClaimDisplayIdentityPartSchema(
+                        key="person", label=None, state="missing"
+                    ),
+                    ClaimDisplayIdentityPartSchema(
+                        key="role", label=None, state="missing"
+                    ),
+                ],
+                qualifiers=[],
+            )
+        )
+        assert build_display_value("theme", {"exists": False}, labels) == (
+            ClaimDisplayValueSchema(
+                identity=[
+                    ClaimDisplayIdentityPartSchema(
+                        key="theme", label=None, state="missing"
+                    )
+                ],
+                qualifiers=[],
+            )
+        )
+        assert build_display_value("abbreviation", {"exists": False}, labels) == (
+            ClaimDisplayValueSchema(
+                identity=[
+                    ClaimDisplayIdentityPartSchema(
+                        key="value", label=None, state="missing"
+                    )
+                ],
+                qualifiers=[],
+            )
+        )
+        assert build_display_value("person_alias", {"exists": False}, labels) == (
+            ClaimDisplayValueSchema(
+                identity=[
+                    ClaimDisplayIdentityPartSchema(
+                        key="alias_value", label=None, state="missing"
+                    )
+                ],
+                qualifiers=[],
+            )
+        )
+
+    def test_alias_uses_display_key_override_when_present(self):
+        # Load-bearing assertion: the backend chose the override (alias_display)
+        # for the identity slot's ``label``, but kept the identity key name
+        # ``alias_value`` so the wire format is self-describing.
+        labels = LabelLookup()
+        value = {
+            "alias_value": "the patster",
+            "alias_display": "The Patster",
+            "exists": True,
+        }
+        assert build_display_value(
+            "person_alias", value, labels
+        ) == ClaimDisplayValueSchema(
+            identity=_identity([("alias_value", "The Patster")]),
+            qualifiers=[],
+        )
+
+    def test_alias_falls_back_to_canonical_when_display_missing(self):
+        labels = LabelLookup()
+        value = {"alias_value": "the patster", "exists": True}
+        assert build_display_value(
+            "person_alias", value, labels
+        ) == ClaimDisplayValueSchema(
+            identity=_identity([("alias_value", "the patster")]),
+            qualifiers=[],
+        )
+
+    def test_alias_falls_back_to_canonical_when_display_empty(self):
+        # Empty string override → fall through to canonical identity.
+        # Mirrors the historical ``val.get("alias_display") or alias_val``.
+        labels = LabelLookup()
+        value = {"alias_value": "the patster", "alias_display": "", "exists": True}
+        assert build_display_value(
+            "person_alias", value, labels
+        ) == ClaimDisplayValueSchema(
+            identity=_identity([("alias_value", "the patster")]),
+            qualifiers=[],
+        )
+
+    def test_alias_display_key_target_is_not_also_emitted_as_qualifier(self):
+        # The ``alias_display`` spec is named by ``alias_value.display_key``;
+        # it MUST NOT also appear in the qualifiers list. Otherwise the
+        # frontend would render the value twice.
+        labels = LabelLookup()
+        value = {
+            "alias_value": "the patster",
+            "alias_display": "The Patster",
+            "exists": True,
+        }
+        result = build_display_value("person_alias", value, labels)
+        assert result is not None
+        assert all(q.key != "alias_display" for q in result.qualifiers)
+
+    def test_media_attachment_emits_identity_and_qualifiers(self):
+        # Exercises the multi-qualifier case: FK identity + str qualifier
+        # (category) + bool qualifier (is_primary, with bool/int distinction).
+        # No need to materialize a real MediaAsset — the missing-target
+        # ``<deleted>`` fallback is sufficient to exercise the engine.
+        labels = LabelLookup()
+        value = {
+            "media_asset": 42,
+            "category": "flyer",
+            "is_primary": True,
+            "exists": True,
+        }
+        result = build_display_value("media_attachment", value, labels)
+        assert result is not None
+        # pk=42 is synthetic / unresolved → state="deleted".
+        assert result.identity == [
+            ClaimDisplayIdentityPartSchema(
+                key="media_asset", label=None, state="deleted"
+            )
+        ]
+        # Declaration order: category before is_primary.
+        assert result.qualifiers == _qualifiers(
+            [("category", "flyer"), ("is_primary", True)]
+        )
+
+    def test_media_attachment_emits_falsy_qualifiers_when_present(self):
+        # Backend is data-faithful: ``is_primary: false`` and an empty
+        # category are emitted with their raw values. The frontend decides
+        # whether to hide them.
+        labels = LabelLookup()
+        value = {
+            "media_asset": 42,
+            "category": "",
+            "is_primary": False,
+            "exists": True,
+        }
+        result = build_display_value("media_attachment", value, labels)
+        assert result is not None
+        assert result.qualifiers == _qualifiers(
+            [("category", ""), ("is_primary", False)]
+        )
+
+    def test_preserves_bool_through_pydantic_union(self):
+        # Guards against Pydantic v2 coercing True → 1 because bool is an int
+        # subclass. ClaimDisplayQualifierPartSchema.value declares bool before int
+        # so this round-trip should preserve the type.
+        labels = LabelLookup()
+        value = {"media_asset": 42, "is_primary": True, "exists": True}
+        result = build_display_value("media_attachment", value, labels)
+        assert result is not None
+        primary = next(q for q in result.qualifiers if q.key == "is_primary")
+        assert primary.value is True
+        assert type(primary.value) is bool
 
     def test_unknown_namespace_returns_none(self):
         # Direct-field claims (scalar new_value, not a registered namespace)
         # fall through — frontend renders the raw scalar.
         labels = LabelLookup()
-        assert build_display_label("year", 1998, labels) is None
+        assert build_display_value("year", 1998, labels) is None
         assert (
-            build_display_label("technology_generation", "solid-state", labels) is None
+            build_display_value("technology_generation", "solid-state", labels) is None
         )
 
     def test_non_dict_value_returns_none(self):
         labels = LabelLookup()
-        assert build_display_label("credit", None, labels) is None
-        assert build_display_label("credit", "string", labels) is None
+        assert build_display_value("credit", None, labels) is None
+        assert build_display_value("credit", "string", labels) is None
 
     def test_resolve_labels_ignores_direct_fields_and_bare_markers(self):
-        # Resolve over a mixed batch: a creditable dict, a theme dict, a
+        # Resolve over a mixed batch: a credit dict, a theme dict, a
         # direct-field scalar (year), and a bare retraction marker. The
         # resulting lookup should only know about the FKs that were
         # genuinely referenced.
@@ -155,7 +374,7 @@ class TestQueryCountDoesNotScale:
     def test_credits_resolved_in_batched_queries(self, client, bootstrap_source):
         """Adding more credits must not add per-credit FK lookup queries.
 
-        Failure mode this guards against: build_display_label calling
+        Failure mode this guards against: build_display_value calling
         ``str(instance)`` via a lazy FK fetch inside the per-row loop,
         producing one query per credit on top of the batched baseline.
         """
@@ -168,7 +387,7 @@ class TestQueryCountDoesNotScale:
 
         def add_credits(n: int) -> None:
             # New Person each iteration → maximises distinct FK pks
-            # build_display_label must resolve across the two measured fetches.
+            # build_display_value must resolve across the two measured fetches.
             nonlocal counter
             client.force_login(user)
             for _ in range(n):
@@ -202,6 +421,6 @@ class TestQueryCountDoesNotScale:
 
         assert scaled == base, (
             f"edit-history query count scales with credit count: {base} -> {scaled}. "
-            f"build_display_label is likely resolving FK labels per-row "
+            f"build_display_value is likely resolving FK labels per-row "
             f"instead of via the batched resolve_labels() pass."
         )

--- a/backend/apps/provenance/tests/test_revert.py
+++ b/backend/apps/provenance/tests/test_revert.py
@@ -397,7 +397,7 @@ class TestRevertInHistory:
         assert revert_cs["note"] == "Reverting year"
         assert len(revert_cs["retractions"]) == 1
         assert revert_cs["retractions"][0]["field_name"] == "year"
-        assert revert_cs["retractions"][0]["old_value"] == 2005
+        assert revert_cs["retractions"][0]["old_value"]["raw"] == 2005
 
 
 # ── Claim metadata in edit history ───────────────────────────────
@@ -433,7 +433,7 @@ class TestEditHistoryClaimMetadata:
         original = next(
             cs
             for cs in data
-            if cs["changes"] and cs["changes"][0].get("new_value") == 2005
+            if cs["changes"] and cs["changes"][0]["new_value"]["raw"] == 2005
         )
         change = original["changes"][0]
         assert change["is_active"] is False

--- a/backend/apps/provenance/tests/test_validation.py
+++ b/backend/apps/provenance/tests/test_validation.py
@@ -1078,3 +1078,239 @@ class TestRegisterRelationshipSchemaGuards:
         # pre-existing entry (there shouldn't be one) to stay robust if a
         # future catalog namespace happens to be called "name".
         assert _relationship_schemas.get("name") == existing
+
+    def test_display_key_on_non_identity_rejected(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        from apps.provenance.validation import (
+            ValueKeySpec,
+            _relationship_schemas,
+            register_relationship_schema,
+        )
+
+        with pytest.raises(
+            ImproperlyConfigured, match="display_key is only allowed on identity specs"
+        ):
+            register_relationship_schema(
+                namespace="_test_display_key_non_identity",
+                value_keys=(
+                    ValueKeySpec(
+                        name="x",
+                        scalar_type=str,
+                        required=False,
+                        display_key="y",
+                    ),
+                    ValueKeySpec(name="y", scalar_type=str, required=False),
+                ),
+                valid_subjects={Theme},
+            )
+        assert "_test_display_key_non_identity" not in _relationship_schemas
+
+    def test_display_key_dangling_target_rejected(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        from apps.provenance.validation import (
+            ValueKeySpec,
+            _relationship_schemas,
+            register_relationship_schema,
+        )
+
+        with pytest.raises(ImproperlyConfigured, match="does not name a sibling spec"):
+            register_relationship_schema(
+                namespace="_test_display_key_dangling",
+                value_keys=(
+                    ValueKeySpec(
+                        name="x",
+                        scalar_type=str,
+                        required=True,
+                        identity="x",
+                        display_key="nope",
+                    ),
+                ),
+                valid_subjects={Theme},
+            )
+        assert "_test_display_key_dangling" not in _relationship_schemas
+
+    def test_display_key_target_is_identity_rejected(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        from apps.provenance.validation import (
+            ValueKeySpec,
+            _relationship_schemas,
+            register_relationship_schema,
+        )
+
+        with pytest.raises(ImproperlyConfigured, match="must be non-identity"):
+            register_relationship_schema(
+                namespace="_test_display_key_target_identity",
+                value_keys=(
+                    ValueKeySpec(
+                        name="a",
+                        scalar_type=str,
+                        required=True,
+                        identity="a",
+                        display_key="b",
+                    ),
+                    ValueKeySpec(
+                        name="b",
+                        scalar_type=str,
+                        required=True,
+                        identity="b",
+                    ),
+                ),
+                valid_subjects={Theme},
+            )
+        assert "_test_display_key_target_identity" not in _relationship_schemas
+
+    def test_display_key_scalar_type_mismatch_rejected(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        from apps.provenance.validation import (
+            ValueKeySpec,
+            _relationship_schemas,
+            register_relationship_schema,
+        )
+
+        with pytest.raises(ImproperlyConfigured, match="scalar_type"):
+            register_relationship_schema(
+                namespace="_test_display_key_type_mismatch",
+                value_keys=(
+                    ValueKeySpec(
+                        name="x",
+                        scalar_type=str,
+                        required=True,
+                        identity="x",
+                        display_key="y",
+                    ),
+                    ValueKeySpec(name="y", scalar_type=int, required=False),
+                ),
+                valid_subjects={Theme},
+            )
+        assert "_test_display_key_type_mismatch" not in _relationship_schemas
+
+    def test_display_key_target_with_fk_target_rejected(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        from apps.provenance.validation import (
+            FkTarget,
+            ValueKeySpec,
+            _relationship_schemas,
+            register_relationship_schema,
+        )
+
+        with pytest.raises(ImproperlyConfigured, match="must not declare fk_target"):
+            register_relationship_schema(
+                namespace="_test_display_key_target_fk",
+                value_keys=(
+                    ValueKeySpec(
+                        name="x",
+                        scalar_type=str,
+                        required=True,
+                        identity="x",
+                        display_key="y",
+                    ),
+                    ValueKeySpec(
+                        name="y",
+                        scalar_type=str,
+                        required=False,
+                        fk_target=FkTarget(Person, "slug"),
+                    ),
+                ),
+                valid_subjects={Theme},
+            )
+        assert "_test_display_key_target_fk" not in _relationship_schemas
+
+    def test_two_identity_specs_naming_same_display_key_rejected(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        from apps.provenance.validation import (
+            ValueKeySpec,
+            _relationship_schemas,
+            register_relationship_schema,
+        )
+
+        with pytest.raises(ImproperlyConfigured, match="both declare display_key"):
+            register_relationship_schema(
+                namespace="_test_display_key_collision",
+                value_keys=(
+                    ValueKeySpec(
+                        name="a",
+                        scalar_type=str,
+                        required=True,
+                        identity="a",
+                        display_key="shared",
+                    ),
+                    ValueKeySpec(
+                        name="b",
+                        scalar_type=str,
+                        required=True,
+                        identity="b",
+                        display_key="shared",
+                    ),
+                    ValueKeySpec(name="shared", scalar_type=str, required=False),
+                ),
+                valid_subjects={Theme},
+            )
+        assert "_test_display_key_collision" not in _relationship_schemas
+
+
+class TestGetDisplayOverride:
+    """get_display_override truthy semantics match the resolver's historical
+    ``val.get("alias_display") or alias_val`` expression."""
+
+    def test_returns_override_when_truthy(self):
+        from apps.provenance.validation import (
+            get_display_override,
+            get_relationship_schema,
+        )
+
+        schema = get_relationship_schema("person_alias")
+        assert schema is not None
+        override = get_display_override(
+            {"alias_value": "the patster", "alias_display": "The Patster"},
+            schema,
+            "alias_value",
+        )
+        assert override == "The Patster"
+
+    def test_returns_none_when_override_absent(self):
+        from apps.provenance.validation import (
+            get_display_override,
+            get_relationship_schema,
+        )
+
+        schema = get_relationship_schema("person_alias")
+        assert schema is not None
+        override = get_display_override(
+            {"alias_value": "the patster"}, schema, "alias_value"
+        )
+        assert override is None
+
+    def test_returns_none_when_override_empty(self):
+        # Empty strings fall through to canonical identity — preserves the
+        # historical ``or`` semantics in the resolver.
+        from apps.provenance.validation import (
+            get_display_override,
+            get_relationship_schema,
+        )
+
+        schema = get_relationship_schema("person_alias")
+        assert schema is not None
+        override = get_display_override(
+            {"alias_value": "the patster", "alias_display": ""},
+            schema,
+            "alias_value",
+        )
+        assert override is None
+
+    def test_returns_none_when_no_display_key_declared(self):
+        # ``theme`` identity has no display_key — override is always None.
+        from apps.provenance.validation import (
+            get_display_override,
+            get_relationship_schema,
+        )
+
+        schema = get_relationship_schema("theme")
+        assert schema is not None
+        override = get_display_override({"theme": 7}, schema, "theme")
+        assert override is None

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -59,6 +59,12 @@ class ValueKeySpec:
 
     **INVARIANT**: ``identity is not None`` ⇒ ``required=True``. Enforced at
     registration time in ``register_relationship_schema``.
+
+    ``display_key`` (identity specs only) names a sibling spec whose value is
+    this identity's user-facing rendering — e.g. ``alias_value`` declares
+    ``display_key="alias_display"`` so resolvers and display engines both
+    read the override from one declaration. See
+    ``register_relationship_schema`` for the full set of invariants.
     """
 
     name: str
@@ -67,6 +73,7 @@ class ValueKeySpec:
     nullable: bool = False
     identity: str | None = None
     fk_target: FkTarget | None = None
+    display_key: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,6 +175,51 @@ def register_relationship_schema(
                 f"(identity={spec.identity!r}, required=False)"
             )
 
+    # display_key invariants. Naming a sibling spec lets one declaration drive
+    # both the resolver (which stores the override into AliasModel.value) and
+    # the display engine (which renders identity slots in edit history). The
+    # checks below catch malformed declarations at app-ready time.
+    specs_by_name = {spec.name: spec for spec in value_keys}
+    seen_display_keys: dict[str, str] = {}  # display_key → identity spec name
+    for spec in value_keys:
+        if spec.display_key is None:
+            continue
+        if spec.identity is None:
+            raise ImproperlyConfigured(
+                f"namespace {namespace!r}, value_key {spec.name!r}: "
+                f"display_key is only allowed on identity specs"
+            )
+        target = specs_by_name.get(spec.display_key)
+        if target is None:
+            raise ImproperlyConfigured(
+                f"namespace {namespace!r}, value_key {spec.name!r}: "
+                f"display_key {spec.display_key!r} does not name a sibling spec"
+            )
+        if target.identity is not None:
+            raise ImproperlyConfigured(
+                f"namespace {namespace!r}, value_key {spec.name!r}: "
+                f"display_key target {spec.display_key!r} must be non-identity"
+            )
+        if target.scalar_type is not spec.scalar_type:
+            raise ImproperlyConfigured(
+                f"namespace {namespace!r}, value_key {spec.name!r}: "
+                f"display_key target {spec.display_key!r} scalar_type "
+                f"{target.scalar_type.__name__} must match identity scalar_type "
+                f"{spec.scalar_type.__name__}"
+            )
+        if target.fk_target is not None:
+            raise ImproperlyConfigured(
+                f"namespace {namespace!r}, value_key {spec.name!r}: "
+                f"display_key target {spec.display_key!r} must not declare fk_target"
+            )
+        prior = seen_display_keys.get(spec.display_key)
+        if prior is not None:
+            raise ImproperlyConfigured(
+                f"namespace {namespace!r}: identity specs {prior!r} and "
+                f"{spec.name!r} both declare display_key={spec.display_key!r}"
+            )
+        seen_display_keys[spec.display_key] = spec.name
+
     # Lock down the input here so the schema's invariant (immutability) is
     # an internal guarantee, not something callers must satisfy.
     frozen_subjects = frozenset(valid_subjects)
@@ -216,6 +268,37 @@ def get_relationship_namespaces() -> frozenset[str]:
     if _namespaces_cache is None:
         _namespaces_cache = frozenset(_relationship_schemas)
     return _namespaces_cache
+
+
+def get_display_override(
+    value: Mapping[str, object],
+    schema: RelationshipSchema,
+    identity_spec_name: str,
+) -> object | None:
+    """Return the user-facing rendering override for one identity slot, or None.
+
+    Reads ``display_key`` from the identity spec named ``identity_spec_name``;
+    if set and the named sibling key has a truthy value in ``value``, returns
+    that value. Otherwise returns ``None`` so callers fall back to the
+    canonical identity value.
+
+    Truthy semantics match the historical resolver expression
+    ``val.get("alias_display") or alias_val`` so empty strings fall through
+    to the canonical identity rather than being treated as an override.
+
+    Shared by the catalog alias resolver (which stores the override into
+    ``AliasModel.value``) and the provenance display engine (which renders
+    the identity slot in edit history).
+    """
+    spec = next(
+        s
+        for s in schema.value_keys
+        if s.name == identity_spec_name and s.identity is not None
+    )
+    if spec.display_key is None:
+        return None
+    candidate = value.get(spec.display_key)
+    return candidate if candidate else None
 
 
 def is_valid_subject(

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -265,9 +265,9 @@ Code MUST be as strongly typed as possible.
 The following smells are _sometimes_ legitimate, but are usually a sign the type can be tightened:
 
 - Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING`, `# type: ignore`, `# noqa`
-- `tuple[...]` with 3+ positional fields, or the same tuple shape repeated across modules
+- Compound types in signatures whose meaning isn't obvious from the types alone — `tuple[...]`, nested dicts (`dict[X, dict[Y, Z]]`), `Callable[[A, B, C], R]`. **Heuristic**: if a reader would need a comment to know what each position/key means, name it. Applies to 2-tuples that cross a module boundary or appear in a public signature; locally unpacked pairs (`found, value = _lookup(key)`) are fine as plain tuples.
 
-Prefer NamedTuple, dataclass, or TypedDict. For the full catalogue and legitimate exceptions, see [docs/Python.md](Python.md).
+Prefer NamedTuple, dataclass, or TypedDict. For worked examples (including the no-op decorator pattern that pins `Callable` implementations to a typed contract) and the full catalogue of exceptions, see [docs/Python.md](Python.md).
 
 ## Data Modeling
 

--- a/docs/Python.md
+++ b/docs/Python.md
@@ -7,7 +7,7 @@ Code MUST be as strongly typed as possible.
 The following smells are _sometimes_ legitimate, but are usually a sign the type can be tightened:
 
 - Use of `Any`, `object`, `cast`, `isinstance`, `setattr`, `getattr`, `TYPE_CHECKING`, `# type: ignore`, `# noqa`
-- `tuple[...]` with 3+ positional fields, or the same tuple shape repeated across modules
+- Compound types in signatures whose meaning isn't obvious from the types alone — `tuple[...]`, nested dicts (`dict[X, dict[Y, Z]]`), `Callable[[A, B, C], R]`. **Heuristic**: if a reader would need a comment to know what each position/key means, name it (`NamedTuple` / `TypedDict` / `dataclass` / type alias). Applies to 2-tuples that cross a module boundary or appear in a public signature; locally unpacked pairs (`found, value = _lookup(key)`) are fine as plain tuples.
 
 ### Valid exceptions to strong types
 
@@ -31,6 +31,48 @@ Every exception needs a short reason at the use site.
 - Do not use `dict[str, Any]` for JSON-shaped data:
   - Use `apps.core.types.JsonData` for read-side JSON mappings
   - Use `apps.core.types.JsonBody` for mutable/test-client JSON bodies
+
+#### Worked examples
+
+```python
+# Bad — reader has to remember what the positions mean.
+def resolve_labels(items: Iterable[tuple[str, object]]) -> ...
+
+# Good — the record has a name and the fields are self-describing.
+class FieldValue(NamedTuple):
+    field_name: str
+    value: object
+
+def resolve_labels(items: Iterable[FieldValue]) -> ...
+```
+
+```python
+# Bad — three concepts (target model, pk, label) smushed into a nested dict.
+labels: dict[tuple[type[Model], int], str]
+
+# Good — the (model, pk) pair is named; the dict is just "labels keyed by FK refs."
+class FkRef(NamedTuple):
+    model: type[Model]
+    pk: int
+
+labels: dict[FkRef, str]
+```
+
+```python
+# Bad — Callable signature with non-obvious parameters; signature drift
+# is only caught wherever the formatter happens to be assigned.
+ValueFormatter = Callable[[dict[str, object], RelationshipSchema, LabelLookup], str | None]
+
+def _format_credit(value, schema, labels) -> str: ...
+
+# Good — a no-op decorator pins each implementation to the contract,
+# so signature drift is flagged on the function itself.
+def value_formatter(fn: ValueFormatter) -> ValueFormatter:
+    return fn
+
+@value_formatter
+def _format_credit(value, schema, labels) -> str: ...
+```
 
 ### Django typing idioms
 

--- a/frontend/src/lib/components/ClaimDisplay.svelte
+++ b/frontend/src/lib/components/ClaimDisplay.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  /**
+   * Render a relationship claim's structured display. The segment-building
+   * rules live in `claim-display.ts` (pure, unit-tested); this component
+   * is only responsible for turning segments into DOM.
+   */
+  import type { ClaimDisplayValueSchema } from '$lib/api/schema';
+  import { buildDisplaySegments } from './claim-display';
+
+  let { display }: { display: ClaimDisplayValueSchema } = $props();
+
+  let segments = $derived(buildDisplaySegments(display));
+</script>
+
+<!--
+  One-line each body: any whitespace between adjacent iterations (newlines,
+  indentation) survives as DOM text nodes and corrupts the rendering. Keep
+  everything between `{#each}` and `{/each}` flush.
+-->
+{#each segments as seg, i (i)}{#if seg.missing}<span class="missing-ref">{seg.text}</span
+    >{:else}{seg.text}{/if}{/each}
+
+<style>
+  .missing-ref {
+    font-style: italic;
+    color: var(--color-text-muted);
+  }
+</style>

--- a/frontend/src/lib/components/ClaimValue.dom.test.ts
+++ b/frontend/src/lib/components/ClaimValue.dom.test.ts
@@ -1,0 +1,81 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+import ClaimValueFixture from './ClaimValue.fixture.svelte';
+
+describe('ClaimValue', () => {
+  describe('with backend-supplied display', () => {
+    it('renders the display string for a positive relationship claim', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: { person: 13, role: 9, exists: true },
+        display: 'Pat Lawlor — Art',
+      });
+      expect(container.textContent).toBe('Pat Lawlor — Art');
+      expect(container.querySelector('s')).toBeNull();
+    });
+
+    it('strikes through the display when the underlying claim asserts exists:false', () => {
+      // Negative claim with payload: "I assert that Pat Lawlor is NOT the
+      // artist." display is still the human label; the <s> distinguishes
+      // it from a positive assertion of the same label.
+      const { container } = render(ClaimValueFixture, {
+        value: { person: 13, role: 9, exists: false },
+        display: 'Pat Lawlor — Art',
+      });
+      const struck = container.querySelector('s');
+      expect(struck).not.toBeNull();
+      expect(struck!.textContent).toBe('Pat Lawlor — Art');
+    });
+
+    it('prefers display over the simplify fallback', () => {
+      // value would simplify to "DW" on its own, but display takes priority.
+      const { container } = render(ClaimValueFixture, {
+        value: { value: 'DW', exists: true },
+        display: 'Doctor Who (abbrev.)',
+      });
+      expect(container.textContent).toBe('Doctor Who (abbrev.)');
+    });
+  });
+
+  describe('without display (simplify fallback)', () => {
+    it('renders a single-string-key claim as the bare scalar', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: { value: 'DW', exists: true },
+      });
+      expect(container.textContent).toBe('DW');
+      expect(container.querySelector('s')).toBeNull();
+    });
+
+    it('strikes through a negative single-string-key claim', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: { value: 'DW', exists: false },
+      });
+      const struck = container.querySelector('s');
+      expect(struck).not.toBeNull();
+      expect(struck!.textContent).toBe('DW');
+    });
+  });
+
+  describe('without display or simplify (formatValue fallback)', () => {
+    it('renders bare scalars verbatim', () => {
+      const { container } = render(ClaimValueFixture, { value: 'solid-state' });
+      expect(container.textContent).toBe('solid-state');
+    });
+
+    it('renders null / undefined / empty string as em-dash', () => {
+      const cases: unknown[] = [null, undefined, ''];
+      for (const value of cases) {
+        const { container } = render(ClaimValueFixture, { value });
+        expect(container.textContent).toBe('—');
+      }
+    });
+
+    it('JSON-stringifies unrecognised dict shapes', () => {
+      // Multi-key relationship claims the backend declined fall through.
+      const { container } = render(ClaimValueFixture, {
+        value: { person: 13, role: 9, exists: true },
+      });
+      expect(container.textContent).toBe('{"person":13,"role":9,"exists":true}');
+    });
+  });
+});

--- a/frontend/src/lib/components/ClaimValue.dom.test.ts
+++ b/frontend/src/lib/components/ClaimValue.dom.test.ts
@@ -1,46 +1,230 @@
 import { render } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ClaimValueFixture from './ClaimValue.fixture.svelte';
+import { _resetQualifierWarnings } from './qualifier-renderers';
 
 describe('ClaimValue', () => {
-  describe('with backend-supplied display', () => {
-    it('renders the display string for a positive relationship claim', () => {
+  describe('with structured display (relationship claims)', () => {
+    it('renders a two-identity claim joined with em-dash', () => {
       const { container } = render(ClaimValueFixture, {
-        value: { person: 13, role: 9, exists: true },
-        display: 'Pat Lawlor — Art',
+        value: {
+          raw: { person: 13, role: 9, exists: true },
+          display: {
+            identity: [
+              { key: 'person', label: 'Pat Lawlor', state: 'resolved' },
+              { key: 'role', label: 'Art', state: 'resolved' },
+            ],
+            qualifiers: [],
+          },
+        },
       });
-      expect(container.textContent).toBe('Pat Lawlor — Art');
+      expect(container.textContent).toBe('Pat Lawlor — Art');
       expect(container.querySelector('s')).toBeNull();
     });
 
-    it('strikes through the display when the underlying claim asserts exists:false', () => {
-      // Negative claim with payload: "I assert that Pat Lawlor is NOT the
-      // artist." display is still the human label; the <s> distinguishes
-      // it from a positive assertion of the same label.
+    it('strikes through when raw asserts exists:false', () => {
       const { container } = render(ClaimValueFixture, {
-        value: { person: 13, role: 9, exists: false },
-        display: 'Pat Lawlor — Art',
+        value: {
+          raw: { person: 13, role: 9, exists: false },
+          display: {
+            identity: [
+              { key: 'person', label: 'Pat Lawlor', state: 'resolved' },
+              { key: 'role', label: 'Art', state: 'resolved' },
+            ],
+            qualifiers: [],
+          },
+        },
       });
       const struck = container.querySelector('s');
       expect(struck).not.toBeNull();
-      expect(struck!.textContent).toBe('Pat Lawlor — Art');
+      expect(struck!.textContent).toBe('Pat Lawlor — Art');
     });
 
-    it('prefers display over the simplify fallback', () => {
-      // value would simplify to "DW" on its own, but display takes priority.
+    it('appends ×N when count > 1', () => {
       const { container } = render(ClaimValueFixture, {
-        value: { value: 'DW', exists: true },
-        display: 'Doctor Who (abbrev.)',
+        value: {
+          raw: { gameplay_feature: 5, count: 3, exists: true },
+          display: {
+            identity: [{ key: 'gameplay_feature', label: 'Multiball', state: 'resolved' }],
+            qualifiers: [{ key: 'count', value: 3 }],
+          },
+        },
       });
-      expect(container.textContent).toBe('Doctor Who (abbrev.)');
+      expect(container.textContent).toBe('Multiball ×3');
+    });
+
+    it('omits the count suffix when count is 1', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: {
+          raw: { gameplay_feature: 5, count: 1, exists: true },
+          display: {
+            identity: [{ key: 'gameplay_feature', label: 'Multiball', state: 'resolved' }],
+            qualifiers: [{ key: 'count', value: 1 }],
+          },
+        },
+      });
+      expect(container.textContent).toBe('Multiball');
+    });
+
+    it('renders identity-only when no qualifiers are present', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: {
+          raw: { theme: 7, exists: true },
+          display: {
+            identity: [{ key: 'theme', label: 'Horror', state: 'resolved' }],
+            qualifiers: [],
+          },
+        },
+      });
+      expect(container.textContent).toBe('Horror');
+    });
+
+    it('renders category and is_primary qualifiers together', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: {
+          raw: { media_asset: 42, category: 'flyer', is_primary: true, exists: true },
+          display: {
+            identity: [{ key: 'media_asset', label: 'Title cover', state: 'resolved' }],
+            qualifiers: [
+              { key: 'category', value: 'flyer' },
+              { key: 'is_primary', value: true },
+            ],
+          },
+        },
+      });
+      expect(container.textContent).toBe('Title cover (flyer) [primary]');
+    });
+
+    it('omits is_primary when false', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: {
+          raw: { media_asset: 42, category: 'flyer', is_primary: false, exists: true },
+          display: {
+            identity: [{ key: 'media_asset', label: 'Title cover', state: 'resolved' }],
+            qualifiers: [
+              { key: 'category', value: 'flyer' },
+              { key: 'is_primary', value: false },
+            ],
+          },
+        },
+      });
+      expect(container.textContent).toBe('Title cover (flyer)');
+    });
+
+    it('omits category when null', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: {
+          raw: { media_asset: 42, category: null, is_primary: false, exists: true },
+          display: {
+            identity: [{ key: 'media_asset', label: 'Title cover', state: 'resolved' }],
+            qualifiers: [
+              { key: 'category', value: null },
+              { key: 'is_primary', value: false },
+            ],
+          },
+        },
+      });
+      expect(container.textContent).toBe('Title cover');
+    });
+
+    it('renders an alias identity whose label is the chosen display form', () => {
+      // Backend chose `alias_display` over `alias_value`; identity key stays
+      // as the identity slot (`alias_value`) while `label` carries the
+      // user-facing rendering.
+      const { container } = render(ClaimValueFixture, {
+        value: {
+          raw: { alias_value: 'the patster', alias_display: 'The Patster', exists: true },
+          display: {
+            identity: [{ key: 'alias_value', label: 'The Patster', state: 'resolved' }],
+            qualifiers: [],
+          },
+        },
+      });
+      expect(container.textContent).toBe('The Patster');
+    });
+
+    it('renders a deleted-target identity distinctly', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: {
+          raw: { person: 99, role: 9, exists: true },
+          display: {
+            identity: [
+              { key: 'person', label: null, state: 'deleted' },
+              { key: 'role', label: 'Art', state: 'resolved' },
+            ],
+            qualifiers: [],
+          },
+        },
+      });
+      expect(container.textContent).toBe('(deleted) — Art');
+      const dim = container.querySelector('.missing-ref');
+      expect(dim).not.toBeNull();
+      expect(dim!.textContent).toBe('(deleted)');
+    });
+
+    it('renders a missing identity distinctly from deleted', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: {
+          raw: { role: 9, exists: true },
+          display: {
+            identity: [
+              { key: 'person', label: null, state: 'missing' },
+              { key: 'role', label: 'Art', state: 'resolved' },
+            ],
+            qualifiers: [],
+          },
+        },
+      });
+      expect(container.textContent).toBe('(missing) — Art');
+    });
+
+    describe('unknown qualifier keys', () => {
+      let warnSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        _resetQualifierWarnings();
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        warnSpy.mockRestore();
+      });
+
+      it('renders unknown keys with default format and warns once', () => {
+        const { container } = render(ClaimValueFixture, {
+          value: {
+            raw: { thing: 1, weirdkey: 'hello', exists: true },
+            display: {
+              identity: [{ key: 'thing', label: 'Widget', state: 'resolved' }],
+              qualifiers: [{ key: 'weirdkey', value: 'hello' }],
+            },
+          },
+        });
+        expect(container.textContent).toBe('Widget (weirdkey: hello)');
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain('weirdkey');
+      });
+
+      it('omits unknown keys whose value is null / false / empty', () => {
+        const { container } = render(ClaimValueFixture, {
+          value: {
+            raw: { thing: 1, weirdkey: null, exists: true },
+            display: {
+              identity: [{ key: 'thing', label: 'Widget', state: 'resolved' }],
+              qualifiers: [{ key: 'weirdkey', value: null }],
+            },
+          },
+        });
+        expect(container.textContent).toBe('Widget');
+      });
     });
   });
 
   describe('without display (simplify fallback)', () => {
     it('renders a single-string-key claim as the bare scalar', () => {
       const { container } = render(ClaimValueFixture, {
-        value: { value: 'DW', exists: true },
+        value: { raw: { value: 'DW', exists: true } },
       });
       expect(container.textContent).toBe('DW');
       expect(container.querySelector('s')).toBeNull();
@@ -48,7 +232,7 @@ describe('ClaimValue', () => {
 
     it('strikes through a negative single-string-key claim', () => {
       const { container } = render(ClaimValueFixture, {
-        value: { value: 'DW', exists: false },
+        value: { raw: { value: 'DW', exists: false } },
       });
       const struck = container.querySelector('s');
       expect(struck).not.toBeNull();
@@ -58,12 +242,17 @@ describe('ClaimValue', () => {
 
   describe('without display or simplify (formatValue fallback)', () => {
     it('renders bare scalars verbatim', () => {
-      const { container } = render(ClaimValueFixture, { value: 'solid-state' });
+      const { container } = render(ClaimValueFixture, { value: { raw: 'solid-state' } });
       expect(container.textContent).toBe('solid-state');
     });
 
-    it('renders null / undefined / empty string as em-dash', () => {
-      const cases: unknown[] = [null, undefined, ''];
+    it('renders null raw as em-dash', () => {
+      const { container } = render(ClaimValueFixture, { value: { raw: null } });
+      expect(container.textContent).toBe('—');
+    });
+
+    it('renders a null/undefined value prop as em-dash', () => {
+      const cases: (null | undefined)[] = [null, undefined];
       for (const value of cases) {
         const { container } = render(ClaimValueFixture, { value });
         expect(container.textContent).toBe('—');
@@ -71,9 +260,8 @@ describe('ClaimValue', () => {
     });
 
     it('JSON-stringifies unrecognised dict shapes', () => {
-      // Multi-key relationship claims the backend declined fall through.
       const { container } = render(ClaimValueFixture, {
-        value: { person: 13, role: 9, exists: true },
+        value: { raw: { person: 13, role: 9, exists: true } },
       });
       expect(container.textContent).toBe('{"person":13,"role":9,"exists":true}');
     });

--- a/frontend/src/lib/components/ClaimValue.fixture.svelte
+++ b/frontend/src/lib/components/ClaimValue.fixture.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import ClaimValue from './ClaimValue.svelte';
+
+  let { value, display }: { value: unknown; display?: string | null } = $props();
+</script>
+
+<ClaimValue {value} {display} />

--- a/frontend/src/lib/components/ClaimValue.fixture.svelte
+++ b/frontend/src/lib/components/ClaimValue.fixture.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import type { ClaimValueSchema } from '$lib/api/schema';
   import ClaimValue from './ClaimValue.svelte';
 
-  let { value, display }: { value: unknown; display?: string | null } = $props();
+  let { value }: { value: ClaimValueSchema | null | undefined } = $props();
 </script>
 
-<ClaimValue {value} {display} />
+<ClaimValue {value} />

--- a/frontend/src/lib/components/ClaimValue.svelte
+++ b/frontend/src/lib/components/ClaimValue.svelte
@@ -1,12 +1,31 @@
 <script lang="ts">
   import { formatValue, simplifyClaimValue } from './change-display';
 
-  let { value }: { value: unknown } = $props();
+  let { value, display = undefined }: { value: unknown; display?: string | null | undefined } =
+    $props();
 
   let simple = $derived(simplifyClaimValue(value));
+
+  // A relationship-claim dict with exists:false is a negative assertion
+  // ("X is *not* the value"). The backend produces the same display
+  // string for positive and negative assertions, so the strike-through
+  // — driven by the raw value's exists flag, not by the display string
+  // — is what disambiguates the two.
+  let negated = $derived(
+    typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      (value as { exists?: unknown }).exists === false,
+  );
 </script>
 
-{#if simple}
+{#if display}
+  {#if negated}
+    <s>{display}</s>
+  {:else}
+    {display}
+  {/if}
+{:else if simple}
   {#if simple.exists}
     {simple.display}
   {:else}

--- a/frontend/src/lib/components/ClaimValue.svelte
+++ b/frontend/src/lib/components/ClaimValue.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { formatValue, simplifyClaimValue } from './change-display';
+
+  let { value }: { value: unknown } = $props();
+
+  let simple = $derived(simplifyClaimValue(value));
+</script>
+
+{#if simple}
+  {#if simple.exists}
+    {simple.display}
+  {:else}
+    <s>{simple.display}</s>
+  {/if}
+{:else}
+  {formatValue(value)}
+{/if}

--- a/frontend/src/lib/components/ClaimValue.svelte
+++ b/frontend/src/lib/components/ClaimValue.svelte
@@ -1,29 +1,32 @@
 <script lang="ts">
+  import type { ClaimValueSchema } from '$lib/api/schema';
+  import ClaimDisplay from './ClaimDisplay.svelte';
   import { formatValue, simplifyClaimValue } from './change-display';
 
-  let { value, display = undefined }: { value: unknown; display?: string | null | undefined } =
-    $props();
+  let { value }: { value: ClaimValueSchema | null | undefined } = $props();
 
-  let simple = $derived(simplifyClaimValue(value));
+  let raw = $derived(value?.raw);
+  let display = $derived(value?.display);
+  let simple = $derived(simplifyClaimValue(raw));
 
   // A relationship-claim dict with exists:false is a negative assertion
-  // ("X is *not* the value"). The backend produces the same display
-  // string for positive and negative assertions, so the strike-through
-  // — driven by the raw value's exists flag, not by the display string
-  // — is what disambiguates the two.
+  // ("X is *not* the value"). The backend's `display` struct is the same
+  // shape for positive and negative assertions; the strike-through —
+  // driven by the raw value's `exists` flag — is what disambiguates the
+  // two visually.
   let negated = $derived(
-    typeof value === 'object' &&
-      value !== null &&
-      !Array.isArray(value) &&
-      (value as { exists?: unknown }).exists === false,
+    typeof raw === 'object' &&
+      raw !== null &&
+      !Array.isArray(raw) &&
+      (raw as { exists?: unknown }).exists === false,
   );
 </script>
 
 {#if display}
   {#if negated}
-    <s>{display}</s>
+    <s><ClaimDisplay {display} /></s>
   {:else}
-    {display}
+    <ClaimDisplay {display} />
   {/if}
 {:else if simple}
   {#if simple.exists}
@@ -32,5 +35,5 @@
     <s>{simple.display}</s>
   {/if}
 {:else}
-  {formatValue(value)}
+  {formatValue(raw)}
 {/if}

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -119,6 +119,14 @@
   }
 </script>
 
+{#snippet oldValue(value: unknown, display: string | null | undefined)}
+  <span class="old-value"><ClaimValue {value} {display} /></span>
+{/snippet}
+
+{#snippet newValue(value: unknown, display: string | null | undefined)}
+  <span class="new-value"><ClaimValue {value} {display} /></span>
+{/snippet}
+
 {#snippet revertControls(change: FieldChange)}
   {#if canRevert(change)}
     <div class="revert-cell">
@@ -203,9 +211,7 @@
                         {/if}
                       </dd>
                       {#if isUnchanged(change)}
-                        <dd>
-                          <span class="old-value"><ClaimValue value={change.new_value} /></span>
-                        </dd>
+                        <dd>{@render oldValue(change.new_value, change.new_display)}</dd>
                       {:else if isDiffable(change)}
                         <dd>
                           <InlineDiff oldValue={change.old_value} newValue={change.new_value} />
@@ -213,26 +219,24 @@
                       {:else}
                         <dd>
                           {#if hasMeaningfulValue(change.old_value)}
-                            <span class="old-value"><ClaimValue value={change.old_value} /></span>
+                            {@render oldValue(change.old_value, change.old_display)}
                             <span class="arrow">&rarr;</span>
                           {/if}
-                          <span class="old-value"><ClaimValue value={change.new_value} /></span>
+                          {@render oldValue(change.new_value, change.new_display)}
                         </dd>
                       {/if}
                     </div>
                   {:else if isUnchanged(change)}
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
-                      <dd>
-                        <span class="new-value"><ClaimValue value={change.new_value} /></span>
-                      </dd>
+                      <dd>{@render newValue(change.new_value, change.new_display)}</dd>
                       {@render revertControls(change)}
                     </div>
                   {:else if isDeletion(change)}
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
                       <dd>
-                        <span class="old-value"><ClaimValue value={change.old_value} /></span>
+                        {@render oldValue(change.old_value, change.old_display)}
                         <span class="deleted-marker" aria-label="removed">&#x2715;</span>
                       </dd>
                       {@render revertControls(change)}
@@ -250,10 +254,10 @@
                       <dt>{change.field_name}</dt>
                       <dd>
                         {#if hasMeaningfulValue(change.old_value)}
-                          <span class="old-value"><ClaimValue value={change.old_value} /></span>
+                          {@render oldValue(change.old_value, change.old_display)}
                           <span class="arrow">&rarr;</span>
                         {/if}
-                        <span class="new-value"><ClaimValue value={change.new_value} /></span>
+                        {@render newValue(change.new_value, change.new_display)}
                       </dd>
                       {@render revertControls(change)}
                     </div>
@@ -266,7 +270,7 @@
                       <dt>{retraction.field_name}</dt>
                       <dd>
                         <span class="reverted-badge">reverted</span>
-                        <span class="old-value"><ClaimValue value={retraction.old_value} /></span>
+                        {@render oldValue(retraction.old_value, retraction.old_display)}
                       </dd>
                     </div>
                   {/if}

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -10,7 +10,7 @@
   import ClaimValue from './ClaimValue.svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { getEntityContext } from '$lib/entity-context';
-  import { isDeletion, isDiffable, isUnchanged } from './change-display';
+  import { hasMeaningfulValue, isDeletion, isDiffable, isUnchanged } from './change-display';
 
   type ChangeSet = ChangeSetSchema;
   type FieldChange = FieldChangeSchema;
@@ -212,7 +212,7 @@
                         </dd>
                       {:else}
                         <dd>
-                          {#if change.old_value !== null && change.old_value !== undefined}
+                          {#if hasMeaningfulValue(change.old_value)}
                             <span class="old-value"><ClaimValue value={change.old_value} /></span>
                             <span class="arrow">&rarr;</span>
                           {/if}
@@ -249,7 +249,7 @@
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
                       <dd>
-                        {#if change.old_value !== null && change.old_value !== undefined}
+                        {#if hasMeaningfulValue(change.old_value)}
                           <span class="old-value"><ClaimValue value={change.old_value} /></span>
                           <span class="arrow">&rarr;</span>
                         {/if}

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -2,7 +2,12 @@
   import { invalidateAll } from '$app/navigation';
   import client from '$lib/api/client';
   import { parseApiError } from '$lib/api/parse-api-error';
-  import type { ChangeSetSchema, ClaimAttributionSchema, FieldChangeSchema } from '$lib/api/schema';
+  import type {
+    ChangeSetSchema,
+    ClaimAttributionSchema,
+    ClaimValueSchema,
+    FieldChangeSchema,
+  } from '$lib/api/schema';
   import { auth } from '$lib/auth.svelte';
   import FocusContentShell from './FocusContentShell.svelte';
   import InlineDiff from './InlineDiff.svelte';
@@ -119,12 +124,12 @@
   }
 </script>
 
-{#snippet oldValue(value: unknown, display: string | null | undefined)}
-  <span class="old-value"><ClaimValue {value} {display} /></span>
+{#snippet oldValue(value: ClaimValueSchema | null | undefined)}
+  <span class="old-value"><ClaimValue {value} /></span>
 {/snippet}
 
-{#snippet newValue(value: unknown, display: string | null | undefined)}
-  <span class="new-value"><ClaimValue {value} {display} /></span>
+{#snippet newValue(value: ClaimValueSchema | null | undefined)}
+  <span class="new-value"><ClaimValue {value} /></span>
 {/snippet}
 
 {#snippet revertControls(change: FieldChange)}
@@ -211,32 +216,35 @@
                         {/if}
                       </dd>
                       {#if isUnchanged(change)}
-                        <dd>{@render oldValue(change.new_value, change.new_display)}</dd>
+                        <dd>{@render oldValue(change.new_value)}</dd>
                       {:else if isDiffable(change)}
                         <dd>
-                          <InlineDiff oldValue={change.old_value} newValue={change.new_value} />
+                          <InlineDiff
+                            oldValue={change.old_value.raw}
+                            newValue={change.new_value.raw}
+                          />
                         </dd>
                       {:else}
                         <dd>
-                          {#if hasMeaningfulValue(change.old_value)}
-                            {@render oldValue(change.old_value, change.old_display)}
+                          {#if hasMeaningfulValue(change.old_value?.raw)}
+                            {@render oldValue(change.old_value)}
                             <span class="arrow">&rarr;</span>
                           {/if}
-                          {@render oldValue(change.new_value, change.new_display)}
+                          {@render oldValue(change.new_value)}
                         </dd>
                       {/if}
                     </div>
                   {:else if isUnchanged(change)}
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
-                      <dd>{@render newValue(change.new_value, change.new_display)}</dd>
+                      <dd>{@render newValue(change.new_value)}</dd>
                       {@render revertControls(change)}
                     </div>
                   {:else if isDeletion(change)}
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
                       <dd>
-                        {@render oldValue(change.old_value, change.old_display)}
+                        {@render oldValue(change.old_value)}
                         <span class="deleted-marker" aria-label="removed">&#x2715;</span>
                       </dd>
                       {@render revertControls(change)}
@@ -245,7 +253,10 @@
                     <div class="field-row field-row-diff">
                       <dt>{change.field_name}</dt>
                       <dd>
-                        <InlineDiff oldValue={change.old_value} newValue={change.new_value} />
+                        <InlineDiff
+                          oldValue={change.old_value.raw}
+                          newValue={change.new_value.raw}
+                        />
                       </dd>
                       {@render revertControls(change)}
                     </div>
@@ -253,11 +264,11 @@
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
                       <dd>
-                        {#if hasMeaningfulValue(change.old_value)}
-                          {@render oldValue(change.old_value, change.old_display)}
+                        {#if hasMeaningfulValue(change.old_value?.raw)}
+                          {@render oldValue(change.old_value)}
                           <span class="arrow">&rarr;</span>
                         {/if}
-                        {@render newValue(change.new_value, change.new_display)}
+                        {@render newValue(change.new_value)}
                       </dd>
                       {@render revertControls(change)}
                     </div>
@@ -270,7 +281,7 @@
                       <dt>{retraction.field_name}</dt>
                       <dd>
                         <span class="reverted-badge">reverted</span>
-                        {@render oldValue(retraction.old_value, retraction.old_display)}
+                        {@render oldValue(retraction.old_value)}
                       </dd>
                     </div>
                   {/if}

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -7,9 +7,10 @@
   import FocusContentShell from './FocusContentShell.svelte';
   import InlineDiff from './InlineDiff.svelte';
   import ClaimAttribution from './ClaimAttribution.svelte';
+  import ClaimValue from './ClaimValue.svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { getEntityContext } from '$lib/entity-context';
-  import { isDiffable, isUnchanged, formatValue } from './change-display';
+  import { isDiffable, isUnchanged } from './change-display';
 
   type ChangeSet = ChangeSetSchema;
   type FieldChange = FieldChangeSchema;
@@ -203,7 +204,7 @@
                       </dd>
                       {#if isUnchanged(change)}
                         <dd>
-                          <span class="old-value">{formatValue(change.new_value)}</span>
+                          <span class="old-value"><ClaimValue value={change.new_value} /></span>
                         </dd>
                       {:else if isDiffable(change)}
                         <dd>
@@ -212,10 +213,10 @@
                       {:else}
                         <dd>
                           {#if change.old_value !== null && change.old_value !== undefined}
-                            <span class="old-value">{formatValue(change.old_value)}</span>
+                            <span class="old-value"><ClaimValue value={change.old_value} /></span>
                             <span class="arrow">&rarr;</span>
                           {/if}
-                          <span class="old-value">{formatValue(change.new_value)}</span>
+                          <span class="old-value"><ClaimValue value={change.new_value} /></span>
                         </dd>
                       {/if}
                     </div>
@@ -223,7 +224,7 @@
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
                       <dd>
-                        <span class="new-value">{formatValue(change.new_value)}</span>
+                        <span class="new-value"><ClaimValue value={change.new_value} /></span>
                       </dd>
                       {@render revertControls(change)}
                     </div>
@@ -240,10 +241,10 @@
                       <dt>{change.field_name}</dt>
                       <dd>
                         {#if change.old_value !== null && change.old_value !== undefined}
-                          <span class="old-value">{formatValue(change.old_value)}</span>
+                          <span class="old-value"><ClaimValue value={change.old_value} /></span>
                           <span class="arrow">&rarr;</span>
                         {/if}
-                        <span class="new-value">{formatValue(change.new_value)}</span>
+                        <span class="new-value"><ClaimValue value={change.new_value} /></span>
                       </dd>
                       {@render revertControls(change)}
                     </div>
@@ -256,7 +257,7 @@
                       <dt>{retraction.field_name}</dt>
                       <dd>
                         <span class="reverted-badge">reverted</span>
-                        <span class="old-value">{formatValue(retraction.old_value)}</span>
+                        <span class="old-value"><ClaimValue value={retraction.old_value} /></span>
                       </dd>
                     </div>
                   {/if}

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -10,7 +10,7 @@
   import ClaimValue from './ClaimValue.svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { getEntityContext } from '$lib/entity-context';
-  import { isDiffable, isUnchanged } from './change-display';
+  import { isDeletion, isDiffable, isUnchanged } from './change-display';
 
   type ChangeSet = ChangeSetSchema;
   type FieldChange = FieldChangeSchema;
@@ -228,6 +228,15 @@
                       </dd>
                       {@render revertControls(change)}
                     </div>
+                  {:else if isDeletion(change)}
+                    <div class="field-row">
+                      <dt>{change.field_name}</dt>
+                      <dd>
+                        <span class="old-value"><ClaimValue value={change.old_value} /></span>
+                        <span class="deleted-marker" aria-label="removed">&#x2715;</span>
+                      </dd>
+                      {@render revertControls(change)}
+                    </div>
                   {:else if isDiffable(change)}
                     <div class="field-row field-row-diff">
                       <dt>{change.field_name}</dt>
@@ -366,6 +375,12 @@
   .arrow {
     color: var(--color-text-muted);
     font-size: var(--font-size-0);
+  }
+
+  .deleted-marker {
+    color: var(--color-error-text);
+    font-size: var(--font-size-0);
+    margin-left: var(--size-1);
   }
 
   .new-value {

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -9,7 +9,7 @@
   import ClaimAttribution from './ClaimAttribution.svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { getEntityContext } from '$lib/entity-context';
-  import { isDiffable, formatValue } from './change-display';
+  import { isDiffable, isUnchanged, formatValue } from './change-display';
 
   type ChangeSet = ChangeSetSchema;
   type FieldChange = FieldChangeSchema;
@@ -201,7 +201,11 @@
                             {info.note}{/if}
                         {/if}
                       </dd>
-                      {#if isDiffable(change)}
+                      {#if isUnchanged(change)}
+                        <dd>
+                          <span class="old-value">{formatValue(change.new_value)}</span>
+                        </dd>
+                      {:else if isDiffable(change)}
                         <dd>
                           <InlineDiff oldValue={change.old_value} newValue={change.new_value} />
                         </dd>
@@ -214,6 +218,14 @@
                           <span class="old-value">{formatValue(change.new_value)}</span>
                         </dd>
                       {/if}
+                    </div>
+                  {:else if isUnchanged(change)}
+                    <div class="field-row">
+                      <dt>{change.field_name}</dt>
+                      <dd>
+                        <span class="new-value">{formatValue(change.new_value)}</span>
+                      </dd>
+                      {@render revertControls(change)}
                     </div>
                   {:else if isDiffable(change)}
                     <div class="field-row field-row-diff">

--- a/frontend/src/lib/components/EditHistory.svelte
+++ b/frontend/src/lib/components/EditHistory.svelte
@@ -303,6 +303,7 @@
     border: 1px solid var(--color-border-soft);
     border-radius: var(--radius-2);
     padding: var(--size-3);
+    container-type: inline-size;
   }
 
   .changeset-header {
@@ -385,6 +386,38 @@
 
   .new-value {
     font-weight: 500;
+  }
+
+  /*
+   * Narrow layout: when a changeset card is too narrow for `dt | dd | revert`
+   * to fit comfortably, stack to two rows — dt + revert on top, dd below.
+   * Short values then live alongside the field name? No — that would require
+   * value-length-aware layout, which CSS can't do. We optimise for legibility
+   * of the long-value case (json blobs, diffs) at the cost of a second line
+   * for short ones.
+   */
+  @container (max-width: 32rem) {
+    .field-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      column-gap: var(--size-2);
+      row-gap: var(--size-1);
+    }
+
+    .field-row dt {
+      min-width: 0;
+      grid-column: 1;
+    }
+
+    .field-row dd {
+      grid-column: 1 / -1;
+    }
+
+    .revert-cell {
+      grid-column: 2;
+      grid-row: 1;
+      margin-left: 0;
+    }
   }
 
   .no-history {

--- a/frontend/src/lib/components/change-display.test.ts
+++ b/frontend/src/lib/components/change-display.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   formatValue,
+  hasMeaningfulValue,
   isDeletion,
   isDiffable,
   isUnchanged,
@@ -179,6 +180,32 @@ describe('isUnchanged', () => {
   });
 });
 
+describe('hasMeaningfulValue', () => {
+  it('rejects null, undefined, and empty string', () => {
+    expect(hasMeaningfulValue(null)).toBe(false);
+    expect(hasMeaningfulValue(undefined)).toBe(false);
+    expect(hasMeaningfulValue('')).toBe(false);
+  });
+
+  it('rejects a bare retraction marker {exists: false}', () => {
+    expect(hasMeaningfulValue({ exists: false })).toBe(false);
+  });
+
+  it('accepts a positive relationship claim {value, exists: true}', () => {
+    expect(hasMeaningfulValue({ value: 'DW', exists: true })).toBe(true);
+  });
+
+  it('accepts a negative relationship claim with payload {value, exists: false}', () => {
+    expect(hasMeaningfulValue({ value: 'DW', exists: false })).toBe(true);
+  });
+
+  it('accepts ordinary scalars', () => {
+    expect(hasMeaningfulValue('solid-state')).toBe(true);
+    expect(hasMeaningfulValue(0)).toBe(true);
+    expect(hasMeaningfulValue(false)).toBe(true);
+  });
+});
+
 describe('isDeletion', () => {
   it('is true when old has a value and new is null', () => {
     expect(
@@ -231,6 +258,20 @@ describe('isDeletion', () => {
         claim_key: 'k',
         old_value: null,
         new_value: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when old is a bare retraction marker (no prior assertion)', () => {
+    // Repro for the display_subtype case: after delete-then-re-set, the
+    // backend supplies the prior retraction marker as old_value. That is
+    // not a real prior value, so this is a creation, not an edit.
+    expect(
+      isDeletion({
+        field_name: 'display_subtype',
+        claim_key: 'k',
+        old_value: { exists: false },
+        new_value: 'plasma-dmd',
       }),
     ).toBe(false);
   });

--- a/frontend/src/lib/components/change-display.test.ts
+++ b/frontend/src/lib/components/change-display.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { FieldChangeSchema } from '$lib/api/schema';
 import {
   formatValue,
   hasMeaningfulValue,
@@ -8,17 +9,32 @@ import {
   simplifyClaimValue,
 } from './change-display';
 
+/** Build a minimal FieldChangeSchema with raw-only old/new values. */
+function fc(
+  oldRaw: unknown,
+  newRaw: unknown,
+  field_name = 'field',
+  claim_key = 'k',
+): FieldChangeSchema {
+  return {
+    field_name,
+    claim_key,
+    old_value: oldRaw === undefined ? null : { raw: oldRaw },
+    new_value: { raw: newRaw },
+  };
+}
+
 describe('formatValue', () => {
   it('returns em-dash for null', () => {
-    expect(formatValue(null)).toBe('\u2014');
+    expect(formatValue(null)).toBe('—');
   });
 
   it('returns em-dash for undefined', () => {
-    expect(formatValue(undefined)).toBe('\u2014');
+    expect(formatValue(undefined)).toBe('—');
   });
 
   it('returns em-dash for empty string', () => {
-    expect(formatValue('')).toBe('\u2014');
+    expect(formatValue('')).toBe('—');
   });
 
   it('returns short strings verbatim', () => {
@@ -52,131 +68,72 @@ describe('formatValue', () => {
 });
 
 describe('isDiffable', () => {
-  it('returns true when old_value is a long string', () => {
-    const change = {
-      field_name: 'description',
-      claim_key: 'k',
-      old_value: 'a'.repeat(81),
-      new_value: 'short',
-    };
-    expect(isDiffable(change)).toBe(true);
+  it('returns true when old_value.raw is a long string', () => {
+    expect(isDiffable(fc('a'.repeat(81), 'short'))).toBe(true);
   });
 
-  it('returns true when new_value is a long string', () => {
-    const change = {
-      field_name: 'description',
-      claim_key: 'k',
-      old_value: 'short',
-      new_value: 'b'.repeat(81),
-    };
-    expect(isDiffable(change)).toBe(true);
+  it('returns true when new_value.raw is a long string', () => {
+    expect(isDiffable(fc('short', 'b'.repeat(81)))).toBe(true);
   });
 
   it('returns false when both strings are short', () => {
-    const change = {
-      field_name: 'name',
-      claim_key: 'k',
-      old_value: 'short old',
-      new_value: 'short new',
-    };
-    expect(isDiffable(change)).toBe(false);
+    expect(isDiffable(fc('short old', 'short new'))).toBe(false);
   });
 
   it('returns false when old_value is null', () => {
-    const change = {
+    const change: FieldChangeSchema = {
       field_name: 'name',
       claim_key: 'k',
       old_value: null,
-      new_value: 'a'.repeat(100),
+      new_value: { raw: 'a'.repeat(100) },
     };
     expect(isDiffable(change)).toBe(false);
   });
 
-  it('returns false when new_value is a number', () => {
-    const change = {
-      field_name: 'year',
-      claim_key: 'k',
-      old_value: 'a'.repeat(100),
-      new_value: 1990,
-    };
-    expect(isDiffable(change)).toBe(false);
+  it('returns false when new_value.raw is a number', () => {
+    expect(isDiffable(fc('a'.repeat(100), 1990))).toBe(false);
   });
 
   it('returns false at exactly the 80-character boundary', () => {
-    const change = {
-      field_name: 'desc',
-      claim_key: 'k',
-      old_value: 'a'.repeat(80),
-      new_value: 'b'.repeat(80),
-    };
-    expect(isDiffable(change)).toBe(false);
+    expect(isDiffable(fc('a'.repeat(80), 'b'.repeat(80)))).toBe(false);
   });
 
   it('returns true when one string is exactly 81 characters', () => {
-    const change = {
-      field_name: 'desc',
-      claim_key: 'k',
-      old_value: 'a'.repeat(81),
-      new_value: 'short',
-    };
-    expect(isDiffable(change)).toBe(true);
+    expect(isDiffable(fc('a'.repeat(81), 'short'))).toBe(true);
   });
 });
 
 describe('isUnchanged', () => {
   it('is true when scalar values are equal', () => {
-    expect(
-      isUnchanged({
-        field_name: 'tech',
-        claim_key: 'k',
-        old_value: 'solid-state',
-        new_value: 'solid-state',
-      }),
-    ).toBe(true);
+    expect(isUnchanged(fc('solid-state', 'solid-state'))).toBe(true);
   });
 
   it('is false when scalar values differ', () => {
-    expect(
-      isUnchanged({
-        field_name: 'tech',
-        claim_key: 'k',
-        old_value: 'electromechanical',
-        new_value: 'solid-state',
-      }),
-    ).toBe(false);
+    expect(isUnchanged(fc('electromechanical', 'solid-state'))).toBe(false);
   });
 
   it('is false when only one side is null', () => {
-    expect(
-      isUnchanged({
-        field_name: 'tech',
-        claim_key: 'k',
-        old_value: null,
-        new_value: 'solid-state',
-      }),
-    ).toBe(false);
+    const change: FieldChangeSchema = {
+      field_name: 'tech',
+      claim_key: 'k',
+      old_value: null,
+      new_value: { raw: 'solid-state' },
+    };
+    expect(isUnchanged(change)).toBe(false);
   });
 
   it('is true when both sides are null (nothing asserted)', () => {
-    expect(
-      isUnchanged({
-        field_name: 'tech',
-        claim_key: 'k',
-        old_value: null,
-        new_value: null,
-      }),
-    ).toBe(true);
+    const change: FieldChangeSchema = {
+      field_name: 'tech',
+      claim_key: 'k',
+      old_value: null,
+      new_value: { raw: null },
+    };
+    expect(isUnchanged(change)).toBe(true);
   });
 
   it('is true when arrays have the same contents', () => {
-    expect(
-      isUnchanged({
-        field_name: 'aliases',
-        claim_key: 'k',
-        old_value: ['a', 'b'],
-        new_value: ['a', 'b'],
-      }),
-    ).toBe(true);
+    expect(isUnchanged(fc(['a', 'b'], ['a', 'b']))).toBe(true);
   });
 });
 
@@ -208,72 +165,42 @@ describe('hasMeaningfulValue', () => {
 
 describe('isDeletion', () => {
   it('is true when old has a value and new is null', () => {
-    expect(
-      isDeletion({
-        field_name: 'tagline',
-        claim_key: 'k',
-        old_value: 'Save the universe',
-        new_value: null,
-      }),
-    ).toBe(true);
+    expect(isDeletion(fc('Save the universe', null))).toBe(true);
   });
 
   it('is true when old has a value and new is empty string', () => {
-    expect(
-      isDeletion({
-        field_name: 'tagline',
-        claim_key: 'k',
-        old_value: 'Save the universe',
-        new_value: '',
-      }),
-    ).toBe(true);
+    expect(isDeletion(fc('Save the universe', ''))).toBe(true);
   });
 
   it('is false for a normal edit (both sides have a value)', () => {
-    expect(
-      isDeletion({
-        field_name: 'tagline',
-        claim_key: 'k',
-        old_value: 'foo',
-        new_value: 'bar',
-      }),
-    ).toBe(false);
+    expect(isDeletion(fc('foo', 'bar'))).toBe(false);
   });
 
-  it('is false for a creation (old is null)', () => {
-    expect(
-      isDeletion({
-        field_name: 'tagline',
-        claim_key: 'k',
-        old_value: null,
-        new_value: 'bar',
-      }),
-    ).toBe(false);
+  it('is false for a creation (old_value bundle is null)', () => {
+    const change: FieldChangeSchema = {
+      field_name: 'tagline',
+      claim_key: 'k',
+      old_value: null,
+      new_value: { raw: 'bar' },
+    };
+    expect(isDeletion(change)).toBe(false);
   });
 
   it('is false when both sides are empty (no real change to display)', () => {
-    expect(
-      isDeletion({
-        field_name: 'tagline',
-        claim_key: 'k',
-        old_value: null,
-        new_value: null,
-      }),
-    ).toBe(false);
+    const change: FieldChangeSchema = {
+      field_name: 'tagline',
+      claim_key: 'k',
+      old_value: null,
+      new_value: { raw: null },
+    };
+    expect(isDeletion(change)).toBe(false);
   });
 
   it('is false when old is a bare retraction marker (no prior assertion)', () => {
-    // Repro for the display_subtype case: after delete-then-re-set, the
-    // backend supplies the prior retraction marker as old_value. That is
-    // not a real prior value, so this is a creation, not an edit.
-    expect(
-      isDeletion({
-        field_name: 'display_subtype',
-        claim_key: 'k',
-        old_value: { exists: false },
-        new_value: 'plasma-dmd',
-      }),
-    ).toBe(false);
+    // After delete-then-re-set, the backend supplies the prior retraction
+    // marker as old_value.raw. That is not a real prior value, so this is
+    // a creation, not an edit.
+    expect(isDeletion(fc({ exists: false }, 'plasma-dmd'))).toBe(false);
   });
 });
 

--- a/frontend/src/lib/components/change-display.test.ts
+++ b/frontend/src/lib/components/change-display.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { formatValue, isDiffable, isUnchanged, simplifyClaimValue } from './change-display';
+import {
+  formatValue,
+  isDeletion,
+  isDiffable,
+  isUnchanged,
+  simplifyClaimValue,
+} from './change-display';
 
 describe('formatValue', () => {
   it('returns em-dash for null', () => {
@@ -170,6 +176,63 @@ describe('isUnchanged', () => {
         new_value: ['a', 'b'],
       }),
     ).toBe(true);
+  });
+});
+
+describe('isDeletion', () => {
+  it('is true when old has a value and new is null', () => {
+    expect(
+      isDeletion({
+        field_name: 'tagline',
+        claim_key: 'k',
+        old_value: 'Save the universe',
+        new_value: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('is true when old has a value and new is empty string', () => {
+    expect(
+      isDeletion({
+        field_name: 'tagline',
+        claim_key: 'k',
+        old_value: 'Save the universe',
+        new_value: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('is false for a normal edit (both sides have a value)', () => {
+    expect(
+      isDeletion({
+        field_name: 'tagline',
+        claim_key: 'k',
+        old_value: 'foo',
+        new_value: 'bar',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for a creation (old is null)', () => {
+    expect(
+      isDeletion({
+        field_name: 'tagline',
+        claim_key: 'k',
+        old_value: null,
+        new_value: 'bar',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when both sides are empty (no real change to display)', () => {
+    expect(
+      isDeletion({
+        field_name: 'tagline',
+        claim_key: 'k',
+        old_value: null,
+        new_value: null,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/frontend/src/lib/components/change-display.test.ts
+++ b/frontend/src/lib/components/change-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatValue, isDiffable, isUnchanged } from './change-display';
+import { formatValue, isDiffable, isUnchanged, simplifyClaimValue } from './change-display';
 
 describe('formatValue', () => {
   it('returns em-dash for null', () => {
@@ -170,5 +170,54 @@ describe('isUnchanged', () => {
         new_value: ['a', 'b'],
       }),
     ).toBe(true);
+  });
+});
+
+describe('simplifyClaimValue', () => {
+  it('extracts a positive abbreviation claim', () => {
+    expect(simplifyClaimValue({ value: 'DW', exists: true })).toEqual({
+      display: 'DW',
+      exists: true,
+    });
+  });
+
+  it('extracts a negative abbreviation claim', () => {
+    expect(simplifyClaimValue({ value: 'DW', exists: false })).toEqual({
+      display: 'DW',
+      exists: false,
+    });
+  });
+
+  it('extracts an alias-style single-key claim regardless of key name', () => {
+    expect(simplifyClaimValue({ alias_value: 'Doctor Who', exists: true })).toEqual({
+      display: 'Doctor Who',
+      exists: true,
+    });
+  });
+
+  it('returns null for credit-style multi-key claims', () => {
+    expect(simplifyClaimValue({ person: 1, role: 2, exists: true })).toBeNull();
+  });
+
+  it('returns null for FK-pk integer values (not human-readable)', () => {
+    expect(simplifyClaimValue({ theme: 1, exists: true })).toBeNull();
+  });
+
+  it('returns null when exists is missing', () => {
+    expect(simplifyClaimValue({ value: 'DW' })).toBeNull();
+  });
+
+  it('returns null for bare scalars', () => {
+    expect(simplifyClaimValue('solid-state')).toBeNull();
+    expect(simplifyClaimValue(42)).toBeNull();
+    expect(simplifyClaimValue(null)).toBeNull();
+  });
+
+  it('returns null for arrays', () => {
+    expect(simplifyClaimValue(['a', 'b'])).toBeNull();
+  });
+
+  it('returns null for retraction-only dicts (just exists:false)', () => {
+    expect(simplifyClaimValue({ exists: false })).toBeNull();
   });
 });

--- a/frontend/src/lib/components/change-display.test.ts
+++ b/frontend/src/lib/components/change-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatValue, isDiffable } from './change-display';
+import { formatValue, isDiffable, isUnchanged } from './change-display';
 
 describe('formatValue', () => {
   it('returns em-dash for null', () => {
@@ -113,5 +113,62 @@ describe('isDiffable', () => {
       new_value: 'short',
     };
     expect(isDiffable(change)).toBe(true);
+  });
+});
+
+describe('isUnchanged', () => {
+  it('is true when scalar values are equal', () => {
+    expect(
+      isUnchanged({
+        field_name: 'tech',
+        claim_key: 'k',
+        old_value: 'solid-state',
+        new_value: 'solid-state',
+      }),
+    ).toBe(true);
+  });
+
+  it('is false when scalar values differ', () => {
+    expect(
+      isUnchanged({
+        field_name: 'tech',
+        claim_key: 'k',
+        old_value: 'electromechanical',
+        new_value: 'solid-state',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when only one side is null', () => {
+    expect(
+      isUnchanged({
+        field_name: 'tech',
+        claim_key: 'k',
+        old_value: null,
+        new_value: 'solid-state',
+      }),
+    ).toBe(false);
+  });
+
+  it('is true when both sides are null (nothing asserted)', () => {
+    expect(
+      isUnchanged({
+        field_name: 'tech',
+        claim_key: 'k',
+        old_value: null,
+        new_value: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('is true when arrays have the same contents', () => {
+    expect(
+      isUnchanged({
+        field_name: 'aliases',
+        claim_key: 'k',
+        old_value: ['a', 'b'],
+        new_value: ['a', 'b'],
+      }),
+    ).toBe(true);
   });
 });

--- a/frontend/src/lib/components/change-display.ts
+++ b/frontend/src/lib/components/change-display.ts
@@ -30,15 +30,30 @@ export function isUnchanged(change: FieldChange): boolean {
 }
 
 /**
- * True when a change deletes a scalar field — old had a value, new is null /
- * undefined / empty string. These should render as just the struck-through
- * old value with a removed indicator, not as `old → —`.
+ * True when a claim value represents an actual assertion — i.e. not null,
+ * undefined, empty string, or a bare retraction marker like `{exists: false}`
+ * with no other keys. Used to decide whether to render an `old → new`
+ * transition or treat the change as a creation / deletion.
+ */
+export function hasMeaningfulValue(v: unknown): boolean {
+  if (v === null || v === undefined || v === '') return false;
+  if (typeof v === 'object' && !Array.isArray(v)) {
+    const obj = v as Record<string, unknown>;
+    if (obj.exists === false) {
+      const otherKeys = Object.keys(obj).filter((k) => k !== 'exists');
+      if (otherKeys.length === 0) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * True when a change deletes a value — old asserted something, new asserts
+ * nothing. These render as just the struck-through old value with a removed
+ * indicator, not as `old → —`.
  */
 export function isDeletion(change: FieldChange): boolean {
-  const { old_value, new_value } = change;
-  const hadValue = old_value !== null && old_value !== undefined && old_value !== '';
-  const hasValue = new_value !== null && new_value !== undefined && new_value !== '';
-  return hadValue && !hasValue;
+  return hasMeaningfulValue(change.old_value) && !hasMeaningfulValue(change.new_value);
 }
 
 /**

--- a/frontend/src/lib/components/change-display.ts
+++ b/frontend/src/lib/components/change-display.ts
@@ -1,19 +1,32 @@
-import type { FieldChangeSchema } from '$lib/api/schema';
+import type { ClaimDisplayValueSchema, ClaimValueSchema, FieldChangeSchema } from '$lib/api/schema';
 
 type FieldChange = FieldChangeSchema;
 
+/** A `ClaimValueSchema` whose `raw` payload is known to be a string. */
+type StringClaimValue = Omit<ClaimValueSchema, 'raw'> & {
+  raw: string;
+  display?: ClaimDisplayValueSchema | null;
+};
+
 /**
- * Type guard: true when both old and new values are strings and at least one
- * exceeds 80 characters, meaning the change should render as an InlineDiff
- * rather than a simple old → new display.
+ * True when both old and new values are strings and at least one exceeds
+ * 80 characters, meaning the change should render as an InlineDiff rather
+ * than a simple old → new display. Operates on `.raw` since long-string
+ * diffs only make sense for direct-field scalars (no display struct).
+ *
+ * Type guard: inside an `isDiffable(change)` branch, callers get
+ * `change.old_value.raw` and `change.new_value.raw` narrowed to `string`
+ * without needing an `as string` cast.
  */
 export function isDiffable(
   change: FieldChange,
-): change is FieldChange & { old_value: string; new_value: string } {
+): change is FieldChange & { old_value: StringClaimValue; new_value: StringClaimValue } {
+  const oldRaw = change.old_value?.raw;
+  const newRaw = change.new_value.raw;
   return (
-    typeof change.old_value === 'string' &&
-    typeof change.new_value === 'string' &&
-    (change.old_value.length > 80 || change.new_value.length > 80)
+    typeof oldRaw === 'string' &&
+    typeof newRaw === 'string' &&
+    (oldRaw.length > 80 || newRaw.length > 80)
   );
 }
 
@@ -23,10 +36,18 @@ export function isDiffable(
  * render as a single value, not as an old → new transition.
  */
 export function isUnchanged(change: FieldChange): boolean {
-  const { old_value, new_value } = change;
-  if (old_value === new_value) return true;
-  if (old_value == null || new_value == null) return false;
-  return JSON.stringify(old_value) === JSON.stringify(new_value);
+  // Normalize "no prior" (old_value bundle is null) and "prior was JSON null"
+  // (old_value.raw is null) to the same nothing-asserted state. The wire
+  // format doesn't distinguish them, and UX-wise rendering "—> null" as a
+  // creation row would be noise: there's no observable difference between
+  // "field didn't exist before" and "field was null before" when the new
+  // value is also null. If we later want creation-of-null to read as a
+  // distinct event (e.g. for ingest provenance), tighten this here.
+  const oldRaw = change.old_value?.raw ?? null;
+  const newRaw = change.new_value.raw ?? null;
+  if (oldRaw === newRaw) return true;
+  if (oldRaw == null || newRaw == null) return false;
+  return JSON.stringify(oldRaw) === JSON.stringify(newRaw);
 }
 
 /**
@@ -53,18 +74,20 @@ export function hasMeaningfulValue(v: unknown): boolean {
  * indicator, not as `old → —`.
  */
 export function isDeletion(change: FieldChange): boolean {
-  return hasMeaningfulValue(change.old_value) && !hasMeaningfulValue(change.new_value);
+  return hasMeaningfulValue(change.old_value?.raw) && !hasMeaningfulValue(change.new_value.raw);
 }
 
 /**
- * If `v` is a simple relationship-claim dict — `{exists: bool, <key>: string}`
- * with exactly one non-`exists` key and a string value — return the scalar
- * along with the existence flag, so the caller can render `DW` (or struck-
- * through `DW` when `exists` is false) instead of the raw JSON dict.
+ * Defensive fallback: extract a single-string-key claim dict
+ * (`{exists: bool, <key>: string}`) into `{display, exists}` so the caller
+ * can render `DW` (or struck-through `DW` when `exists` is false) instead
+ * of raw JSON.
  *
- * Returns null for shapes that need richer rendering (credits, gameplay
- * features, media attachments, FK-pk relationships, alias_value+display).
- * Bare scalars also return null — those go straight through `formatValue`.
+ * Primarily a safety net for claim values whose namespace isn't registered
+ * with a `RelationshipSchema` — those don't get a `display` struct from
+ * the backend, so `ClaimValue.svelte` falls through to this. In steady
+ * state every registered namespace produces a `display`, making this path
+ * rarely exercised; keep it for resilience.
  */
 export function simplifyClaimValue(v: unknown): { display: string; exists: boolean } | null {
   if (v === null || typeof v !== 'object' || Array.isArray(v)) return null;
@@ -79,7 +102,7 @@ export function simplifyClaimValue(v: unknown): { display: string; exists: boole
 
 /** Format an unknown claim value for inline display, with truncation. */
 export function formatValue(v: unknown): string {
-  if (v === null || v === undefined || v === '') return '\u2014';
+  if (v === null || v === undefined || v === '') return '—';
   const s = typeof v === 'string' ? v : JSON.stringify(v);
   return s.length > 120 ? s.slice(0, 120) + '...' : s;
 }

--- a/frontend/src/lib/components/change-display.ts
+++ b/frontend/src/lib/components/change-display.ts
@@ -30,6 +30,18 @@ export function isUnchanged(change: FieldChange): boolean {
 }
 
 /**
+ * True when a change deletes a scalar field — old had a value, new is null /
+ * undefined / empty string. These should render as just the struck-through
+ * old value with a removed indicator, not as `old → —`.
+ */
+export function isDeletion(change: FieldChange): boolean {
+  const { old_value, new_value } = change;
+  const hadValue = old_value !== null && old_value !== undefined && old_value !== '';
+  const hasValue = new_value !== null && new_value !== undefined && new_value !== '';
+  return hadValue && !hasValue;
+}
+
+/**
  * If `v` is a simple relationship-claim dict — `{exists: bool, <key>: string}`
  * with exactly one non-`exists` key and a string value — return the scalar
  * along with the existence flag, so the caller can render `DW` (or struck-

--- a/frontend/src/lib/components/change-display.ts
+++ b/frontend/src/lib/components/change-display.ts
@@ -29,6 +29,27 @@ export function isUnchanged(change: FieldChange): boolean {
   return JSON.stringify(old_value) === JSON.stringify(new_value);
 }
 
+/**
+ * If `v` is a simple relationship-claim dict — `{exists: bool, <key>: string}`
+ * with exactly one non-`exists` key and a string value — return the scalar
+ * along with the existence flag, so the caller can render `DW` (or struck-
+ * through `DW` when `exists` is false) instead of the raw JSON dict.
+ *
+ * Returns null for shapes that need richer rendering (credits, gameplay
+ * features, media attachments, FK-pk relationships, alias_value+display).
+ * Bare scalars also return null — those go straight through `formatValue`.
+ */
+export function simplifyClaimValue(v: unknown): { display: string; exists: boolean } | null {
+  if (v === null || typeof v !== 'object' || Array.isArray(v)) return null;
+  const obj = v as Record<string, unknown>;
+  if (typeof obj.exists !== 'boolean') return null;
+  const otherKeys = Object.keys(obj).filter((k) => k !== 'exists');
+  if (otherKeys.length !== 1) return null;
+  const scalar = obj[otherKeys[0]];
+  if (typeof scalar !== 'string') return null;
+  return { display: scalar, exists: obj.exists };
+}
+
 /** Format an unknown claim value for inline display, with truncation. */
 export function formatValue(v: unknown): string {
   if (v === null || v === undefined || v === '') return '\u2014';

--- a/frontend/src/lib/components/change-display.ts
+++ b/frontend/src/lib/components/change-display.ts
@@ -17,6 +17,18 @@ export function isDiffable(
   );
 }
 
+/**
+ * True when a change asserts the same value that already existed — e.g. a
+ * second ingest source confirming the canonical value. Such rows should
+ * render as a single value, not as an old → new transition.
+ */
+export function isUnchanged(change: FieldChange): boolean {
+  const { old_value, new_value } = change;
+  if (old_value === new_value) return true;
+  if (old_value == null || new_value == null) return false;
+  return JSON.stringify(old_value) === JSON.stringify(new_value);
+}
+
 /** Format an unknown claim value for inline display, with truncation. */
 export function formatValue(v: unknown): string {
   if (v === null || v === undefined || v === '') return '\u2014';

--- a/frontend/src/lib/components/claim-display.test.ts
+++ b/frontend/src/lib/components/claim-display.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClaimDisplayValueSchema } from '$lib/api/schema';
+import {
+  buildDisplaySegments,
+  DELETED_PLACEHOLDER,
+  IDENTITY_SEPARATOR,
+  MISSING_PLACEHOLDER,
+} from './claim-display';
+import { _resetQualifierWarnings } from './qualifier-renderers';
+
+function display(partial: Partial<ClaimDisplayValueSchema>): ClaimDisplayValueSchema {
+  return { identity: [], qualifiers: [], ...partial };
+}
+
+describe('buildDisplaySegments', () => {
+  it('renders a single resolved identity as one text segment', () => {
+    const out = buildDisplaySegments(
+      display({ identity: [{ key: 'theme', label: 'Horror', state: 'resolved' }] }),
+    );
+    expect(out).toEqual([{ text: 'Horror', missing: false }]);
+  });
+
+  it('joins two resolved identities with the em-dash separator', () => {
+    const out = buildDisplaySegments(
+      display({
+        identity: [
+          { key: 'person', label: 'Pat Lawlor', state: 'resolved' },
+          { key: 'role', label: 'Art', state: 'resolved' },
+        ],
+      }),
+    );
+    expect(out).toEqual([
+      { text: 'Pat Lawlor', missing: false },
+      { text: IDENTITY_SEPARATOR, missing: false },
+      { text: 'Art', missing: false },
+    ]);
+  });
+
+  it('marks deleted identities for placeholder styling', () => {
+    const out = buildDisplaySegments(
+      display({ identity: [{ key: 'person', label: null, state: 'deleted' }] }),
+    );
+    expect(out).toEqual([{ text: DELETED_PLACEHOLDER, missing: true }]);
+  });
+
+  it('marks missing identities for placeholder styling', () => {
+    const out = buildDisplaySegments(
+      display({ identity: [{ key: 'person', label: null, state: 'missing' }] }),
+    );
+    expect(out).toEqual([{ text: MISSING_PLACEHOLDER, missing: true }]);
+  });
+
+  it('treats a resolved-but-null label as empty text rather than placeholder', () => {
+    // Empty-string identity (e.g. a deliberately blank abbreviation) renders
+    // as "" with normal styling. Backend signals this as state="resolved"
+    // with label="" or null; either way the renderer treats it as data.
+    const out = buildDisplaySegments(
+      display({ identity: [{ key: 'value', label: null, state: 'resolved' }] }),
+    );
+    expect(out).toEqual([{ text: '', missing: false }]);
+  });
+
+  it('appends qualifier fragments after the identity', () => {
+    const out = buildDisplaySegments(
+      display({
+        identity: [{ key: 'gameplay_feature', label: 'Multiball', state: 'resolved' }],
+        qualifiers: [{ key: 'count', value: 3 }],
+      }),
+    );
+    expect(out).toEqual([
+      { text: 'Multiball', missing: false },
+      { text: ' ×3', missing: false },
+    ]);
+  });
+
+  it('omits the qualifier segment when all qualifiers render to empty', () => {
+    // count=1 → '' per the qualifier renderer rules.
+    const out = buildDisplaySegments(
+      display({
+        identity: [{ key: 'gameplay_feature', label: 'Multiball', state: 'resolved' }],
+        qualifiers: [{ key: 'count', value: 1 }],
+      }),
+    );
+    expect(out).toEqual([{ text: 'Multiball', missing: false }]);
+  });
+
+  describe('unknown qualifier keys', () => {
+    beforeEach(() => {
+      _resetQualifierWarnings();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('falls through to default rendering for unknown keys', () => {
+      const out = buildDisplaySegments(
+        display({
+          identity: [{ key: 'thing', label: 'Widget', state: 'resolved' }],
+          qualifiers: [{ key: 'weirdkey', value: 'hello' }],
+        }),
+      );
+      expect(out).toEqual([
+        { text: 'Widget', missing: false },
+        { text: ' (weirdkey: hello)', missing: false },
+      ]);
+    });
+  });
+});

--- a/frontend/src/lib/components/claim-display.ts
+++ b/frontend/src/lib/components/claim-display.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure data transform: turn a backend `ClaimDisplayValueSchema` into the
+ * flat list of segments the renderer iterates over. Kept Svelte-free so
+ * the rendering rules — identity-joined-by-em-dash, deleted/missing get
+ * placeholder text, qualifiers concatenated at the end — can be covered
+ * by unit tests without a DOM.
+ */
+import type { ClaimDisplayValueSchema } from '$lib/api/schema';
+import { renderQualifier } from './qualifier-renderers';
+
+export type DisplaySegment = { text: string; missing: boolean };
+
+// Non-breaking spaces around the em-dash so a long name doesn't wrap
+// mid-separator.
+export const IDENTITY_SEPARATOR = ' — ';
+
+export const DELETED_PLACEHOLDER = '(deleted)';
+export const MISSING_PLACEHOLDER = '(missing)';
+
+export function buildDisplaySegments(display: ClaimDisplayValueSchema): DisplaySegment[] {
+  const out: DisplaySegment[] = [];
+  display.identity.forEach((part, i) => {
+    if (i > 0) out.push({ text: IDENTITY_SEPARATOR, missing: false });
+    if (part.state === 'resolved') {
+      out.push({ text: part.label ?? '', missing: false });
+    } else if (part.state === 'deleted') {
+      out.push({ text: DELETED_PLACEHOLDER, missing: true });
+    } else {
+      out.push({ text: MISSING_PLACEHOLDER, missing: true });
+    }
+  });
+  const qf = display.qualifiers.map((q) => renderQualifier(q.key, q.value)).join('');
+  if (qf) out.push({ text: qf, missing: false });
+  return out;
+}

--- a/frontend/src/lib/components/qualifier-renderers.ts
+++ b/frontend/src/lib/components/qualifier-renderers.ts
@@ -1,0 +1,52 @@
+/**
+ * Per-qualifier-key rendering for relationship-claim display values.
+ *
+ * The backend emits structured `ClaimDisplayQualifierPartSchema` entries
+ * with `{key, value}`; this module turns each into a string fragment to
+ * append to the identity rendering. Keying on the qualifier `ValueKeySpec`
+ * name (`count`, `category`, `is_primary`) — not on the namespace — means
+ * any future relationship that happens to carry one of these qualifiers
+ * gets the same rendering for free.
+ */
+
+export type QualifierValue = boolean | number | string | null | undefined;
+export type QualifierRenderer = (value: QualifierValue) => string;
+
+export const qualifierRenderers: Record<string, QualifierRenderer> = {
+  count: (v) => (typeof v === 'number' && v > 1 ? ` ×${v}` : ''),
+  category: (v) => (v ? ` (${v})` : ''),
+  is_primary: (v) => (v === true ? ' [primary]' : ''),
+};
+
+/**
+ * Default rendering for qualifier keys the frontend hasn't been taught
+ * about. Mirrors `category`'s truthiness skip (null/false/empty → omit)
+ * so unknown data with no visible payload silently disappears.
+ */
+export function renderDefaultQualifier(key: string, value: QualifierValue): string {
+  if (value === null || value === undefined || value === false || value === '') return '';
+  return ` (${key}: ${value})`;
+}
+
+const warnedKeys = new Set<string>();
+
+/**
+ * Render one qualifier entry. Unknown keys go through `renderDefaultQualifier`
+ * and emit a one-shot `console.warn` per key — the chip still shows the data
+ * (edit history's whole job is transparency about what changed) and the
+ * dev-team alert flags the missing rendering rule.
+ */
+export function renderQualifier(key: string, value: QualifierValue): string {
+  const renderer = qualifierRenderers[key];
+  if (renderer) return renderer(value);
+  if (!warnedKeys.has(key)) {
+    warnedKeys.add(key);
+    console.warn(`[ClaimValue] No qualifier renderer registered for key "${key}"`);
+  }
+  return renderDefaultQualifier(key, value);
+}
+
+/** Test-only: reset the once-per-key warn dedupe. */
+export function _resetQualifierWarnings(): void {
+  warnedKeys.clear();
+}

--- a/frontend/src/routes/changesets/+page.svelte
+++ b/frontend/src/routes/changesets/+page.svelte
@@ -235,18 +235,21 @@
                       <div class="field-row field-row-diff">
                         <dt>{change.field_name}</dt>
                         <dd>
-                          <InlineDiff oldValue={change.old_value} newValue={change.new_value} />
+                          <InlineDiff
+                            oldValue={change.old_value.raw}
+                            newValue={change.new_value.raw}
+                          />
                         </dd>
                       </div>
                     {:else}
                       <div class="field-row">
                         <dt>{change.field_name}</dt>
                         <dd>
-                          {#if change.old_value !== null && change.old_value !== undefined}
-                            <span class="old-value">{formatValue(change.old_value)}</span>
+                          {#if change.old_value != null}
+                            <span class="old-value">{formatValue(change.old_value.raw)}</span>
                             <span class="arrow">&rarr;</span>
                           {/if}
-                          <span class="new-value">{formatValue(change.new_value)}</span>
+                          <span class="new-value">{formatValue(change.new_value.raw)}</span>
                         </dd>
                       </div>
                     {/if}
@@ -261,7 +264,7 @@
                       <dt>{retraction.field_name}</dt>
                       <dd>
                         <span class="retraction-label">Removed</span>
-                        <span class="old-value">{formatValue(retraction.old_value)}</span>
+                        <span class="old-value">{formatValue(retraction.old_value.raw)}</span>
                       </dd>
                     </div>
                   {/each}


### PR DESCRIPTION
## What's Changed

### Improve display of edit history:

- Render relationship claims with proper display labels, collapse confirming ingest claims to a single value, show deletions as struck-through with a red ✕, and treat bare retraction markers as "no prior value."
- Stack edit-history rows to two lines on narrow cards for readability.

### Rearchitect edit history's claim rendering

- Move edit-history claim rendering from ad-hoc frontend formatters to a model-driven display layer: the backend emits structured display payloads (labels, qualifiers, retraction markers) and the frontend renders them via shared `ClaimValue` / `ClaimDisplay` components.

### Improve typing documentation

- Tighten typing guidance in docs/Python.md and CLAUDE.md