### PR TITLE
docs(schemas): add class docstrings to clarify non-obvious schemas

### DIFF
--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -25,6 +25,12 @@ class EntityCreateInputSchema(ChangeSetInputSchema):
 
 
 class ClaimPatchSchema(ChangeSetInputSchema):
+    """Generic claim-patch body for entity types with no list-shaped
+    payloads beyond ``fields``. Entity types that own M2M/list relations
+    (parents, aliases, themes, credits, …) use the per-entity subclasses
+    below instead.
+    """
+
     # ``fields`` maps claim-field name → new value. Values are polymorphic per
     # field (str, int, bool, slug string for FK-backed claims, None) and are
     # validated downstream by ``validate_claim_value``; no fixed TypedDict.
@@ -32,6 +38,10 @@ class ClaimPatchSchema(ChangeSetInputSchema):
 
 
 class HierarchyClaimPatchSchema(ChangeSetInputSchema):
+    """Patch body for hierarchy-shaped taxonomies (themes, locations,
+    technology generations, …) whose claims include parent links and aliases.
+    """
+
     # See ClaimPatchSchema.fields — polymorphic per claim field, validated downstream.
     fields: dict[str, Any] = {}
     parents: list[str] | None = None
@@ -39,22 +49,37 @@ class HierarchyClaimPatchSchema(ChangeSetInputSchema):
 
 
 class CorporateEntityClaimPatchSchema(ChangeSetInputSchema):
+    """Patch body for manufacturer/operator/etc. — aliases, but no parents
+    (corporate entities are flat, not hierarchical)."""
+
     # See ClaimPatchSchema.fields — polymorphic per claim field, validated downstream.
     fields: dict[str, Any] = {}
     aliases: list[str] | None = None
 
 
 class GameplayFeatureInputSchema(Schema):
+    """Nested entry in :class:`ModelClaimPatchSchema.gameplay_features` —
+    standalone because each entry carries a ``count`` alongside the slug.
+    """
+
     slug: str
     count: int | None = None
 
 
 class CreditInputSchema(Schema):
+    """Nested entry in :class:`ModelClaimPatchSchema.credits` — standalone
+    because each entry pairs a person slug with a role.
+    """
+
     person_slug: str
     role: str
 
 
 class ModelClaimPatchSchema(ChangeSetInputSchema):
+    """Patch body for Model — the widest entity, with several list payloads
+    on top of the generic ``fields`` bag.
+    """
+
     # See ClaimPatchSchema.fields — polymorphic per claim field, validated downstream.
     fields: dict[str, Any] = {}
     themes: list[str] | None = None
@@ -66,6 +91,10 @@ class ModelClaimPatchSchema(ChangeSetInputSchema):
 
 
 class TitleClaimPatchSchema(ChangeSetInputSchema):
+    """Patch body for Title — narrow because most attributes live on Model
+    (see [docs/SingleModelTitles.md] for the asymmetric split).
+    """
+
     # See ClaimPatchSchema.fields — polymorphic per claim field, validated downstream.
     fields: dict[str, Any] = {}
     abbreviations: list[str] | None = None
@@ -269,11 +298,21 @@ class CreditSchema(Schema):
 
 
 class CorporateEntityLocationAncestorRef(Schema):
+    """Narrowed ancestor row in :class:`CorporateEntityLocationSchema.ancestors`
+    — omits ``slug``/``location_type`` because ancestors render as a
+    breadcrumb, not as links.
+    """
+
     display_name: str
     location_path: str
 
 
 class CorporateEntityLocationSchema(Schema):
+    """A corporate entity's location plus its ancestor chain. The location
+    itself is linkable (``slug``, ``location_type``); ancestors use the
+    narrower :class:`CorporateEntityLocationAncestorRef`.
+    """
+
     location_path: str
     location_type: str
     display_name: str

--- a/backend/apps/citation/schemas.py
+++ b/backend/apps/citation/schemas.py
@@ -42,6 +42,12 @@ class CitationSourceParentSchema(Schema):
 
 
 class CitationRecognitionSchema(Schema):
+    """A URL or ISBN typed into citation search was recognized as belonging
+    to a known parent source. ``child`` is set when a record with the
+    extracted ``identifier`` already exists; otherwise the UI has enough to
+    prefill a create form.
+    """
+
     parent: CitationSourceParentSchema
     child: CitationSourceMatchSchema | None = None
     identifier: str | None = None
@@ -172,6 +178,11 @@ class CitationExtractDraftSchema(Schema):
 
 
 class CitationExtractResultSchema(Schema):
+    """Result of looking up a pasted URL/ISBN via an external API.
+    ``match`` points at an existing source if one was found; ``draft`` is a
+    prefill for the create form; ``error`` is a user-facing failure reason.
+    """
+
     draft: CitationExtractDraftSchema | None = None
     match: CitationSourceMatchSchema | None = None
     error: str | None = None

--- a/backend/apps/core/schemas.py
+++ b/backend/apps/core/schemas.py
@@ -70,7 +70,10 @@ class EntityLinkSchema(Schema):
 
 
 class LinkTypeSchema(Schema):
-    """One entry in the autocomplete type picker."""
+    """One *kind* of wikilink target (title, model, person, …) — populates
+    the type selector in the wikilink picker. Targets within a chosen type
+    are returned as :class:`LinkTargetSchema`.
+    """
 
     name: str
     label: str
@@ -79,10 +82,8 @@ class LinkTypeSchema(Schema):
 
 
 class LinkTargetSchema(Schema):
-    """Serialized shape for one autocomplete result.
-
-    Returned by ``LinkType.autocomplete_serialize`` and consumed by the
-    ``/link-types/targets/`` endpoint.
+    """One autocomplete result within a chosen :class:`LinkTypeSchema`.
+    ``ref`` is the wikilink string the editor inserts.
     """
 
     ref: str

--- a/backend/apps/media/schemas.py
+++ b/backend/apps/media/schemas.py
@@ -23,12 +23,20 @@ class UploadedMediaSchema(Schema):
 
 
 class RenditionUrlsSchema(Schema):
+    """Rendition URLs returned in the upload response. Includes ``original``,
+    unlike the public-facing :class:`MediaRenditionsSchema`.
+    """
+
     original: str
     thumb: str
     display: str
 
 
 class AttachmentMetaSchema(Schema):
+    """Echo of where an upload was attached, returned inside
+    :class:`UploadSchema`.
+    """
+
     entity_type: str
     public_id: str
     category: str | None

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -125,6 +125,12 @@ class FieldChangeSchema(Schema):
 
 
 class RetractionSchema(Schema):
+    """A claim that was retracted (not superseded) within a ChangeSet.
+
+    Distinct from :class:`FieldChangeSchema`: a retraction removes a prior
+    claim without replacing it, so there is no ``new_value``.
+    """
+
     claim_id: int
     field_name: str
     claim_key: str
@@ -264,6 +270,13 @@ class RichTextSchema(Schema):
 
 
 class CitationSourceSchema(Schema):
+    """A reusable citation source (a book, website, person, etc.).
+
+    The source itself — not an individual reference *to* it. Distinct from
+    :class:`CitationInstanceSchema`, which is one use of a source on a
+    specific claim.
+    """
+
     name: str
     slug: str
     source_type: str
@@ -273,6 +286,15 @@ class CitationSourceSchema(Schema):
 
 
 class ReviewClaimSchema(Schema):
+    """A flagged claim as surfaced in the global review queue.
+
+    Self-contains subject context (``subject_*``, ``title_slug``,
+    ``review_links``) because the review UI displays claims *outside* any
+    entity page. Distinct from :class:`ClaimSchema`, which assumes the
+    entity context is already known (Sources page) and instead carries
+    priority/citation metadata (``citation``, ``is_winner``).
+    """
+
     id: int
     source_name: str
     field_name: str
@@ -293,18 +315,31 @@ class ReviewClaimSchema(Schema):
 
 
 class RevertNoteSchema(Schema):
+    """Input for reverting a single claim to a prior value. ``note`` is required."""
+
     note: str
 
 
 class UndoChangeSetSchema(Schema):
+    """Input for undoing an entire ChangeSet (a create/edit/delete grouping)."""
+
     note: str = ""
 
 
 class UndoResultSchema(Schema):
+    """Result of an undo: the id of the new compensating ChangeSet."""
+
     changeset_id: int
 
 
 class CitationInstanceSchema(Schema):
+    """One use of a CitationSource on a specific claim, with a locator.
+
+    The "instance" half of source/instance: a :class:`CitationSourceSchema`
+    is the source itself; a CitationInstance attaches it to a claim with a
+    page number, URL fragment, or other locator.
+    """
+
     id: int
     citation_source_id: int
     citation_source_name: str
@@ -314,6 +349,13 @@ class CitationInstanceSchema(Schema):
 
 
 class CitationInstanceBatchSchema(Schema):
+    """A CitationInstance flattened with its source fields for batch rendering.
+
+    Used where the UI needs source metadata (name, type, author, year)
+    alongside the instance without a separate source lookup — typically
+    when rendering many citations at once.
+    """
+
     id: int
     source_name: str
     source_type: str
@@ -324,5 +366,7 @@ class CitationInstanceBatchSchema(Schema):
 
 
 class CitationInstanceCreateSchema(Schema):
+    """Input for creating a new CitationInstance against an existing source."""
+
     citation_source_id: int
     locator: str = ""


### PR DESCRIPTION
## Summary

- Add brief class docstrings to Schema classes across `citation`, `core`, `media`, `catalog`, and `provenance` whose purpose isn't obvious from the name alone, or that are easily confused with sibling schemas.
- Focus on the *why* and on distinctions from neighbors (e.g. `RenditionUrlsSchema` vs `MediaRenditionsSchema`, the parallel `*ClaimPatchSchema` per entity type, `LinkTypeSchema` vs `LinkTargetSchema`).
- No behavior changes.

## Test plan

- [x] Pre-commit hooks pass (ruff, mypy, backend tests)
- [ ] Skim the rendered docstrings in an editor to confirm cross-references resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)