### PR TITLE
feat(provenance): render resolved claim values on Sources, Global Changes, and Claim Review

### DIFF
--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -29,6 +29,7 @@ from apps.core.authz.types import Activity
 from apps.core.models import LinkableModel
 from apps.core.schemas import ErrorDetailSchema
 
+from .display import FieldValue, claim_value, resolve_labels
 from .models import CitationInstance, Claim, ClaimControlledModel, Source
 from .page_endpoints import pages_router
 from .schemas import (
@@ -108,11 +109,12 @@ def _build_claim_review_context(
 @decorate_view(cache_control(no_cache=True))
 def list_review_claims(request: HttpRequest) -> list[ReviewClaimSchema]:
     """Return all active claims flagged for review."""
-    claims = (
+    claims = list(
         Claim.objects.filter(is_active=True, needs_review=True)
         .select_related("source", "content_type")
         .order_by("-created_at")
     )
+    labels = resolve_labels(FieldValue(c.field_name, c.value) for c in claims)
 
     results: list[ReviewClaimSchema] = []
     for claim in claims:
@@ -131,7 +133,7 @@ def list_review_claims(request: HttpRequest) -> list[ReviewClaimSchema]:
                 id=claim.pk,
                 source_name=claim.source.name if claim.source else "User",
                 field_name=claim.field_name,
-                value=claim.value,
+                value=claim_value(claim.field_name, claim.value, labels),
                 needs_review_notes=claim.needs_review_notes,
                 created_at=claim.created_at.isoformat(),
                 subject_type=_subject_entity_type(claim),

--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -112,6 +112,7 @@ def list_review_claims(request: HttpRequest) -> list[ReviewClaimSchema]:
     claims = list(
         Claim.objects.filter(is_active=True, needs_review=True)
         .select_related("source", "content_type")
+        .prefetch_related("subject")
         .order_by("-created_at")
     )
     labels = resolve_labels(FieldValue(c.field_name, c.value) for c in claims)

--- a/backend/apps/provenance/display.py
+++ b/backend/apps/provenance/display.py
@@ -12,7 +12,7 @@ the frontend; the backend's job is FK-pk-to-label resolution.
 Usage::
 
     labels = resolve_labels([FieldValue(field_name, value), ...])
-    display = build_display_value(field_name, value, labels)
+    bundled = claim_value(field_name, value, labels)  # {raw, display}
 
 ``resolve_labels`` queries one row per FK target model (no per-row N+1).
 Bare scalars (direct-field claims like ``technology_generation``) and
@@ -34,6 +34,7 @@ from .schemas import (
     ClaimDisplayIdentityState,
     ClaimDisplayQualifierPartSchema,
     ClaimDisplayValueSchema,
+    ClaimValueSchema,
 )
 from .validation import (
     RelationshipSchema,
@@ -340,3 +341,12 @@ def build_display_value(
         )
 
     return ClaimDisplayValueSchema(identity=identity_parts, qualifiers=qualifier_parts)
+
+
+def claim_value(
+    field_name: str, value: object, labels: LabelLookup
+) -> ClaimValueSchema:
+    """Bundle a raw claim value with its structured display rendering."""
+    return ClaimValueSchema(
+        raw=value, display=build_display_value(field_name, value, labels)
+    )

--- a/backend/apps/provenance/helpers.py
+++ b/backend/apps/provenance/helpers.py
@@ -8,6 +8,7 @@ from typing import cast
 from django.db import models
 from django.db.models import Case, F, IntegerField, Prefetch, QuerySet, Value, When
 
+from .display import FieldValue, claim_value, resolve_labels
 from .models import CitationInstance, Claim
 from .schemas import ClaimAttributionSchema, ClaimSchema
 
@@ -76,7 +77,12 @@ def build_sources(claims: Iterable[Claim]) -> list[ClaimSchema]:
 
     Claims should be ordered by claim_key, -priority, -created_at. The first
     claim seen per claim_key is marked as the winner.
+
+    The iterable is materialized to a list internally so FK display labels can
+    be resolved in a single batched pass before the per-claim loop.
     """
+    claims = list(claims)
+    labels = resolve_labels(FieldValue(c.field_name, c.value) for c in claims)
     winners: set[str] = set()
     sources: list[ClaimSchema] = []
     for claim in claims:
@@ -91,7 +97,7 @@ def build_sources(claims: Iterable[Claim]) -> list[ClaimSchema]:
                     created_at=claim.created_at.isoformat(),
                 ),
                 field_name=claim.field_name,
-                value=claim.value,
+                value=claim_value(claim.field_name, claim.value, labels),
                 citation=claim.citation,
                 is_winner=is_winner,
                 changeset_note=claim.changeset.note if claim.changeset else None,

--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -4,18 +4,18 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
+from itertools import chain
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Case, F, IntegerField, Model, Prefetch, Q, Value, When
 
 from apps.core.authz import PolicyUser, compute_row_capabilities
 
-from .display import FieldValue, LabelLookup, build_display_value, resolve_labels
+from .display import FieldValue, LabelLookup, claim_value, resolve_labels
 from .models import ChangeSet, Claim
 from .schemas import (
     ChangeSetSchema,
     ClaimAttributionSchema,
-    ClaimValueSchema,
     FieldChangeSchema,
     RetractionSchema,
 )
@@ -59,33 +59,18 @@ def build_changes(
     rets = list(retracted)
 
     if labels is None:
-
-        def _label_refs() -> Iterable[FieldValue]:
-            for c in own:
-                yield FieldValue(c.field_name, c.value)
-            for c in rets:
-                yield FieldValue(c.field_name, c.value)
-            for chain in history_by_key.values():
-                for c in chain:
-                    yield FieldValue(c.field_name, c.value)
-
-        labels = resolve_labels(_label_refs())
+        labels = resolve_labels(
+            FieldValue(c.field_name, c.value)
+            for c in chain(own, rets, *history_by_key.values())
+        )
 
     changes: list[FieldChangeSchema] = []
     for claim in own:
         prior = _prior_value(claim, history_by_key.get(claim.claim_key, []))
         old_value = (
-            ClaimValueSchema(
-                raw=prior,
-                display=build_display_value(claim.field_name, prior, labels),
-            )
-            if prior is not None
-            else None
+            claim_value(claim.field_name, prior, labels) if prior is not None else None
         )
-        new_value = ClaimValueSchema(
-            raw=claim.value,
-            display=build_display_value(claim.field_name, claim.value, labels),
-        )
+        new_value = claim_value(claim.field_name, claim.value, labels)
         changes.append(
             FieldChangeSchema(
                 field_name=claim.field_name,
@@ -107,10 +92,7 @@ def build_changes(
             claim_id=c.pk,
             field_name=c.field_name,
             claim_key=c.claim_key,
-            old_value=ClaimValueSchema(
-                raw=c.value,
-                display=build_display_value(c.field_name, c.value, labels),
-            ),
+            old_value=claim_value(c.field_name, c.value, labels),
         )
         for c in rets
     ]

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -190,18 +190,11 @@ class ChangeSetSchema(ChangeSetBaseSchema):
 
 
 class ClaimSchema(Schema):
-    """A single per-field claim as surfaced to the Sources UI.
-
-    ``value`` is the raw JSONField payload — kept flat (``object``, not
-    bundled into :class:`ClaimValueSchema`) until Sources UI display
-    rendering is actually implemented. Bundling now would require
-    rewriting the live Sources consumers (``EntitySources.svelte``,
-    ``entity-sources.ts``) — out of scope for this PR.
-    """
+    """A single per-field claim as surfaced to the Sources UI."""
 
     attribution: ClaimAttributionSchema
     field_name: str
-    value: object
+    value: ClaimValueSchema
     citation: str
     is_winner: bool
     changeset_note: str | None = None
@@ -298,10 +291,7 @@ class ReviewClaimSchema(Schema):
     id: int
     source_name: str
     field_name: str
-    # ``value`` is the raw JSONField payload — kept flat (``object``, not
-    # bundled into :class:`ClaimValueSchema`) until the review UI grows
-    # structured display rendering.
-    value: object
+    value: ClaimValueSchema
     needs_review_notes: str
     created_at: str
     # Context about the subject (the entity this claim targets).

--- a/backend/apps/provenance/tests/test_api_review.py
+++ b/backend/apps/provenance/tests/test_api_review.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from apps.catalog.models import CreditRole, Person, Series
 from apps.catalog.tests.conftest import make_machine_model
@@ -60,3 +62,39 @@ class TestReviewClaimsDisplay:
         row = next(r for r in resp.json() if r["field_name"] == "name")
         assert row["value"]["raw"] == "Some Name"
         assert row["value"]["display"] is None
+
+
+@pytest.mark.django_db
+def test_review_claims_query_count_does_not_scale_with_rows(client, source):
+    """The GFK ``Claim.subject`` is accessed inside the per-claim loop;
+    without ``prefetch_related("subject")`` each access fires a query."""
+
+    def _seed(start: int, count: int) -> None:
+        for i in range(start, start + count):
+            series = Series.objects.create(slug=f"s-{i}", name=f"S {i}")
+            claim = Claim.objects.assert_claim(
+                series, "name", f"Name {i}", source=source
+            )
+            _flag(claim)
+
+    _seed(start=0, count=2)
+    with CaptureQueriesContext(connection) as small_ctx:
+        resp = client.get("/api/review/claims/")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+    small_count = len(small_ctx.captured_queries)
+
+    _seed(start=2, count=8)
+    with CaptureQueriesContext(connection) as big_ctx:
+        resp = client.get("/api/review/claims/")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 10
+    big_count = len(big_ctx.captured_queries)
+
+    assert big_count == small_count, (
+        f"Query count scaled with row count: {small_count} queries at N=2, "
+        f"{big_count} at N=10. Likely a missing prefetch on the GFK "
+        f"``Claim.subject``.\n"
+        f"Extra queries:\n"
+        + "\n".join(q["sql"] for q in big_ctx.captured_queries[small_count:])
+    )

--- a/backend/apps/provenance/tests/test_api_review.py
+++ b/backend/apps/provenance/tests/test_api_review.py
@@ -1,0 +1,62 @@
+"""Tests for the review queue endpoint."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.catalog.models import CreditRole, Person, Series
+from apps.catalog.tests.conftest import make_machine_model
+from apps.provenance.models import Claim, Source
+
+
+@pytest.fixture
+def source(db):
+    return Source.objects.create(
+        name="S", slug="s", source_type="editorial", priority=1
+    )
+
+
+def _flag(claim: Claim) -> None:
+    claim.needs_review = True
+    claim.save(update_fields=["needs_review"])
+
+
+@pytest.mark.django_db
+class TestReviewClaimsDisplay:
+    """Wiring check: ``/api/review/claims/`` must populate ``value.display``
+    for relationship claims and leave it null for scalars."""
+
+    def test_relationship_claim_value_has_display(self, client, source):
+        pm = make_machine_model(name="MM", slug="mm-review", year=1997)
+        person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
+        role = CreditRole.objects.create(name="Art", slug="art")
+        claim = Claim.objects.assert_claim(
+            pm,
+            "credit",
+            {"person": person.pk, "role": role.pk, "exists": True},
+            source=source,
+            claim_key=f"credit|person:{person.pk}|role:{role.pk}",
+        )
+        _flag(claim)
+
+        resp = client.get("/api/review/claims/")
+        assert resp.status_code == 200
+        rows = [r for r in resp.json() if r["field_name"] == "credit"]
+        assert len(rows) == 1
+        display = rows[0]["value"]["display"]
+        assert display is not None
+        assert [(p["key"], p["label"]) for p in display["identity"]] == [
+            ("person", "Pat Lawlor"),
+            ("role", "Art"),
+        ]
+
+    def test_scalar_claim_value_has_null_display(self, client, source):
+        series = Series.objects.create(slug="s", name="S")
+        claim = Claim.objects.assert_claim(series, "name", "Some Name", source=source)
+        _flag(claim)
+
+        resp = client.get("/api/review/claims/")
+        assert resp.status_code == 200
+        row = next(r for r in resp.json() if r["field_name"] == "name")
+        assert row["value"]["raw"] == "Some Name"
+        assert row["value"]["display"] is None

--- a/backend/apps/provenance/tests/test_display.py
+++ b/backend/apps/provenance/tests/test_display.py
@@ -22,6 +22,7 @@ from apps.provenance.display import (
     FkRef,
     LabelLookup,
     build_display_value,
+    claim_value,
     resolve_labels,
 )
 from apps.provenance.models import Claim, Source
@@ -346,6 +347,43 @@ class TestBuildDisplayValue:
         assert labels.get(FkRef(Theme, theme.pk)) == "Sci-Fi"
         # Pks that were never referenced return None.
         assert labels.get(FkRef(Person, 999)) is None
+
+
+@pytest.mark.django_db
+class TestClaimValue:
+    def test_relationship_field_bundles_display(self):
+        person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
+        role = CreditRole.objects.create(name="Art", slug="art")
+        value = {"person": person.pk, "role": role.pk, "exists": True}
+
+        labels = resolve_labels([FieldValue("credit", value)])
+        bundled = claim_value("credit", value, labels)
+
+        assert bundled.raw == value
+        assert bundled.display == ClaimDisplayValueSchema(
+            identity=_identity([("person", "Pat Lawlor"), ("role", "Art")]),
+            qualifiers=[],
+        )
+
+    def test_scalar_field_has_null_display(self):
+        bundled = claim_value("name", "Medieval Madness", LabelLookup())
+        assert bundled.raw == "Medieval Madness"
+        assert bundled.display is None
+
+    def test_deleted_fk_target_emits_deleted_state(self):
+        person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
+        role = CreditRole.objects.create(name="Art", slug="art")
+        value = {"person": person.pk, "role": role.pk, "exists": True}
+
+        person.delete()
+        # Resolve after deletion to simulate a stale-but-stored FK pk.
+        labels = resolve_labels([FieldValue("credit", value)])
+        bundled = claim_value("credit", value, labels)
+
+        assert bundled.display is not None
+        states = {part.key: part.state for part in bundled.display.identity}
+        assert states["person"] == "deleted"
+        assert states["role"] == "resolved"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/provenance/tests/test_helpers.py
+++ b/backend/apps/provenance/tests/test_helpers.py
@@ -1,10 +1,12 @@
-"""Tests for provenance helpers: active_claims() and citation_instances()."""
+"""Tests for provenance helpers: active_claims(), citation_instances(), build_sources()."""
 
 import pytest
 
-from apps.catalog.models import Series
+from apps.catalog.models import CreditRole, Person, Series
+from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.helpers import (
     active_claims,
+    build_sources,
     citation_instances,
     claims_prefetch,
 )
@@ -56,3 +58,42 @@ class TestCitationInstances:
 
         with pytest.raises(AssertionError, match="claims_prefetch"):
             citation_instances(bare_claim)
+
+
+@pytest.mark.django_db
+class TestBuildSources:
+    """Wiring check: ``build_sources()`` must populate ``value.display`` for
+    relationship claims and leave it null for scalars. Guards against the
+    helper being called with an empty ``LabelLookup``."""
+
+    def test_relationship_claim_value_has_display(self, source):
+        pm = make_machine_model(name="MM", slug="mm", year=1997)
+        person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
+        role = CreditRole.objects.create(name="Art", slug="art")
+        Claim.objects.assert_claim(
+            pm,
+            "credit",
+            {"person": person.pk, "role": role.pk, "exists": True},
+            source=source,
+            claim_key=f"credit|person:{person.pk}|role:{role.pk}",
+        )
+
+        loaded = pm.__class__.objects.prefetch_related(claims_prefetch()).get(pk=pm.pk)
+        sources = build_sources(active_claims(loaded))
+        credit = next(s for s in sources if s.field_name == "credit")
+
+        assert credit.value.display is not None
+        assert [(p.key, p.label) for p in credit.value.display.identity] == [
+            ("person", "Pat Lawlor"),
+            ("role", "Art"),
+        ]
+
+    def test_scalar_claim_value_has_null_display(self, source):
+        series = Series.objects.create(slug="s", name="S")
+        Claim.objects.assert_claim(series, "name", "S", source=source)
+
+        loaded = Series.objects.prefetch_related(claims_prefetch()).get(pk=series.pk)
+        sources = build_sources(active_claims(loaded))
+
+        assert sources[0].value.raw == "S"
+        assert sources[0].value.display is None

--- a/frontend/src/lib/components/EntitySources.dom.test.ts
+++ b/frontend/src/lib/components/EntitySources.dom.test.ts
@@ -10,7 +10,7 @@ const sampleClaim = {
     created_at: '2026-04-07T00:00:00Z',
   },
   field_name: 'year',
-  value: 1997,
+  value: { raw: 1997 },
   citation: '',
   is_winner: true,
   changeset_note: null,
@@ -51,6 +51,24 @@ describe('EntitySources', () => {
     expect(screen.getByText('Williams Flyer')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Sources', level: 1 })).toBeInTheDocument();
     expect(screen.getByText('Single source (1 field)')).toBeInTheDocument();
+  });
+
+  it('renders the claim value text', () => {
+    render(EntitySources, {
+      props: { sources: [sampleClaim], evidence: [] },
+    });
+
+    expect(screen.getByText('1997')).toBeInTheDocument();
+  });
+
+  it('renders a long scalar value verbatim (no string truncation)', () => {
+    const long = 'a'.repeat(200);
+    const longClaim = { ...sampleClaim, field_name: 'description', value: { raw: long } };
+    render(EntitySources, {
+      props: { sources: [longClaim], evidence: [] },
+    });
+
+    expect(screen.getByText(long)).toBeInTheDocument();
   });
 
   it('omits the Evidence section when no cited changesets are supplied', () => {

--- a/frontend/src/lib/components/EntitySources.svelte
+++ b/frontend/src/lib/components/EntitySources.svelte
@@ -2,6 +2,7 @@
   import type { CitedChangeSetSchema, ClaimSchema } from '$lib/api/schema';
   import ClaimAttribution from './ClaimAttribution.svelte';
   import ClaimAuthor from './ClaimAuthor.svelte';
+  import ClaimValue from './ClaimValue.svelte';
   import FocusContentShell from './FocusContentShell.svelte';
   import { getEntityContext } from '$lib/entity-context';
   import { groupSourcesByField } from './entity-sources';
@@ -23,16 +24,11 @@
   function claimAttribution(claim: Claim): string {
     return claim.attribution.source_name ?? claim.attribution.user_username ?? 'Unknown';
   }
-
-  function formatValue(v: unknown): string {
-    const s = typeof v === 'string' ? v : JSON.stringify(v);
-    return s.length > 100 ? s.slice(0, 100) + '...' : s;
-  }
 </script>
 
 {#snippet claimDetail(claim: Claim)}
   <ClaimAuthor attribution={claim.attribution} />
-  {formatValue(claim.value)}
+  <span class="claim-value-inline"><ClaimValue value={claim.value} /></span>
   {#if claim.is_winner}
     <span class="badge-used">used</span>
   {/if}
@@ -135,9 +131,13 @@
                 <dt>{field}</dt>
                 <dd>
                   <span class="claim used">
-                    {formatValue(claims[0].value)}
+                    <span class="claim-value-inline"><ClaimValue value={claims[0].value} /></span>
                     <span class="source-list">
-                      {claims.map(claimAttribution).join(', ')}
+                      {#each claims as claim, i (i)}
+                        {#if i > 0},
+                        {/if}
+                        <ClaimAuthor attribution={claim.attribution} />
+                      {/each}
                     </span>
                   </span>
                 </dd>
@@ -287,6 +287,14 @@
 
   .claim.used {
     opacity: 1;
+  }
+
+  .claim-value-inline {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .badge-used {

--- a/frontend/src/lib/components/change-display.test.ts
+++ b/frontend/src/lib/components/change-display.test.ts
@@ -41,16 +41,9 @@ describe('formatValue', () => {
     expect(formatValue('hello')).toBe('hello');
   });
 
-  it('truncates strings longer than 120 characters', () => {
+  it('preserves long strings verbatim (callers control overflow via CSS)', () => {
     const long = 'a'.repeat(150);
-    const result = formatValue(long);
-    expect(result).toBe('a'.repeat(120) + '...');
-    expect(result.length).toBe(123);
-  });
-
-  it('preserves strings of exactly 120 characters', () => {
-    const exact = 'b'.repeat(120);
-    expect(formatValue(exact)).toBe(exact);
+    expect(formatValue(long)).toBe(long);
   });
 
   it('JSON-serializes non-string values', () => {
@@ -59,11 +52,9 @@ describe('formatValue', () => {
     expect(formatValue({ key: 'val' })).toBe('{"key":"val"}');
   });
 
-  it('truncates long JSON-serialized values', () => {
+  it('preserves long JSON-serialized values verbatim', () => {
     const obj = { data: 'x'.repeat(200) };
-    const result = formatValue(obj);
-    expect(result.length).toBe(123);
-    expect(result.endsWith('...')).toBe(true);
+    expect(formatValue(obj)).toBe(JSON.stringify(obj));
   });
 });
 

--- a/frontend/src/lib/components/change-display.ts
+++ b/frontend/src/lib/components/change-display.ts
@@ -100,9 +100,13 @@ export function simplifyClaimValue(v: unknown): { display: string; exists: boole
   return { display: scalar, exists: obj.exists };
 }
 
-/** Format an unknown claim value for inline display, with truncation. */
+/**
+ * Format an unknown claim value as a plain string. Null/undefined/empty
+ * collapse to em-dash; non-strings are JSON-serialized. No truncation:
+ * callers control overflow via container CSS (ellipsis vs. wrap), so the
+ * full value reaches the DOM and is available for copy/paste and a11y.
+ */
 export function formatValue(v: unknown): string {
   if (v === null || v === undefined || v === '') return '—';
-  const s = typeof v === 'string' ? v : JSON.stringify(v);
-  return s.length > 120 ? s.slice(0, 120) + '...' : s;
+  return typeof v === 'string' ? v : JSON.stringify(v);
 }

--- a/frontend/src/lib/components/entity-sources.test.ts
+++ b/frontend/src/lib/components/entity-sources.test.ts
@@ -7,7 +7,7 @@ describe('groupSourcesByField', () => {
     const result = groupSourcesByField([
       {
         field_name: 'year',
-        value: 1997,
+        value: { raw: 1997 },
         attribution: {
           source_name: 'IPDB',
           user_username: null,
@@ -19,7 +19,7 @@ describe('groupSourcesByField', () => {
       },
       {
         field_name: 'year',
-        value: 1998,
+        value: { raw: 1998 },
         attribution: {
           source_name: 'OPDB',
           user_username: null,
@@ -31,7 +31,7 @@ describe('groupSourcesByField', () => {
       },
       {
         field_name: 'description',
-        value: 'Updated copy',
+        value: { raw: 'Updated copy' },
         attribution: {
           source_name: null,
           user_username: 'editor',
@@ -43,7 +43,7 @@ describe('groupSourcesByField', () => {
       },
       {
         field_name: 'description',
-        value: 'Updated copy',
+        value: { raw: 'Updated copy' },
         attribution: {
           source_name: 'IPDB',
           user_username: null,
@@ -55,7 +55,7 @@ describe('groupSourcesByField', () => {
       },
       {
         field_name: 'manufacturer',
-        value: 'Williams',
+        value: { raw: 'Williams' },
         attribution: {
           source_name: 'IPDB',
           user_username: null,

--- a/frontend/src/lib/components/entity-sources.ts
+++ b/frontend/src/lib/components/entity-sources.ts
@@ -23,7 +23,7 @@ export function groupSourcesByField(sources: Claim[]): {
     if (claims.length === 1) {
       single.push(group);
     } else {
-      const values = claims.map((c) => JSON.stringify(c.value));
+      const values = claims.map((c) => JSON.stringify(c.value.raw));
       const allSame = values.every((v) => v === values[0]);
       if (allSame) agreed.push(group);
       else conflicts.push(group);

--- a/frontend/src/routes/changesets/+page.svelte
+++ b/frontend/src/routes/changesets/+page.svelte
@@ -5,9 +5,10 @@
   import { SITE_TITLE } from '$lib/constants';
   import { resolveHref } from '$lib/utils';
   import ClaimAttribution from '$lib/components/ClaimAttribution.svelte';
+  import ClaimValue from '$lib/components/ClaimValue.svelte';
   import InlineDiff from '$lib/components/InlineDiff.svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
-  import { isDiffable, formatValue } from '$lib/components/change-display';
+  import { isDiffable } from '$lib/components/change-display';
   import { changesLabel } from './changes';
 
   type ChangeSetSummary = ChangeSetSummarySchema;
@@ -246,10 +247,14 @@
                         <dt>{change.field_name}</dt>
                         <dd>
                           {#if change.old_value != null}
-                            <span class="old-value">{formatValue(change.old_value.raw)}</span>
+                            <span class="old-value claim-value-inline"
+                              ><ClaimValue value={change.old_value} /></span
+                            >
                             <span class="arrow">&rarr;</span>
                           {/if}
-                          <span class="new-value">{formatValue(change.new_value.raw)}</span>
+                          <span class="new-value claim-value-inline"
+                            ><ClaimValue value={change.new_value} /></span
+                          >
                         </dd>
                       </div>
                     {/if}
@@ -264,7 +269,9 @@
                       <dt>{retraction.field_name}</dt>
                       <dd>
                         <span class="retraction-label">Removed</span>
-                        <span class="old-value">{formatValue(retraction.old_value.raw)}</span>
+                        <span class="old-value claim-value-inline"
+                          ><ClaimValue value={retraction.old_value} /></span
+                        >
                       </dd>
                     </div>
                   {/each}
@@ -500,6 +507,15 @@
 
   .new-value {
     font-weight: 500;
+  }
+
+  .claim-value-inline {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
   }
 
   /* Retractions */

--- a/frontend/src/routes/review/+page.svelte
+++ b/frontend/src/routes/review/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import ClaimValue from '$lib/components/ClaimValue.svelte';
   import Page from '$lib/components/Page.svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
   import { pageTitle } from '$lib/constants';
@@ -31,6 +32,9 @@
               >{claim.field_name === 'group' ? 'title' : claim.field_name}</span
             >
             <span class="source">{claim.source_name}</span>
+          </div>
+          <div class="claim-value">
+            <ClaimValue value={claim.value} />
           </div>
           <div class="claim-subject">
             <span class="label">Model:</span>
@@ -107,6 +111,12 @@
   .source {
     font-size: var(--font-size-0);
     color: var(--color-text-muted);
+  }
+
+  .claim-value {
+    font-size: var(--font-size-1);
+    margin-bottom: var(--size-2);
+    overflow-wrap: anywhere;
   }
 
   .claim-subject {


### PR DESCRIPTION
## Summary

Sources, Global Changes (Changesets detail), and Review queue now render resolved claim values — e.g. "Pat Lawlor — Art" — instead of raw JSON like `{"person": 13, "role": 9}`, matching the display already shipped on Edit History.

- Promotes `ClaimSchema.value` and `ReviewClaimSchema.value` to `ClaimValueSchema` so every claim value crossing the API carries `{raw, display}`
- Frontend renders all four surfaces via a unified `<ClaimValue>` component, with a new `inline` variant (CSS ellipsis instead of string truncation — full value reaches the DOM for copy/paste and a11y)
- Review queue, which previously did not render claim values at all, now shows them
- Internals: extracts a shared `claim_value()` helper in `display.py` so the three call sites (`build_changes`, `build_sources`, `list_review_claims`) stop duplicating the wrap-each-value scaffolding; fixes `groupSourcesByField` to compare `c.value.raw` only so two claims with the same raw value but different `display` projections (e.g. deleted FK) still group as agreed
- Separate commit: adds `prefetch_related("subject")` to `list_review_claims()` to fix a GFK N+1 (1 query per flagged claim)

Implements [plan](/Users/moses/.claude/plans/we-recently-reacrchitected-and-dreamy-whisper.md).

## Test plan

- [ ] `make test` (backend + frontend) passes
- [ ] `make mypy` and `make lint` pass
- [ ] Sources page with a relationship claim → "Label — Qualifier" inline, not raw JSON
- [ ] Sources page where two sources assert the same raw value but `display` differs (deleted FK) → still groups as agreed
- [ ] Review queue with a flagged relationship claim → renders structured value
- [ ] Changesets detail page → old/new render structured
- [ ] Edit-history rendering unchanged (regression check)