### PR TITLE
refactor(provenance): refactor ClaimAttribution author into a tagged union

### DIFF
--- a/backend/apps/accounts/tests/test_user_profile.py
+++ b/backend/apps/accounts/tests/test_user_profile.py
@@ -217,9 +217,7 @@ class TestEditHistoryIngestAttribution:
         assert len(attributions) == 2
 
         ingest_attr = attributions[ingest_cs.pk]
-        assert ingest_attr["user_username"] is None
-        assert ingest_attr["source_name"] == "IPDB"
+        assert ingest_attr["author"] == {"kind": "source", "name": "IPDB"}
 
         user_attr = attributions[user_cs.pk]
-        assert user_attr["user_username"] == user.username
-        assert user_attr["source_name"] is None
+        assert user_attr["author"] == {"kind": "user", "username": user.username}

--- a/backend/apps/catalog/tests/test_api_credit_roles.py
+++ b/backend/apps/catalog/tests/test_api_credit_roles.py
@@ -339,6 +339,9 @@ class TestCreditRoleEditHistory:
         body = resp.json()
         assert len(body) == 1
         entry = body[0]
-        assert entry["attribution"]["user_username"] == user.username
+        assert entry["attribution"]["author"] == {
+            "kind": "user",
+            "username": user.username,
+        }
         # The PATCH we issued edits the description field.
         assert [c["field_name"] for c in entry["changes"]] == ["description"]

--- a/backend/apps/catalog/tests/test_api_models.py
+++ b/backend/apps/catalog/tests/test_api_models.py
@@ -127,7 +127,10 @@ class TestModelsAPI:
             c for c in sources_resp.json()["sources"] if c["field_name"] == "year"
         ]
         assert len(year_claims) == 1
-        assert year_claims[0]["attribution"]["source_name"] == "IPDB"
+        assert year_claims[0]["attribution"]["author"] == {
+            "kind": "source",
+            "name": "IPDB",
+        }
         assert year_claims[0]["is_winner"] is True
 
     def test_get_model_detail_images(self, client, db):

--- a/backend/apps/provenance/evidence.py
+++ b/backend/apps/provenance/evidence.py
@@ -29,7 +29,7 @@ class CitedCitation:
 class CitedChangeset:
     id: int
     user_id: int
-    user_username: str | None
+    user_username: str
     note: str
     created_at: str
     fields: list[str]
@@ -42,7 +42,7 @@ class _CitedChangesetBuilder:
 
     id: int
     user_id: int
-    user_username: str | None
+    user_username: str
     note: str
     created_at: str
     fields: list[str] = field(default_factory=list)
@@ -55,14 +55,13 @@ def build_cited_changesets(claims: Iterable[Claim]) -> list[CitedChangeset]:
     grouped: dict[int, _CitedChangesetBuilder] = {}
 
     for claim in claims:
-        # Filter on ``claim.changeset.user_id`` rather than
-        # ``claim.user_id``. The policy targets the changeset's author;
-        # the two match by write-time convention but aren't a DB
-        # invariant. Reading off the loaded changeset prevents a future
-        # drift (revert flows, ingest oddity, ORM bug) from silently
-        # misattributing authorship to the claim's writer.
+        # Read authorship off ``claim.changeset.user`` rather than
+        # ``claim.user``. The two match by write-time convention but
+        # aren't a DB invariant — revert flows can attach source-attributed
+        # claims to a user changeset, in which case ``claim.user`` is null.
+        # The changeset's user is the policy-relevant author.
         changeset = claim.changeset
-        if changeset is None or changeset.user_id is None:
+        if changeset is None or changeset.user is None:
             continue
 
         claim_citations = citation_instances(claim)
@@ -73,8 +72,8 @@ def build_cited_changesets(claims: Iterable[Claim]) -> list[CitedChangeset]:
         if entry is None:
             entry = _CitedChangesetBuilder(
                 id=changeset.pk,
-                user_id=changeset.user_id,
-                user_username=claim.user.username if claim.user else None,
+                user_id=changeset.user.pk,
+                user_username=changeset.user.username,
                 note=changeset.note,
                 created_at=changeset.created_at.isoformat(),
             )

--- a/backend/apps/provenance/helpers.py
+++ b/backend/apps/provenance/helpers.py
@@ -9,8 +9,30 @@ from django.db import models
 from django.db.models import Case, F, IntegerField, Prefetch, QuerySet, Value, When
 
 from .display import FieldValue, claim_value, resolve_labels
-from .models import CitationInstance, Claim
-from .schemas import ClaimAttributionSchema, ClaimSchema
+from .models import ChangeSet, CitationInstance, Claim
+from .schemas import (
+    ClaimAttributionSchema,
+    ClaimAuthorSchema,
+    ClaimSchema,
+    ClaimSourceAuthorSchema,
+    ClaimUserAuthorSchema,
+)
+
+
+def claim_author(claim: Claim) -> ClaimAuthorSchema:
+    """Build the tagged author for a Claim. Exactly one FK is set (DB CHECK)."""
+    if claim.user is not None:
+        return ClaimUserAuthorSchema(username=claim.user.username)
+    assert claim.source is not None
+    return ClaimSourceAuthorSchema(name=claim.source.name)
+
+
+def changeset_author(cs: ChangeSet) -> ClaimAuthorSchema:
+    """Build the tagged author for a ChangeSet. Exactly one FK is set (DB CHECK)."""
+    if cs.user is not None:
+        return ClaimUserAuthorSchema(username=cs.user.username)
+    assert cs.ingest_run is not None
+    return ClaimSourceAuthorSchema(name=cs.ingest_run.source.name)
 
 
 def claims_prefetch(
@@ -21,7 +43,7 @@ def claims_prefetch(
         "claims",
         queryset=Claim.objects.filter(is_active=True)
         .exclude(source__is_enabled=False)
-        .select_related("source", "user", "changeset")
+        .select_related("source", "user", "changeset__user")
         .prefetch_related(
             Prefetch(
                 "citation_instances",
@@ -92,8 +114,7 @@ def build_sources(claims: Iterable[Claim]) -> list[ClaimSchema]:
         sources.append(
             ClaimSchema(
                 attribution=ClaimAttributionSchema(
-                    user_username=claim.user.username if claim.user else None,
-                    source_name=claim.source.name if claim.source else None,
+                    author=claim_author(claim),
                     created_at=claim.created_at.isoformat(),
                 ),
                 field_name=claim.field_name,

--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -12,6 +12,7 @@ from django.db.models import Case, F, IntegerField, Model, Prefetch, Q, Value, W
 from apps.core.authz import PolicyUser, compute_row_capabilities
 
 from .display import FieldValue, LabelLookup, claim_value, resolve_labels
+from .helpers import changeset_author
 from .models import ChangeSet, Claim
 from .schemas import (
     ChangeSetSchema,
@@ -214,8 +215,7 @@ def build_edit_history(entity: Model, user: PolicyUser) -> list[ChangeSetSchema]
             ChangeSetSchema(
                 id=cs.pk,
                 attribution=ClaimAttributionSchema(
-                    user_username=cs.user.username if cs.user else None,
-                    source_name=cs.ingest_run.source.name if cs.ingest_run else None,
+                    author=changeset_author(cs),
                     created_at=cs.created_at.isoformat(),
                 ),
                 note=cs.note,

--- a/backend/apps/provenance/page_endpoints.py
+++ b/backend/apps/provenance/page_endpoints.py
@@ -30,7 +30,7 @@ from apps.core.types import EntityKey
 
 from .entity_resolution import batch_resolve_entities
 from .evidence import build_cited_changesets
-from .helpers import active_claims, build_sources, claims_prefetch
+from .helpers import active_claims, build_sources, changeset_author, claims_prefetch
 from .history import build_changes, build_edit_history
 from .models.changeset import ChangeSet
 from .schemas import (
@@ -39,6 +39,7 @@ from .schemas import (
     CitationLinkSchema,
     ClaimAttributionSchema,
     ClaimSchema,
+    ClaimUserAuthorSchema,
     FieldChangeSchema,
     RetractionSchema,
 )
@@ -174,35 +175,36 @@ def sources_page(
     claims = active_claims(entity)
     sources = build_sources(claims)
     caller = policy_user(request.user)
-    evidence = [
-        CitedChangeSetSchema(
-            id=row.id,
-            attribution=ClaimAttributionSchema(
-                user_username=row.user_username,
-                created_at=row.created_at,
-            ),
-            note=row.note,
-            fields=row.fields,
-            citations=[
-                CitedChangeSetCitationSchema(
-                    source_name=c.source_name,
-                    source_type=c.source_type,
-                    author=c.author,
-                    year=c.year,
-                    locator=c.locator,
-                    links=[
-                        CitationLinkSchema(url=link.url, label=link.label)
-                        for link in c.links
-                    ],
-                )
-                for c in row.citations
-            ],
-            capabilities=compute_row_capabilities(
-                caller, row, CitedChangeSetSchema.policy_activities
-            ),
+    evidence: list[CitedChangeSetSchema] = []
+    for row in build_cited_changesets(claims):
+        evidence.append(
+            CitedChangeSetSchema(
+                id=row.id,
+                attribution=ClaimAttributionSchema(
+                    author=ClaimUserAuthorSchema(username=row.user_username),
+                    created_at=row.created_at,
+                ),
+                note=row.note,
+                fields=row.fields,
+                citations=[
+                    CitedChangeSetCitationSchema(
+                        source_name=c.source_name,
+                        source_type=c.source_type,
+                        author=c.author,
+                        year=c.year,
+                        locator=c.locator,
+                        links=[
+                            CitationLinkSchema(url=link.url, label=link.label)
+                            for link in c.links
+                        ],
+                    )
+                    for c in row.citations
+                ],
+                capabilities=compute_row_capabilities(
+                    caller, row, CitedChangeSetSchema.policy_activities
+                ),
+            )
         )
-        for row in build_cited_changesets(claims)
-    ]
     return SourcesPageSchema(
         sources=sources,
         evidence=evidence,
@@ -313,8 +315,7 @@ def list_changes(
             ChangeSetSummarySchema(
                 id=cs.pk,
                 attribution=ClaimAttributionSchema(
-                    user_username=cs.user.username if cs.user else None,
-                    source_name=cs.ingest_run.source.name if cs.ingest_run_id else None,
+                    author=changeset_author(cs),
                     created_at=cs.created_at.isoformat(),
                 ),
                 note=cs.note,
@@ -385,13 +386,11 @@ def change_detail(
 
     changes, retractions = build_changes(claims, retracted, by_key)
 
-    ingest_run = cs.ingest_run
     assert cs.pk is not None
     return ChangeSetDetailSchema(
         id=cs.pk,
         attribution=ClaimAttributionSchema(
-            user_username=cs.user.username if cs.user else None,
-            source_name=ingest_run.source.name if ingest_run is not None else None,
+            author=changeset_author(cs),
             created_at=cs.created_at.isoformat(),
         ),
         note=cs.note,

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -12,7 +12,7 @@ constrains each field's shape.
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal
+from typing import Annotated, ClassVar, Literal
 
 from django.db.models import Model
 from ninja import Field, Schema
@@ -137,15 +137,34 @@ class RetractionSchema(Schema):
     old_value: ClaimValueSchema
 
 
+class ClaimUserAuthorSchema(Schema):
+    """A Claim/ChangeSet authored by a user."""
+
+    kind: Literal["user"] = "user"
+    username: str
+
+
+class ClaimSourceAuthorSchema(Schema):
+    """A Claim/ChangeSet attributed to an ingest source."""
+
+    kind: Literal["source"] = "source"
+    name: str
+
+
+ClaimAuthorSchema = Annotated[
+    ClaimUserAuthorSchema | ClaimSourceAuthorSchema,
+    Field(discriminator="kind"),
+]
+"""Tagged union: a Claim/ChangeSet is authored by exactly one of a user or
+an ingest source. Mirrors the DB-level XOR CHECK constraints
+(``provenance_claim_source_xor_user``,
+``provenance_changeset_user_xor_ingest_run``) on the wire."""
+
+
 class ClaimAttributionSchema(Schema):
-    """Who asserted a Claim and when.
+    """Who asserted a Claim and when."""
 
-    Exactly one of ``user_username`` / ``source_name`` is non-null — set
-    by user (``user_username``) or ingest (``source_name``), never both.
-    """
-
-    user_username: str | None = None
-    source_name: str | None = None
+    author: ClaimAuthorSchema
     created_at: str
 
 

--- a/backend/apps/provenance/tests/test_api_edit_history.py
+++ b/backend/apps/provenance/tests/test_api_edit_history.py
@@ -63,7 +63,10 @@ class TestEditHistoryBasic:
         assert len(data) == 1
 
         cs = data[0]
-        assert cs["attribution"]["user_username"] == user.username
+        assert cs["attribution"]["author"] == {
+            "kind": "user",
+            "username": user.username,
+        }
         assert cs["note"] == ""
         assert len(cs["changes"]) == 1
         assert cs["changes"][0]["field_name"] == "year"
@@ -143,12 +146,18 @@ class TestEditHistoryMultiUser:
         assert len(data) == 2
 
         # User B's edit is newest — old value is User A's prior claim
-        assert data[0]["attribution"]["user_username"] == user_b.username
+        assert data[0]["attribution"]["author"] == {
+            "kind": "user",
+            "username": user_b.username,
+        }
         assert data[0]["changes"][0]["old_value"]["raw"] == 1998
         assert data[0]["changes"][0]["new_value"]["raw"] == 1999
 
         # User A's edit — no prior claim, so no old value
-        assert data[1]["attribution"]["user_username"] == user.username
+        assert data[1]["attribution"]["author"] == {
+            "kind": "user",
+            "username": user.username,
+        }
         assert data[1]["changes"][0]["old_value"] is None
         assert data[1]["changes"][0]["new_value"]["raw"] == 1998
 

--- a/backend/apps/provenance/tests/test_changes.py
+++ b/backend/apps/provenance/tests/test_changes.py
@@ -120,11 +120,13 @@ class TestChangesList:
         data = resp.json()
         assert len(data["items"]) == 1
         item = data["items"][0]
-        assert item["attribution"]["user_username"] == user.username
+        assert item["attribution"]["author"] == {
+            "kind": "user",
+            "username": user.username,
+        }
         assert item["entity"]["name"] == "Medieval Madness"
         assert item["entity"]["type_label"] == "Model"
         assert item["changes_count"] >= 1
-        assert item["attribution"]["source_name"] is None
 
     def test_excludes_ingest_by_default(self, client, source, pm):
         run = IngestRun.objects.create(
@@ -154,8 +156,7 @@ class TestChangesList:
         assert resp.status_code == 200
         items = resp.json()["items"]
         assert len(items) == 1
-        assert items[0]["attribution"]["source_name"] == "IPDB"
-        assert items[0]["attribution"]["user_username"] is None
+        assert items[0]["attribution"]["author"] == {"kind": "source", "name": "IPDB"}
 
     def test_entity_type_filter(self, client, user, pm, mfr):
         client.force_login(user)

--- a/frontend/src/lib/components/ClaimAuthor.svelte
+++ b/frontend/src/lib/components/ClaimAuthor.svelte
@@ -3,14 +3,13 @@
   import UserLink from './UserLink.svelte';
 
   let { attribution }: { attribution: ClaimAttributionSchema } = $props();
+  const author = $derived(attribution.author);
 </script>
 
-{#if attribution.source_name}
-  <span class="source-badge">{attribution.source_name}</span>
-{:else if attribution.user_username}
-  <UserLink username={attribution.user_username} />
+{#if author.kind === 'source'}
+  <span class="source-badge">{author.name}</span>
 {:else}
-  system
+  <UserLink username={author.username} />
 {/if}
 
 <style>

--- a/frontend/src/lib/components/EntitySources.dom.test.ts
+++ b/frontend/src/lib/components/EntitySources.dom.test.ts
@@ -5,8 +5,7 @@ import EntitySources from './EntitySources.test-harness.svelte';
 
 const sampleClaim = {
   attribution: {
-    source_name: 'IPDB',
-    user_username: null,
+    author: { kind: 'source' as const, name: 'IPDB' },
     created_at: '2026-04-07T00:00:00Z',
   },
   field_name: 'year',
@@ -25,8 +24,7 @@ describe('EntitySources', () => {
           {
             id: 1,
             attribution: {
-              user_username: 'editor',
-              source_name: null,
+              author: { kind: 'user' as const, username: 'editor' },
               created_at: '2026-04-08T00:00:00Z',
             },
             note: 'Documented the flyer',

--- a/frontend/src/lib/components/EntitySources.svelte
+++ b/frontend/src/lib/components/EntitySources.svelte
@@ -22,7 +22,8 @@
   const entity = getEntityContext();
 
   function claimAttribution(claim: Claim): string {
-    return claim.attribution.source_name ?? claim.attribution.user_username ?? 'Unknown';
+    const author = claim.attribution.author;
+    return author.kind === 'source' ? author.name : author.username;
   }
 </script>
 

--- a/frontend/src/lib/components/entity-sources.test.ts
+++ b/frontend/src/lib/components/entity-sources.test.ts
@@ -9,8 +9,7 @@ describe('groupSourcesByField', () => {
         field_name: 'year',
         value: { raw: 1997 },
         attribution: {
-          source_name: 'IPDB',
-          user_username: null,
+          author: { kind: 'source', name: 'IPDB' },
           created_at: '2026-04-08T00:00:00Z',
         },
         citation: '',
@@ -21,8 +20,7 @@ describe('groupSourcesByField', () => {
         field_name: 'year',
         value: { raw: 1998 },
         attribution: {
-          source_name: 'OPDB',
-          user_username: null,
+          author: { kind: 'source', name: 'OPDB' },
           created_at: '2026-04-07T00:00:00Z',
         },
         citation: '',
@@ -33,8 +31,7 @@ describe('groupSourcesByField', () => {
         field_name: 'description',
         value: { raw: 'Updated copy' },
         attribution: {
-          source_name: null,
-          user_username: 'editor',
+          author: { kind: 'user', username: 'editor' },
           created_at: '2026-04-08T00:00:00Z',
         },
         citation: '',
@@ -45,8 +42,7 @@ describe('groupSourcesByField', () => {
         field_name: 'description',
         value: { raw: 'Updated copy' },
         attribution: {
-          source_name: 'IPDB',
-          user_username: null,
+          author: { kind: 'source', name: 'IPDB' },
           created_at: '2026-04-07T00:00:00Z',
         },
         citation: '',
@@ -57,8 +53,7 @@ describe('groupSourcesByField', () => {
         field_name: 'manufacturer',
         value: { raw: 'Williams' },
         attribution: {
-          source_name: 'IPDB',
-          user_username: null,
+          author: { kind: 'source', name: 'IPDB' },
           created_at: '2026-04-07T00:00:00Z',
         },
         citation: '',


### PR DESCRIPTION
## Summary
- Replace parallel nullable `user_username` / `source_name` on `ClaimAttributionSchema` with a discriminated `author: ClaimUserAuthorSchema | ClaimSourceAuthorSchema` tagged union, mirroring the DB-level XOR CHECK constraints on the wire.
- Drop the provably-unreachable `{:else} system` branch in `ClaimAuthor.svelte` and the matching `'Unknown'` fallback in `EntitySources`. Consumers now narrow on `author.kind`.
- Fix a pre-existing latent bug in `build_cited_changesets`: read authorship off `changeset.user` (the filter's intent) rather than `claim.user`, which can legitimately be `None` on a user changeset containing source-attributed claims (revert flows). `CitedChangeset.user_username` tightens from `str | None` to `str`; added `changeset__user` to `claims_prefetch` select_related.

Closes #396.

## Test plan
- [x] `make lint` clean
- [x] `make mypy` clean
- [x] Full backend pytest (2637 passed)
- [x] Frontend `pnpm check` + `pnpm test` (1178 passed)
- [ ] Manual smoke: open a model's Sources and Edit-History pages; confirm both user-authored and ingest-authored attribution lines render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)