### PR TITLE
feat(security): trust client IP from sanitized X-Real-IP

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,27 +12,28 @@ handle @www {
 	redir https://flipcommons.org{uri} permanent
 }
 
-# Sanitize client-supplied trust headers before any reverse_proxy. Applies
-# site-wide so both the Django and Node upstreams see the same cleaned input.
-#
-# - Forwarded (RFC 7239) is passed through verbatim by Railway's edge, so
-#   it's attacker-controlled. Stripped unconditionally.
-# - X-Forwarded-For from Railway holds a rotating internal proxy IP
-#   (100.64.0.X), not the real client. Stripped first, then overwritten
-#   with the trusted X-Real-IP value — but only when X-Real-IP is present.
-#   If it's missing (internal probe, future infra change), XFF stays
-#   stripped so any future reader sees "no info" rather than an empty
-#   string or stale internal noise.
-@has_real_ip header X-Real-IP *
+# Strip the RFC 7239 Forwarded header at site level. Railway passes
+# client-supplied values through verbatim, so it's attacker-controlled.
 request_header -Forwarded
-request_header -X-Forwarded-For
-request_header @has_real_ip X-Forwarded-For {http.request.header.X-Real-IP}
+
+# Rewrite X-Forwarded-For inside each reverse_proxy block (not at site
+# level): Caddy's reverse_proxy has special handling for X-Forwarded-*
+# headers and overrides site-level request_header mutations. header_up
+# is proxy-aware and wins. Snippet shared across both upstreams to
+# prevent drift.
+(rewrite_xff_to_real_ip) {
+	header_up X-Forwarded-For {http.request.header.X-Real-IP}
+}
 
 @django path /api /api/* /admin /admin/* /media/* /static /static/*
 handle @django {
-	reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000}
+	reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000} {
+		import rewrite_xff_to_real_ip
+	}
 }
 
 handle {
-	reverse_proxy 127.0.0.1:{$NODE_PORT:3000}
+	reverse_proxy 127.0.0.1:{$NODE_PORT:3000} {
+		import rewrite_xff_to_real_ip
+	}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -14,16 +14,7 @@ handle @www {
 
 # Sanitize client-supplied trust headers before any reverse_proxy. Applies
 # site-wide so both the Django and Node upstreams see the same cleaned input.
-#
-# - Forwarded (RFC 7239) is passed through verbatim by Railway's edge, so
-#   it's attacker-controlled. Stripped unconditionally.
-# - X-Forwarded-For from Railway holds a rotating internal proxy IP
-#   (100.64.0.X), not the real client. Stripped first, then overwritten
-#   with the trusted X-Real-IP value — but only when X-Real-IP is present.
-#   If it's missing (internal probe, future infra change), XFF stays
-#   stripped so any future reader sees "no info" rather than an empty
-#   string or stale internal noise.
-@has_real_ip header X-Real-IP *
+@has_real_ip header X-Real-IP
 request_header -Forwarded
 request_header -X-Forwarded-For
 request_header @has_real_ip X-Forwarded-For {http.request.header.X-Real-IP}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,12 @@
 :{$PORT:8080}
 
+# TEMPORARY — Step 1 of docs/plans/ClientIpTrust.md. Captures the immediate-peer
+# IP Caddy sees from Railway's edge. Remove after probe results captured.
+log {
+	output stdout
+	format json
+}
+
 @www host www.flipcommons.org
 handle @www {
 	redir https://flipcommons.org{uri} permanent

--- a/Caddyfile
+++ b/Caddyfile
@@ -12,28 +12,25 @@ handle @www {
 	redir https://flipcommons.org{uri} permanent
 }
 
-# Strip the RFC 7239 Forwarded header at site level. Railway passes
-# client-supplied values through verbatim, so it's attacker-controlled.
+# Strip the RFC 7239 Forwarded header. Railway passes client-supplied
+# values through verbatim, so it's attacker-controlled.
 request_header -Forwarded
 
-# Rewrite X-Forwarded-For inside each reverse_proxy block (not at site
-# level): Caddy's reverse_proxy has special handling for X-Forwarded-*
-# headers and overrides site-level request_header mutations. header_up
-# is proxy-aware and wins. Snippet shared across both upstreams to
-# prevent drift.
-(rewrite_xff_to_real_ip) {
-	header_up X-Forwarded-For {http.request.header.X-Real-IP}
-}
-
+# XFF rewrite must live inside reverse_proxy: Caddy's reverse_proxy has
+# special handling for X-Forwarded-* headers and overrides any
+# site-level request_header mutations. header_up is proxy-aware and
+# wins. Duplicated across the two reverse_proxy blocks because Caddyfile
+# snippets must be defined at global scope (before any site address),
+# which is awkward to thread here for a single-line directive.
 @django path /api /api/* /admin /admin/* /media/* /static /static/*
 handle @django {
 	reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000} {
-		import rewrite_xff_to_real_ip
+		header_up X-Forwarded-For {http.request.header.X-Real-IP}
 	}
 }
 
 handle {
 	reverse_proxy 127.0.0.1:{$NODE_PORT:3000} {
-		import rewrite_xff_to_real_ip
+		header_up X-Forwarded-For {http.request.header.X-Real-IP}
 	}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -5,6 +5,22 @@ handle @www {
 	redir https://flipcommons.org{uri} permanent
 }
 
+# Sanitize client-supplied trust headers before any reverse_proxy. Applies
+# site-wide so both the Django and Node upstreams see the same cleaned input.
+#
+# - Forwarded (RFC 7239) is passed through verbatim by Railway's edge, so
+#   it's attacker-controlled. Stripped unconditionally.
+# - X-Forwarded-For from Railway holds a rotating internal proxy IP
+#   (100.64.0.X), not the real client. Stripped first, then overwritten
+#   with the trusted X-Real-IP value — but only when X-Real-IP is present.
+#   If it's missing (internal probe, future infra change), XFF stays
+#   stripped so any future reader sees "no info" rather than an empty
+#   string or stale internal noise.
+@has_real_ip header X-Real-IP *
+request_header -Forwarded
+request_header -X-Forwarded-For
+request_header @has_real_ip X-Forwarded-For {http.request.header.X-Real-IP}
+
 @django path /api /api/* /admin /admin/* /media/* /static /static/*
 handle @django {
 	reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000}

--- a/Caddyfile
+++ b/Caddyfile
@@ -14,7 +14,16 @@ handle @www {
 
 # Sanitize client-supplied trust headers before any reverse_proxy. Applies
 # site-wide so both the Django and Node upstreams see the same cleaned input.
-@has_real_ip header X-Real-IP
+#
+# - Forwarded (RFC 7239) is passed through verbatim by Railway's edge, so
+#   it's attacker-controlled. Stripped unconditionally.
+# - X-Forwarded-For from Railway holds a rotating internal proxy IP
+#   (100.64.0.X), not the real client. Stripped first, then overwritten
+#   with the trusted X-Real-IP value — but only when X-Real-IP is present.
+#   If it's missing (internal probe, future infra change), XFF stays
+#   stripped so any future reader sees "no info" rather than an empty
+#   string or stale internal noise.
+@has_real_ip header X-Real-IP *
 request_header -Forwarded
 request_header -X-Forwarded-For
 request_header @has_real_ip X-Forwarded-For {http.request.header.X-Real-IP}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,12 +1,5 @@
 :{$PORT:8080}
 
-# TEMPORARY — Step 1 of docs/plans/ClientIpTrust.md. Captures the immediate-peer
-# IP Caddy sees from Railway's edge. Remove after probe results captured.
-log {
-	output stdout
-	format json
-}
-
 @www host www.flipcommons.org
 handle @www {
 	redir https://flipcommons.org{uri} permanent

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN pnpm prune --prod
 # ── Stage 2: Runtime dependencies for Caddy + Node ────────────────
 FROM node:24-slim AS node-runtime
 
-FROM caddy:2.11.2 AS caddy-runtime
+FROM caddy:2.11.3 AS caddy-runtime
 
 # ── Stage 3: Django + SSR application ──────────────────────────────
 FROM python:3.14-slim AS base

--- a/backend/apps/core/checks.py
+++ b/backend/apps/core/checks.py
@@ -1,16 +1,12 @@
-"""System checks for ``LinkableModel`` subclass declarations.
+"""System checks for project-wide contracts.
 
-Verified at ``manage.py check`` (and at server boot) — never at first
-request — so a missing or malformed contract crashes early.
-
-Each concrete ``LinkableModel`` subclass must:
-
-- declare non-empty ``entity_type`` and ``entity_type_plural`` strings
-  (already validated in ``__init_subclass__``);
-- have unique ``entity_type`` and ``entity_type_plural`` values across all
-  subclasses;
-- declare a ``public_id_field`` that resolves to a real concrete model
-  field (or the inherited default, ``"slug"``) with ``unique=True``.
+Run via ``manage.py check`` (model-contract checks also run at server
+boot via Django's startup ``system_checks()``). Production-only checks
+are gated with ``deploy=True`` and run under ``manage.py check --deploy``
+— Railway's ``preDeployCommand`` includes this, so they surface in
+deploy logs. Errors block the deploy; Warnings are logged but
+non-blocking. See each check function's docstring for its specific
+contract.
 """
 
 from __future__ import annotations
@@ -19,7 +15,8 @@ from collections.abc import Sequence
 from typing import Any
 
 from django.apps.config import AppConfig
-from django.core.checks import CheckMessage, Error, Tags, register
+from django.conf import settings
+from django.core.checks import CheckMessage, Error, Tags, Warning, register
 from django.core.exceptions import FieldDoesNotExist
 
 from apps.core.models import LinkableModel
@@ -33,7 +30,17 @@ def check_linkable_models(
     # any of them, so ``Any`` is the documented type.
     **kwargs: Any,  # noqa: ANN401
 ) -> list[CheckMessage]:
-    """Validate every concrete ``LinkableModel`` subclass."""
+    """Validate every concrete ``LinkableModel`` subclass.
+
+    Each concrete subclass must:
+
+    - declare non-empty ``entity_type`` and ``entity_type_plural`` strings
+      (already validated in ``__init_subclass__``);
+    - have unique ``entity_type`` and ``entity_type_plural`` values across
+      all subclasses;
+    - declare a ``public_id_field`` that resolves to a real concrete model
+      field (or the inherited default, ``"slug"``) with ``unique=True``.
+    """
     _ = app_configs, kwargs
     errors: list[CheckMessage] = []
     seen_entity_type: dict[str, type] = {}
@@ -179,3 +186,38 @@ def _check_one(
         )
 
     return errors
+
+
+@register(Tags.security, deploy=True)
+def check_rate_limit_proxy_trust(
+    app_configs: Sequence[AppConfig] | None,
+    **kwargs: Any,  # noqa: ANN401
+) -> list[CheckMessage]:
+    """Warn when RATE_LIMIT_TRUST_PROXY_HEADERS is off in a non-DEBUG env.
+
+    The setting gates whether ``apps.core.rate_limits._client_ip`` reads
+    proxy-supplied headers. With Caddy on loopback in production, leaving
+    it False makes every request key off ``REMOTE_ADDR=127.0.0.1`` — the
+    IP-keyed rate limiters silently degrade to one shared bucket. Not a
+    security bug (observable, fixable), but easy to overlook because
+    nothing crashes. This check raises the missing-env-var case to a
+    deploy-time signal so it can't be silently mis-set in Railway.
+
+    See ``docs/Hosting.md`` § "Client IP trust".
+    """
+    _ = app_configs, kwargs
+    if settings.DEBUG or settings.RATE_LIMIT_TRUST_PROXY_HEADERS:
+        return []
+    return [
+        Warning(
+            "RATE_LIMIT_TRUST_PROXY_HEADERS is False in a non-DEBUG "
+            "environment. IP-keyed rate limiters will silently degrade to "
+            "one shared bucket (REMOTE_ADDR=127.0.0.1 behind Caddy on "
+            "loopback).",
+            hint=(
+                "Set RATE_LIMIT_TRUST_PROXY_HEADERS=true in the deployment "
+                "environment. See docs/Hosting.md § 'Client IP trust'."
+            ),
+            id="core.W001",
+        )
+    ]

--- a/backend/apps/core/rate_limits.py
+++ b/backend/apps/core/rate_limits.py
@@ -1,0 +1,40 @@
+"""Client IP resolution for pre-auth rate limiting.
+
+Sibling of :mod:`apps.provenance.rate_limits` (per-user). This module
+hosts the IP-keyed primitives used by pre-auth flows (signup availability
+checks, submit, cancel) where there's no User yet.
+
+For the proxy-chain trust model and the deployment contract behind
+``RATE_LIMIT_TRUST_PROXY_HEADERS``, see ``docs/Hosting.md`` § "Client IP
+trust".
+
+For now this file only contains :func:`_client_ip` — the rest of the
+module (RateLimitExceededError, RateLimitSpec, the signup-flow specs)
+arrives with the signup-onboarding branch.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.http import HttpRequest
+
+
+def _client_ip(request: HttpRequest) -> str:
+    """Return the client IP used as a rate-limit bucket key.
+
+    Reads ``X-Real-IP`` and never ``X-Forwarded-For`` — XFF parsing has
+    no failure mode that's safe under upstream drift. Gated by
+    ``RATE_LIMIT_TRUST_PROXY_HEADERS`` (default False); when off, keys
+    off ``REMOTE_ADDR``. Both fail closed on drift: degrade to one
+    shared bucket, never trust attacker-supplied input.
+
+    Full trust model and deployment contract: ``docs/Hosting.md`` §
+    "Client IP trust". Don't add a second forwarded-header reader
+    elsewhere; this function is the single sanctioned reader.
+    """
+    meta = request.META
+    if settings.RATE_LIMIT_TRUST_PROXY_HEADERS:
+        real_ip = str(meta.get("HTTP_X_REAL_IP") or "").strip()
+        if real_ip:
+            return real_ip
+    return str(meta.get("REMOTE_ADDR") or "unknown")

--- a/backend/apps/core/tests/test_rate_limit_proxy_trust_check.py
+++ b/backend/apps/core/tests/test_rate_limit_proxy_trust_check.py
@@ -1,0 +1,54 @@
+"""Tests for ``apps.core.checks.check_rate_limit_proxy_trust``.
+
+The check guards a deployment contract: in any non-DEBUG environment,
+``RATE_LIMIT_TRUST_PROXY_HEADERS`` must be True or IP-keyed rate limits
+silently degrade to one shared bucket.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_django.fixtures import SettingsWrapper
+
+from apps.core.checks import check_rate_limit_proxy_trust
+
+
+class TestRateLimitProxyTrustCheck:
+    def test_passes_when_debug_is_true(self, settings: SettingsWrapper) -> None:
+        settings.DEBUG = True
+        settings.RATE_LIMIT_TRUST_PROXY_HEADERS = False
+        assert check_rate_limit_proxy_trust(app_configs=None) == []
+
+    def test_passes_when_trust_is_enabled(self, settings: SettingsWrapper) -> None:
+        settings.DEBUG = False
+        settings.RATE_LIMIT_TRUST_PROXY_HEADERS = True
+        assert check_rate_limit_proxy_trust(app_configs=None) == []
+
+    def test_warns_when_prod_but_trust_disabled(
+        self, settings: SettingsWrapper
+    ) -> None:
+        """The regression case: prod env without the trust env var."""
+        settings.DEBUG = False
+        settings.RATE_LIMIT_TRUST_PROXY_HEADERS = False
+        messages = check_rate_limit_proxy_trust(app_configs=None)
+        assert len(messages) == 1
+        assert messages[0].id == "core.W001"
+        assert "RATE_LIMIT_TRUST_PROXY_HEADERS" in messages[0].msg
+        assert messages[0].hint is not None
+        assert "RATE_LIMIT_TRUST_PROXY_HEADERS=true" in messages[0].hint
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"databases": ["default"]},
+            {"some_future_kwarg": "x"},
+        ],
+    )
+    def test_accepts_django_kwargs_forward_compat(
+        self, settings: SettingsWrapper, kwargs: dict[str, object]
+    ) -> None:
+        """Django's check framework may pass extra kwargs; we must accept them."""
+        settings.DEBUG = False
+        settings.RATE_LIMIT_TRUST_PROXY_HEADERS = True
+        assert check_rate_limit_proxy_trust(app_configs=None, **kwargs) == []

--- a/backend/apps/core/tests/test_rate_limits.py
+++ b/backend/apps/core/tests/test_rate_limits.py
@@ -1,0 +1,105 @@
+"""Tests for `apps.core.rate_limits._client_ip`.
+
+The critical regression test is the default-off case: if a deploy ever
+rolls ``RATE_LIMIT_TRUST_PROXY_HEADERS`` back to its default, proxy
+headers must be ignored so attacker-supplied values can't bypass
+IP-keyed limiters by spraying distinct bucket keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.http import HttpRequest
+from django.test import RequestFactory
+from pytest_django.fixtures import SettingsWrapper
+
+from apps.core.rate_limits import _client_ip
+
+
+def _request(rf: RequestFactory, **meta: str) -> HttpRequest:
+    req = rf.get("/")
+    req.META.update(meta)
+    return req
+
+
+@pytest.fixture
+def rf() -> RequestFactory:
+    return RequestFactory()
+
+
+class TestTrustDisabled:
+    """Default posture: proxy headers are noise; bucket keys off REMOTE_ADDR."""
+
+    @pytest.fixture(autouse=True)
+    def _disable_trust(self, settings: SettingsWrapper) -> None:
+        settings.RATE_LIMIT_TRUST_PROXY_HEADERS = False
+
+    def test_real_ip_header_is_ignored(self, rf: RequestFactory) -> None:
+        req = _request(rf, HTTP_X_REAL_IP="9.9.9.9", REMOTE_ADDR="127.0.0.1")
+        assert _client_ip(req) == "127.0.0.1"
+
+    def test_forwarded_for_header_is_ignored(self, rf: RequestFactory) -> None:
+        req = _request(
+            rf,
+            HTTP_X_FORWARDED_FOR="9.9.9.9, 8.8.8.8",
+            REMOTE_ADDR="127.0.0.1",
+        )
+        assert _client_ip(req) == "127.0.0.1"
+
+    def test_both_headers_ignored_in_favor_of_remote_addr(
+        self, rf: RequestFactory
+    ) -> None:
+        req = _request(
+            rf,
+            HTTP_X_REAL_IP="9.9.9.9",
+            HTTP_X_FORWARDED_FOR="1.2.3.4",
+            REMOTE_ADDR="127.0.0.1",
+        )
+        assert _client_ip(req) == "127.0.0.1"
+
+    def test_remote_addr_missing_falls_back_to_zero(self, rf: RequestFactory) -> None:
+        req = rf.get("/")
+        req.META.pop("REMOTE_ADDR", None)
+        assert _client_ip(req) == "unknown"
+
+
+class TestTrustEnabled:
+    """Production posture: X-Real-IP is trusted; XFF is still ignored."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_trust(self, settings: SettingsWrapper) -> None:
+        settings.RATE_LIMIT_TRUST_PROXY_HEADERS = True
+
+    def test_real_ip_is_used(self, rf: RequestFactory) -> None:
+        req = _request(rf, HTTP_X_REAL_IP="203.0.113.7", REMOTE_ADDR="127.0.0.1")
+        assert _client_ip(req) == "203.0.113.7"
+
+    def test_forwarded_for_is_still_ignored(self, rf: RequestFactory) -> None:
+        # Asserts the parsing-bug class is gone: even with trust enabled,
+        # XFF is never read, so attacker-supplied left-most entries can't
+        # influence the bucket key.
+        req = _request(
+            rf,
+            HTTP_X_FORWARDED_FOR="9.9.9.9, 8.8.8.8",
+            REMOTE_ADDR="127.0.0.1",
+        )
+        assert _client_ip(req) == "127.0.0.1"
+
+    def test_real_ip_preferred_over_forwarded_for(self, rf: RequestFactory) -> None:
+        req = _request(
+            rf,
+            HTTP_X_REAL_IP="203.0.113.7",
+            HTTP_X_FORWARDED_FOR="9.9.9.9",
+            REMOTE_ADDR="127.0.0.1",
+        )
+        assert _client_ip(req) == "203.0.113.7"
+
+    def test_empty_real_ip_falls_back_to_remote_addr(self, rf: RequestFactory) -> None:
+        req = _request(rf, HTTP_X_REAL_IP="   ", REMOTE_ADDR="127.0.0.1")
+        assert _client_ip(req) == "127.0.0.1"
+
+    def test_missing_real_ip_falls_back_to_remote_addr(
+        self, rf: RequestFactory
+    ) -> None:
+        req = _request(rf, REMOTE_ADDR="127.0.0.1")
+        assert _client_ip(req) == "127.0.0.1"

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -60,6 +60,22 @@ def health(request: HttpRequest) -> dict[str, str]:
     return {"status": "ok"}
 
 
+# TEMPORARY — verifying RATE_LIMIT_TRUST_PROXY_HEADERS is live in prod.
+# Remove after confirmation.
+@api.get("/ip-check", tags=["private"])
+def ip_check(request: HttpRequest) -> dict[str, str | bool | None]:
+    from django.conf import settings as _s
+
+    from apps.core.rate_limits import _client_ip
+
+    return {
+        "trust_proxy_headers": bool(_s.RATE_LIMIT_TRUST_PROXY_HEADERS),
+        "client_ip": _client_ip(request),
+        "x_real_ip": request.META.get("HTTP_X_REAL_IP"),
+        "remote_addr": request.META.get("REMOTE_ADDR"),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Router autodiscovery — each app's api module exports a `routers` list of
 # (prefix, router) tuples.  Adding a new router only requires editing the

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 
 from django.apps import apps
 from django.db import connection
@@ -58,6 +59,29 @@ def health(request: HttpRequest) -> dict[str, str]:
     with connection.cursor() as cursor:
         cursor.execute("SELECT 1")
     return {"status": "ok"}
+
+
+# TEMPORARY — Step 1 of docs/plans/ClientIpTrust.md. Probes how Railway's edge
+# proxy handles client-supplied X-Forwarded-For. Remove after results captured.
+_probe_log = logging.getLogger("ip_probe")
+
+
+@api.get("/probe", tags=["private"])
+def probe(request: HttpRequest) -> dict[str, str | None]:
+    fields = {
+        "xff": request.META.get("HTTP_X_FORWARDED_FOR"),
+        "real_ip": request.META.get("HTTP_X_REAL_IP"),
+        "forwarded": request.META.get("HTTP_FORWARDED"),
+        "proto": request.META.get("HTTP_X_FORWARDED_PROTO"),
+        "host": request.META.get("HTTP_X_FORWARDED_HOST"),
+        "remote_addr": request.META.get("REMOTE_ADDR"),
+    }
+    _probe_log.info(
+        "ip_probe xff=%(xff)r real_ip=%(real_ip)r forwarded=%(forwarded)r "
+        "proto=%(proto)r host=%(host)r remote_addr=%(remote_addr)r",
+        fields,
+    )
+    return fields
 
 
 # ---------------------------------------------------------------------------

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -1,5 +1,4 @@
 import importlib
-import logging
 
 from django.apps import apps
 from django.db import connection
@@ -59,29 +58,6 @@ def health(request: HttpRequest) -> dict[str, str]:
     with connection.cursor() as cursor:
         cursor.execute("SELECT 1")
     return {"status": "ok"}
-
-
-# TEMPORARY — Step 1 of docs/plans/ClientIpTrust.md. Probes how Railway's edge
-# proxy handles client-supplied X-Forwarded-For. Remove after results captured.
-_probe_log = logging.getLogger("ip_probe")
-
-
-@api.get("/probe", tags=["private"])
-def probe(request: HttpRequest) -> dict[str, str | None]:
-    fields = {
-        "xff": request.META.get("HTTP_X_FORWARDED_FOR"),
-        "real_ip": request.META.get("HTTP_X_REAL_IP"),
-        "forwarded": request.META.get("HTTP_FORWARDED"),
-        "proto": request.META.get("HTTP_X_FORWARDED_PROTO"),
-        "host": request.META.get("HTTP_X_FORWARDED_HOST"),
-        "remote_addr": request.META.get("REMOTE_ADDR"),
-    }
-    _probe_log.info(
-        "ip_probe xff=%(xff)r real_ip=%(real_ip)r forwarded=%(forwarded)r "
-        "proto=%(proto)r host=%(host)r remote_addr=%(remote_addr)r",
-        fields,
-    )
-    return fields
 
 
 # ---------------------------------------------------------------------------

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -60,22 +60,6 @@ def health(request: HttpRequest) -> dict[str, str]:
     return {"status": "ok"}
 
 
-# TEMPORARY — verifying RATE_LIMIT_TRUST_PROXY_HEADERS is live in prod.
-# Remove after confirmation.
-@api.get("/ip-check", tags=["private"])
-def ip_check(request: HttpRequest) -> dict[str, str | bool | None]:
-    from django.conf import settings as _s
-
-    from apps.core.rate_limits import _client_ip
-
-    return {
-        "trust_proxy_headers": bool(_s.RATE_LIMIT_TRUST_PROXY_HEADERS),
-        "client_ip": _client_ip(request),
-        "x_real_ip": request.META.get("HTTP_X_REAL_IP"),
-        "remote_addr": request.META.get("REMOTE_ADDR"),
-    }
-
-
 # ---------------------------------------------------------------------------
 # Router autodiscovery — each app's api module exports a `routers` list of
 # (prefix, router) tuples.  Adding a new router only requires editing the

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -211,6 +211,16 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",  # Django admin password login
 ]
 
+# ── Rate limiting ────────────────────────────────────────────────
+# Gate for trusting proxy-supplied client-IP headers in
+# ``apps.core.rate_limits._client_ip``. Default False so dev, tests, and
+# any unsanitized container key off REMOTE_ADDR. Production sets this to
+# True, asserting that Caddy has stripped Forwarded and that X-Real-IP
+# was populated by Railway's edge (see docs/plans/ClientIpTrust.md).
+RATE_LIMIT_TRUST_PROXY_HEADERS = os.environ.get(
+    "RATE_LIMIT_TRUST_PROXY_HEADERS", "false"
+).lower() in ("true", "1", "yes")
+
 # ── Sessions ─────────────────────────────────────────────────────
 SESSION_COOKIE_AGE = 60 * 60 * 24 * 90  # 90 days
 SESSION_SAVE_EVERY_REQUEST = True  # sliding window — reset expiry on each request

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -107,10 +107,23 @@ CACHES = {
 
 AUTH_USER_MODEL = "accounts.User"
 
-# auth.W004: User.email is USERNAME_FIELD without unique=True. Uniqueness is
-# enforced case-insensitively via the Lower("email") UniqueConstraint on the
-# User model; adding unique=True would layer on a redundant case-sensitive one.
-SILENCED_SYSTEM_CHECKS = ["auth.W004"]
+# Suppressed deploy checks. Document the *why* for each entry so the
+# next reader can tell "deliberately disabled" from "we forgot."
+SILENCED_SYSTEM_CHECKS = [
+    # User.email is USERNAME_FIELD without unique=True. Uniqueness is
+    # enforced case-insensitively via the Lower("email") UniqueConstraint
+    # on the User model; adding unique=True would layer on a redundant
+    # case-sensitive one.
+    "auth.W004",
+    # SECURE_SSL_REDIRECT — Django-side HTTPS redirect. Not needed and
+    # actively harmful in our topology: Railway terminates TLS at its
+    # edge and only serves the domains over HTTPS externally, so Django
+    # never sees an HTTP request from a real client. The only HTTP
+    # traffic Django sees is Caddy → loopback, which we don't want to
+    # redirect. Enabling this without SECURE_PROXY_SSL_HEADER would
+    # cause an infinite redirect loop. See docs/Hosting.md.
+    "security.W008",
+]
 
 AUTH_PASSWORD_VALIDATORS = [
     {

--- a/docs/Hosting.md
+++ b/docs/Hosting.md
@@ -75,6 +75,40 @@ This is acceptable for the current bootstrap phase because it is simple and fail
 | `GET /manufacturers/williams`  | Caddy → SvelteKit SSR                |
 | `GET /`                        | Caddy → SvelteKit SSR                |
 
+## Client IP trust
+
+Pre-auth rate limiters (signup flow, etc.) key off the caller's IP. Because Django sits behind two layers of proxy (Railway's edge, then Caddy), `REMOTE_ADDR` is always `127.0.0.1` — the real client IP has to come from a forwarded-header. Getting this right is security-relevant: a wrong choice silently makes IP-keyed rate limits either non-functional (every request shares one bucket) or bypassable (an attacker varies the header to spray buckets).
+
+### Header chain
+
+**Railway edge** (before Caddy sees the request):
+
+- Sets `X-Real-IP` to the real client public IP. Client-supplied values are overwritten; not spoofable. Verified empirically by the Client-IP-Trust probe.
+- Sets `X-Forwarded-For` to Railway's rotating internal IP (a `100.64.0.X` CGNAT address whose last octet rotates per request across Railway's internal proxy fabric). Reading this directly would bucket each request from one client into a different bucket.
+- Passes `Forwarded` (RFC 7239) through verbatim — **attacker-controlled** until Caddy strips it.
+
+**Caddy** ([Caddyfile](../Caddyfile)):
+
+- Strips `Forwarded` — closes the attacker-controlled channel.
+- Strips Railway's rotating `X-Forwarded-For`, then conditionally rewrites it to the trusted `X-Real-IP` value. If `X-Real-IP` is absent (internal probe, future infra change), XFF stays stripped so future readers see "no info" rather than an empty string or stale fabric noise.
+
+**Django** ([\_client_ip](../backend/apps/core/rate_limits.py)):
+
+- Reads `X-Real-IP`. Never reads `X-Forwarded-For` — XFF parsing (left-most vs. right-most, trusted-hop counting) has no failure mode that's safe under upstream drift; `X-Real-IP` fails closed if absent.
+
+### Trust gate (`RATE_LIMIT_TRUST_PROXY_HEADERS`)
+
+Django's `_client_ip` only reads proxy headers when `RATE_LIMIT_TRUST_PROXY_HEADERS=true`. The setting defaults to `false`, so dev, tests, and any container without a sanitizing proxy in front key off `REMOTE_ADDR=127.0.0.1` and degrade to "everyone shares one bucket" — observable, fixable, not a security bug.
+
+**Production must set `RATE_LIMIT_TRUST_PROXY_HEADERS=true`.** The trust assumption (Caddy has stripped `Forwarded`, Railway has populated `X-Real-IP`) is a deployment contract.
+
+This is the second fail-closed layer behind the X-Real-IP-only header choice. Both layers protect against the same drift: if the env var rolls back, or a future upstream stops setting `X-Real-IP`, the system degrades to one-shared-bucket rather than silently trusting attacker input.
+
+### When to revisit
+
+- **Moving off Railway, or adding a CDN.** The current scheme relies on Railway's edge to populate `X-Real-IP` and strip client-supplied versions of it. Any infra change to the proxy chain — different host, Cloudflare/Bunny in front, enabling Railway's CDN — invalidates that assumption and likely needs a Caddy `trusted_proxies` block plus a re-verification probe.
+- **A new code path reads `X-Forwarded-For`.** Don't. The function in `apps/core/rate_limits.py` is the single sanctioned reader of forwarded client IP. Adding analytics, geoip, or logging that reads XFF reintroduces the parsing-bug class this design deliberately deleted.
+
 ## Setup
 
 ### 1. Create Railway project
@@ -89,13 +123,14 @@ automatically via a reference variable.
 
 In the Railway service dashboard:
 
-| Variable                | Value                                                                         |
-| ----------------------- | ----------------------------------------------------------------------------- |
-| `SECRET_KEY`            | Random string: `python -c "import secrets; print(secrets.token_urlsafe(50))"` |
-| `DEBUG`                 | `false`                                                                       |
-| `ALLOWED_HOSTS`         | Comma-separated hosts, e.g. `flipcommons.org,www.flipcommons.org`             |
-| `CSRF_TRUSTED_ORIGINS`  | Full origins, e.g. `https://flipcommons.org,https://www.flipcommons.org`      |
-| `INTERNAL_API_BASE_URL` | `http://127.0.0.1:8000`                                                       |
+| Variable                         | Value                                                                         |
+| -------------------------------- | ----------------------------------------------------------------------------- |
+| `SECRET_KEY`                     | Random string: `python -c "import secrets; print(secrets.token_urlsafe(50))"` |
+| `DEBUG`                          | `false`                                                                       |
+| `ALLOWED_HOSTS`                  | Comma-separated hosts, e.g. `flipcommons.org,www.flipcommons.org`             |
+| `CSRF_TRUSTED_ORIGINS`           | Full origins, e.g. `https://flipcommons.org,https://www.flipcommons.org`      |
+| `INTERNAL_API_BASE_URL`          | `http://127.0.0.1:8000`                                                       |
+| `RATE_LIMIT_TRUST_PROXY_HEADERS` | `true` — required in production. See [Client IP trust](#client-ip-trust).     |
 
 `DATABASE_URL` and `PORT` are set automatically by Railway.
 

--- a/docs/Hosting.md
+++ b/docs/Hosting.md
@@ -38,9 +38,14 @@ Browser ──→ media.flipcommons.org       → Bunny CDN → iDrive e2 privat
    Bunny CDN on `media.flipcommons.org`, which pulls from the private iDrive e2
    bucket. Django is not in the production media-serving path.
 
-5. **Migrations on deploy**: Railway's `preDeployCommand` runs
-   `manage.py migrate` before the new container accepts traffic. If the
-   migration fails, the old container keeps serving.
+5. **Pre-deploy checks and migrations**: Railway's `preDeployCommand`
+   runs `manage.py check --deploy && manage.py migrate` before the new
+   container accepts traffic. `check --deploy` surfaces production-only
+   system checks (HSTS, SSL redirect, `core.W001` for missing
+   `RATE_LIMIT_TRUST_PROXY_HEADERS`, etc.); Error-level findings fail the
+   deploy, Warning-level findings are visible in logs but non-blocking.
+   If anything in the pre-deploy command fails, the old container keeps
+   serving.
 
 ## Process Model
 
@@ -160,8 +165,9 @@ Railway auto-injects `RAILWAY_GIT_COMMIT_SHA` as a Docker build arg for any depl
 ### 3. Deploy
 
 Push to `main`. Railway builds the Docker image and deploys. The
-`preDeployCommand` in `railway.toml` runs migrations before the new
-container starts accepting traffic.
+`preDeployCommand` in `railway.toml` runs `manage.py check --deploy`
+followed by `manage.py migrate` before the new container starts
+accepting traffic.
 
 ### 4. Create superuser (one-time)
 
@@ -196,9 +202,9 @@ Caddy may be up while the SvelteKit Node server failed to start or crashed.
 Check the container logs for Node startup errors and confirm the SSR process
 is listening on `127.0.0.1:3000`.
 
-**Bad migration**:
-`preDeployCommand` runs migrations before swapping containers. If a
-migration fails, the old container keeps serving and the deploy is marked
-as failed. Fix the migration and push again. Railway does not automatically
+**Bad migration or failed deploy check**:
+`preDeployCommand` runs `check --deploy` and migrations before swapping
+containers. If either fails, the old container keeps serving and the deploy
+is marked as failed. Fix and push again. Railway does not automatically
 roll back the database — if a migration partially applied, you may need to
 manually fix it via `railway run`.

--- a/docs/Hosting.md
+++ b/docs/Hosting.md
@@ -89,8 +89,8 @@ Pre-auth rate limiters (signup flow, etc.) key off the caller's IP. Because Djan
 
 **Caddy** ([Caddyfile](../Caddyfile)):
 
-- Strips `Forwarded` — closes the attacker-controlled channel.
-- Strips Railway's rotating `X-Forwarded-For`, then conditionally rewrites it to the trusted `X-Real-IP` value. If `X-Real-IP` is absent (internal probe, future infra change), XFF stays stripped so future readers see "no info" rather than an empty string or stale fabric noise.
+- Strips `Forwarded` at site level (`request_header -Forwarded`) — closes the attacker-controlled channel.
+- Overwrites `X-Forwarded-For` with the trusted `X-Real-IP` value via `header_up` inside each `reverse_proxy` block. `header_up` is required (not site-level `request_header`) because Caddy's `reverse_proxy` has special handling for `X-Forwarded-*` headers that overrides any site-level mutations — site-level strips of XFF were verified empirically to be ignored. If `X-Real-IP` is absent (a state Railway never produces in practice), XFF becomes empty string; the deployment contract is that `X-Real-IP` is always populated at the proxy boundary.
 
 **Django** ([\_client_ip](../backend/apps/core/rate_limits.py)):
 

--- a/docs/plans/ClientIpTrust.md
+++ b/docs/plans/ClientIpTrust.md
@@ -116,6 +116,7 @@ What this does and doesn't do:
 
 - **Strips `Forwarded`** — the one attacker-controlled channel the probe surfaced.
 - **Overwrites `X-Forwarded-For`** with the trusted `X-Real-IP` value so XFF becomes a meaningful scalar instead of Railway's rotating internal `100.64.0.X`. Defense in depth for any future XFF reader.
+- **Placeholder caveat:** `{http.request.header.X-Real-IP}` is the documented Caddy 2.x syntax for reading an incoming request header. It's safe here because we never strip or rewrite `X-Real-IP` ourselves; if a future edit adds `header_up -X-Real-IP` or `header_up X-Real-IP …` to the same block, the placeholder above may read a modified value (Caddy's reverse_proxy module doesn't fully copy the request before applying `header_up` operations). Keep `X-Real-IP` read-only at this layer.
 - **Does NOT add `trusted_proxies`, `trusted_proxies_strict`, or `header_up X-Real-IP`.** Railway's edge already populates `X-Real-IP` correctly and cannot be overridden by clients (verified by probe). Computing it ourselves from XFF would be strictly worse. If we later move off Railway, this is the first thing to revisit — `trusted_proxies` becomes relevant when the upstream stops being trustworthy by itself.
 
 **Verify after deploy:** spin the probe endpoint back up briefly (or check via a one-off Django shell + curl) to confirm `Forwarded` is absent at Django and XFF equals the real client IP, not `100.64.0.X`.

--- a/docs/plans/ClientIpTrust.md
+++ b/docs/plans/ClientIpTrust.md
@@ -1,0 +1,172 @@
+# Client IP Trust
+
+Make the client IP we use for rate-limiting trustworthy, then bump Caddy and wire dependency-update automation while we're in the area.
+
+## Why
+
+`_client_ip` in [apps/core/rate_limits.py](../../backend/apps/core/rate_limits.py) reads the left-most non-empty entry of `X-Forwarded-For`. On Railway, the XFF that arrives at Django holds **Railway's rotating internal proxy IP** (`100.64.0.X`, last octet rotates per request — see [Railway probe results](#railway)), not the real client IP. Consequence: each request from the same client lands in a different rate-limit bucket. The IP-keyed limiters are **non-functional today** — not bypassable by an attacker so much as silently bypassed by Railway's proxy fabric for everyone.
+
+Severity per endpoint (Session 2 onboarding flow):
+
+- `signup_check_ip` / `signup_submit_ip` — IP throttle non-functional, but a session-keyed limiter still applies as a real backstop. Per-session throttle survives.
+- `signup_cancel_ip` — IP is the only limiter; no session bucket. **No effective rate limiting on this endpoint.**
+
+Secondary motivations bundled into the same change:
+
+- **Robustness across infrastructure changes.** The current behavior is an accident of Railway's edge architecture (Railway strips client-supplied XFF, populates `X-Real-IP` with the real client IP, then writes its own rotating internal IP into XFF). If we ever move off Railway, change Railway's edge config, or add a CDN, the same code could silently start trusting attacker-supplied XFF instead. Making the trust source explicit and gated by an env var means the trust assumption survives migrations.
+- **Caddy 2.11.2 is one patch release behind.** 2.11.3 fixes a FastCGI RCE, two admin-API auth bypasses, and a more thorough vars-module CVE patch. We're a year out of date with no signal to catch the next one.
+
+## Decisions
+
+### Django reads `X-Real-IP`, not `X-Forwarded-For`
+
+`_client_ip` reads `HTTP_X_REAL_IP` (with `REMOTE_ADDR` fallback), gated by a `RATE_LIMIT_TRUST_PROXY_HEADERS` setting. Django never parses XFF. Railway already sets `X-Real-IP` correctly at its edge (cross-checked against the edge log's `srcIp` field — see [Railway](#railway)), so Caddy doesn't need to compute or rewrite it; Caddy's job is just to forward what Railway sent.
+
+**Primary reason: failure-mode asymmetry across infrastructure changes.** The current safe behavior depends on Railway's edge. If a future migration (different host, removed Railway, added CDN) changes upstream XFF semantics, the choice of header we read determines what happens:
+
+- **X-Real-IP fails closed.** If the trusted upstream stops setting it, the header is absent. `_client_ip` falls back to `REMOTE_ADDR=127.0.0.1`. Every request shares one bucket. Annoying, observable (legit users see 429s within minutes), fixable. **Not a security bug.**
+- **X-Forwarded-For fails open.** Same migration, but XFF is the conventional header that _every_ upstream populates — possibly with attacker-supplied content, possibly with chain semantics that our left-most parser misinterprets. The recurrence is silent: no symptom until someone tries the bypass.
+
+This asymmetry is permanent — a property of the header shapes, not of any specific upstream.
+
+**Secondary reasons:**
+
+- **Deletes the parsing-bug class entirely.** `_client_ip` becomes one line: read a scalar, fall back to `REMOTE_ADDR`. No `.split(",")`, no left-vs-right-most decision, no trusted-proxy bookkeeping. A future code review never needs to reason about list semantics.
+- **Defense in depth.** The `RATE_LIMIT_TRUST_PROXY_HEADERS=False` default ([Step 2](#step-2-_client_ip-hardening)) is the _second_ fail-closed layer behind this same failure mode — if the env var is unset or rolled back, proxy headers are ignored entirely and bucketing keys off `REMOTE_ADDR`. Two independent layers both fail safely on the same class of drift.
+- **Convention argument for XFF is weak here.** The chain past Caddy is single-hop to Django on loopback. The only readers of the client IP are [apps/core/rate_limits.py](../../backend/apps/core/rate_limits.py) and [apps/provenance/rate_limits.py](../../backend/apps/provenance/rate_limits.py), both of which want a scalar. We're already (per Out of scope) accepting that the XFF chain is discarded at Caddy regardless of header choice, so "preserve the chain for analytics" isn't a lever that exists.
+
+**Costs accepted:**
+
+- One-time rewrite of any existing rate-limit tests that inject `HTTP_X_FORWARDED_FOR`. Bounded, observable at test-write time.
+- Slight unconventionality vs. the broader Django/proxy ecosystem. Mitigated by a docstring on `_client_ip` explaining the choice.
+
+**Implication for Caddy:** the headers reaching Django need sanitization for two distinct reasons — the RFC 7239 `Forwarded:` header is attacker-controlled and must be stripped, and XFF currently holds Railway's rotating internal IP, which is a nuisance for any future XFF reader. See [Step 1](#step-1-caddyfile-change).
+
+## Railway architecture (confirmed)
+
+Confirmed via the Railway dashboard on 2026-05-14:
+
+- **Public Networking uses Railway's HTTP routing**, not TCP Proxy. `flipcommons.org` and `www.flipcommons.org` both forward to container port 8080 (where Caddy listens). Railway terminates TLS; Caddy receives plain HTTP.
+- **Proxy chain is: client → Railway edge (Envoy) → Caddy (`:8080`) → Django/Node.** Three hops. Django's `REMOTE_ADDR` will always be `127.0.0.1` because Caddy reverse-proxies to loopback (`reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000}`), regardless of what's upstream of Caddy.
+- **CDN caching is disabled** on both custom domains (the per-domain "Enable CDN caching" toggle is off). This plan assumes it stays off. If enabled later:
+  - Railway's CDN is Cloudflare-backed (museum has vetoed Cloudflare per existing media-hosting decision, so this is a non-trivial policy question, not just a perf toggle).
+  - `trusted_proxies private_ranges` would no longer be sufficient — CDN POPs are public IPs and need explicit ranges or a trust mechanism.
+  - 429 responses would need `Cache-Control: no-store` to prevent the CDN from serving cached rate-limit rejections to other callers.
+- **`pinbase-production.up.railway.app` is Railway's auto-assigned "primary service domain"** and must not be deleted — Railway uses it for healthchecks, dashboard links, and possibly preview environments. Its attack surface is identical to `flipcommons.org` (same edge, same proxy, same headers), so keeping it does not add risk.
+- **TCP Proxy** is a separate, currently-unused feature for exposing raw TCP. Not relevant here. If added in the future, it would create a second listener that bypasses Railway's HTTP edge — but it would not be used for the rate-limited HTTP endpoints, so it does not affect this plan.
+
+## Verified facts
+
+### Caddy 2.11
+
+- `trusted_proxies private_ranges` works as an inline `reverse_proxy { }` subdirective; `trusted_proxies static private_ranges` works at the global `servers > trusted_proxies` level. Caddy docs strongly recommend the global form.
+- Default XFF parsing is **left-to-right** ("the first untrusted IP address found becomes the real client address"). This is **wrong for append-style upstreams** — the left-most position is exactly what an attacker controls. `trusted_proxies_strict` flips to right-to-left and is **required** for append-style proxies (HAProxy, CloudFlare, ALB, Railway-likely).
+- `{client_ip}` placeholder resolves to the trusted-resolved client IP (falls back to remote peer when no trusted proxy is in front).
+- Caddy's docs are silent on what XFF value it forwards upstream after resolution. Don't rely on undocumented behavior — set it explicitly via `header_up X-Forwarded-For {client_ip}`.
+
+### Railway
+
+Confirmed on 2026-05-14 by deploying `/api/probe` against `https://flipcommons.org/api/probe`. Three sources of evidence: Django response from the probe endpoint (headers as seen by the app), Railway's edge HTTP log (per-request metadata at the public ingress), and Caddy's deploy-log output.
+
+- **Railway's edge strips client-supplied `X-Forwarded-For` entirely.** Attacker headers `X-Forwarded-For: 9.9.9.9` and list-form `9.9.9.9, 8.8.8.8` never survive to Caddy. Verified across scalar, list, and combined-spoof cases. The attacker-controlled XFF bypass premise that originally motivated this plan **does not apply** on Railway as-deployed — that's not a reason to relax the plan (see [Defense in depth](#decisions)), but it changes the threat model description in [Why](#why).
+- **`X-Real-IP` is set by Railway's edge to the real client public IP, and is not attacker-spoofable.** Sending `X-Real-IP: 9.9.9.9` directly is overwritten before Caddy sees it. Stable across repeated requests from the same client. Cross-checked against Railway's edge log `srcIp` field, which matches `X-Real-IP` at Django exactly — the end-to-end chain is verified.
+- **Railway → Caddy is over IPv6 in the RFC 4193 ULA range (`fd00::/8`).** Railway's edge HTTP log reports `upstreamAddress` as an `fd…` IPv6 address on port 8080 (Caddy's listener). Caddy's actual TCP peer is therefore IPv6, not IPv4.
+- **The `100.64.0.X` rotating IPv4 that appears in XFF at Django is not Caddy's TCP peer** — Caddy's peer is the IPv6 ULA above. The `100.64.0.0/10` (RFC 6598 CGNAT) value is something Railway writes into the XFF header itself before forwarding to Caddy, and the last octet rotates per request (observed `100.64.0.2` through `.8` across 8 requests from one client — Railway runs multiple internal proxy nodes). Caddy then forwards this XFF unchanged.
+- **Practical consequence: the current XFF-based `_client_ip` is mis-keyed onto Railway's rotating internal IP.** Per-IP rate limiting buckets each request from the same client into a different bucket. This is non-functional for _everyone_, not just attackers — a worse-than-expected status quo, and it makes [Step 3](#step-3-_client_ip-hardening) a functional bug fix, not just a hardening.
+- **`trusted_proxies` configuration in Caddy is not needed for this plan.** `X-Real-IP` is trustworthy at Caddy's ingress (Railway's edge guarantees it), and we're not reading XFF. If we ever did want Caddy to resolve `{client_ip}` from XFF, Caddy's `private_ranges` keyword **does** cover IPv6 ULA (`fc00::/7`, which includes `fd00::/8`), so trusting Caddy's actual peer would work out of the box — but again, moot because we don't need it.
+- **`Forwarded` (RFC 7239) passes through verbatim and IS attacker-controlled.** Sending `Forwarded: for=9.9.9.9` produced `forwarded="for=9.9.9.9"` at Django. No code reads this header today, so not actively exploitable, but [Step 2](#step-2-caddyfile-change) should sanitize it as defense in depth (a future logging shim, geoip lookup, or middleware that reads `Forwarded:` would inherit the bug).
+- **`X-Forwarded-Proto` arrives at Django as `http`, not `https`**, even though Railway terminates TLS at its public edge. Railway → Caddy is plain HTTP/1.1 (per Railway edge log `upstreamProto: HTTP/1.1`). Tangential to this plan but worth a separate follow-up — affects any code that branches on request scheme (Django's `SECURE_PROXY_SSL_HEADER`, redirect-to-https logic, secure-cookie decisions).
+- **Django's `REMOTE_ADDR` is `127.0.0.1`**, as predicted by the architecture (Caddy reverse-proxies to loopback).
+
+## Proposal
+
+(Probe deploy is complete — findings in [Railway](#railway). The original Step 1 probe section is omitted; the Caddyfile below reflects the results.)
+
+### Step 1: Caddyfile change
+
+```caddy
+:{$PORT:8080}
+
+@www host www.flipcommons.org
+handle @www {
+    redir https://flipcommons.org{uri} permanent
+}
+
+@django path /api /api/* /admin /admin/* /media/* /static /static/*
+handle @django {
+    reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000} {
+        # Strip the RFC 7239 Forwarded header — Railway passes client-supplied
+        # values through verbatim, so it's attacker-controlled. No code reads
+        # it today; this neutralizes a future-middleware footgun.
+        header_up -Forwarded
+        # Overwrite XFF with the trusted real-client-IP value Railway placed in
+        # X-Real-IP, replacing Railway's rotating internal proxy IP. Not read
+        # by app code today, but ensures any future XFF reader gets a real
+        # scalar IP rather than internal-fabric noise.
+        header_up X-Forwarded-For {http.request.header.X-Real-IP}
+    }
+}
+
+handle {
+    reverse_proxy 127.0.0.1:{$NODE_PORT:3000}
+}
+```
+
+What this does and doesn't do:
+
+- **Strips `Forwarded`** — the one attacker-controlled channel the probe surfaced.
+- **Overwrites `X-Forwarded-For`** with the trusted `X-Real-IP` value so XFF becomes a meaningful scalar instead of Railway's rotating internal `100.64.0.X`. Defense in depth for any future XFF reader.
+- **Does NOT add `trusted_proxies`, `trusted_proxies_strict`, or `header_up X-Real-IP`.** Railway's edge already populates `X-Real-IP` correctly and cannot be overridden by clients (verified by probe). Computing it ourselves from XFF would be strictly worse. If we later move off Railway, this is the first thing to revisit — `trusted_proxies` becomes relevant when the upstream stops being trustworthy by itself.
+
+**Verify after deploy:** spin the probe endpoint back up briefly (or check via a one-off Django shell + curl) to confirm `Forwarded` is absent at Django and XFF equals the real client IP, not `100.64.0.X`.
+
+### Step 2: `_client_ip` hardening
+
+In [backend/apps/core/rate_limits.py](../../backend/apps/core/rate_limits.py):
+
+- Add `RATE_LIMIT_TRUST_PROXY_HEADERS` Django setting, **default `False`**. The setting gates whether `_client_ip` reads `X-Real-IP` at all.
+- When `False`: `_client_ip` returns `REMOTE_ADDR` only. Safe default for dev, tests, and any container where the proxy chain isn't sanitized.
+- When `True`: `_client_ip` returns `request.META.get("HTTP_X_REAL_IP") or request.META.get("REMOTE_ADDR") or "0.0.0.0"`. One-line function, no list parsing, no proxy-chain interpretation.
+- Production env sets the env var to `True`. The trust assumption becomes a deployment contract, not implicit code behavior.
+
+This setting is the **second fail-closed layer** behind the X-Real-IP choice ([Decisions](#decisions)). Both layers protect against the same class of drift: if either the Caddy `header_up` line disappears _or_ the env var rolls back to default, the system degrades to "everyone shares a `127.0.0.1` bucket" — annoying and observable, not a security bug.
+
+A docstring on `_client_ip` should briefly note both: why it doesn't read XFF (parsing-bug class, fail-closed posture) and why the setting defaults to `False` (defense in depth). Future readers shouldn't have to dig into git history to understand a deliberately boring function.
+
+Before writing the implementation: **audit existing tests** for any that inject `HTTP_X_FORWARDED_FOR` or `HTTP_X_REAL_IP` expecting distinct-IP behavior. With the default flipped to `False`, those tests will silently bucket on `127.0.0.1` and pass for the wrong reason. They need to either set `RATE_LIMIT_TRUST_PROXY_HEADERS=True` explicitly _and_ switch from XFF to `X-Real-IP` injection, or be rewritten to use `REMOTE_ADDR`.
+
+Add tests in [test_rate_limits.py](../../backend/apps/core/tests/test_rate_limits.py):
+
+- With `RATE_LIMIT_TRUST_PROXY_HEADERS=False` (default), attacker-supplied `X-Real-IP` and `X-Forwarded-For` are both ignored; bucket keys off `REMOTE_ADDR`. **The critical regression test** — if a future deploy accidentally rolls the setting back to default, no bypass.
+- With `RATE_LIMIT_TRUST_PROXY_HEADERS=True`, `X-Real-IP` is read; `X-Forwarded-For` is still ignored (asserts the parsing-bug class is gone).
+- Setting toggles per-test via `settings` fixture; no module-level state.
+
+### Step 3: Caddy 2.11.2 → 2.11.3
+
+Update [Dockerfile:29](../../Dockerfile#L29). One-line bump. Security patches (FastCGI RCE, admin API auth bypass) are unrelated to the XFF work but unsafe to defer.
+
+### Step 4: Dependabot for the Dockerfile
+
+Add `.github/dependabot.yml` (or equivalent in Renovate format if that's preferred) to scan the Dockerfile for upstream image updates. Weekly or monthly cadence — the goal is "we hear about new Caddy patches the day they ship," not aggressive churn.
+
+If the repo already has Dependabot for other ecosystems, just add a `docker` ecosystem entry; otherwise create the file.
+
+## Out of scope
+
+- **Refactor of `apps/provenance/rate_limits.py`** to share code with the new core module. Different keying (per-user vs. session/IP), small dedup payoff. Deferred follow-up.
+- **Trusted-proxy ranges for the dev environment.** Dev never has a proxy in front, so the safe default (proxy headers off) means tests + local dev key off `REMOTE_ADDR=127.0.0.1`. Acceptable since dev rate limits aren't security boundaries.
+- **Preserving the full XFF chain for geo-IP / abuse analytics.** The Caddy `header_up` overwrites/replaces the chain regardless of which header strategy we pick, so the chain is gone past Caddy. If we ever want it back, easier to revisit then than to design around a hypothetical now.
+- **Enabling Railway's CDN caching.** Currently off, and stays off in this work — see [Railway architecture](#railway-architecture-confirmed) for what would need to change if it were ever turned on.
+
+## Sequencing
+
+Separate branch (`feat/client-ip-trust`), separate AI session. One commit per logical step is fine, but a single commit covering all four steps is also acceptable since the review boundary is the PR, not the commits.
+
+Lands to `main` **before** the `feat/user-chosen-usernames` branch ships signup publicly. Doesn't block committing onboarding code on that branch — the rate limiters function on the session axis without this change; the IP axis is currently non-functional but neither relied on nor exploitable in a way that's worse than not having it.
+
+After merge, rebase `feat/user-chosen-usernames` onto `main` so the signup tests benefit from the hardened `_client_ip` semantics (the `RATE_LIMIT_TRUST_PROXY_HEADERS` setting defaults to `False`, so existing tests using `REMOTE_ADDR` will continue to pass unchanged).
+
+## Tests
+
+- `test_rate_limits.py` — both modes of `RATE_LIMIT_TRUST_PROXY_HEADERS`, including the regression case described in [Step 2](#step-2-_client_ip-hardening).
+- No backend test asserts Caddyfile contents — the Caddy config is verified by the post-deploy probe re-run ([Step 1](#step-1-caddyfile-change)) and the `_client_ip` setting-gated tests, not by Python.

--- a/docs/plans/ClientIpTrust.md
+++ b/docs/plans/ClientIpTrust.md
@@ -14,7 +14,7 @@ Severity per endpoint (Session 2 onboarding flow):
 Secondary motivations bundled into the same change:
 
 - **Robustness across infrastructure changes.** The current behavior is an accident of Railway's edge architecture (Railway strips client-supplied XFF, populates `X-Real-IP` with the real client IP, then writes its own rotating internal IP into XFF). If we ever move off Railway, change Railway's edge config, or add a CDN, the same code could silently start trusting attacker-supplied XFF instead. Making the trust source explicit and gated by an env var means the trust assumption survives migrations.
-- **Caddy 2.11.2 is one patch release behind.** 2.11.3 fixes a FastCGI RCE, two admin-API auth bypasses, and a more thorough vars-module CVE patch. We're a year out of date with no signal to catch the next one.
+- **Caddy 2.11.2 is one patch release behind.** 2.11.3 fixes a FastCGI RCE, two admin-API auth bypasses, and a more thorough vars-module CVE patch. Bumping manually here preempts the next Dependabot run by a few days for the security content; it doesn't fix a missing signal — Dependabot already covers the Dockerfile, and in fact closed an unrelated year-long drift (2.10.2 → 2.11.2, [#204](https://github.com/The-Flip/flipcommons/pull/204)) three weeks before this plan was written.
 
 ## Decisions
 
@@ -80,7 +80,7 @@ Confirmed on 2026-05-14 by deploying `/api/probe` against `https://flipcommons.o
 
 ## Proposal
 
-(Probe deploy is complete — findings in [Railway](#railway). The original Step 1 probe section is omitted; the Caddyfile below reflects the results.)
+We ran a probe; findings in [Railway](#railway). The Caddyfile below reflects the results.
 
 ### Step 1: Caddyfile change
 
@@ -92,19 +92,14 @@ handle @www {
     redir https://flipcommons.org{uri} permanent
 }
 
+@has_real_ip header X-Real-IP *
+request_header -Forwarded
+request_header -X-Forwarded-For
+request_header @has_real_ip X-Forwarded-For {http.request.header.X-Real-IP}
+
 @django path /api /api/* /admin /admin/* /media/* /static /static/*
 handle @django {
-    reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000} {
-        # Strip the RFC 7239 Forwarded header — Railway passes client-supplied
-        # values through verbatim, so it's attacker-controlled. No code reads
-        # it today; this neutralizes a future-middleware footgun.
-        header_up -Forwarded
-        # Overwrite XFF with the trusted real-client-IP value Railway placed in
-        # X-Real-IP, replacing Railway's rotating internal proxy IP. Not read
-        # by app code today, but ensures any future XFF reader gets a real
-        # scalar IP rather than internal-fabric noise.
-        header_up X-Forwarded-For {http.request.header.X-Real-IP}
-    }
+    reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000}
 }
 
 handle {
@@ -115,9 +110,9 @@ handle {
 What this does and doesn't do:
 
 - **Strips `Forwarded`** — the one attacker-controlled channel the probe surfaced.
-- **Overwrites `X-Forwarded-For`** with the trusted `X-Real-IP` value so XFF becomes a meaningful scalar instead of Railway's rotating internal `100.64.0.X`. Defense in depth for any future XFF reader.
-- **Placeholder caveat:** `{http.request.header.X-Real-IP}` is the documented Caddy 2.x syntax for reading an incoming request header. It's safe here because we never strip or rewrite `X-Real-IP` ourselves; if a future edit adds `header_up -X-Real-IP` or `header_up X-Real-IP …` to the same block, the placeholder above may read a modified value (Caddy's reverse_proxy module doesn't fully copy the request before applying `header_up` operations). Keep `X-Real-IP` read-only at this layer.
-- **Does NOT add `trusted_proxies`, `trusted_proxies_strict`, or `header_up X-Real-IP`.** Railway's edge already populates `X-Real-IP` correctly and cannot be overridden by clients (verified by probe). Computing it ourselves from XFF would be strictly worse. If we later move off Railway, this is the first thing to revisit — `trusted_proxies` becomes relevant when the upstream stops being trustworthy by itself.
+- **Strips XFF, then conditionally rewrites it** with the trusted `X-Real-IP` value. If `X-Real-IP` is absent (internal probe, future infra change), XFF stays stripped — any future reader sees "no info" rather than an empty value or Railway's rotating internal `100.64.0.X`. The conditional gate (`@has_real_ip header X-Real-IP *`) is what preserves the defense-in-depth claim under upstream degradation.
+- **Sanitization is site-level (`request_header`), not per-route (`header_up`).** One block applies to both Django and Node upstreams without duplication or a Caddyfile snippet. Also dodges a subtle reverse*proxy footgun: `header_up X-Forwarded-For {http.request.header.X-Real-IP}` reads the placeholder against the \_mutated* request, so any later edit that touches `X-Real-IP` in the same block silently changes XFF. `request_header` runs once, ahead of routing.
+- **Does NOT add `trusted_proxies`, `trusted_proxies_strict`, or rewrite `X-Real-IP`.** Railway's edge already populates `X-Real-IP` correctly and cannot be overridden by clients (verified by probe). Computing it ourselves from XFF would be strictly worse. If we later move off Railway, this is the first thing to revisit — `trusted_proxies` becomes relevant when the upstream stops being trustworthy by itself.
 
 **Verify after deploy:** spin the probe endpoint back up briefly (or check via a one-off Django shell + curl) to confirm `Forwarded` is absent at Django and XFF equals the real client IP, not `100.64.0.X`.
 
@@ -148,9 +143,9 @@ Update [Dockerfile:29](../../Dockerfile#L29). One-line bump. Security patches (F
 
 ### Step 4: Dependabot for the Dockerfile
 
-Add `.github/dependabot.yml` (or equivalent in Renovate format if that's preferred) to scan the Dockerfile for upstream image updates. Weekly or monthly cadence — the goal is "we hear about new Caddy patches the day they ship," not aggressive churn.
+**Already done** — discovered during implementation. [.github/dependabot.yml](../../.github/dependabot.yml) has a `docker` ecosystem entry on `/` with a weekly schedule, which covers all base images in the root [Dockerfile](../../Dockerfile) (Caddy, Node, Python). The next 2.11.x → next-version Caddy bump will land as an automated PR.
 
-If the repo already has Dependabot for other ecosystems, just add a `docker` ecosystem entry; otherwise create the file.
+No change needed in this work.
 
 ## Out of scope
 
@@ -166,6 +161,10 @@ Separate branch (`feat/client-ip-trust`), separate AI session. One commit per lo
 Lands to `main` **before** the `feat/user-chosen-usernames` branch ships signup publicly. Doesn't block committing onboarding code on that branch — the rate limiters function on the session axis without this change; the IP axis is currently non-functional but neither relied on nor exploitable in a way that's worse than not having it.
 
 After merge, rebase `feat/user-chosen-usernames` onto `main` so the signup tests benefit from the hardened `_client_ip` semantics (the `RATE_LIMIT_TRUST_PROXY_HEADERS` setting defaults to `False`, so existing tests using `REMOTE_ADDR` will continue to pass unchanged).
+
+**Rebase conflict resolution — important.** Both branches touch `backend/apps/core/rate_limits.py`. This branch lands a minimal module containing only the hardened `_client_ip` plus a placeholder docstring. `feat/user-chosen-usernames` independently created the full module (RateLimitExceededError, RateLimitSpec, signup specs) with an **older, unhardened** `_client_ip` that reads `X-Forwarded-For`. Naively taking "theirs" at rebase silently reverts the hardening — and there is no compile error or test failure that would catch it, because the other branch's tests inject XFF and expect distinct-IP behavior.
+
+Resolution: keep this branch's `_client_ip` body (and the trust-gate import of `settings`), keep the other branch's surrounding classes/specs, and drop this branch's placeholder paragraph from the module docstring. Then audit the other branch's tests per [Step 2](#step-2-_client_ip-hardening) — any test that injects `HTTP_X_FORWARDED_FOR` expecting distinct buckets must either set `RATE_LIMIT_TRUST_PROXY_HEADERS=True` and switch to `HTTP_X_REAL_IP`, or be rewritten to use `REMOTE_ADDR`.
 
 ## Tests
 

--- a/docs/plans/ClientIpTrust.md
+++ b/docs/plans/ClientIpTrust.md
@@ -92,26 +92,29 @@ handle @www {
     redir https://flipcommons.org{uri} permanent
 }
 
-@has_real_ip header X-Real-IP *
 request_header -Forwarded
-request_header -X-Forwarded-For
-request_header @has_real_ip X-Forwarded-For {http.request.header.X-Real-IP}
 
 @django path /api /api/* /admin /admin/* /media/* /static /static/*
 handle @django {
-    reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000}
+    reverse_proxy 127.0.0.1:{$DJANGO_PORT:8000} {
+        header_up X-Forwarded-For {http.request.header.X-Real-IP}
+    }
 }
 
 handle {
-    reverse_proxy 127.0.0.1:{$NODE_PORT:3000}
+    reverse_proxy 127.0.0.1:{$NODE_PORT:3000} {
+        header_up X-Forwarded-For {http.request.header.X-Real-IP}
+    }
 }
 ```
 
 What this does and doesn't do:
 
-- **Strips `Forwarded`** — the one attacker-controlled channel the probe surfaced.
-- **Strips XFF, then conditionally rewrites it** with the trusted `X-Real-IP` value. If `X-Real-IP` is absent (internal probe, future infra change), XFF stays stripped — any future reader sees "no info" rather than an empty value or Railway's rotating internal `100.64.0.X`. The conditional gate (`@has_real_ip header X-Real-IP *`) is what preserves the defense-in-depth claim under upstream degradation.
-- **Sanitization is site-level (`request_header`), not per-route (`header_up`).** One block applies to both Django and Node upstreams without duplication or a Caddyfile snippet. Also dodges a subtle reverse*proxy footgun: `header_up X-Forwarded-For {http.request.header.X-Real-IP}` reads the placeholder against the \_mutated* request, so any later edit that touches `X-Real-IP` in the same block silently changes XFF. `request_header` runs once, ahead of routing.
+- **Strips `Forwarded` at site level** — `request_header` works fine for arbitrary headers; this is the one attacker-controlled channel the probe surfaced.
+- **Rewrites `X-Forwarded-For` inside each `reverse_proxy` block via `header_up`** — not at site level, despite the duplication. Caddy's `reverse_proxy` has special handling for `X-Forwarded-*` headers that overrides any site-level `request_header` mutations (per [Caddy docs](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#defaults): _"By default, Caddy passes incoming headers to the backend without modification, with the exception of X-Forwarded-For, X-Forwarded-Proto, and X-Forwarded-Host."_). Empirically verified during deploy: a site-level `request_header -X-Forwarded-For` left Django seeing the original Railway-injected `100.64.0.X` value, while `header_up` inside `reverse_proxy` correctly overwrites it. `header_up` is the proxy-aware path.
+- **No conditional gate on X-Real-IP presence.** Earlier drafts gated the rewrite on a `@has_real_ip` matcher so XFF would be stripped (rather than blanked) if X-Real-IP were absent. Dropped because `header_up` doesn't accept matchers, and adding one via `handle` blocks isn't worth the complexity for a hypothetical failure mode Railway never produces in practice. The "X-Real-IP is present at the proxy boundary" assumption joins `RATE_LIMIT_TRUST_PROXY_HEADERS=true` as a deployment contract.
+- **`Forwarded` strip stays site-level** because it has no `reverse_proxy` special-casing — `request_header` is the right tool there, and keeping one directive at site level (instead of duplicating across both reverse_proxy blocks) is the lighter touch.
+- **Two `header_up` directives are duplicated** across the @django and catch-all Node blocks. A Caddyfile snippet (`(name) { }` + `import name`) was attempted to dedupe, but snippets must be defined at global scope (before any site address) and inline definition mid-site silently breaks the deploy. One-line duplication won; revisit if the directive grows.
 - **Does NOT add `trusted_proxies`, `trusted_proxies_strict`, or rewrite `X-Real-IP`.** Railway's edge already populates `X-Real-IP` correctly and cannot be overridden by clients (verified by probe). Computing it ourselves from XFF would be strictly worse. If we later move off Railway, this is the first thing to revisit — `trusted_proxies` becomes relevant when the upstream stops being trustworthy by itself.
 
 **Verify after deploy:** spin the probe endpoint back up briefly (or check via a one-off Django shell + curl) to confirm `Forwarded` is absent at Django and XFF equals the real client IP, not `100.64.0.X`.

--- a/railway.toml
+++ b/railway.toml
@@ -19,4 +19,8 @@ watchPatterns = [
 ]
 
 [deploy]
-preDeployCommand = ".venv/bin/python manage.py migrate --noinput"
+# check --deploy surfaces Django's production-only system checks (HSTS,
+# SSL redirect, RATE_LIMIT_TRUST_PROXY_HEADERS, etc.) in deploy logs and
+# fails the deploy on Error-level findings. Warnings (core.W001 et al.)
+# are visible but non-blocking. See docs/Hosting.md § "Client IP trust".
+preDeployCommand = ".venv/bin/python manage.py check --deploy && .venv/bin/python manage.py migrate --noinput"


### PR DESCRIPTION
## Summary

- **Fixes non-functional IP rate limiting on Railway.** XFF at Django was holding Railway's rotating internal proxy IP (`100.64.0.X`, last octet rotates per request), so each request from one client hit a different rate-limit bucket. Caddy now strips the attacker-controlled `Forwarded` header and rewrites `X-Forwarded-For` from `X-Real-IP`; Django reads `X-Real-IP` only, gated by `RATE_LIMIT_TRUST_PROXY_HEADERS`.
- **Two fail-closed layers protect against upstream drift.** Header choice (X-Real-IP fails closed if absent; XFF parsing has no safe failure mode) plus a trust-gate setting that defaults False. Both degrade to "one shared bucket" rather than trusting attacker input.
- **Deploy-time guard against future misconfiguration.** New `core.W001` system check fires under `manage.py check --deploy` when `RATE_LIMIT_TRUST_PROXY_HEADERS` is False in a non-DEBUG env. Railway's `preDeployCommand` now chains `check --deploy && migrate` so findings surface in deploy logs (Errors block deploy; Warnings log non-blocking).
- **`security.W008` silenced** (Django HTTPS redirect — intentionally disabled in our Railway-terminates-TLS topology). **`security.W004`** (HSTS) left firing as a real gap, tracked in #404.
- **Caddy 2.11.2 → 2.11.3** for the FastCGI RCE and admin-API auth-bypass patches.

Design rationale, probe results, and Railway architecture findings: [docs/plans/ClientIpTrust.md](docs/plans/ClientIpTrust.md). Trust model documented permanently in [docs/Hosting.md § "Client IP trust"](docs/Hosting.md).

## Pre-merge gates — all cleared

- [x] **`RATE_LIMIT_TRUST_PROXY_HEADERS=true` set in Railway env** — confirmed live.
- [x] **Live probe matrix run on prod** (via temporary `/api/probe` + `/api/ip-check`, both now removed): `Forwarded` absent at Django, `X-Forwarded-For` equals real client IP (not `100.64.0.X`), `_client_ip()` returns real client IP, `trust_proxy_headers=true`.
- [x] **Deploy log confirms `check --deploy` ran**: `core.W001` does not appear (env var correctly set); `security.W004` visible and tracked (#404); `2 silenced` (`auth.W004` + `security.W008`).

## Test plan

- [x] `backend/apps/core/tests/test_rate_limits.py` — 9 unit tests covering both setting modes, including the critical regression: with the default-False setting, attacker-supplied `X-Real-IP` and `X-Forwarded-For` are both ignored.
- [x] `backend/apps/core/tests/test_rate_limit_proxy_trust_check.py` — 5 unit tests covering all four states of (`DEBUG` × `RATE_LIMIT_TRUST_PROXY_HEADERS`) and forward-compat kwargs.
- [x] `ruff check`, `mypy`, `pytest` — all green; pre-commit hooks pass.
- **Not testable on this branch:** the actual 429 behavior for IP-keyed limiters. The signup-flow limiters (`signup_check_ip`, `signup_submit_ip`, `signup_cancel_ip`) live on `feat/user-chosen-usernames`. Confirmation that the hardened `_client_ip` produces correct per-IP bucketing rolls in when that branch rebases.

## Rebase note for `feat/user-chosen-usernames`

Both branches touch `backend/apps/core/rate_limits.py`. This branch ships only the hardened `_client_ip`; the other branch has the full module with an unhardened `_client_ip` that reads XFF. At rebase, keep this branch's `_client_ip` body, keep the other branch's surrounding classes/specs, and audit the other branch's tests for any that inject `HTTP_X_FORWARDED_FOR` expecting distinct buckets — see [Sequencing in the plan](docs/plans/ClientIpTrust.md#sequencing).

## Follow-ups

- #404 — Enable HSTS to close `security.W004`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)