### PR TITLE
docs(observability): create the canonical stable o11y docs

### DIFF
--- a/docs/Hosting.md
+++ b/docs/Hosting.md
@@ -197,6 +197,57 @@ uv run python manage.py createsuperuser
 2. Update `ALLOWED_HOSTS` to include the domain
 3. Update `CSRF_TRUSTED_ORIGINS` to include `https://yourdomain.com`
 
+## Sentry
+
+We use [Sentry.io](https://sentry.io) for production error monitoring. See [Observability.md](Observability.md) for the contract (what we capture, privacy posture, code wiring).
+
+### Sentry Projects
+
+In Sentry, we have two projects:
+
+- `flipcommons-backend`: Python/Django
+- `flipcommons-frontend`: JavaScript/SvelteKit — both SSR and browser report here
+
+### Sentry env vars on Railway
+
+Local, CI, and test environments leave these unset. The empty-DSN guard at SDK init is the master switch.
+
+- `SENTRY_DSN` — backend runtime. Backend project DSN. Empty = Sentry off (master switch).
+- `PUBLIC_SENTRY_DSN` — frontend SSR + browser runtime. Frontend project DSN. Empty = Sentry off (master switch).
+- `SENTRY_AUTH_TOKEN` — frontend build (Docker `ARG` → `ENV`). Org-scoped, secret. The only Sentry value that's actually secret; DSNs are public-by-design write-only keys. Required for sourcemap upload.
+- `SENTRY_ORG` — frontend build. Org slug. Required for sourcemap upload.
+- `SENTRY_PROJECT` — frontend build. `flipcommons-frontend`. Required for sourcemap upload.
+
+All three `SENTRY_*` build-time vars are declared as `ARG`s in the frontend build stage of the [Dockerfile](../Dockerfile) and `ENV`-promoted before `pnpm build` — multi-stage Docker doesn't inherit host env vars into build stages, and forgetting one silently produces a build with no sourcemaps uploaded.
+
+### Sentry dashboard config
+
+#### Privacy config
+
+This part of our [Privacy.md](Privacy.md) contract is manually configured on the Sentry website:
+
+**Advanced Data Scrubbing** (Project Settings → Security & Privacy → Advanced Data Scrubbing). These are part of the privacy contract — without them, emails or IPs interpolated into log messages, or query strings carrying user input, would be stored.
+
+- `[Mask] [@email] from [$string]`
+- `[Mask] [@ip] from [$string]`
+- `[Remove] [$request.query_string]`
+
+#### Alert rules\*\*
+
+Mirrored across both projects:
+
+- **New issue** → alert all maintainers
+- **Regression of a resolved issue** → alert all maintainers
+  Default issue assignment: **unassigned**. Either founder may grab an issue.
+
+### Per-maintainer routing
+
+Each maintainer is an org member with their own destination (email or chat). Adding or removing a maintainer is a single membership change. Production alerts go to all maintainers as co-responders.
+
+### Sourcemaps
+
+`@sentry/vite-plugin` (wrapped by `sentrySvelteKit`) uploads at build time, tagged with `RAILWAY_GIT_COMMIT_SHA`. The plugin's `sourcemaps.filesToDeleteAfterUpload` is configured explicitly so maps don't ship to browsers (the plugin doesn't delete by default).
+
 ## Troubleshooting
 
 **Health check fails after deploy**:

--- a/docs/Observability.md
+++ b/docs/Observability.md
@@ -1,0 +1,51 @@
+# Observability
+
+We use **[Sentry.io](https://sentry.io)** to learn when production has problems before a user has to tell us. Error capture and alerting — nothing else. No tracing, no profiling, no session replay, no analytics.
+
+In Sentry, we have two projects:
+
+- `flipcommons-backend`: Python/Django
+- `flipcommons-frontend`: JavaScript/SvelteKit — both SSR and browser report here
+
+## Sentry config
+
+For the Sentry-side configuration (env vars, scrubbing rules, alert rules), see [Hosting.md § Sentry](Hosting.md#sentry).
+
+## The master switch: DSN presence
+
+A **DSN** (Data Source Name) is Sentry's name for the per-project URL to posts events to. It identifies the project and authenticates the write — it's a public write-only key by design, not a secret. Each of our two projects has its own DSN.
+
+Each runtime's SDK init runs only when its own DSN env var is non-empty: the backend gates on `SENTRY_DSN`, the frontend (SSR + browser) gates on `PUBLIC_SENTRY_DSN`. Local, CI, and test environments leave both unset and the init blocks no-op. There is no per-environment matrix and no runtime kill switch — disabling Sentry in prod means removing the DSN and redeploying.
+
+## What we capture
+
+- Unhandled backend exceptions (via `DjangoIntegration`).
+- Unhandled SSR and browser exceptions (via `@sentry/sveltekit`).
+- Explicit `sentry_sdk.capture_*` calls for swallowed-but-noteworthy cases.
+
+## Things we don't capture
+
+Some of the things we explicitly don't capture:
+
+- **Backend**: validation errors, expected permission denials, expected 404s, structured 4xx errors (rate limits, etc.).
+- **Frontend**: `ResizeObserver` notifications, navigation aborts, `ChunkLoadError`, non-Error throws.
+
+## Logs ≠ alerts
+
+`logger.info/warning/error` flows to stdout and stays there. To send to Sentry, code must call the Sentry SDK's `capture_*` API explicitly. On the backend, `LoggingIntegration(level=INFO, event_level=None)` attaches log records as breadcrumbs on real events but never promotes them to standalone Sentry events. This keeps authz denials, validation errors, and rate-limit hits out of the alert stream by construction.
+
+## Privacy
+
+Sentry **does not store**: emails, IPs, request bodies, cookies, session tokens. (Some never leave the app — the SDK is configured not to extract them. The rest are stripped server-side at ingest by Sentry's Advanced Data Scrubbing rules before storage.)
+
+Sentry **does store**: route name, HTTP method, status code, exception type/message/stack trace, release SHA, environment, user id and username (authenticated requests only), `auth_state` tag (`"auth"`/`"anon"`), full User-Agent (plus `ua_family` tag for filtering).
+
+Differnt bits of this enforcement live in different layers:
+
+- Sentry SDK init options
+- A Sentry-provided Python `EventScrubber`
+- Sentry Advanced Data Scrubbing rules — see [Hosting.md § Sentry](Hosting.md#sentry) for the dashboard half.
+
+## Release correlation
+
+Events and uploaded sourcemaps are both tagged with `RAILWAY_GIT_COMMIT_SHA`, so production stack traces resolve to source and issues tie to a specific deploy in Sentry.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ For setup and common commands, start with the repository [README](../README.md).
 - [Media.md](Media.md) media storage, uploads, claims, attachment resolution.
 - [Ingest.md](Ingest.md) external data sources and the ingest pipeline.
 - [Hosting.md](Hosting.md) Railway deployment topology.
+- [Observability.md](Observability.md) Error monitoring and alerting.
 - [DeployAutomation.md](DeployAutomation.md) philosophy behind the deploy safeguards (refuse-don't-warn, two refusal phases).
 - [BuildChecks.md](BuildChecks.md) build-phase refusal gate (Dockerfile, sourcemap upload, build-time secrets).
 - [DeployChecks.md](DeployChecks.md) preDeploy refusal gate (Django system checks).


### PR DESCRIPTION
## Summary

Now that the observability work has shipped, lift the contract-level content out of `docs/plans/observability/` into stable docs.

- **New `docs/Observability.md`** — what Sentry sees vs. stores, what we capture and don't, logs-aren't-alerts, release correlation. Contracts only; implementation detail stays in code, plan/rationale stays in `docs/plans/`.
- **New `## Sentry` section in `docs/Hosting.md`** — operator-facing setup: Railway env vars, dashboard scrubbing rules, alert rules, per-maintainer routing.
- **`docs/README.md`** indexes the new doc.

`docs/plans/observability/*` is retained unchanged as historical context.

## Test plan

- [ ] Skim `docs/Observability.md` end-to-end — does it read as a current-state contract doc, or does it leak forward-looking or code-level content?
- [ ] Skim `docs/Hosting.md § Sentry` — is the operator setup actionable without cross-referencing the plan docs?
- [ ] Confirm internal links resolve (Hosting → Privacy, Observability → Hosting § Sentry, README → Observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)