### PR TITLE
feat(analytics): track pageviews via PostHog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,14 @@ WORKOS_REDIRECT_URI=http://localhost:5173/api/auth/callback/
 # SENTRY_ORG=the-flip
 # SENTRY_PROJECT=flipcommons-frontend
 
+# ── PostHog (analytics) ──────────────────────────────────────────────
+# Leave unset in local dev, CI, preview, and any environment without a real
+# project key. The analytics module reads this via `$env/dynamic/public` and
+# selects its noop adapter when the value is missing or blank — same shape
+# as the PUBLIC_SENTRY_DSN guard above. Set as a Railway production variable.
+#
+# PUBLIC_POSTHOG_KEY=
+
 # ── Cloudflare R2 (ingest source storage) ────────────────────────────
 # Public read URL (no auth needed — used by pull_ingest_sources):
 R2_PUBLIC_URL=https://pub-8a5220445534421c879b6ff9ede350f1.r2.dev

--- a/docs/plans/analytics/AnalyticsArchitecture.md
+++ b/docs/plans/analytics/AnalyticsArchitecture.md
@@ -189,7 +189,7 @@ The vendor integration must satisfy these constraints. The concrete knobs that i
 - Client IP stripped at ingest
 - Server-side geoip disabled
 
-**Pageviews are explicit, not auto-captured.** The vendor's auto-pageview is off; pageviews fire from a SvelteKit `afterNavigate` hook so every CSR route change is recorded — not just the initial SSR load. Implementation in [AnalyticsUntypedEventsPlan.md § Pageviews](AnalyticsUntypedEventsPlan.md#phase-pageviews).
+**Pageviews use PostHog's built-in SPA tracking, with query strings stripped.** `capture_pageview: 'history_change'` fires `$pageview` on every SvelteKit CSR navigation (pushState/replaceState/popstate) as well as the initial load. A `before_send` hook scrubs the query string off `$current_url` and `$pathname` so URL cardinality stays bounded and search terms / query-encoded state don't leak into the firehose. Implementation in [AnalyticsUntypedEventsPlan.md § Pageviews](AnalyticsUntypedEventsPlan.md#phase-pageviews).
 
 Mapping to the [non-goals](Analytics.md#non-goals):
 
@@ -269,6 +269,14 @@ Per the project's [strong-typing rule](../../Python.md), backend properties are 
 
 PostHog ships several features that appear in our [non-goals](Analytics.md#non-goals): autocapture, session replay, heatmaps, surveys, behavioral cohorts. The init config below disables them at the integration boundary.
 
+### Bundle cost
+
+We use `posthog-js` (the full SDK, ~70 KB gzipped), not `posthog-js-lite`. Rationale:
+
+- Once any call site imports `$lib/analytics`, `posthog-js` ships in every production bundle. The runtime key check (see [AnalyticsUntypedEventsPlan.md § Skeleton](AnalyticsUntypedEventsPlan.md#phase-skeleton)) gates whether events _fire_, not whether the SDK _ships_ — Rollup can't see through a runtime guard, and `posthog-js` doesn't declare `sideEffects: false`.
+- `posthog-js-lite` (~4 KB gzipped) was a tempting fit for our locked-down posture, but PostHog archived its standalone repo in 2025 and its README states `posthog-js` is the only officially supported feature-complete web SDK. The adapter abstraction keeps a future swap mechanical if PostHog changes that stance.
+- `posthog-js` and `@sentry/sveltekit` are vendor-split into their own Rollup chunks via `manualChunks` in `vite.config.ts`. Both load eagerly from the root layout, so without splitting they'd live in the layout chunk whose hash rolls on every app deploy. The split keeps SDK bytes cached across deploys; HTTP/2/3 multiplexing makes the two-extra-requests cost negligible. Vendor-splitting (not dynamic import) is the right lever here because instrumentation SDKs need their `pushState`/`popstate` listeners attached early — dynamic import would race init against the user's first interaction.
+
 ### Adapter files
 
 - Frontend: `frontend/src/lib/analytics/posthog.ts` + `config.ts`
@@ -278,18 +286,20 @@ These are the only files that import `posthog-js` or the `posthog` Python packag
 
 ### Frontend init lockdown
 
-**Literal (locked-down init; the integration test asserts every option):**
+**Literal (locked-down init; the integration test asserts every option). The `key` argument is the PostHog project key, read at call time from `$env/dynamic/public` and passed in by `index.ts` — see [AnalyticsUntypedEventsPlan.md § Skeleton](AnalyticsUntypedEventsPlan.md#phase-skeleton):**
 
 ```ts
-posthog.init(PUBLIC_POSTHOG_KEY, {
+posthog.init(key, {
   api_host: "https://eu.posthog.com",
   persistence: "memory", // satisfies "no persistent client-side identity"
   autocapture: false, // satisfies "no autocapture / implicit tracking"
-  capture_pageview: false, // we call pageview() explicitly from afterNavigate
-  capture_pageleave: false,
+  capture_pageview: "history_change", // SPA-aware: initial load + every CSR navigation
+  capture_pageleave: "if_capture_pageview",
   disable_session_recording: true,
   disable_surveys: true,
-  disable_external_dependency_loading: true, // no runtime fetch of feature-flag/survey configs — reduces fingerprinting surface
+  disable_external_dependency_loading: true, // blocks runtime <script> loads (session-recording.js, surveys.js, …)
+  advanced_disable_flags: true, // blocks the separate /flags HTTP request (the flag/decide endpoint isn't gated by disable_external_dependency_loading)
+  save_campaign_params: false, // don't extract utm_*, gclid, fbclid, msclkid, gbraid, wbraid, li_fat_id, … as top-level props
 
   ip: false, // satisfies "no IP-based attribution"
   property_denylist: [
@@ -298,7 +308,35 @@ posthog.init(PUBLIC_POSTHOG_KEY, {
     "$screen_width",
     "$viewport_height",
     "$viewport_width",
+    "ph_keyword", // search-engine-referrer query, auto-extracted with no config toggle
+    "$search_engine",
   ],
+
+  // Strip query strings from URLs before send — bounds cardinality and keeps
+  // query-encoded search terms / state out of the firehose. `$pathname` and
+  // `$current_url` are PostHog-set; `$prev_pageview_pathname` is populated
+  // automatically when capture_pageview is on; `$referrer` carries the
+  // external referring document's full URL (search-engine referrers in
+  // particular ship their query string).
+  before_send: (event) => {
+    if (!event || !event.properties) return event;
+    const props = event.properties;
+    for (const key of ["$current_url", "$referrer"]) {
+      const v = props[key];
+      if (typeof v === "string" && URL.canParse(v)) {
+        const u = new URL(v);
+        props[key] = u.origin + u.pathname;
+      }
+    }
+    for (const key of ["$pathname", "$prev_pageview_pathname"]) {
+      const v = props[key];
+      if (typeof v === "string") {
+        const q = v.indexOf("?");
+        if (q !== -1) props[key] = v.slice(0, q);
+      }
+    }
+    return event;
+  },
 });
 ```
 

--- a/docs/plans/analytics/AnalyticsUntypedEventsPlan.md
+++ b/docs/plans/analytics/AnalyticsUntypedEventsPlan.md
@@ -6,59 +6,39 @@ This is the launch path. It stands up the SDK with the locked-down privacy confi
 
 ## Phase: Skeleton
 
-Stand up `frontend/src/lib/analytics/` with the module structure from [AnalyticsArchitecture.md § Module Layout](AnalyticsArchitecture.md#module-layout). No events fire yet.
+Stand up `frontend/src/lib/analytics/` with the module structure from [AnalyticsArchitecture.md § Module Layout](AnalyticsArchitecture.md#module-layout). The SDK is initialized with the locked-down config; pageviews therefore start firing in any environment where `PUBLIC_POSTHOG_KEY` is set to a real value (i.e. staging/prod). The next phase is then a no-code verification phase.
 
 **Deliverables:**
 
-- `index.ts` — public API exporting the active adapter as `analytics`. Selects `noop` when `import.meta.env.DEV` **or** `PUBLIC_POSTHOG_KEY` is empty; the PostHog adapter otherwise. The key-presence check means staging/preview/CI builds without a key fall back to noop instead of crashing at init. `capture()`, `pageview()`, `identify()`, `reset()` per the [`Analytics` interface](AnalyticsArchitecture.md#the-api). All four are no-ops on every adapter at this phase; bodies land in later phases (`pageview()` next phase, `identify()`/`reset()` in typed-events).
-- `posthog.ts` — PostHog adapter. Imports the locked-down options from `config.ts` and calls `posthog.init()` guarded by `browser` from `$app/environment` so the SDK never touches `window` during SSR. At this phase the four interface methods are empty bodies.
-- `noop.ts` — no-op adapter for tests, dev, and opt-out.
-- `config.ts` — the literal init options object, imported by `posthog.ts`. Isolating it makes the integration test below trivial. Specified in [AnalyticsArchitecture.md § Frontend init lockdown](AnalyticsArchitecture.md#frontend-init-lockdown); do not deviate.
+- `index.ts` — public API exporting the active adapter as `analytics`. Selects `noop` when `import.meta.env.DEV`, or when `PUBLIC_POSTHOG_KEY` is missing/blank at runtime, or under SSR (`browser` from `$app/environment` is false); the PostHog adapter otherwise. The SSR fallback to noop keeps server-side `analytics.*` calls from hitting an uninitialized SDK once typed-events lands real call sites. The key-presence check means staging/preview/CI builds without a real key fall back to noop instead of crashing at init. After selecting the PostHog adapter, `index.ts` calls its `init(key)` once. `capture()`, `pageview()`, `identify()`, `reset()` per the [`Analytics` interface](AnalyticsArchitecture.md#the-api). `identify()`/`reset()` are no-ops until typed-events; `pageview()` is a no-op everywhere because PostHog's `capture_pageview: 'history_change'` handles pageviews automatically (the method exists for symmetry with the backend interface and future-proofing if we switch providers).
+- `posthog.ts` — PostHog adapter. Module scope is side-effect-free: the only top-level statements are the `import posthog from 'posthog-js'`, the import of the options from `config.ts`, and the exported adapter object with an `init(key)` method that wraps `posthog.init(key, config)`. The browser-only call to `init()` lives in `index.ts`, not at module load. With the init config alone, the SPA pageview firehose is already wired — no additional adapter logic is required at this phase.
+- `noop.ts` — no-op adapter for dev and opt-out. The `RecordingAnalytics` test fixture described in [AnalyticsArchitecture.md § Testing](AnalyticsArchitecture.md#testing) ships with the typed-events frontend plan, when the first `analytics.*` call sites land — this phase has none.
+- `config.ts` — the literal init options object (including `before_send`), imported by `posthog.ts`. Isolating it makes the integration test below trivial. Specified in [AnalyticsArchitecture.md § Frontend init lockdown](AnalyticsArchitecture.md#frontend-init-lockdown); do not deviate.
 - `events.ts` — empty `EventRegistry` type, ready to grow.
-- `PUBLIC_POSTHOG_KEY` wired through SvelteKit env via `$env/static/public` (build-time constant; lets the DEV/noop branch tree-shake the SDK out of dev bundles entirely). Document in `.env.example`.
+- `PUBLIC_POSTHOG_KEY` read via `$env/dynamic/public`. This matches the established project pattern for optional PUBLIC\_ vars (see the `PUBLIC_SENTRY_DSN` handling in [hooks.client.ts](../../../frontend/src/hooks.client.ts) — same shape: optional runtime var + early guard as the master switch). The runtime key check is the master switch for whether events fire; posthog-js itself ships in every production bundle that imports `$lib/analytics`, key or no key (Rollup can't see through a runtime guard, and posthog-js doesn't declare `sideEffects: false`). See [AnalyticsArchitecture.md § Bundle cost](AnalyticsArchitecture.md#bundle-cost) for the rationale. Document `PUBLIC_POSTHOG_KEY` in `.env.example` as a commented-out entry following the `PUBLIC_SENTRY_DSN` precedent; no global "must be defined" contract.
 - ESLint `no-restricted-imports` rule banning `posthog-js` outside `posthog.ts`.
+- Side-effect import of `$lib/analytics` in `src/routes/+layout.svelte`. Nothing else triggers the analytics module's adapter selection and PostHog `init()` — without this consumer the rest of the skeleton is dead code. Layout is the natural home: it loads on every page and runs before any route-level code.
+- `manualChunks` config in `vite.config.ts` that splits `posthog-js` and `@sentry/sveltekit` into their own chunks. Both SDKs load eagerly from the root layout (~150 KB gzipped combined); without splitting they'd land in the layout chunk whose hash rolls on every app deploy, forcing users to re-download unchanged SDK bytes. See [AnalyticsArchitecture.md § Bundle cost](AnalyticsArchitecture.md#bundle-cost).
 
 **Verification:**
 
-- An integration test (vitest) that imports `config.ts` and asserts every locked-down option matches the architecture doc. Weakening any option fails the test.
-- A vitest covering adapter selection across three cases: (a) `DEV=true` → noop, (b) `DEV=false` + empty key → noop, (c) `DEV=false` + key set → PostHog adapter. Use `vi.stubEnv` to drive `import.meta.env`. Confirm in a dev-run by inspecting the network tab — no requests to `eu.posthog.com`.
-- A vitest asserting that importing `index.ts` in a non-browser environment (the vitest default) does not import `posthog-js` — the `browser` guard keeps SSR safe.
+- An integration test (vitest) that imports `config.ts` and asserts every locked-down option matches the architecture doc, including driving the `before_send` hook with a synthetic event whose `$current_url` / `$pathname` / `$prev_pageview_pathname` carry query strings, and asserting they come out stripped. Weakening any option fails the test.
+- A parametrized vitest covering adapter selection: (a) `DEV=true` → noop, (b) `DEV=false` + blank key → noop, (c) `DEV=false` + key set → PostHog adapter, _and_ `posthog.init` was called exactly once with the key and the config object from `config.ts`. Folding the init-call assertion into case (c) guards the contract that selecting the PostHog adapter actually wires the locked-down init — a refactor that drops the call to `init()` would otherwise pass silently. `PUBLIC_POSTHOG_KEY` comes from `$env/dynamic/public`, so per-case it must be mocked with `vi.doMock('$env/dynamic/public', () => ({ env: { PUBLIC_POSTHOG_KEY: '...' } }))` followed by `vi.resetModules()` before re-importing `index.ts`. `vi.stubEnv` is the right knob for `import.meta.env.DEV`.
+- A separate vitest that mocks `posthog-js` and `$app/environment`, then imports `index.ts` with `DEV=false` + a non-empty key under `browser: false`. Assert that `posthog.init` is never called on SSR. The browser-side init-was-called assertion lives in case (c) above.
 
 ## Phase: Pageviews
 
-PostHog's auto-pageview is off (`capture_pageview: false`); pageviews fire from a SvelteKit `afterNavigate` hook in the root layout, so every CSR route change is captured — not just the initial SSR load.
+With `capture_pageview: 'history_change'` in the init config, PostHog fires `$pageview` on the initial load and on every SvelteKit CSR navigation automatically — no per-route wiring required. The `before_send` hook in [AnalyticsArchitecture.md § Frontend init lockdown](AnalyticsArchitecture.md#frontend-init-lockdown) strips query strings; PostHog populates `$prev_pageview_pathname` for in-SPA referrer attribution, and the existing `$referrer` / `$referring_domain` cover external referrers.
 
-**Deliverables:**
+This phase therefore ships nothing new in code — the Skeleton-phase deliverables (locked-down config + layout-level side-effect import) are the entire implementation. Verification:
 
-- `afterNavigate` hook in `frontend/src/routes/+layout.svelte`:
-
-  ```svelte
-  <script lang="ts">
-    import { afterNavigate } from "$app/navigation";
-    import { analytics } from "$lib/analytics";
-
-    afterNavigate(({ to }) => {
-      if (!to) return;
-      analytics.pageview(to.url.pathname);
-    });
-  </script>
-  ```
-
-  `afterNavigate` fires on client-side hydration after the initial SSR load **and** after every subsequent CSR navigation, so a single hook covers the whole SPA. Without this, the SPA would look like a one-page-per-visit site to PostHog — pages-per-session would always be 1, bounce rate would be 100%.
-
-- Only the pathname is captured (`to.url.pathname`), not the query string or hash. Deliberate: keeps URL cardinality bounded and avoids leaking search terms or other query-encoded state into the firehose. Typed events (next phases) carry meaningful query-derived properties explicitly.
-- No pageview fires from `+layout.server.ts`. Server-rendered HTML doesn't imply the user saw the page (bots, prefetches, etc.) — and since `afterNavigate` is client-only, a bot or `curl` that never hydrates produces no pageview, which is the intended behavior.
-- Extend `posthog.ts`: track the previously-captured pathname in a module-level variable, attach it to each `$pageview` event as `internal_referrer` (the SPA's prior pathname, distinct from PostHog's `$referrer`, which reflects the external referring document). `reset()` clears it. `identify()` remains a no-op until typed-events.
-
-**Verification:**
-
-- A vitest using `RecordingAnalytics` that simulates an initial load + two CSR navigations and asserts three pageview events with the expected pathnames.
-- A vitest on the PostHog adapter with `posthog-js` mocked at the module boundary: drive three `pageview()` calls and assert the mocked `posthog.capture` is invoked with `$pageview` and `internal_referrer` values of `null`, then the first path, then the second path. A fourth call after `reset()` asserts `internal_referrer: null` again.
-- Staging spot-check: load the homepage, click through a few links, find the events in PostHog. Confirm `$referrer` and `$referring_domain` are present (set by PostHog at session start from `document.referrer`), distinct from `internal_referrer`, which is attached by our adapter and holds the previous in-SPA pathname.
+- Staging spot-check: load the homepage, click through a few links (including a link with `?foo=bar`), find the events in PostHog. Assert `$pageview` fires on the initial load and each CSR navigation; `$current_url` and `$pathname` have no query string; `$prev_pageview_pathname` reflects the previous in-SPA pathname; `$referrer` / `$referring_domain` reflect the external referring document on the first event of the session.
 
 ## Test patterns
 
-The default adapter under vitest is `RecordingAnalytics`, which captures calls into an array and exposes them to assertions. The PostHog adapter is never exercised in unit tests. The Skeleton-phase integration test on `config.ts` is the one place that touches the real adapter, and it asserts the locked-down init config, not the network.
+The default adapter under vitest is `RecordingAnalytics`, which captures calls into an array and exposes them to assertions. Application code that calls `analytics.*` is tested against `RecordingAnalytics`, never against PostHog.
+
+Two narrow exceptions exercise the PostHog adapter directly, both with `posthog-js` mocked at the module boundary: the `config.ts` integration test asserts the locked-down options (including `before_send`), and the init test asserts `posthog.init` is called once in the browser with that config and never on SSR. Neither hits the network. No other test should import the PostHog adapter.
 
 ## What this doc does NOT cover
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -57,10 +57,22 @@ export default ts.config(
     },
   },
   {
-    // The createApiClient factory is an implementation detail of the api/
-    // folder. App code uses the default `client` export from $lib/api/client
-    // (browser) or `createServerClient` from $lib/api/server (SSR). Reaching
-    // into $lib/api/internal/ from outside the api/ folder is a layering bug.
+    // `no-restricted-imports` policies. Both restrictions are colocated in a
+    // single config block because ESLint flat config merges rule options by
+    // override (last block wins) rather than by union — splitting them would
+    // silently drop one of the two restrictions on overlapping files.
+    //
+    // - api/internal: the createApiClient factory is an implementation detail
+    //   of the api/ folder. App code uses the default `client` export from
+    //   $lib/api/client (browser) or `createServerClient` from $lib/api/server
+    //   (SSR). Reaching into $lib/api/internal/ from outside api/ is a
+    //   layering bug — the rule is suppressed inside src/lib/api/** via the
+    //   per-file override below.
+    // - posthog-js: the analytics vendor SDK. Only src/lib/analytics/posthog.ts
+    //   may touch it; everywhere else routes through the abstraction in
+    //   $lib/analytics. This keeps the vendor boundary one-file-wide so a
+    //   future swap is mechanical (see
+    //   docs/plans/analytics/AnalyticsArchitecture.md § Migration).
     files: [
       'src/**/*.ts',
       'src/**/*.js',
@@ -68,7 +80,51 @@ export default ts.config(
       'src/**/*.svelte.ts',
       'src/**/*.svelte.js',
     ],
-    ignores: ['src/lib/api/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'posthog-js',
+              message:
+                "Don't import posthog-js directly — use the `analytics` export from $lib/analytics. Only src/lib/analytics/posthog.ts may touch the SDK.",
+              allowTypeImports: true,
+            },
+          ],
+          patterns: [
+            {
+              group: ['$lib/api/internal/*', '**/api/internal/*'],
+              message:
+                "Don't import from $lib/api/internal/ — use the default `client` from $lib/api/client or `createServerClient` from $lib/api/server.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // The api/ folder is allowed to import from its own internals.
+    files: ['src/lib/api/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'posthog-js',
+              message:
+                "Don't import posthog-js directly — use the `analytics` export from $lib/analytics. Only src/lib/analytics/posthog.ts may touch the SDK.",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // The PostHog adapter is the one file that's allowed to import the SDK.
+    files: ['src/lib/analytics/posthog.ts'],
     rules: {
       'no-restricted-imports': [
         'error',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,8 @@
     "diff": "^9.0.0",
     "open-props": "^1.7.23",
     "openapi-fetch": "^0.17.0",
-    "postcss-jit-props": "^1.0.16"
+    "postcss-jit-props": "^1.0.16",
+    "posthog-js": "^1.374.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       postcss-jit-props:
         specifier: ^1.0.16
         version: 1.0.16(postcss@8.5.14)
+      posthog-js:
+        specifier: ^1.374.0
+        version: 1.374.0
     devDependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.5.4
@@ -572,6 +575,10 @@ packages:
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.212.0':
     resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
     engines: {node: '>=8.0.0'}
@@ -584,6 +591,12 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/core@2.2.0':
+    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/core@2.6.1':
     resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -595,6 +608,12 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0':
+    resolution: {integrity: sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/instrumentation-amqplib@0.61.0':
     resolution: {integrity: sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==}
@@ -722,8 +741,44 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.208.0':
+    resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.208.0':
+    resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.2.0':
+    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/resources@2.7.1':
     resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.208.0':
+    resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.2.0':
+    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.2.0':
+    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -985,10 +1040,46 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@posthog/core@1.29.3':
+    resolution: {integrity: sha512-OvJSAzqVfZx+L7D874q56FVRTxOIsFBVB3wSB/Uny+DhmfNRGDi1rpZAruEmQYl9WQlQJb1q6JXGAC+rxVXjPA==}
+
+  '@posthog/types@1.374.0':
+    resolution: {integrity: sha512-qouREpHIxsBS3Gc6a5gZvg6/ykK+4TJAs4wYTUIH/emH1HQfaaLrWzGoEm+/OPwlNxHzw4tQn9OOyxsmr9NF2g==}
+
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
     peerDependencies:
       '@opentelemetry/api': ^1.8
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@redocly/ajv@8.17.4':
     resolution: {integrity: sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA==}
@@ -1869,6 +1960,9 @@ packages:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cosmiconfig@9.0.1:
     resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
@@ -1953,6 +2047,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.5:
+    resolution: {integrity: sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -2123,6 +2220,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@11.1.3:
     resolution: {integrity: sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==}
@@ -2457,6 +2557,9 @@ packages:
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
@@ -2824,6 +2927,12 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-js@1.374.0:
+    resolution: {integrity: sha512-3M2xsHXU7Hl64KGZjljq13jIKiJ4N7npY1n+1Q7VQmQKdVsoTc9geaeoHprZEZCMXp3b2qbWZEvIYjekUN5lAg==}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2847,6 +2956,10 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  protobufjs@7.5.9:
+    resolution: {integrity: sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==}
+    engines: {node: '>=12.0.0'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -2861,6 +2974,9 @@ packages:
   qified@0.10.1:
     resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
     engines: {node: '>=20'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3264,6 +3380,9 @@ packages:
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
+
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -3752,6 +3871,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api-logs@0.212.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -3762,6 +3885,11 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
   '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -3771,6 +3899,15 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3954,10 +4091,53 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
+      protobufjs: 7.5.9
+
+  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
   '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
@@ -4107,12 +4287,40 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@posthog/core@1.29.3':
+    dependencies:
+      '@posthog/types': 1.374.0
+
+  '@posthog/types@1.374.0': {}
+
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@redocly/ajv@8.17.4':
     dependencies:
@@ -4941,6 +5149,8 @@ snapshots:
 
   cookie@0.6.0: {}
 
+  core-js@3.49.0: {}
+
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
@@ -5015,6 +5225,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.5:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -5219,6 +5433,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.4.8: {}
 
   file-entry-cache@11.1.3:
     dependencies:
@@ -5547,6 +5763,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.truncate@4.4.2: {}
+
+  long@5.3.2: {}
 
   lru-cache@11.3.6: {}
 
@@ -6048,6 +6266,24 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  posthog-js@1.374.0:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@posthog/core': 1.29.3
+      '@posthog/types': 1.374.0
+      core-js: 3.49.0
+      dompurify: 3.4.5
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.2.0
+
+  preact@10.29.2: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.7(@typescript-eslint/types@8.59.3)):
@@ -6065,6 +6301,21 @@ snapshots:
 
   progress@2.0.3: {}
 
+  protobufjs@7.5.9:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.8.0
+      long: 5.3.2
+
   proxy-from-env@1.1.0: {}
 
   punycode.js@2.3.1: {}
@@ -6074,6 +6325,8 @@ snapshots:
   qified@0.10.1:
     dependencies:
       hookified: 2.2.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -6509,6 +6762,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   walk-up-path@4.0.0: {}
+
+  web-vitals@5.2.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/frontend/src/lib/analytics/config.test.ts
+++ b/frontend/src/lib/analytics/config.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { config } from './config';
+
+// Integration test for the locked-down PostHog init config. Each option below
+// is a contract — see docs/plans/analytics/AnalyticsArchitecture.md § Frontend
+// init lockdown. Weakening any option fails this test, which is the point.
+describe('analytics config (locked-down PostHog init)', () => {
+  it('uses the EU API host', () => {
+    expect(config.api_host).toBe('https://eu.posthog.com');
+  });
+
+  it('uses heap-only persistence (no cookies, no storage)', () => {
+    expect(config.persistence).toBe('memory');
+  });
+
+  it('disables autocapture', () => {
+    expect(config.autocapture).toBe(false);
+  });
+
+  it('enables SPA-aware pageview tracking', () => {
+    expect(config.capture_pageview).toBe('history_change');
+    expect(config.capture_pageleave).toBe('if_capture_pageview');
+  });
+
+  it('disables session recording, surveys, and external script loading', () => {
+    expect(config.disable_session_recording).toBe(true);
+    expect(config.disable_surveys).toBe(true);
+    expect(config.disable_external_dependency_loading).toBe(true);
+  });
+
+  it('disables /flags remote-config fetching', () => {
+    // `disable_external_dependency_loading` only gates external script loads;
+    // the feature-flag/decide HTTP request is controlled separately by
+    // `advanced_disable_flags`. Both must be set to fully suppress runtime
+    // calls to PostHog's flag endpoints.
+    expect(config.advanced_disable_flags).toBe(true);
+  });
+
+  it('disables campaign-param extraction (utm_*, gclid, fbclid, …)', () => {
+    // PostHog defaults to extracting query-string campaign params (utm_*,
+    // gclid, fbclid, msclkid, gbraid, wbraid, li_fat_id, ttclid, etc.) and
+    // surfacing them as top-level event properties. Our $current_url scrub
+    // strips the URL itself but doesn't reach those props — disable the
+    // extractor at the source.
+    expect(config.save_campaign_params).toBe(false);
+  });
+
+  it('strips IP at ingest', () => {
+    expect(config.ip).toBe(false);
+  });
+
+  it('denylists fingerprinting-grade and search-extracted properties', () => {
+    expect(config.property_denylist).toEqual([
+      '$ip',
+      '$screen_height',
+      '$screen_width',
+      '$viewport_height',
+      '$viewport_width',
+      // PostHog auto-extracts these from search-engine referrers and there's
+      // no config flag to disable that path. Denylisting at send is the fix.
+      'ph_keyword',
+      '$search_engine',
+    ]);
+  });
+
+  describe('before_send query-string scrub', () => {
+    const callBeforeSend = (properties: Record<string, unknown>) => {
+      const before_send = config.before_send;
+      if (typeof before_send !== 'function') {
+        throw new Error('before_send must be a function');
+      }
+      const event = {
+        uuid: 'test-uuid',
+        event: '$pageview',
+        properties,
+      };
+      return before_send(event);
+    };
+
+    it('strips query strings from $current_url, $referrer, $pathname, and $prev_pageview_pathname', () => {
+      const result = callBeforeSend({
+        $current_url: 'https://example.com/search?q=secret&page=2',
+        $referrer: 'https://www.google.com/search?q=our-private-keyword',
+        $pathname: '/search?q=secret',
+        $prev_pageview_pathname: '/prior?ref=external',
+      });
+
+      expect(result?.properties.$current_url).toBe('https://example.com/search');
+      expect(result?.properties.$referrer).toBe('https://www.google.com/search');
+      expect(result?.properties.$pathname).toBe('/search');
+      expect(result?.properties.$prev_pageview_pathname).toBe('/prior');
+    });
+
+    it('passes through URLs without query strings unchanged', () => {
+      const result = callBeforeSend({
+        $current_url: 'https://example.com/about',
+        $pathname: '/about',
+      });
+
+      expect(result?.properties.$current_url).toBe('https://example.com/about');
+      expect(result?.properties.$pathname).toBe('/about');
+    });
+
+    it('leaves a malformed $current_url alone instead of throwing', () => {
+      const result = callBeforeSend({ $current_url: 'not a url' });
+      expect(result?.properties.$current_url).toBe('not a url');
+    });
+
+    it('leaves a malformed $referrer alone instead of throwing', () => {
+      const result = callBeforeSend({ $referrer: 'not a url' });
+      expect(result?.properties.$referrer).toBe('not a url');
+    });
+
+    it('returns null events unchanged', () => {
+      const before_send = config.before_send;
+      if (typeof before_send !== 'function') {
+        throw new Error('before_send must be a function');
+      }
+      expect(before_send(null)).toBeNull();
+    });
+  });
+});

--- a/frontend/src/lib/analytics/config.ts
+++ b/frontend/src/lib/analytics/config.ts
@@ -1,0 +1,74 @@
+import type { PostHogConfig } from 'posthog-js';
+// Type-only import — the lint rule allows this via `allowTypeImports`.
+// `config.ts` ships no runtime reference to the SDK.
+
+// Locked-down PostHog init options. The integration test asserts every option
+// here matches docs/plans/analytics/AnalyticsArchitecture.md § Frontend init
+// lockdown — weakening any of them fails the test. Reviewers should reject
+// any change here that isn't accompanied by an architecture-doc update.
+export const config: Partial<PostHogConfig> = {
+  api_host: 'https://eu.posthog.com',
+  persistence: 'memory', // satisfies "no persistent client-side identity"
+  autocapture: false, // satisfies "no autocapture / implicit tracking"
+  capture_pageview: 'history_change', // SPA-aware: initial load + every CSR navigation
+  capture_pageleave: 'if_capture_pageview',
+  disable_session_recording: true,
+  disable_surveys: true,
+  // Stop the SDK from fetching session-recording.js, surveys.js, etc. at runtime.
+  disable_external_dependency_loading: true,
+  // Stop the SDK from POSTing to /flags for remote feature-flag / decide config.
+  // `disable_external_dependency_loading` does NOT cover this — it only gates
+  // external <script> loads. The flag fetch is a separate XHR controlled by
+  // `advanced_disable_flags` (current name; replaces deprecated
+  // `advanced_disable_decide`). Without this, every $pageview from a fresh
+  // SPA instance also triggers a /flags request even though we never read
+  // feature flags. Satisfies "feature-flag SDK unused" in the architecture.
+  advanced_disable_flags: true,
+  // PostHog defaults to extracting utm_*, gclid, fbclid, msclkid, gbraid,
+  // wbraid, li_fat_id, etc. from the landing URL and storing them as top-level
+  // event properties. Our scrub of `$current_url` doesn't reach those — they
+  // ship as separate props. Disable the extractor entirely.
+  save_campaign_params: false,
+
+  // satisfies "no IP-based attribution"
+  ip: false,
+  property_denylist: [
+    '$ip', // belt-and-suspenders alongside ip: false
+    '$screen_height', // satisfies "no fingerprinting-grade properties"
+    '$screen_width',
+    '$viewport_height',
+    '$viewport_width',
+    // PostHog detects search-engine referrers (google/bing/yahoo/duckduckgo)
+    // and surfaces the search query as `ph_keyword` plus `$search_engine`.
+    // There's no config flag to disable that path; denylisting them at send
+    // time is the documented mitigation.
+    'ph_keyword',
+    '$search_engine',
+  ],
+
+  // Strip query strings from URLs before send — bounds cardinality and keeps
+  // query-encoded search terms / state out of the firehose. `$pathname` and
+  // `$current_url` are PostHog-set; `$prev_pageview_pathname` is populated
+  // automatically when capture_pageview is on; `$referrer` carries the
+  // external referring document's full URL including any query string the
+  // referrer chose to send (search-result URLs typically include the query).
+  before_send: (event) => {
+    if (!event || !event.properties) return event;
+    const props = event.properties;
+    for (const key of ['$current_url', '$referrer'] as const) {
+      const v = props[key];
+      if (typeof v === 'string' && URL.canParse(v)) {
+        const u = new URL(v);
+        props[key] = u.origin + u.pathname;
+      }
+    }
+    for (const key of ['$pathname', '$prev_pageview_pathname'] as const) {
+      const v = props[key];
+      if (typeof v === 'string') {
+        const q = v.indexOf('?');
+        if (q !== -1) props[key] = v.slice(0, q);
+      }
+    }
+    return event;
+  },
+};

--- a/frontend/src/lib/analytics/events.ts
+++ b/frontend/src/lib/analytics/events.ts
@@ -1,0 +1,11 @@
+// Typed registry of frontend-emitted analytics events.
+//
+// Empty by design at the untyped-events skeleton phase — grows as events
+// are added in the typed-events frontend plan. Until then, calls to
+// `analytics.capture()` won't type-check, which is the intended gate.
+//
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface EventRegistry {}
+
+export type EventName = keyof EventRegistry & string;
+export type EventProperties<E extends EventName> = EventRegistry[E];

--- a/frontend/src/lib/analytics/index.test.ts
+++ b/frontend/src/lib/analytics/index.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Adapter-selection tests for the analytics module.
+//
+// `PUBLIC_POSTHOG_KEY` comes from `$env/dynamic/public`, so per-case the
+// module's `env` export must be mocked with `vi.doMock(...)` followed by
+// `vi.resetModules()` before re-importing `./index`. `vi.stubEnv` handles
+// `import.meta.env.DEV`.
+
+type IndexModule = typeof import('./index');
+type NoopModule = typeof import('./noop');
+type PosthogModule = typeof import('./posthog');
+
+async function loadIndex(opts: {
+  dev: boolean;
+  key: string | undefined;
+  browser: boolean;
+}): Promise<{
+  index: IndexModule;
+  noop: NoopModule;
+  posthog: PosthogModule;
+  posthogInitMock: ReturnType<typeof vi.fn>;
+}> {
+  vi.resetModules();
+  vi.stubEnv('DEV', opts.dev);
+  vi.stubEnv('PROD', !opts.dev);
+
+  vi.doMock('$env/dynamic/public', () => ({
+    env: { PUBLIC_POSTHOG_KEY: opts.key },
+  }));
+  vi.doMock('$app/environment', () => ({ browser: opts.browser }));
+
+  const posthogInitMock = vi.fn();
+  vi.doMock('posthog-js', () => ({
+    default: { init: posthogInitMock },
+  }));
+
+  const noop = await import('./noop');
+  const posthog = await import('./posthog');
+  const index = await import('./index');
+  return { index, noop, posthog, posthogInitMock };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.doUnmock('$env/dynamic/public');
+  vi.doUnmock('$app/environment');
+  vi.doUnmock('posthog-js');
+  vi.resetModules();
+});
+
+describe('analytics adapter selection', () => {
+  it('selects the noop adapter in DEV builds (key set)', async () => {
+    const { index, noop, posthogInitMock } = await loadIndex({
+      dev: true,
+      key: 'phc_real_key',
+      browser: true,
+    });
+    expect(index.analytics).toBe(noop.noopAdapter);
+    expect(posthogInitMock).not.toHaveBeenCalled();
+  });
+
+  it('selects the noop adapter when PUBLIC_POSTHOG_KEY is blank', async () => {
+    const { index, noop, posthogInitMock } = await loadIndex({
+      dev: false,
+      key: '',
+      browser: true,
+    });
+    expect(index.analytics).toBe(noop.noopAdapter);
+    expect(posthogInitMock).not.toHaveBeenCalled();
+  });
+
+  it('selects the noop adapter when PUBLIC_POSTHOG_KEY is undefined', async () => {
+    const { index, noop, posthogInitMock } = await loadIndex({
+      dev: false,
+      key: undefined,
+      browser: true,
+    });
+    expect(index.analytics).toBe(noop.noopAdapter);
+    expect(posthogInitMock).not.toHaveBeenCalled();
+  });
+
+  it('selects the PostHog adapter and calls init() once on the browser when DEV=false and key is set', async () => {
+    const { index, posthog, posthogInitMock } = await loadIndex({
+      dev: false,
+      key: 'phc_real_key',
+      browser: true,
+    });
+    expect(index.analytics).toBe(posthog.posthogAdapter);
+    expect(posthogInitMock).toHaveBeenCalledTimes(1);
+
+    const { config } = await import('./config');
+    expect(posthogInitMock).toHaveBeenCalledWith('phc_real_key', config);
+  });
+});
+
+describe('analytics SSR guard', () => {
+  it('returns the noop adapter and does not call posthog.init() under SSR (browser=false), even with a real key', async () => {
+    const { index, noop, posthogInitMock } = await loadIndex({
+      dev: false,
+      key: 'phc_real_key',
+      browser: false,
+    });
+    // Important: returning noop on SSR keeps server-side `analytics.*` calls
+    // from hitting an uninitialized SDK once typed-events adds real call sites.
+    expect(index.analytics).toBe(noop.noopAdapter);
+    expect(posthogInitMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/analytics/index.ts
+++ b/frontend/src/lib/analytics/index.ts
@@ -1,0 +1,47 @@
+// Public analytics API. Call sites import `analytics` from here and never
+// touch the vendor SDK directly — see docs/plans/analytics/AnalyticsArchitecture.md
+// for the abstraction contract and privacy-lockdown spec.
+//
+// Adapter selection:
+//   - dev builds                              → noop
+//   - PUBLIC_POSTHOG_KEY missing/blank        → noop (staging/preview/CI without a real key)
+//   - SSR (browser=false)                     → noop (keeps server-side analytics.* calls
+//                                                from hitting an uninitialized SDK)
+//   - otherwise                               → PostHog adapter, initialized once
+//
+// The key check is a runtime guard, matching the established PUBLIC_SENTRY_DSN
+// pattern in hooks.client.ts. The runtime guard is the master switch — note that
+// posthog-js itself ships in every production bundle once any call site imports
+// `$lib/analytics`, regardless of whether a key is set. See
+// docs/plans/analytics/AnalyticsArchitecture.md § Bundle cost for the rationale
+// (locked-down config still uses the full SDK; lite SDK is officially
+// de-emphasized).
+
+import { browser } from '$app/environment';
+import { env } from '$env/dynamic/public';
+
+import type { EventName, EventProperties } from './events';
+import { noopAdapter } from './noop';
+import { posthogAdapter } from './posthog';
+
+export interface Analytics {
+  pageview(path: string): void;
+  capture<E extends EventName>(event: E, properties: EventProperties<E>): void;
+  identify(pseudonym: string): void;
+  reset(): void;
+}
+
+function selectAdapter(): Analytics {
+  if (import.meta.env.DEV) return noopAdapter;
+  const key = env.PUBLIC_POSTHOG_KEY;
+  if (!key) return noopAdapter;
+  // SSR returns noop so server-side `analytics.*` calls (e.g. from load
+  // functions in the typed-events phase) don't hit an uninitialized SDK.
+  // The PostHog adapter is only safe to use once `init()` has run, which
+  // requires `window` — that only happens on the browser.
+  if (!browser) return noopAdapter;
+  posthogAdapter.init(key);
+  return posthogAdapter;
+}
+
+export const analytics: Analytics = selectAdapter();

--- a/frontend/src/lib/analytics/noop.ts
+++ b/frontend/src/lib/analytics/noop.ts
@@ -1,0 +1,14 @@
+// No-op adapter — used in dev builds, when PUBLIC_POSTHOG_KEY is empty, and
+// (eventually) when a user opts out. Vitest currently selects this branch
+// too; the `RecordingAnalytics` test fixture described in AnalyticsArchitecture.md
+// will replace that role when the typed-events frontend plan adds the first
+// `analytics.*` call sites.
+
+import type { Analytics } from './index';
+
+export const noopAdapter: Analytics = {
+  pageview() {},
+  capture() {},
+  identify() {},
+  reset() {},
+};

--- a/frontend/src/lib/analytics/posthog.ts
+++ b/frontend/src/lib/analytics/posthog.ts
@@ -1,0 +1,30 @@
+// PostHog adapter — the only file outside `analytics/` allowed to import
+// `posthog-js`. Module scope is intentionally side-effect-free: nothing here
+// touches `window` or fires a request at import time. `index.ts` is the only
+// caller of `init()` and only calls it when `browser` is true and a real key
+// is present.
+
+import posthog from 'posthog-js';
+
+import { config } from './config';
+import type { Analytics } from './index';
+
+export interface PosthogAdapter extends Analytics {
+  init(key: string): void;
+}
+
+export const posthogAdapter: PosthogAdapter = {
+  init(key) {
+    posthog.init(key, config);
+  },
+  // `capture_pageview: 'history_change'` in the init config fires `$pageview`
+  // on initial load and every CSR navigation automatically, so this method is
+  // a no-op. The method exists for symmetry with the backend interface and
+  // future-proofing if we switch providers.
+  pageview() {},
+  // No typed events are emitted yet (registry is empty). Once the typed-events
+  // frontend plan lands, these forward to posthog.capture / .identify / .reset.
+  capture() {},
+  identify() {},
+  reset() {},
+};

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import '../app.css';
+  // Side-effect import: triggers the analytics module's adapter selection and
+  // (when a real PUBLIC_POSTHOG_KEY is set in the browser) PostHog init. See
+  // docs/plans/analytics/AnalyticsUntypedEventsPlan.md § Skeleton.
+  import '$lib/analytics';
   import { page, updated } from '$app/state';
   import { beforeNavigate } from '$app/navigation';
   import SiteShell from '$lib/components/SiteShell.svelte';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -34,6 +34,26 @@ export default defineConfig({
     }),
     sveltekit(),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        // Vendor-split heavy third-party SDKs into their own chunks so app
+        // deploys don't invalidate cached SDK bytes. Both Sentry and PostHog
+        // are loaded eagerly from the root layout (Sentry via hooks.client.ts;
+        // PostHog via the side-effect import of $lib/analytics in
+        // +layout.svelte), so without this they'd land in the layout chunk
+        // whose hash changes on every app deploy — re-downloading ~150 KB
+        // gzipped of unchanged SDK code each time. Two separate chunks
+        // (rather than one combined "vendor") because the SDKs version
+        // independently; HTTP/2/3 multiplexing makes the extra request cost
+        // negligible.
+        manualChunks: (id) => {
+          if (id.includes('/posthog-js/')) return 'vendor-posthog';
+          if (id.includes('/@sentry/')) return 'vendor-sentry';
+        },
+      },
+    },
+  },
   server: {
     proxy: {
       '/api/': {


### PR DESCRIPTION
## Summary

Tracks pageviews via PostHog analytics. 

Wires up `frontend/src/lib/analytics/` as a one-file-wide vendor boundary: app code imports `analytics` from `$lib/analytics`, only the adapter touches `posthog-js`, and an ESLint rule pins that. Pageviews (initial load + every CSR navigation) fire automatically via `capture_pageview: 'history_change'` once a real `PUBLIC_POSTHOG_KEY` is set; no per-route wiring.

The init config is locked down at the integration boundary: memory-only persistence (no cookies, no storage), no autocapture, no session recording, no surveys, no remote `/flags` calls, no utm_*/gclid extraction, IP stripped, screen/viewport/search-keyword properties denylisted, and a `before_send` hook that scrubs query strings off `$current_url` / `$referrer` / `$pathname` / `$prev_pageview_pathname` to bound URL cardinality and keep query-encoded search terms out of the firehose. An integration test asserts every option — weakening any of them fails the test.

Adapter selection returns the noop adapter in dev builds, when `PUBLIC_POSTHOG_KEY` is missing or blank (staging/preview/CI without a real key), or under SSR; the PostHog adapter otherwise, with `init()` called exactly once. `vite.config.ts` vendor-splits `posthog-js` and `@sentry/sveltekit` into their own Rollup chunks so SDK bytes stay cached across app deploys.

## Test plan

- [x] `config.test.ts` asserts every locked-down option and drives `before_send` with query-stringed URLs, malformed URLs, and a null event.
- [x] `index.test.ts` covers all four adapter-selection cases (DEV, blank key, undefined key, real key) plus the SSR guard, and asserts `posthog.init` is called once with the literal config object.
- [ ] Staging spot-check (post-deploy, requires real `PUBLIC_POSTHOG_KEY`): load the homepage, click through a few links including one with `?foo=bar`, confirm `\$pageview` fires on initial load and each CSR navigation with query strings stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)