### PR TITLE
fix(frontend): point PostHog at US cloud, not EU

### DIFF
--- a/frontend/src/lib/analytics/config.test.ts
+++ b/frontend/src/lib/analytics/config.test.ts
@@ -6,8 +6,8 @@ import { config } from './config';
 // is a contract — see docs/plans/analytics/AnalyticsArchitecture.md § Frontend
 // init lockdown. Weakening any option fails this test, which is the point.
 describe('analytics config (locked-down PostHog init)', () => {
-  it('uses the EU API host', () => {
-    expect(config.api_host).toBe('https://eu.posthog.com');
+  it('uses the US API host', () => {
+    expect(config.api_host).toBe('https://us.posthog.com');
   });
 
   it('uses heap-only persistence (no cookies, no storage)', () => {

--- a/frontend/src/lib/analytics/config.ts
+++ b/frontend/src/lib/analytics/config.ts
@@ -7,7 +7,7 @@ import type { PostHogConfig } from 'posthog-js';
 // lockdown — weakening any of them fails the test. Reviewers should reject
 // any change here that isn't accompanied by an architecture-doc update.
 export const config: Partial<PostHogConfig> = {
-  api_host: 'https://eu.posthog.com',
+  api_host: 'https://us.posthog.com',
   persistence: 'memory', // satisfies "no persistent client-side identity"
   autocapture: false, // satisfies "no autocapture / implicit tracking"
   capture_pageview: 'history_change', // SPA-aware: initial load + every CSR navigation


### PR DESCRIPTION
## Summary

The PostHog project is hosted on US cloud; the frontend was initializing against `eu.posthog.com`, so events never reached the project. Switch `api_host` to `https://us.posthog.com` and update the locked-down init contract test to match.

## Test plan

- [ ] `pnpm vitest run src/lib/analytics/config.test.ts` (from `frontend/`) passes
- [ ] Load the app, navigate between pages, and verify pageview events appear in the PostHog US project