### PR TITLE
docs(analytics): reflect shipped untyped-events state

### DIFF
--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -1,0 +1,21 @@
+# Analytics
+
+We use **[PostHog](https://posthog.com)** for product analytics.
+
+## Current surface area
+
+Pageviews only. No typed events.
+
+### Enabling & disabling analytics
+
+Analytics can only be enabled in prod. Disabling analytics in prod means clearing `PUBLIC_POSTHOG_KEY` and redeploying — same pattern as `PUBLIC_SENTRY_DSN`.
+
+`posthog-js` ships in every production bundle once any call site imports `$lib/analytics`, regardless of whether the key is set. The runtime guard is the master switch, not the bundle.
+
+## Privacy posture (what's stored)
+
+PostHog **does not store**: IPs, cookies, localStorage identity, autocaptured clicks/inputs, screen/viewport dimensions, UTM/click-id campaign params, search-engine keyword props, URL query strings.
+
+PostHog **does store**: path-only pageviews, browser/OS user-agent fields it derives server-side, referrer origin+path (no query), session id (memory-scoped, dies on tab close).
+
+For the project-wide privacy contract see [Privacy.md](Privacy.md).

--- a/docs/plans/analytics/AnalyticsArchitecture.md
+++ b/docs/plans/analytics/AnalyticsArchitecture.md
@@ -290,7 +290,7 @@ These are the only files that import `posthog-js` or the `posthog` Python packag
 
 ```ts
 posthog.init(key, {
-  api_host: "https://eu.posthog.com",
+  api_host: "https://us.posthog.com",
   persistence: "memory", // satisfies "no persistent client-side identity"
   autocapture: false, // satisfies "no autocapture / implicit tracking"
   capture_pageview: "history_change", // SPA-aware: initial load + every CSR navigation
@@ -345,7 +345,7 @@ posthog.init(key, {
 **Literal (locked-down init; the integration test asserts every line):**
 
 ```python
-posthog.host = "https://eu.posthog.com"
+posthog.host = "https://us.posthog.com"
 posthog.disable_geoip = True  # satisfies "no IP-based attribution"
 ```
 

--- a/docs/plans/analytics/AnalyticsPlan.md
+++ b/docs/plans/analytics/AnalyticsPlan.md
@@ -8,35 +8,26 @@ Also see:
 
 ## Tracks
 
-Each track answers a different slice of the questions in [AnalyticsQuestions.md](AnalyticsQuestions.md) using a different data source. Tracks are independent and ship as appetite allows.
+Tracks are independent and ship as appetite allows.
 
-- **[AnalyticsUntypedEventsPlan.md](AnalyticsUntypedEventsPlan.md)** — SDK skeleton + pageview firehose from the browser. Privacy lockdown lives here. This is the quick path — lightest weight, most value for the change.
-- **[AnalyticsTypedEventsPlan.md](AnalyticsTypedEventsPlan.md)** — typed, named events for questions the firehose can't answer. Strictly sequential internal phases: Backend Pseudonym → Backend Events → Frontend Events.
-- **[AnalyticsDbStatsPlan.md](AnalyticsDbStatsPlan.md)** — SQL against the production database for "what's in the system right now" stats (signups, edits, retention, the 80/20 editor curve). No PostHog involvement, no charting library.
+- ✅ DONE: **[AnalyticsUntypedEventsPlan.md](AnalyticsUntypedEventsPlan.md)** — SDK skeleton + pageview firehose from the browser. Privacy lockdown lives here.
+- **[AnalyticsTypedEventsPlan.md](AnalyticsTypedEventsPlan.md)** — typed, named events for questions the firehose can't answer.
+- **[AnalyticsDbStatsPlan.md](AnalyticsDbStatsPlan.md)** — SQL against the production database for "what's in the system right now" stats (signups, edits, retention, the 80/20 editor curve). No analytics vendor involvement.
 
 ## Which track answers which question
 
-The high-level questions from [AnalyticsQuestions.md § Root questions](AnalyticsQuestions.md#root-questions), mapped to the track that answers them. ✅ marks questions answered by the launch (Untyped Events) — i.e. "slap PostHog in and call it a day." Everything else is deferred until appetite calls for it.
+The high-level questions from [AnalyticsQuestions.md § Root questions](AnalyticsQuestions.md#root-questions), mapped to the track that answers them.
 
 | High-level question                                                | Track that answers it                                                                                                   |
 | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| Are we growing?                                                    | ✅ [Untyped Events](AnalyticsUntypedEventsPlan.md) for traffic; [DB Stats](AnalyticsDbStatsPlan.md) for signups + edits |
-| What's driving growth? — external sources                          | ✅ [Untyped Events](AnalyticsUntypedEventsPlan.md) (referrer breakdown)                                                 |
-| What's driving growth? — our content                               | ✅ [Untyped Events](AnalyticsUntypedEventsPlan.md) (per-URL pageview counts)                                            |
+| Are we growing?                                                    | [Untyped Events](AnalyticsUntypedEventsPlan.md) for traffic; [DB Stats](AnalyticsDbStatsPlan.md) for signups + edits    |
+| What's driving growth? — external sources                          | [Untyped Events](AnalyticsUntypedEventsPlan.md) (referrer breakdown)                                                    |
+| What's driving growth? — our content                               | [Untyped Events](AnalyticsUntypedEventsPlan.md) (per-URL pageview counts)                                               |
+| Theses borne out? — browsing-as-discovery                          | [Untyped Events](AnalyticsUntypedEventsPlan.md) (session pageview depth, free from the firehose)                        |
+| Right features? — page-level usage                                 | [Untyped Events](AnalyticsUntypedEventsPlan.md)                                                                         |
 | Theses borne out? — title-vs-model market                          | [Typed Events](AnalyticsTypedEventsPlan.md) (search-click target)                                                       |
-| Theses borne out? — browsing-as-discovery                          | ✅ [Untyped Events](AnalyticsUntypedEventsPlan.md) (session pageview depth, free from the firehose)                     |
-| Theses borne out? — personas                                       | Not telemetry-answerable; user research                                                                                 |
-| Editor community healthy / engaged / growing?                      | [DB Stats](AnalyticsDbStatsPlan.md) (active contributors, retention, 80/20 curve)                                       |
-| Right features? — page-level usage                                 | ✅ [Untyped Events](AnalyticsUntypedEventsPlan.md)                                                                      |
 | Right features? — in-page usage (claim revert, edit history, etc.) | [Typed Events](AnalyticsTypedEventsPlan.md) (generic `feature_used`)                                                    |
 | Right features? — missing the mark / drop-off                      | [Typed Events](AnalyticsTypedEventsPlan.md) for flow-starts; [DB Stats](AnalyticsDbStatsPlan.md) for flow-completions   |
+| Editor community healthy / engaged / growing?                      | [DB Stats](AnalyticsDbStatsPlan.md) (active contributors, retention, 80/20 curve)                                       |
+| Theses borne out? — personas                                       | Not telemetry-answerable; user research                                                                                 |
 | Right features? — missing features                                 | Mostly user research; zero-result on-site searches via [Typed Events](AnalyticsTypedEventsPlan.md) hint at catalog gaps |
-
-## Definition of Done
-
-Each track's plan owns its own DoD. The cross-cutting requirements that hold across every PostHog-touching track:
-
-- PostHog receives no PII, no IP, no fingerprinting-grade properties (verified by inspecting a real event payload, not just by reading the init config).
-- Joining the PostHog dataset to the `User` table requires both the database and `ANALYTICS_PSEUDONYM_KEY` — there is no FK or table that bridges them.
-- Lint pins prevent `posthog-js` / `posthog` imports outside the adapter modules.
-- The locked-down init config is asserted by an integration test on each side; weakening any option fails the test.

--- a/docs/plans/analytics/AnalyticsTypedEventsBackendPlan.md
+++ b/docs/plans/analytics/AnalyticsTypedEventsBackendPlan.md
@@ -12,7 +12,7 @@ Stand up the `apps/analytics/` app with the module structure from [AnalyticsArch
 
 - `apps/analytics/__init__.py` — public API re-exporting `analytics.capture()` and `analytics.identify()`.
 - `apps/analytics/pseudonym.py` — `pseudonym_for(user_id)` per the spec in [AnalyticsArchitecture.md § Identity & Pseudonymization](AnalyticsArchitecture.md#identity--pseudonymization).
-- `apps/analytics/posthog_adapter.py` — implements the `Analytics` Protocol, applies the locked-down init (`posthog.host = "https://eu.posthog.com"`, `posthog.disable_geoip = True`).
+- `apps/analytics/posthog_adapter.py` — implements the `Analytics` Protocol, applies the locked-down init (`posthog.host = "https://us.posthog.com"`, `posthog.disable_geoip = True`).
 - `apps/analytics/noop.py` — no-op adapter for tests and dev.
 - `apps/analytics/middleware.py` — derives the request user's pseudonym once and caches it on the request object. Anonymous requests get `None`.
 - `apps/analytics/events.py` — empty `TypedDict` registry, ready to grow.

--- a/docs/plans/analytics/AnalyticsUntypedEventsPlan.md
+++ b/docs/plans/analytics/AnalyticsUntypedEventsPlan.md
@@ -2,7 +2,13 @@
 
 This doc covers the untyped-events track of [AnalyticsPlan.md](AnalyticsPlan.md). Contracts live in [AnalyticsArchitecture.md](AnalyticsArchitecture.md).
 
-This is the launch path. It stands up the SDK with the locked-down privacy config and starts firing anonymous pageviews. No typed events, no backend involvement, no pseudonym, no identify. The PostHog firehose alone answers most of the high-level questions in [AnalyticsQuestions.md § Root questions](AnalyticsQuestions.md#root-questions) — see [AnalyticsPlan.md § Which phase answers which question](AnalyticsPlan.md#which-phase-answers-which-question) for the mapping.
+## Status: ✅ Implementd
+
+This plan has been implemented
+
+## Overview
+
+Stands up the PostHog SDK with the locked-down privacy config and starts firing anonymous pageviews. No typed events, no backend involvement, no pseudonym, no identify. The PostHog firehose alone answers most of the high-level questions in [AnalyticsQuestions.md § Root questions](AnalyticsQuestions.md#root-questions) — see [AnalyticsPlan.md § Which phase answers which question](AnalyticsPlan.md#which-phase-answers-which-question) for the mapping.
 
 ## Phase: Skeleton
 


### PR DESCRIPTION
## Summary

Add canonical `docs/Analytics.md` describing the now-shipped PostHog pageview surface and privacy posture, and update the analytics plan docs to mark the Untyped Events track as done.

- New `docs/Analytics.md`: current surface area (pageviews only), enable/disable mechanics, what PostHog does and doesn't store
- `AnalyticsPlan.md`: mark Untyped Events ✅ DONE, drop the launch-vs-deferred ✅ column, remove cross-cutting DoD (now reflected in shipped state)
- Minor copy edits in sibling plan docs

## Test plan

- [ ] `docs/Analytics.md` renders correctly on GitHub
- [ ] Internal links resolve (Privacy.md, plan docs)