### PR TITLE
feat(admin): stats dashboard with signups/edits/uploads counts

### DIFF
--- a/backend/apps/core/api/__init__.py
+++ b/backend/apps/core/api/__init__.py
@@ -1,0 +1,15 @@
+"""API endpoints for the core app.
+
+Routers are auto-discovered via the ``routers`` list convention in
+``config/api.py``.
+"""
+
+from __future__ import annotations
+
+from apps.core.api.admin_dashboard_page import admin_pages_router
+from apps.core.api.link_types import link_types_router
+
+routers = [
+    ("/link-types/", link_types_router),
+    ("/pages/admin/", admin_pages_router),
+]

--- a/backend/apps/core/api/admin_dashboard_page.py
+++ b/backend/apps/core/api/admin_dashboard_page.py
@@ -1,0 +1,100 @@
+"""Admin dashboard page API.
+
+`GET /api/pages/admin/dashboard/` — at-a-glance counts (signups, edits,
+uploads) over rolling 24h / 7d / total windows, plus the most recent
+event time for each. Gated by ``Activity.VIEW_ADMIN_AREA``.
+
+See docs/plans/AdminDashboard.md.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from django.db.models import Count, Max, Model, Q, QuerySet
+from django.http import HttpRequest
+from django.utils import timezone
+from ninja import Router, Schema
+from ninja.security import django_auth
+
+from apps.accounts.models import User
+from apps.core.authz.markers import requires
+from apps.core.authz.types import Activity
+from apps.media.models import MediaAsset
+from apps.provenance.models import ChangeSet
+
+admin_pages_router = Router(tags=["private"], auth=django_auth)
+
+
+class AdminMetricSchema(Schema):
+    last_24h: int
+    last_7d: int
+    total: int
+    # Most recent event of this kind, or None if the table is empty
+    # (or has no rows matching the metric's filter).
+    last_at: datetime | None
+
+
+class AdminDashboardPageSchema(Schema):
+    signups: AdminMetricSchema
+    edits: AdminMetricSchema
+    uploads: AdminMetricSchema
+    generated_at: datetime
+
+
+@admin_pages_router.get("dashboard/", response=AdminDashboardPageSchema)
+@requires(Activity.VIEW_ADMIN_AREA)
+def admin_dashboard(request: HttpRequest) -> AdminDashboardPageSchema:
+    now = timezone.now()
+    cutoff_24h = now - timedelta(hours=24)
+    cutoff_7d = now - timedelta(days=7)
+
+    # Pre-filter each queryset to the row population the metric describes:
+    # edits exclude ingest ChangeSets (user_id IS NULL); uploads count only
+    # successful assets, not in-progress or failed attempts.
+    signups = _metric(User.objects.all(), "date_joined", cutoff_24h, cutoff_7d)
+    edits = _metric(
+        ChangeSet.objects.filter(user_id__isnull=False),
+        "created_at",
+        cutoff_24h,
+        cutoff_7d,
+    )
+    uploads = _metric(
+        MediaAsset.objects.filter(status=MediaAsset.Status.READY),
+        "created_at",
+        cutoff_24h,
+        cutoff_7d,
+    )
+
+    return AdminDashboardPageSchema(
+        signups=signups,
+        edits=edits,
+        uploads=uploads,
+        generated_at=now,
+    )
+
+
+def _metric[M: Model](
+    qs: QuerySet[M],
+    time_field: str,
+    cutoff_24h: datetime,
+    cutoff_7d: datetime,
+) -> AdminMetricSchema:
+    """Aggregate one metric in a single SELECT.
+
+    The caller pre-filters ``qs`` to the row population the metric
+    describes; the windowed counts, total, and ``last_at`` are all
+    computed against that same population.
+    """
+    agg = qs.aggregate(
+        last_24h=Count("pk", filter=Q(**{f"{time_field}__gte": cutoff_24h})),
+        last_7d=Count("pk", filter=Q(**{f"{time_field}__gte": cutoff_7d})),
+        total=Count("pk"),
+        last_at=Max(time_field),
+    )
+    return AdminMetricSchema(
+        last_24h=agg["last_24h"],
+        last_7d=agg["last_7d"],
+        total=agg["total"],
+        last_at=agg["last_at"],
+    )

--- a/backend/apps/core/api/link_types.py
+++ b/backend/apps/core/api/link_types.py
@@ -1,8 +1,4 @@
-"""API endpoints for the core app.
-
-Router: link_types — wikilink autocomplete support.
-Auto-discovered via the ``routers`` list convention in config/api.py.
-"""
+"""Wikilink picker / autocomplete endpoints."""
 
 from __future__ import annotations
 
@@ -77,8 +73,3 @@ def search_link_targets(
 
     results = [pt.autocomplete_serialize(obj) for obj in qs[:AUTOCOMPLETE_RESULT_LIMIT]]
     return LinkTargetListSchema(results=results)
-
-
-routers = [
-    ("/link-types/", link_types_router),
-]

--- a/backend/apps/core/authz/rules.py
+++ b/backend/apps/core/authz/rules.py
@@ -47,3 +47,4 @@ from .types import Activity
 register(Activity.RATE_LIMIT_EXEMPT, is_authenticated, email_verified, is_staff)
 register(Activity.DJANGO_ADMIN_ACCESS, is_authenticated, is_staff)
 register(Activity.OBSERVABILITY_DEBUG, is_authenticated, email_verified, is_staff)
+register(Activity.VIEW_ADMIN_AREA, is_authenticated, email_verified, is_staff)

--- a/backend/apps/core/authz/types.py
+++ b/backend/apps/core/authz/types.py
@@ -37,6 +37,12 @@ class Activity(StrEnum):
     # see docs/plans/observability/ObservabilityArchitecture.md §
     # First-event verification.
     OBSERVABILITY_DEBUG = "observability.debug"
+    # Operator-surface activity gating the admin SPA area (`/a/*`) and
+    # its supporting page-API endpoints. Verb-led `VIEW_` makes the
+    # read-only scope explicit; any future mutating admin action gets
+    # its own activity rather than riding on this one. See
+    # docs/plans/AdminDashboard.md.
+    VIEW_ADMIN_AREA = "admin_area.view"
 
 
 class DenialCode(StrEnum):

--- a/backend/apps/core/tests/test_admin_dashboard_page.py
+++ b/backend/apps/core/tests/test_admin_dashboard_page.py
@@ -1,0 +1,219 @@
+"""Tests for ``/api/pages/admin/dashboard/`` — the admin glance page.
+
+Pins the auth matrix (anon / non-staff / unverified-staff / verified-staff)
+and the metric arithmetic across rolling 24h/7d/total windows.
+
+See docs/plans/AdminDashboard.md.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from django.test import Client
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.accounts.test_factories import make_user
+from apps.media.models import MediaAsset
+from apps.provenance.models import ChangeSet, IngestRun, Source
+from apps.provenance.test_factories import ingest_changeset, user_changeset
+
+DASHBOARD_URL = "/api/pages/admin/dashboard/"
+
+
+# ── auth matrix ───────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestAuthMatrix:
+    def test_anonymous_is_denied(self, client: Client) -> None:
+        # `django_auth` is configured on the Router and rejects before
+        # `@requires` ever fires, so anonymous deterministically gets 401.
+        resp = client.get(DASHBOARD_URL)
+        assert resp.status_code == 401
+
+    def test_non_staff_is_denied(self, client: Client, user: User) -> None:
+        client.force_login(user)
+        resp = client.get(DASHBOARD_URL)
+        assert resp.status_code == 403
+
+    def test_unverified_staff_is_denied(self, client: Client) -> None:
+        unverified_staff = make_user(is_staff=True, email_verified=False)
+        client.force_login(unverified_staff)
+        resp = client.get(DASHBOARD_URL)
+        assert resp.status_code == 403
+
+    def test_verified_staff_gets_200(self, client: Client, staff: User) -> None:
+        # `staff` fixture is email_verified by make_user's default.
+        client.force_login(staff)
+        resp = client.get(DASHBOARD_URL)
+        assert resp.status_code == 200
+
+
+# ── stats correctness ─────────────────────────────────────────────────
+
+
+def _backdate_user(u: User, when: datetime) -> None:
+    """Override ``date_joined`` after creation.
+
+    The `make_user` factory doesn't expose `date_joined`; setting it
+    post-create via `.update()` skips needing a factory parameter.
+    """
+    User.objects.filter(pk=u.pk).update(date_joined=when)
+
+
+def _backdate_changeset(cs: ChangeSet, when: datetime) -> None:
+    ChangeSet.objects.filter(pk=cs.pk).update(created_at=when)
+
+
+def _backdate_asset(asset: MediaAsset, when: datetime) -> None:
+    MediaAsset.objects.filter(pk=asset.pk).update(created_at=when)
+
+
+def _make_asset(
+    uploader: User,
+    status: MediaAsset.Status = MediaAsset.Status.READY,
+) -> MediaAsset:
+    return MediaAsset.objects.create(
+        kind=MediaAsset.Kind.IMAGE,
+        status=status,
+        original_filename="photo.jpg",
+        mime_type="image/jpeg",
+        byte_size=1024,
+        width=800,
+        height=600,
+        uploaded_by=uploader,
+    )
+
+
+@pytest.mark.django_db
+class TestSignupsMetric:
+    def test_counts_split_across_windows(self, client: Client, staff: User) -> None:
+        now = timezone.now()
+        # Backdate the staff fixture out of both windows so the counts
+        # reflect only the explicitly-seeded rows below.
+        _backdate_user(staff, now - timedelta(days=400))
+        inside_24h = make_user()
+        _backdate_user(inside_24h, now - timedelta(hours=2))
+        inside_7d = make_user()
+        _backdate_user(inside_7d, now - timedelta(days=3))
+        ancient = make_user()
+        _backdate_user(ancient, now - timedelta(days=400))
+
+        client.force_login(staff)
+        m = client.get(DASHBOARD_URL).json()["signups"]
+        assert m["last_24h"] == 1  # inside_24h only
+        assert m["last_7d"] == 2  # inside_24h + inside_7d
+        assert m["total"] == 4  # all four (incl. backdated staff + ancient)
+
+
+@pytest.mark.django_db
+class TestEditsMetric:
+    def test_counts_user_changesets_across_windows(
+        self, client: Client, staff: User
+    ) -> None:
+        now = timezone.now()
+        editor = make_user()
+        user_changeset(editor)  # recent — implicit now()
+        weekish = user_changeset(editor)
+        _backdate_changeset(weekish, now - timedelta(days=3))
+        ancient = user_changeset(editor)
+        _backdate_changeset(ancient, now - timedelta(days=400))
+
+        client.force_login(staff)
+        m = client.get(DASHBOARD_URL).json()["edits"]
+        assert m["last_24h"] == 1
+        assert m["last_7d"] == 2
+        assert m["total"] == 3
+
+    def test_ingest_changesets_excluded(self, client: Client, staff: User) -> None:
+        source = Source.objects.create(
+            name="TestSource", slug="test-source", priority=10
+        )
+        run = IngestRun.objects.create(source=source, input_fingerprint="fp-1")
+        ingest_changeset(run)
+        ingest_changeset(run)
+
+        client.force_login(staff)
+        m = client.get(DASHBOARD_URL).json()["edits"]
+        assert m["last_24h"] == 0
+        assert m["last_7d"] == 0
+        assert m["total"] == 0
+        assert m["last_at"] is None
+
+
+@pytest.mark.django_db
+class TestUploadsMetric:
+    def test_counts_ready_assets_across_windows(
+        self, client: Client, staff: User
+    ) -> None:
+        now = timezone.now()
+        uploader = make_user()
+
+        _make_asset(uploader)  # recent — implicit now()
+        weekish = _make_asset(uploader)
+        _backdate_asset(weekish, now - timedelta(days=3))
+        ancient = _make_asset(uploader)
+        _backdate_asset(ancient, now - timedelta(days=400))
+
+        client.force_login(staff)
+        m = client.get(DASHBOARD_URL).json()["uploads"]
+        assert m["last_24h"] == 1
+        assert m["last_7d"] == 2
+        assert m["total"] == 3
+
+    def test_non_ready_assets_excluded(self, client: Client, staff: User) -> None:
+        uploader = make_user()
+        _make_asset(uploader, status=MediaAsset.Status.FAILED)
+        # PROCESSING is image-disallowed; use a video to exercise the path.
+        MediaAsset.objects.create(
+            kind=MediaAsset.Kind.VIDEO,
+            status=MediaAsset.Status.PROCESSING,
+            original_filename="clip.mp4",
+            mime_type="video/mp4",
+            byte_size=2048,
+            uploaded_by=uploader,
+        )
+        _make_asset(uploader, status=MediaAsset.Status.READY)
+
+        client.force_login(staff)
+        m = client.get(DASHBOARD_URL).json()["uploads"]
+        # Pin the filter on every output column — a regression where the
+        # READY filter only applies to `total` would slip past a single
+        # total-only assertion.
+        assert m["last_24h"] == 1
+        assert m["last_7d"] == 1
+        assert m["total"] == 1
+        assert m["last_at"] is not None
+
+
+# ── last_at semantics ─────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestLastAt:
+    def test_empty_population_yields_none(self, client: Client, staff: User) -> None:
+        # No edits exist (staff didn't make any). last_at should be None.
+        client.force_login(staff)
+        m = client.get(DASHBOARD_URL).json()["edits"]
+        assert m["total"] == 0
+        assert m["last_at"] is None
+
+    def test_populated_matches_latest_created_at(
+        self, client: Client, staff: User
+    ) -> None:
+        editor = make_user()
+        older = user_changeset(editor)
+        _backdate_changeset(older, timezone.now() - timedelta(days=2))
+        newer = user_changeset(editor)  # implicit now()
+
+        client.force_login(staff)
+        m = client.get(DASHBOARD_URL).json()["edits"]
+        last_at = datetime.fromisoformat(m["last_at"])
+        newer.refresh_from_db()
+        # Ninja serializes datetimes at millisecond precision; the DB
+        # stores microseconds. Truncate to compare on the wire contract.
+        expected_ms = newer.created_at.microsecond // 1000 * 1000
+        assert last_at == newer.created_at.replace(microsecond=expected_ms)

--- a/docs/plans/AdminDashboard.md
+++ b/docs/plans/AdminDashboard.md
@@ -1,9 +1,182 @@
-# Admin At A Glance Dashboard
+# Admin Dashboard
 
-We want a dashboard page for superusers that show how the system is doing, such as # registered users, # edits, # page views, # errors & warnings in the last 24 hours
+Resolves [#415](https://github.com/The-Flip/flipcommons/issues/415).
 
-Mobile-friendly: this will be a page bookmarked on Moses' phone.
+A mobile-first page for admins showing how the system is doing at a glance: signups, edits, uploads.
 
-This will combine info from multiple systems: the prod database, the analytics system (docs/plans/analytics/Analytics.md), and the observability system (docs/plans/observability/Observability.md).
+**Route**: `/a/dashboard` (SvelteKit), with `/a` redirecting to it. `/a` is an intentionally opaque prefix that will host other admin-only SPA pages over time without mentally binding them to Django's `is_staff` flag.
 
-Remember: this is a docs/SmallTeam.md: nobody's on duty on a daily basis.
+**Scope**: production-database stats only. PostHog (pageviews) and Sentry (errors) are deferred.
+
+The DB-stats subset implemented here is the easy slice of [analytics/AnalyticsDbStatsPlan.md](analytics/AnalyticsDbStatsPlan.md). Retention cohorts and the 80/20 curve live there, not here.
+
+## URL structure
+
+```text
+/a              → redirects to /a/dashboard (v1 has only one admin page;
+                  when a second lands, /a is promoted to a real index)
+/a/dashboard    → the at-a-glance dashboard
+```
+
+Routing layout:
+
+```text
+src/routes/a/
+  +layout.server.ts       ← auth gate (Activity.VIEW_ADMIN_AREA)
+  +page.server.ts         ← throw redirect(303, '/a/dashboard')
+  dashboard/
+    +page.server.ts       ← fetches /api/pages/admin/dashboard
+    +page.svelte          ← renders the cards
+```
+
+The auth gate runs in `+layout.server.ts` before the redirect, so unauthenticated/non-admin users get bounced to login (or 403'd) rather than redirected to a page they can't reach. Future admin-only SPA pages drop into `src/routes/a/<thing>/` and inherit the gate for free.
+
+## Auth gate
+
+One predicate, enforced once at the `/a/*` layout boundary.
+
+- New `Activity.VIEW_ADMIN_AREA = "admin_area.view"` in [`apps/core/authz/types.py`](../../backend/apps/core/authz/types.py). Verb-led `VIEW_` makes the read-only scope explicit; any future mutating admin action gets its own activity rather than silently riding on this one.
+- Registered in [`apps/core/authz/rules.py`](../../backend/apps/core/authz/rules.py) with predicates `is_authenticated, email_verified, is_staff` — same shape as `OBSERVABILITY_DEBUG`.
+- The Ninja endpoint that serves the stats is decorated `@requires(Activity.VIEW_ADMIN_AREA)`.
+- SvelteKit `src/routes/a/+layout.server.ts` calls `requireCapability({ fetch, url, request, activity: 'admin_area.view' })` from [`$lib/require-capability.server`](../../frontend/src/lib/require-capability.server.ts) — same helper used by [`_sentry_test/+page.server.ts`](../../frontend/src/routes/_sentry_test/+page.server.ts). Per the project rule in [CLAUDE.md](../../CLAUDE.md) "Authorization goes through activities" — no raw `is_staff` checks in SSR locals.
+- Every page that later lands under `/a/*` inherits the gate automatically. No second predicate, no copy-pasted check.
+
+## Backend
+
+New page-API endpoint (per [ApiDesign.md § Endpoint design](../ApiDesign.md#endpoint-design)):
+
+```text
+GET /api/pages/admin/dashboard  →  AdminDashboardPageSchema
+```
+
+Tagged `private`, `auth=django_auth`, gated `@requires(Activity.VIEW_ADMIN_AREA)`. Lives at `backend/apps/core/api/admin_dashboard_page.py` — no single app owns the payload (spans `accounts.User`, `provenance.ChangeSet`, `media.Media`), so it goes under `core`.
+
+### Schema
+
+```python
+class AdminMetricSchema(Schema):
+    last_24h: int
+    last_7d: int
+    total: int
+    last_at: datetime | None  # most recent event of this kind, or None
+
+class AdminDashboardPageSchema(Schema):
+    signups: AdminMetricSchema
+    edits: AdminMetricSchema
+    uploads: AdminMetricSchema
+    generated_at: datetime
+```
+
+Three uniform metric cards. An "active editors" distinct-count was considered and dropped from v1 — it's the seed of the 80/20 curve already deferred to [analytics/AnalyticsDbStatsPlan.md](analytics/AnalyticsDbStatsPlan.md), and an isolated number without trend is weak signal next to the windowed metrics.
+
+### Definitions
+
+- **Signups**: `User` rows. Time field: `date_joined`.
+- **Edits**: `ChangeSet` rows where `user_id IS NOT NULL` (any `action`). Ingest ChangeSets are excluded by virtue of having a null user. Time field: `created_at`.
+- **Uploads**: `Media` rows. Time field: `created_at` (only completed uploads persist).
+
+### Time windows
+
+Rolling from the moment the endpoint is called:
+
+- `last_24h`: `created_at >= now() - interval '24 hours'`
+- `last_7d`: `created_at >= now() - interval '7 days'`
+- `total`: all rows.
+
+No timezone gymnastics. The numbers reflect "the last 24 hours" in the literal wall-clock sense, which is what an admin means when they glance at the page.
+
+### Query shape
+
+One query per metric — three aggregates and a `MAX(created_at)` in a single `SELECT` per table. The three queries are independent and could run in parallel via `asyncio.gather`, but the synchronous version is fine for v1 (each query is sub-ms on tables of this size).
+
+## Frontend
+
+Routing layout repeated from [URL structure](#url-structure):
+
+```text
+src/routes/a/
+  +layout.server.ts       ← auth gate (Activity.VIEW_ADMIN_AREA)
+  +page.server.ts         ← throw redirect(303, '/a/dashboard')
+  dashboard/
+    +page.server.ts       ← fetches /api/pages/admin/dashboard via the typed client
+    +page.svelte          ← renders the three cards
+```
+
+`dashboard/+page.server.ts` returns `{ stats }`. The page renders three cards stacked vertically; each card shows three time-windowed counts in a row plus a "last X" timestamp formatted with `smartDate(iso)` from [`$lib/dates`](../../frontend/src/lib/dates.ts) — adaptive output: "8:34pm" today, "Yesterday 6:30pm", "Monday 3pm", "Mar 14". When `last_at` is `null` (fresh DB, no rows of that kind yet), render `∅` in place.
+
+### Auto-refresh every hour
+
+`dashboard/+page.svelte` runs a `setInterval(() => invalidate(...), 60 * 60 * 1000)` on mount. SvelteKit re-runs `dashboard/+page.server.ts`, the typed client refetches, the cards update. Interval cleared on `onDestroy`. No reactive flicker beyond what `invalidate()` already does.
+
+### Layout
+
+Mobile-first. Vertical stack of cards on phones; same stack on desktop (this is a phone page first, the desktop view doesn't need columns). Uses existing `Page.svelte` and `FieldGroup.svelte` primitives where they fit — no new layout primitives.
+
+Phone sketch:
+
+```text
+┌────────────────────┐
+│ Flipcommons / Admin│
+├────────────────────┤
+│ Signups            │
+│   24h   7d   total │
+│    3    12   847   │
+│ last: 6:30pm       │
+├────────────────────┤
+│ Edits              │
+│   24h   7d   total │
+│   18    94   5,213 │
+│ last: 8:21pm       │
+├────────────────────┤
+│ Uploads            │
+│   24h   7d   total │
+│    7    41   2,108 │
+│ last: Yesterday 9pm│
+└────────────────────┘
+(updated 12:04 PM · auto-refresh every hour)
+```
+
+## Testing
+
+Backend (`apps/<location>/tests/`):
+
+- Auth: anonymous → 401/403; non-staff → 403; staff w/o `email_verified` → 403; staff w/ `email_verified` → 200.
+- Stats correctness: factory-built `User`, `ChangeSet`, `Media` rows across the time windows; assert each metric returns the expected counts.
+- Ingest ChangeSets excluded: a ChangeSet with `user_id=NULL` does not contribute to edits.
+- `last_at` semantics: empty table → `None`; populated → matches the latest `created_at`.
+
+Frontend:
+
+- `a/+layout.server.ts` gate: unauthorized hits redirect / 403.
+- `a/+page.server.ts` redirect: authorized hit to `/a` lands on `/a/dashboard`.
+- `a/dashboard/+page.svelte`: renders the three metric cards from a fixture payload.
+- `∅` empty-state: when `last_at` is `null`, the card renders `∅` instead of the formatted timestamp.
+- `smartDate` already has its own tests in [`$lib/dates.test.ts`](../../frontend/src/lib/dates.test.ts); no new helper to test.
+
+## Out of scope
+
+- **PostHog inline** — pageviews, top URLs, referrer breakdown.
+- **Sentry inline** — error/warning counts, latest incidents.
+- **Retention cohorts** — see [analytics/AnalyticsDbStatsPlan.md](analytics/AnalyticsDbStatsPlan.md).
+- **80/20 editor curve** — same plan doc.
+- **Deploy SHA / deploy time** — Sentry already correlates events to releases per [observability/ObservabilityBackendPlan.md](observability/ObservabilityBackendPlan.md) "Release Correlation".
+- **Per-user drill-downs**, **time-series sparklines**, **week-vs-week deltas** — wait for the v1 to be in use before designing v2.
+- **Last 24h error count** (Sentry API) — single number, high signal, justifies the integration cost.
+- **Last 24h pageviews** (PostHog API) — same shape.
+- **First-edit conversion** (of last-7d signups, how many edited) — onboarding pulse.
+- **Top-5 editors this week** — light 80/20 peek; a candidate for a `/staff/contributors` sub-page rather than the glance card.
+
+## Implementation order
+
+A suggested sequence. Each step is independently testable; don't move on until the previous step's tests are green.
+
+1. **Activity.** Add `VIEW_ADMIN_AREA = "admin_area.view"` to [`apps/core/authz/types.py`](../../backend/apps/core/authz/types.py); register predicates `(is_authenticated, email_verified, is_staff)` in [`apps/core/authz/rules.py`](../../backend/apps/core/authz/rules.py). Unit test: predicates match `OBSERVABILITY_DEBUG`'s set.
+2. **Backend page endpoint.** New module `apps/core/api/admin_dashboard_page.py` with `AdminMetricSchema`, `AdminDashboardPageSchema`, and the route handler. Register the router under `/api/pages/admin/`. Tag `private`, decorate `@requires(Activity.VIEW_ADMIN_AREA)`.
+3. **Backend tests.** Auth matrix (anon / non-staff / staff w/o verified / staff w/ verified), per-metric counts across the time windows, ingest-ChangeSet exclusion, `last_at` empty-table → `None`. Use the existing `user_changeset` factory from [`apps/provenance/test_factories.py`](../../backend/apps/provenance/test_factories.py).
+4. **API codegen.** Run `make api-gen` to regenerate `frontend/src/lib/api/schema.d.ts`. Verify the new schema names appear as named exports, and that `Activity` now includes `'admin_area.view'`.
+5. **Frontend route gate.** Create `frontend/src/routes/a/+layout.server.ts` calling `requireCapability({ fetch, url, request, activity: 'admin_area.view' })` from [`$lib/require-capability.server`](../../frontend/src/lib/require-capability.server.ts) — copy the pattern from [`_sentry_test/+page.server.ts`](../../frontend/src/routes/_sentry_test/+page.server.ts). Test: anonymous → redirect to login; non-admin → redirect to verify-email; admin → passes through.
+6. **Frontend `/a` redirect.** `frontend/src/routes/a/+page.server.ts` issues `throw redirect(303, '/a/dashboard')`. Test: authorized hit lands on `/a/dashboard`.
+7. **Frontend dashboard page.** `frontend/src/routes/a/dashboard/+page.server.ts` calls the typed client; `+page.svelte` renders. Extract a `MetricCard.svelte` (the three cards are near-identical). Format `last_at` via `smartDate` from [`$lib/dates`](../../frontend/src/lib/dates.ts); render `∅` when null.
+8. **Auto-refresh.** Define `ADMIN_DASHBOARD_DEPEND_KEY = 'app:admin-dashboard'` in a sibling `_dependencies.ts` module (importable by both `+page.server.ts` and `+page.svelte` — non-`.server.ts` so the client can read it). `+page.server.ts` calls `depends(ADMIN_DASHBOARD_DEPEND_KEY)`; `+page.svelte` uses `setInterval(() => invalidate(ADMIN_DASHBOARD_DEPEND_KEY), 60 * 60 * 1000)` on mount and `clearInterval` on destroy. Also wire a `visibilitychange` listener that calls `invalidate(...)` when the tab returns to foreground — `setInterval` is throttled while backgrounded, and a phone-bookmark reopen should refresh immediately rather than waiting up to an hour. Prefer the dep-key indirection over passing the endpoint URL directly so the typed client stays the only place that knows the URL.
+9. **Mobile UX check.** Load the route on a phone (or DevTools mobile viewport). Verify the cards stack cleanly, the title bar is readable, the `smartDate` strings don't overflow on the longest output ("Yesterday 11:30pm").
+10. **Manual smoke.** Bookmark `/a` on a phone; reopen; confirm the redirect lands on `/a/dashboard` and the numbers look plausible against production-shape seed data.

--- a/docs/plans/analytics/AnalyticsDbStatsPlan.md
+++ b/docs/plans/analytics/AnalyticsDbStatsPlan.md
@@ -4,6 +4,10 @@ This doc covers DB-derived stats for [AnalyticsPlan.md](AnalyticsPlan.md). The q
 
 Whereas the other plans use PostHog to instrument visitor and contributor _behavior_, this plan derives counts and trends directly from the production database — `User`, `ChangeSet`, `Media`, and friends. It's the source of truth for anything about "what's in the system right now": signups, edits, contributors active in a period, retention cohorts, the 80/20 editor curve.
 
+## Admin dashboard answers some of this
+
+The [admin dashboard](../AdminDashboard.md) ships the windowed-counts slice of this plan: signups, user-attributed edits, and successful uploads over rolling 24h / 7d / total windows, each with a `last_at` timestamp. It does not cover first-edit conversion, repeat contributors, monthly distinct-editor counts, retention cohorts, period-over-period deltas, or the 80/20 curve — those remain open below.
+
 ## What Questions It Answers
 
 | Question                                                                               | What data answers it                                                                     |

--- a/frontend/src/lib/components/Nav.svelte
+++ b/frontend/src/lib/components/Nav.svelte
@@ -46,10 +46,20 @@
 
   const myContributionsHref = $derived(resolve(`/users/${auth.username}`));
   const myContributionsActive = $derived(isActive(`/users/${auth.username}`));
+
+  // Single source of truth for "should the ADMIN menu section render at all?"
+  // Both the desktop avatar menu and the mobile hamburger gate on this; a new
+  // admin activity is added here once, not in two `||` chains.
+  const hasAnyAdminSurface = $derived(
+    auth.can('admin_area.view') || auth.can('kiosk.edit') || auth.can('django_admin.access'),
+  );
 </script>
 
 {#snippet adminSection()}
   <MenuSectionHeader>admin</MenuSectionHeader>
+  {#if auth.can('admin_area.view')}
+    <MenuItem href={resolve('/a/dashboard')} current={isActive('/a')}>Stats</MenuItem>
+  {/if}
   {#if auth.can('kiosk.edit')}
     <MenuItem href={resolve('/kiosk/edit')} current={isActive('/kiosk/edit')}>Kiosks</MenuItem>
     <MenuItem href={resolve('/style-lab')} current={isActive('/style-lab')}>Style Lab</MenuItem>
@@ -101,7 +111,7 @@
                 username={auth.username ?? ''}
               />
             {/snippet}
-            {#if auth.can('kiosk.edit') || auth.can('django_admin.access')}
+            {#if hasAnyAdminSurface}
               {@render adminSection()}
               <MenuDivider />
             {/if}
@@ -132,7 +142,7 @@
           Changelog
         </MenuItem>
         {#if auth.loaded}
-          {#if auth.can('kiosk.edit') || auth.can('django_admin.access')}
+          {#if hasAnyAdminSurface}
             <MenuDivider />
             {@render adminSection()}
           {/if}

--- a/frontend/src/routes/a/+layout.server.ts
+++ b/frontend/src/routes/a/+layout.server.ts
@@ -1,0 +1,8 @@
+import { requireCapability } from '$lib/require-capability.server';
+import type { LayoutServerLoad } from './$types';
+
+// Single auth gate for the whole admin SPA area. Any page that lands
+// under `/a/*` inherits this gate; do not re-implement per-page.
+export const load: LayoutServerLoad = async ({ fetch, url, request }) => {
+  await requireCapability({ fetch, url, request, activity: 'admin_area.view' });
+};

--- a/frontend/src/routes/a/+page.server.ts
+++ b/frontend/src/routes/a/+page.server.ts
@@ -1,0 +1,11 @@
+import { redirect } from '@sveltejs/kit';
+import { resolve } from '$app/paths';
+import type { PageServerLoad } from './$types';
+
+// `/a` is an intentionally opaque prefix that will host other admin
+// pages over time. While the dashboard is the only one, hitting `/a`
+// itself routes there. When a second admin page lands, replace this
+// redirect with a real index page.
+export const load: PageServerLoad = () => {
+  throw redirect(303, resolve('/a/dashboard'));
+};

--- a/frontend/src/routes/a/dashboard/+page.server.ts
+++ b/frontend/src/routes/a/dashboard/+page.server.ts
@@ -1,0 +1,19 @@
+import { error } from '@sveltejs/kit';
+import { createServerClient } from '$lib/api/server';
+import { ADMIN_DASHBOARD_DEPEND_KEY } from './_dependencies';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ fetch, url, request, depends }) => {
+  // Lets the page call `invalidate(ADMIN_DASHBOARD_DEPEND_KEY)` to refetch
+  // without re-running the parent layout's auth gate.
+  depends(ADMIN_DASHBOARD_DEPEND_KEY);
+
+  const client = createServerClient(fetch, url, request);
+  const { data, response } = await client.GET('/api/pages/admin/dashboard/');
+
+  if (!data) {
+    throw error(response.status || 500, 'Failed to load admin dashboard');
+  }
+
+  return { stats: data };
+};

--- a/frontend/src/routes/a/dashboard/+page.svelte
+++ b/frontend/src/routes/a/dashboard/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { invalidate } from '$app/navigation';
+  import Page from '$lib/components/Page.svelte';
+  import { SITE_TITLE } from '$lib/constants';
+  import { smartDate } from '$lib/dates';
+  import MetricCard from './MetricCard.svelte';
+  import { ADMIN_DASHBOARD_DEPEND_KEY } from './_dependencies';
+
+  let { data } = $props();
+  let stats = $derived(data.stats);
+
+  const AUTO_REFRESH_MS = 60 * 60 * 1000; // one hour
+
+  $effect(() => {
+    const refresh = () => void invalidate(ADMIN_DASHBOARD_DEPEND_KEY);
+    const id = setInterval(refresh, AUTO_REFRESH_MS);
+    // The hourly setInterval is throttled while the tab is backgrounded,
+    // and a bookmarked /a opened from a phone home screen will show whatever
+    // generated_at was current when the tab was last foregrounded. Refresh
+    // on visibility-restore so reopening the tab is the user's mental
+    // "pull to refresh," not a stale snapshot waiting for the next tick.
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearInterval(id);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  });
+</script>
+
+<svelte:head>
+  <title>Admin — {SITE_TITLE}</title>
+</svelte:head>
+
+<Page width="narrow">
+  <div class="cards">
+    <MetricCard label="Signups" metric={stats.signups} />
+    <MetricCard label="Edits" metric={stats.edits} />
+    <MetricCard label="Uploads" metric={stats.uploads} />
+  </div>
+  <p class="footer">
+    updated {smartDate(stats.generated_at)} · auto-refresh every hour
+  </p>
+</Page>
+
+<style>
+  .cards {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .footer {
+    margin: 1rem 0 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+    text-align: center;
+  }
+</style>

--- a/frontend/src/routes/a/dashboard/MetricCard.dom.test.ts
+++ b/frontend/src/routes/a/dashboard/MetricCard.dom.test.ts
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+import MetricCard from './MetricCard.svelte';
+
+describe('MetricCard', () => {
+  // Compute via Intl directly so the assertion stays locale-agnostic —
+  // CI may format thousands with comma, dot, or non-breaking space.
+  const fmt = (n: number) => new Intl.NumberFormat().format(n);
+
+  it('renders the three windowed counts and a formatted timestamp', () => {
+    render(MetricCard, {
+      label: 'Signups',
+      metric: {
+        last_24h: 3,
+        last_7d: 12,
+        total: 847,
+        last_at: '2026-05-18T18:30:00Z',
+      },
+    });
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Signups');
+    expect(screen.getByText(fmt(3))).toBeInTheDocument();
+    expect(screen.getByText(fmt(12))).toBeInTheDocument();
+    expect(screen.getByText(fmt(847))).toBeInTheDocument();
+    // smartDate output varies by locale/now; just assert the empty-state
+    // marker is NOT rendered when last_at is set.
+    expect(screen.queryByText('∅')).not.toBeInTheDocument();
+  });
+
+  it('renders ∅ in place of the timestamp when last_at is null', () => {
+    render(MetricCard, {
+      label: 'Edits',
+      metric: { last_24h: 0, last_7d: 0, total: 0, last_at: null },
+    });
+    expect(screen.getByText('∅')).toBeInTheDocument();
+  });
+
+  it('thousands-separates large totals via Intl.NumberFormat', () => {
+    render(MetricCard, {
+      label: 'Edits',
+      metric: { last_24h: 0, last_7d: 0, total: 5213, last_at: null },
+    });
+    expect(screen.getByText(fmt(5213))).toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/a/dashboard/MetricCard.svelte
+++ b/frontend/src/routes/a/dashboard/MetricCard.svelte
@@ -1,0 +1,89 @@
+<script module lang="ts">
+  const numberFormatter = new Intl.NumberFormat();
+</script>
+
+<script lang="ts">
+  import { smartDate } from '$lib/dates';
+  import type { AdminMetricSchema } from '$lib/api/schema';
+
+  let {
+    label,
+    metric,
+  }: {
+    label: string;
+    metric: AdminMetricSchema;
+  } = $props();
+</script>
+
+<section class="card">
+  <h2>{label}</h2>
+  <dl class="windows">
+    <div class="cell">
+      <dt>24h</dt>
+      <dd>{numberFormatter.format(metric.last_24h)}</dd>
+    </div>
+    <div class="cell">
+      <dt>7d</dt>
+      <dd>{numberFormatter.format(metric.last_7d)}</dd>
+    </div>
+    <div class="cell">
+      <dt>Total</dt>
+      <dd>{numberFormatter.format(metric.total)}</dd>
+    </div>
+  </dl>
+  <p class="last-at">
+    last: <span class="last-at-value">{metric.last_at ? smartDate(metric.last_at) : '∅'}</span>
+  </p>
+</section>
+
+<style>
+  .card {
+    padding: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background: var(--color-surface);
+  }
+
+  h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .windows {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+    margin: 0 0 0.5rem;
+  }
+
+  .cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .cell dt {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .cell dd {
+    margin: 0;
+    font-size: 1.5rem;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+  }
+
+  .last-at {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  .last-at-value {
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/src/routes/a/dashboard/_dependencies.ts
+++ b/frontend/src/routes/a/dashboard/_dependencies.ts
@@ -1,0 +1,4 @@
+// Shared by `+page.server.ts` (registers the dependency on initial load)
+// and `+page.svelte` (calls invalidate(...) on the hourly refresh tick).
+// Lives outside `*.server.ts` so the client may import it.
+export const ADMIN_DASHBOARD_DEPEND_KEY = 'app:admin-dashboard';

--- a/frontend/src/routes/a/dashboard/page-server.test.ts
+++ b/frontend/src/routes/a/dashboard/page-server.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiGet = vi.fn();
+
+vi.mock('$lib/api/server', () => ({
+  createServerClient: () => ({ GET: apiGet }),
+}));
+
+const { load } = await import('./+page.server');
+
+type LoadEvent = Parameters<typeof load>[0];
+
+function makeEvent(): LoadEvent {
+  const fetchStub = (() => undefined) as unknown as typeof globalThis.fetch;
+  return {
+    fetch: fetchStub,
+    url: new URL('http://localhost/a/dashboard'),
+    request: new Request('http://localhost/a/dashboard'),
+    depends: vi.fn(),
+  } as unknown as LoadEvent;
+}
+
+const samplePayload = {
+  signups: { last_24h: 1, last_7d: 2, total: 3, last_at: '2026-05-18T18:00:00Z' },
+  edits: { last_24h: 0, last_7d: 0, total: 0, last_at: null },
+  uploads: { last_24h: 1, last_7d: 1, total: 1, last_at: '2026-05-18T18:00:00Z' },
+  generated_at: '2026-05-18T18:00:00Z',
+};
+
+describe('/a/dashboard +page.server.ts load', () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+  });
+
+  it('registers the invalidation dependency key', async () => {
+    const { ADMIN_DASHBOARD_DEPEND_KEY } = await import('./_dependencies');
+    apiGet.mockResolvedValueOnce({ data: samplePayload, response: { status: 200 } });
+    const event = makeEvent();
+    await load(event);
+    expect(event.depends).toHaveBeenCalledWith(ADMIN_DASHBOARD_DEPEND_KEY);
+  });
+
+  it('returns the typed stats payload on success', async () => {
+    apiGet.mockResolvedValueOnce({ data: samplePayload, response: { status: 200 } });
+    const result = await load(makeEvent());
+    expect(result).toEqual({ stats: samplePayload });
+  });
+
+  it('throws an error with the upstream status when the page-API fails', async () => {
+    apiGet.mockResolvedValueOnce({ data: undefined, response: { status: 503 } });
+    await expect(load(makeEvent())).rejects.toMatchObject({ status: 503 });
+  });
+});

--- a/frontend/src/routes/a/layout-server.test.ts
+++ b/frontend/src/routes/a/layout-server.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requireCapability = vi.fn();
+
+vi.mock('$lib/require-capability.server', () => ({
+  requireCapability: (...args: unknown[]) => requireCapability(...args),
+}));
+
+const { load } = await import('./+layout.server');
+
+function makeEvent(url: URL) {
+  const fetchStub = (() => undefined) as unknown as typeof globalThis.fetch;
+  const request = new Request(url);
+  return { fetch: fetchStub, url, request };
+}
+
+describe('/a +layout.server.ts load', () => {
+  beforeEach(() => {
+    requireCapability.mockReset();
+  });
+
+  it('gates the admin area through requireCapability with admin_area.view', async () => {
+    requireCapability.mockResolvedValueOnce(undefined);
+    const event = makeEvent(new URL('http://localhost/a/dashboard'));
+
+    await load(event as unknown as Parameters<typeof load>[0]);
+
+    expect(requireCapability).toHaveBeenCalledWith({
+      fetch: event.fetch,
+      url: event.url,
+      request: event.request,
+      activity: 'admin_area.view',
+    });
+  });
+
+  it('propagates the redirect/error thrown by requireCapability', async () => {
+    const denied = Object.assign(new Error('redirect'), { status: 302, location: '/login' });
+    requireCapability.mockRejectedValueOnce(denied);
+    const event = makeEvent(new URL('http://localhost/a/dashboard'));
+
+    await expect(load(event as unknown as Parameters<typeof load>[0])).rejects.toBe(denied);
+  });
+});

--- a/frontend/src/routes/a/page-server.test.ts
+++ b/frontend/src/routes/a/page-server.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { load } from './+page.server';
+
+describe('/a +page.server.ts load', () => {
+  it('redirects (303) to /a/dashboard', () => {
+    let thrown: unknown;
+    try {
+      (load as unknown as () => unknown)();
+    } catch (e) {
+      thrown = e;
+    }
+    // SvelteKit's redirect() throws an object with { status, location }.
+    expect(thrown).toMatchObject({ status: 303, location: '/a/dashboard' });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `/a/dashboard` — a mobile-first at-a-glance page for verified staff showing rolling 24h / 7d / total counts and most-recent-event timestamps for signups, user-attributed edits, and successful media uploads.

- New `Activity.VIEW_ADMIN_AREA = "admin_area.view"` gates the whole `/a/*` route tree at the layout boundary, so future admin pages inherit the gate automatically.
- New page-API endpoint `GET /api/pages/admin/dashboard/` aggregates each metric in a single `SELECT` with `Count(...) FILTER (...)` and `MAX(time_field)`.
- Stats card auto-refreshes hourly via `invalidate(...)` against a shared dependency key, and on tab visibility-restore (so a bookmarked /a on a phone home screen refreshes when you reopen it, not whenever the throttled `setInterval` next fires).
- Adds a **Stats** link under the ADMIN section of the nav menu (desktop avatar + mobile hamburger). The menu's section gate is now a single `$derived(hasAnyAdminSurface)` shared by both surfaces.

Closes #415. Ships the windowed-counts slice of [AnalyticsDbStatsPlan.md](docs/plans/analytics/AnalyticsDbStatsPlan.md); first-edit conversion, retention cohorts, 80/20 curve, and active-editor distinct counts remain out of scope.

## Test plan

- [ ] Logged out, visit `/a` → redirects to `/login`
- [ ] Logged in as a verified-but-non-staff user, visit `/a` → redirects to `/verify-email`
- [ ] Logged in as verified staff, visit `/a` → 303 to `/a/dashboard`; three cards render
- [ ] On phone-width viewport, cards stack cleanly and the longest `smartDate` string ("Yesterday 11:30pm") doesn't overflow
- [ ] Bookmark `/a` on phone, background the tab for several minutes, reopen → `generated_at` ticks immediately on visibility-restore
- [ ] Empty DB / fresh table → `last_at` renders as `∅`
- [ ] Backend tests cover: auth matrix (anon → 401, non-staff → 403, unverified-staff → 403, verified-staff → 200); per-metric counts across the three windows; ingest ChangeSets excluded from edits; non-READY uploads excluded; `last_at` empty → None; `last_at` populated matches the latest `created_at` at millisecond wire precision
- [ ] Frontend tests cover the layout gate, the `/a` redirect, the dashboard page-server load (dep-key registered, success payload, upstream-error pass-through), and the `MetricCard` render (locale-agnostic via `Intl.NumberFormat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)