### PR TITLE
refactor(core): split models.py into a models/ package

### DIFF
--- a/backend/apps/core/models/__init__.py
+++ b/backend/apps/core/models/__init__.py
@@ -1,0 +1,58 @@
+"""Re-exports for ``apps.core.models``.
+
+Implementation lives in submodules:
+
+- ``mixins`` — abstract bases (TimeStampedModel, SluggedModel,
+  LifecycleStatusModel, LinkableModel), the EntityStatus enum, and the
+  unique_slug helper.
+- ``constraints`` — CHECK / UNIQUE constraint factories used in concrete Meta.
+- ``license`` — the License model.
+- ``references`` — RecordReference graph + post_delete cleanup signal.
+"""
+
+from .constraints import (
+    field_lowercase,
+    field_not_blank,
+    meta_unique_fields,
+    nullable_id_not_empty,
+    slug_lowercase,
+    slug_not_blank,
+    status_valid,
+    unique_ci,
+)
+from .license import License
+from .mixins import (
+    EntityStatus,
+    LifecycleManager,
+    LifecycleQuerySet,
+    LifecycleStatusModel,
+    LinkableModel,
+    SluggedModel,
+    TimeStampedModel,
+    active_status_q,
+    unique_slug,
+)
+from .references import RecordReference, register_reference_cleanup
+
+__all__ = [
+    "EntityStatus",
+    "License",
+    "LifecycleManager",
+    "LifecycleQuerySet",
+    "LifecycleStatusModel",
+    "LinkableModel",
+    "RecordReference",
+    "SluggedModel",
+    "TimeStampedModel",
+    "active_status_q",
+    "field_lowercase",
+    "field_not_blank",
+    "meta_unique_fields",
+    "nullable_id_not_empty",
+    "register_reference_cleanup",
+    "slug_lowercase",
+    "slug_not_blank",
+    "status_valid",
+    "unique_ci",
+    "unique_slug",
+]

--- a/backend/apps/core/models/constraints.py
+++ b/backend/apps/core/models/constraints.py
@@ -1,0 +1,130 @@
+"""CHECK / UNIQUE constraint helpers used by models across all apps."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.db.models.functions import Lower
+
+from .mixins import EntityStatus
+
+
+def field_not_blank(field_name: str) -> models.CheckConstraint:
+    """CHECK constraint: field != ''. Use in concrete model Meta.constraints."""
+    return models.CheckConstraint(
+        condition=~models.Q(**{field_name: ""}),
+        name=f"%(app_label)s_%(class)s_{field_name}_not_blank",
+    )
+
+
+def field_lowercase(field_name: str) -> models.CheckConstraint:
+    """CHECK constraint: field equals its own lowercased form.
+
+    Asserts ``field = LOWER(field)`` — a column equals itself only when
+    no character has a distinct lowercase form, which means there are no
+    uppercase letters present (ASCII or Unicode). Pure SQL, portable
+    across PostgreSQL and SQLite, and enforced even when the database is
+    opened by a tool that doesn't load Django's regex function.
+
+    Generic helper for any field that must be lowercase by shape (slugs,
+    derived path strings like Location.location_path, etc.). For slug
+    fields on SluggedModel subclasses use ``slug_lowercase()`` instead —
+    the constraint is identical, the helper just hardcodes the field name.
+
+    Once values are guaranteed lowercase, plain ``unique=True`` already
+    collapses case-equal rows; no Lower()-wrapped UniqueConstraint needed.
+    Pair with ``unique_ci()`` only when the field is mixed-case (names),
+    not when it's lowercase-shape (slugs, paths).
+    """
+    return models.CheckConstraint(
+        condition=models.Q(**{field_name: Lower(field_name)}),
+        name=f"%(app_label)s_%(class)s_{field_name}_lowercase",
+    )
+
+
+def unique_ci(field_name: str) -> models.UniqueConstraint:
+    """Case-insensitive UniqueConstraint on a single field.
+
+    System-wide rule: name-like uniqueness collapses case. Use in Meta
+    constraints in place of ``unique=True`` so ``"Bally"`` and ``"BALLY"``
+    cannot both exist.
+    """
+    return models.UniqueConstraint(
+        Lower(field_name),
+        name=f"%(app_label)s_%(class)s_unique_{field_name}_ci",
+    )
+
+
+def meta_unique_fields(model_class: type[models.Model]) -> set[str]:
+    """Names of fields referenced by any Meta ``UniqueConstraint``.
+
+    Covers both ``fields=[...]`` and expression-based forms like
+    ``UniqueConstraint(Lower("name"))`` — both make the underlying field
+    behave as unique even though ``field.unique`` is False. Walks
+    expression trees and picks up ``F`` references; other expression
+    nodes are ignored.
+    """
+    names: set[str] = set()
+
+    def _collect(expr: object) -> None:
+        if isinstance(expr, models.F):
+            names.add(expr.name)  # type: ignore[attr-defined]  # django-stubs omits F.name
+        children = getattr(expr, "get_source_expressions", None)
+        if callable(children):
+            for child in children():
+                _collect(child)
+
+    for constraint in model_class._meta.constraints:
+        if not isinstance(constraint, models.UniqueConstraint):
+            continue
+        for fname in constraint.fields or ():
+            names.add(fname)
+        for expr in constraint.expressions or ():
+            _collect(expr)
+    return names
+
+
+def nullable_id_not_empty(field_name: str) -> models.CheckConstraint:
+    """CHECK constraint: nullable string ID is NULL or non-empty.
+
+    Prevents '' on optional unique CharField IDs (opdb_id, wikidata_id),
+    which would consume the unique slot while being semantically null.
+    """
+    return models.CheckConstraint(
+        condition=models.Q(**{f"{field_name}__isnull": True})
+        | ~models.Q(**{field_name: ""}),
+        name=f"%(app_label)s_%(class)s_{field_name}_not_empty",
+    )
+
+
+def slug_not_blank() -> models.CheckConstraint:
+    """CHECK constraint: slug != ''. Use in each SluggedModel subclass Meta."""
+    return models.CheckConstraint(
+        condition=~models.Q(slug=""),
+        name="%(app_label)s_%(class)s_slug_not_blank",
+    )
+
+
+def slug_lowercase() -> models.CheckConstraint:
+    """CHECK constraint: slug equals its own lowercased form.
+
+    Slug-specific specialization of :func:`field_lowercase`. Use in each
+    SluggedModel subclass Meta alongside ``slug_not_blank()``. Plain
+    ``unique=True`` on the slug field is sufficient — case-sensitive
+    uniqueness already collapses case-equal rows once values are
+    guaranteed lowercase.
+    """
+    return models.CheckConstraint(
+        condition=models.Q(slug=Lower("slug")),
+        name="%(app_label)s_%(class)s_slug_lowercase",
+    )
+
+
+def status_valid() -> models.CheckConstraint:
+    """CHECK constraint: status must be 'active', 'deleted', or null."""
+    return models.CheckConstraint(
+        condition=(
+            models.Q(status__in=[EntityStatus.ACTIVE, EntityStatus.DELETED])
+            | models.Q(status__isnull=True)
+        ),
+        name="%(app_label)s_%(class)s_status_valid",
+    )

--- a/backend/apps/core/models/license.py
+++ b/backend/apps/core/models/license.py
@@ -1,0 +1,67 @@
+"""License model: content licensing for creative/expressive fields."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import models
+
+from .constraints import (
+    field_not_blank,
+    slug_lowercase,
+    slug_not_blank,
+    unique_ci,
+)
+from .mixins import SluggedModel, TimeStampedModel, unique_slug
+
+
+class License(SluggedModel, TimeStampedModel):
+    """A content license (e.g., Creative Commons, GFDL, or a policy status).
+
+    Used to track the licensing status of creative/expressive content
+    (descriptions, images, logos). Factual fields (names, years, IDs)
+    are not copyrightable and are never subject to licensing.
+    """
+
+    name = models.CharField(max_length=200)
+    slug = models.SlugField(max_length=50, unique=True)
+    spdx_id = models.CharField(
+        max_length=100,
+        unique=True,
+        null=True,
+        blank=True,
+        help_text="Standard SPDX identifier (e.g., CC-BY-SA-4.0). Null for non-standard entries.",
+    )
+    short_name = models.CharField(max_length=50)
+    url = models.URLField(blank=True, help_text="Link to canonical license deed.")
+    allows_display = models.BooleanField(
+        default=False,
+        help_text="Informational: does this license permit public display? Not used as a runtime gate.",
+    )
+    requires_attribution = models.BooleanField(default=False)
+    restricts_commercial = models.BooleanField(default=False)
+    allows_derivatives = models.BooleanField(default=True)
+    requires_share_alike = models.BooleanField(default=False)
+    permissiveness_rank = models.PositiveSmallIntegerField(
+        default=0,
+        help_text="Higher = more permissive. Used by the global display threshold.",
+    )
+
+    class Meta:
+        ordering = ["-permissiveness_rank", "name"]
+        constraints = [
+            field_not_blank("name"),
+            field_not_blank("short_name"),
+            slug_not_blank(),
+            slug_lowercase(),
+            unique_ci("name"),
+            unique_ci("short_name"),
+        ]
+
+    def __str__(self) -> str:
+        return self.short_name
+
+    def save(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401 - matches Model.save's overloaded signature
+        if not self.slug:
+            self.slug = unique_slug(self, self.short_name, "license")
+        super().save(*args, **kwargs)

--- a/backend/apps/core/models/mixins.py
+++ b/backend/apps/core/models/mixins.py
@@ -1,15 +1,12 @@
-"""Shared base models and utilities used across all apps."""
+"""Abstract base mixins shared across all apps."""
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Self, TypeVar
+from typing import ClassVar, Self, TypeVar
 
-from django.contrib.contenttypes.fields import GenericForeignKey
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
-from django.db.models.functions import Lower, Now
-from django.db.models.signals import post_delete
+from django.db.models.functions import Now
 from django.utils.text import slugify
 
 
@@ -21,110 +18,6 @@ class TimeStampedModel(models.Model):
 
     class Meta:
         abstract = True
-
-
-def field_not_blank(field_name: str) -> models.CheckConstraint:
-    """CHECK constraint: field != ''. Use in concrete model Meta.constraints."""
-    return models.CheckConstraint(
-        condition=~models.Q(**{field_name: ""}),
-        name=f"%(app_label)s_%(class)s_{field_name}_not_blank",
-    )
-
-
-def field_lowercase(field_name: str) -> models.CheckConstraint:
-    """CHECK constraint: field equals its own lowercased form.
-
-    Asserts ``field = LOWER(field)`` — a column equals itself only when
-    no character has a distinct lowercase form, which means there are no
-    uppercase letters present (ASCII or Unicode). Pure SQL, portable
-    across PostgreSQL and SQLite, and enforced even when the database is
-    opened by a tool that doesn't load Django's regex function.
-
-    Generic helper for any field that must be lowercase by shape (slugs,
-    derived path strings like Location.location_path, etc.). For slug
-    fields on SluggedModel subclasses use ``slug_lowercase()`` instead —
-    the constraint is identical, the helper just hardcodes the field name.
-
-    Once values are guaranteed lowercase, plain ``unique=True`` already
-    collapses case-equal rows; no Lower()-wrapped UniqueConstraint needed.
-    Pair with ``unique_ci()`` only when the field is mixed-case (names),
-    not when it's lowercase-shape (slugs, paths).
-    """
-    return models.CheckConstraint(
-        condition=models.Q(**{field_name: Lower(field_name)}),
-        name=f"%(app_label)s_%(class)s_{field_name}_lowercase",
-    )
-
-
-def unique_ci(field_name: str) -> models.UniqueConstraint:
-    """Case-insensitive UniqueConstraint on a single field.
-
-    System-wide rule: name-like uniqueness collapses case. Use in Meta
-    constraints in place of ``unique=True`` so ``"Bally"`` and ``"BALLY"``
-    cannot both exist.
-    """
-    return models.UniqueConstraint(
-        Lower(field_name),
-        name=f"%(app_label)s_%(class)s_unique_{field_name}_ci",
-    )
-
-
-def meta_unique_fields(model_class: type[models.Model]) -> set[str]:
-    """Names of fields referenced by any Meta ``UniqueConstraint``.
-
-    Covers both ``fields=[...]`` and expression-based forms like
-    ``UniqueConstraint(Lower("name"))`` — both make the underlying field
-    behave as unique even though ``field.unique`` is False. Walks
-    expression trees and picks up ``F`` references; other expression
-    nodes are ignored.
-    """
-    names: set[str] = set()
-
-    def _collect(expr: object) -> None:
-        if isinstance(expr, models.F):
-            names.add(expr.name)  # type: ignore[attr-defined]  # django-stubs omits F.name
-        children = getattr(expr, "get_source_expressions", None)
-        if callable(children):
-            for child in children():
-                _collect(child)
-
-    for constraint in model_class._meta.constraints:
-        if not isinstance(constraint, models.UniqueConstraint):
-            continue
-        for fname in constraint.fields or ():
-            names.add(fname)
-        for expr in constraint.expressions or ():
-            _collect(expr)
-    return names
-
-
-def nullable_id_not_empty(field_name: str) -> models.CheckConstraint:
-    """CHECK constraint: nullable string ID is NULL or non-empty.
-
-    Prevents '' on optional unique CharField IDs (opdb_id, wikidata_id),
-    which would consume the unique slot while being semantically null.
-    """
-    return models.CheckConstraint(
-        condition=models.Q(**{f"{field_name}__isnull": True})
-        | ~models.Q(**{field_name: ""}),
-        name=f"%(app_label)s_%(class)s_{field_name}_not_empty",
-    )
-
-
-def unique_slug(obj: models.Model, source: str, fallback: str = "item") -> str:
-    """Generate a unique slug with counter disambiguation.
-
-    Appends a counter suffix (-2, -3, …) until the slug is unique within
-    the model's table.
-    """
-    base = slugify(source) or fallback
-    slug = base
-    counter = 2
-    manager = type(obj)._default_manager
-    while manager.filter(slug=slug).exclude(pk=obj.pk).exists():
-        slug = f"{base}-{counter}"
-        counter += 1
-    return slug
 
 
 class SluggedModel(models.Model):
@@ -148,79 +41,20 @@ class SluggedModel(models.Model):
         abstract = True
 
 
-def slug_not_blank() -> models.CheckConstraint:
-    """CHECK constraint: slug != ''. Use in each SluggedModel subclass Meta."""
-    return models.CheckConstraint(
-        condition=~models.Q(slug=""),
-        name="%(app_label)s_%(class)s_slug_not_blank",
-    )
+def unique_slug(obj: models.Model, source: str, fallback: str = "item") -> str:
+    """Generate a unique slug with counter disambiguation.
 
-
-def slug_lowercase() -> models.CheckConstraint:
-    """CHECK constraint: slug equals its own lowercased form.
-
-    Slug-specific specialization of :func:`field_lowercase`. Use in each
-    SluggedModel subclass Meta alongside ``slug_not_blank()``. Plain
-    ``unique=True`` on the slug field is sufficient — case-sensitive
-    uniqueness already collapses case-equal rows once values are
-    guaranteed lowercase.
+    Appends a counter suffix (-2, -3, …) until the slug is unique within
+    the model's table.
     """
-    return models.CheckConstraint(
-        condition=models.Q(slug=Lower("slug")),
-        name="%(app_label)s_%(class)s_slug_lowercase",
-    )
-
-
-class License(SluggedModel, TimeStampedModel):
-    """A content license (e.g., Creative Commons, GFDL, or a policy status).
-
-    Used to track the licensing status of creative/expressive content
-    (descriptions, images, logos). Factual fields (names, years, IDs)
-    are not copyrightable and are never subject to licensing.
-    """
-
-    name = models.CharField(max_length=200)
-    slug = models.SlugField(max_length=50, unique=True)
-    spdx_id = models.CharField(
-        max_length=100,
-        unique=True,
-        null=True,
-        blank=True,
-        help_text="Standard SPDX identifier (e.g., CC-BY-SA-4.0). Null for non-standard entries.",
-    )
-    short_name = models.CharField(max_length=50)
-    url = models.URLField(blank=True, help_text="Link to canonical license deed.")
-    allows_display = models.BooleanField(
-        default=False,
-        help_text="Informational: does this license permit public display? Not used as a runtime gate.",
-    )
-    requires_attribution = models.BooleanField(default=False)
-    restricts_commercial = models.BooleanField(default=False)
-    allows_derivatives = models.BooleanField(default=True)
-    requires_share_alike = models.BooleanField(default=False)
-    permissiveness_rank = models.PositiveSmallIntegerField(
-        default=0,
-        help_text="Higher = more permissive. Used by the global display threshold.",
-    )
-
-    class Meta:
-        ordering = ["-permissiveness_rank", "name"]
-        constraints = [
-            field_not_blank("name"),
-            field_not_blank("short_name"),
-            slug_not_blank(),
-            slug_lowercase(),
-            unique_ci("name"),
-            unique_ci("short_name"),
-        ]
-
-    def __str__(self) -> str:
-        return self.short_name
-
-    def save(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401 - matches Model.save's overloaded signature
-        if not self.slug:
-            self.slug = unique_slug(self, self.short_name, "license")
-        super().save(*args, **kwargs)
+    base = slugify(source) or fallback
+    slug = base
+    counter = 2
+    manager = type(obj)._default_manager
+    while manager.filter(slug=slug).exclude(pk=obj.pk).exists():
+        slug = f"{base}-{counter}"
+        counter += 1
+    return slug
 
 
 # ---------------------------------------------------------------------------
@@ -308,17 +142,6 @@ class LifecycleStatusModel(models.Model):
 
     class Meta:
         abstract = True
-
-
-def status_valid() -> models.CheckConstraint:
-    """CHECK constraint: status must be 'active', 'deleted', or null."""
-    return models.CheckConstraint(
-        condition=(
-            models.Q(status__in=[EntityStatus.ACTIVE, EntityStatus.DELETED])
-            | models.Q(status__isnull=True)
-        ),
-        name="%(app_label)s_%(class)s_status_valid",
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -427,70 +250,3 @@ class LinkableModel(models.Model):
         """Return this entity's URL-identity value (``self.<public_id_field>``)."""
         value: str = getattr(self, self.public_id_field)
         return value
-
-
-# ---------------------------------------------------------------------------
-# Generic link tracking
-# ---------------------------------------------------------------------------
-
-
-class RecordReference(models.Model):
-    """Tracks links between records for 'what links here' queries.
-
-    Uses Django's contenttypes framework for polymorphic source/target.
-    GenericForeignKey doesn't support on_delete, so all target deletions
-    are allowed. Broken links render as 'broken link' text.
-    """
-
-    # Source (the record containing the link)
-    source_type = models.ForeignKey(
-        ContentType, on_delete=models.CASCADE, related_name="+"
-    )
-    source_id = models.PositiveBigIntegerField()
-    source = GenericForeignKey("source_type", "source_id")
-
-    # Target (the record being linked to)
-    target_type = models.ForeignKey(
-        ContentType, on_delete=models.CASCADE, related_name="+"
-    )
-    target_id = models.PositiveBigIntegerField()
-    target = GenericForeignKey("target_type", "target_id")
-
-    class Meta:
-        constraints = [
-            models.UniqueConstraint(
-                fields=["source_type", "source_id", "target_type", "target_id"],
-                name="core_recordreference_unique_source_target",
-            ),
-        ]
-        indexes = [
-            models.Index(fields=["target_type", "target_id"]),  # "What links here"
-            models.Index(fields=["source_type", "source_id"]),  # Cleanup on delete
-        ]
-
-    def __str__(self) -> str:
-        return (
-            f"{self.source_type.model}:{self.source_id}"
-            f" \u2192 {self.target_type.model}:{self.target_id}"
-        )
-
-
-def register_reference_cleanup(*model_classes: type[models.Model]) -> None:
-    """Connect post_delete signals to clean up RecordReference rows for the given models.
-
-    Call from AppConfig.ready() for every model whose text fields can contain
-    ``[[<entity-type>:<public-id>]]`` markdown links (i.e. any model passed to ``sync_references``).
-    """
-
-    def _cleanup_references(
-        sender: type[models.Model], instance: models.Model, **kwargs: object
-    ) -> None:
-        ct = ContentType.objects.get_for_model(sender)
-        RecordReference.objects.filter(source_type=ct, source_id=instance.pk).delete()
-
-    for model_class in model_classes:
-        post_delete.connect(
-            _cleanup_references,
-            sender=model_class,
-            dispatch_uid=f"cleanup_refs_{model_class._meta.label_lower}",
-        )

--- a/backend/apps/core/models/references.py
+++ b/backend/apps/core/models/references.py
@@ -1,0 +1,70 @@
+"""RecordReference graph: tracks links between records for 'what links here'."""
+
+from __future__ import annotations
+
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+from django.db import models
+from django.db.models.signals import post_delete
+
+
+class RecordReference(models.Model):
+    """Tracks links between records for 'what links here' queries.
+
+    Uses Django's contenttypes framework for polymorphic source/target.
+    GenericForeignKey doesn't support on_delete, so all target deletions
+    are allowed. Broken links render as 'broken link' text.
+    """
+
+    # Source (the record containing the link)
+    source_type = models.ForeignKey(
+        ContentType, on_delete=models.CASCADE, related_name="+"
+    )
+    source_id = models.PositiveBigIntegerField()
+    source = GenericForeignKey("source_type", "source_id")
+
+    # Target (the record being linked to)
+    target_type = models.ForeignKey(
+        ContentType, on_delete=models.CASCADE, related_name="+"
+    )
+    target_id = models.PositiveBigIntegerField()
+    target = GenericForeignKey("target_type", "target_id")
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["source_type", "source_id", "target_type", "target_id"],
+                name="core_recordreference_unique_source_target",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["target_type", "target_id"]),  # "What links here"
+            models.Index(fields=["source_type", "source_id"]),  # Cleanup on delete
+        ]
+
+    def __str__(self) -> str:
+        return (
+            f"{self.source_type.model}:{self.source_id}"
+            f" → {self.target_type.model}:{self.target_id}"
+        )
+
+
+def register_reference_cleanup(*model_classes: type[models.Model]) -> None:
+    """Connect post_delete signals to clean up RecordReference rows for the given models.
+
+    Call from AppConfig.ready() for every model whose text fields can contain
+    ``[[<entity-type>:<public-id>]]`` markdown links (i.e. any model passed to ``sync_references``).
+    """
+
+    def _cleanup_references(
+        sender: type[models.Model], instance: models.Model, **kwargs: object
+    ) -> None:
+        ct = ContentType.objects.get_for_model(sender)
+        RecordReference.objects.filter(source_type=ct, source_id=instance.pk).delete()
+
+    for model_class in model_classes:
+        post_delete.connect(
+            _cleanup_references,
+            sender=model_class,
+            dispatch_uid=f"cleanup_refs_{model_class._meta.label_lower}",
+        )

--- a/docs/DataModeling.md
+++ b/docs/DataModeling.md
@@ -77,6 +77,18 @@ Cross-field constraints use `violation_error_code="cross_field"`.
 
 Define range bounds and enum values as module-level constants. Reference them from both validators and constraints so they can't drift apart. See `test_constraint_drift.py` for the meta-test that enforces this.
 
+### Text field length caps
+
+Every user-input text field must be have a max length. Use:
+
+- `CharField(max_length=N)` for identifier-like text
+- `BoundedTextField(max_length=N)` for prose
+- `MarkdownField(max_length=N)` for long-form markdown (default 10,000)
+
+Never use bare `TextField()` for user input.
+
+Cap values are module-level constants imported by the matching Ninja input schema.
+
 ### Storage keys
 
 Store relative paths, never full URLs. The storage prefix (e.g., `media/`) is enforced in application code, not DB constraints, so the storage location stays configurable without schema changes.

--- a/docs/EntityNaming.md
+++ b/docs/EntityNaming.md
@@ -4,7 +4,7 @@ This project's linkable entities (titles, models, manufacturers, people, etc.) s
 
 ## The rule
 
-Every [`LinkableModel`](../backend/apps/core/models.py) subclass declares an `entity_type` attribute: a **hyphenated singular** string (e.g. `title`, `corporate-entity`, `technology-subgeneration`).
+Every [`LinkableModel`](../backend/apps/core/models/mixins.py) subclass declares an `entity_type` attribute: a **hyphenated singular** string (e.g. `title`, `corporate-entity`, `technology-subgeneration`).
 
 From that one attribute:
 


### PR DESCRIPTION
## Summary

Splits the 496-line `apps/core/models.py` into a `models/` package by concern: `mixins.py` (abstract bases), `constraints.py` (helpers + `unique_slug`), `license.py` (the one concrete model), `references.py` (the `RecordReference` graph).

- `__init__.py` re-exports every public name, so all 55 existing `from apps.core.models import ...` sites keep working unchanged — Django-idiomatic split, no call-site churn.
- Also updates [docs/EntityNaming.md](docs/EntityNaming.md) so the `LinkableModel` link points at `models/mixins.py` instead of the deleted file.

## Test plan

- [ ] `make test` passes
- [ ] `make mypy` passes
- [ ] `python manage.py makemigrations --dry-run --check` reports no changes
- [ ] `python manage.py check` is clean