### PR TITLE
Add baseline response security headers in Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -11,12 +11,14 @@ request_header -Forwarded
 
 # Response-side security headers. HSTS is tracked separately (#404); CSP
 # is tracked in #448 — it needs a per-request nonce from SvelteKit, so
-# it doesn't belong here. SAMEORIGIN (not DENY) so Django admin previews
-# and same-origin embeds still work.
+# it doesn't belong here. DENY because we have no use case for
+# same-origin framing. Referrer-Policy here overwrites Django's stricter
+# same-origin default on /admin/ — accepted because the public site
+# needs strict-origin-when-cross-origin for analytics attribution.
 header {
 	X-Content-Type-Options nosniff
 	Referrer-Policy strict-origin-when-cross-origin
-	X-Frame-Options SAMEORIGIN
+	X-Frame-Options DENY
 }
 
 # XFF rewrite must live inside reverse_proxy: Caddy's reverse_proxy has

--- a/Caddyfile
+++ b/Caddyfile
@@ -9,6 +9,16 @@ handle @www {
 # values through verbatim, so it's attacker-controlled.
 request_header -Forwarded
 
+# Response-side security headers. HSTS is tracked separately (#404); CSP
+# is tracked in #448 — it needs a per-request nonce from SvelteKit, so
+# it doesn't belong here. SAMEORIGIN (not DENY) so Django admin previews
+# and same-origin embeds still work.
+header {
+	X-Content-Type-Options nosniff
+	Referrer-Policy strict-origin-when-cross-origin
+	X-Frame-Options SAMEORIGIN
+}
+
 # XFF rewrite must live inside reverse_proxy: Caddy's reverse_proxy has
 # special handling for X-Forwarded-* headers and overrides any
 # site-level request_header mutations. header_up is proxy-aware and


### PR DESCRIPTION
## Summary

Adds three response-side security headers in the Caddyfile:

- `X-Content-Type-Options: nosniff` — blocks MIME-sniffing attacks
- `Referrer-Policy: strict-origin-when-cross-origin` — modern browser default, set explicitly
- `X-Frame-Options: DENY` — clickjacking protection

Top-level `header` directive so it applies to both the Django and SvelteKit proxies.

## Not in this PR

- HSTS — tracked in #404 (sticky, needs care around subdomains and `media.flipcommons.org`)
- CSP — tracked in #448 (needs per-request nonce threading through SvelteKit, plus a report-only rollout)

## Test plan

- [ ] CI passes
- [ ] After deploy, `curl -sI https://flipcommons.org | grep -iE 'x-content-type|referrer|x-frame'` shows all three headers
- [ ] Site still loads, Django admin still loads