### PR TITLE
feat(frontend): custom error pages

### DIFF
--- a/frontend/src/lib/components/ErrorPage.svelte
+++ b/frontend/src/lib/components/ErrorPage.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { SITE_TITLE } from '$lib/constants';
+  import Page from './Page.svelte';
+
+  let {
+    heading,
+    body,
+    cta,
+  }: {
+    heading: string;
+    body: string;
+    cta: Snippet;
+  } = $props();
+</script>
+
+<svelte:head>
+  <title>{heading} — {SITE_TITLE}</title>
+</svelte:head>
+
+<Page width="narrow">
+  <div class="error-content">
+    <section class="error-card" role="alert">
+      <h1>{heading}</h1>
+      <p class="body">{body}</p>
+      <div class="cta-row">{@render cta()}</div>
+    </section>
+  </div>
+</Page>
+
+<style>
+  .error-content {
+    padding: var(--size-6) var(--size-4);
+  }
+
+  .error-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-4);
+    padding: var(--size-5);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-2);
+    background: var(--color-surface);
+  }
+
+  h1 {
+    margin: 0;
+    font-size: var(--font-size-3);
+  }
+
+  .body {
+    margin: 0;
+    color: var(--color-text-muted);
+  }
+
+  .cta-row {
+    display: flex;
+  }
+</style>

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,0 +1,39 @@
+<script lang="ts" module>
+  type Content = {
+    heading: string;
+    body: string;
+  };
+
+  function contentForStatus(status: number): Content {
+    if (status === 404) {
+      return {
+        heading: 'Page not found',
+        body: "We couldn't find what you were looking for. It may have moved or never existed.",
+      };
+    }
+    if (status === 403) {
+      return {
+        heading: 'Not allowed',
+        body: "You don't have access to this page.",
+      };
+    }
+    return {
+      heading: 'Something went wrong',
+      body: 'An unexpected error occurred. Try again in a moment.',
+    };
+  }
+</script>
+
+<script lang="ts">
+  import { page } from '$app/state';
+  import Button from '$lib/components/Button.svelte';
+  import ErrorPage from '$lib/components/ErrorPage.svelte';
+
+  const content = $derived(contentForStatus(page.status));
+</script>
+
+<ErrorPage heading={content.heading} body={content.body}>
+  {#snippet cta()}
+    <Button tag="a" href="/">Back to home</Button>
+  {/snippet}
+</ErrorPage>

--- a/frontend/src/routes/auth/error/+page.svelte
+++ b/frontend/src/routes/auth/error/+page.svelte
@@ -88,62 +88,16 @@
 
 <script lang="ts">
   import { page } from '$app/state';
-  import { SITE_TITLE } from '$lib/constants';
   import Button from '$lib/components/Button.svelte';
-  import Page from '$lib/components/Page.svelte';
+  import ErrorPage from '$lib/components/ErrorPage.svelte';
 
   const content = $derived(resolveAuthErrorContent(page.url.searchParams.get('reason')));
 </script>
 
-<svelte:head>
-  <title>{content.heading} — {SITE_TITLE}</title>
-</svelte:head>
-
-<Page width="narrow">
-  <div class="error-content">
-    <section class="error-card" role="alert">
-      <h1>{content.heading}</h1>
-      <p class="body">{content.body}</p>
-      <div class="cta-row">
-        {#if content.cta.reload}
-          <Button tag="a" href={content.cta.href} data-sveltekit-reload>{content.cta.label}</Button>
-        {:else}
-          <Button tag="a" href={content.cta.href}>{content.cta.label}</Button>
-        {/if}
-      </div>
-    </section>
-  </div>
-</Page>
-
-<style>
-  .error-content {
-    padding: var(--size-6) var(--size-4);
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-6);
-  }
-
-  .error-card {
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-4);
-    padding: var(--size-5);
-    border: 1px solid var(--color-border-soft);
-    border-radius: var(--radius-2);
-    background: var(--color-surface, transparent);
-  }
-
-  h1 {
-    margin: 0;
-    font-size: var(--font-size-3);
-  }
-
-  .body {
-    margin: 0;
-    color: var(--color-text-muted);
-  }
-
-  .cta-row {
-    display: flex;
-  }
-</style>
+<ErrorPage heading={content.heading} body={content.body}>
+  {#snippet cta()}
+    <Button tag="a" href={content.cta.href} data-sveltekit-reload={content.cta.reload || undefined}>
+      {content.cta.label}
+    </Button>
+  {/snippet}
+</ErrorPage>

--- a/frontend/src/routes/error-page.dom.test.ts
+++ b/frontend/src/routes/error-page.dom.test.ts
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { pageState } = vi.hoisted(() => ({
+  pageState: {
+    url: new URL('http://localhost:5173/'),
+    params: {} as Record<string, string>,
+    status: 500,
+  },
+}));
+
+vi.mock('$app/state', () => ({ page: pageState }));
+
+const ErrorPage = (await import('./+error.svelte')).default;
+
+beforeEach(() => {
+  pageState.status = 500;
+});
+
+describe('+error.svelte', () => {
+  const cases = [
+    {
+      status: 404,
+      heading: 'Page not found',
+      body: "We couldn't find what you were looking for. It may have moved or never existed.",
+    },
+    {
+      status: 403,
+      heading: 'Not allowed',
+      body: "You don't have access to this page.",
+    },
+    {
+      status: 500,
+      heading: 'Something went wrong',
+      body: 'An unexpected error occurred. Try again in a moment.',
+    },
+  ] as const;
+
+  for (const { status, heading, body } of cases) {
+    it(`renders status ${status} with the right heading and body`, () => {
+      pageState.status = status;
+      render(ErrorPage);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(heading);
+      expect(screen.getByText(body)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Back to home' })).toHaveAttribute('href', '/');
+    });
+  }
+
+  it('falls through to the generic copy for unrecognized statuses', () => {
+    pageState.status = 418;
+    render(ErrorPage);
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Something went wrong');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a SvelteKit `+error.svelte` at the root so 404/403/generic failures get a real page instead of the framework default
- Extracts the shared error shell (narrow centered card, heading, body, CTA slot, document title) into `$lib/components/ErrorPage.svelte`
- Refactors `/auth/error` to consume the new primitive — both consumers now only own their content-lookup logic

## Test plan

- [ ] Visit `/this-route-does-not-exist` → "Page not found" with a "Back to home" CTA; tab title updates
- [ ] Temporarily throw in a `+page.server.ts` load → generic 500 copy renders; revert
- [ ] `/auth/error?reason=state_invalid` → retry CTA, link has `data-sveltekit-reload`, full reload to Django
- [ ] `/auth/error?reason=account_conflict` → "Back to home" CTA, no reload attribute, client-side nav
- [ ] `/auth/error` and `/auth/error?reason=bogus` → fallback copy
- [ ] Resize to ~375px → card holds its padding off the viewport edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)