### PR TITLE
feat(legal): add PostHog analytics to privacy policy

### DIFF
--- a/frontend/src/routes/(legal)/privacy/+page.svelte
+++ b/frontend/src/routes/(legal)/privacy/+page.svelte
@@ -93,10 +93,10 @@
   </li>
   <li>
     <strong><a href="https://posthog.com">PostHog</a></strong> — helps us understand which parts of
-    the site are used and where contributors get stuck, so we can improve them. It receives a record each
-    time you visit a page, and may in future also record specific actions like a successful edit or a
-    failed upload. Each record includes the page you were on (without anything after the <code>?</code>
-    in the address bar), the site that referred you (if any), and your browser and operating system family.
+    the site are used and where contributors get stuck, so we can improve them. We notify PostHog each
+    time you do specific actions like visit a page, successfully save an edit, or have an upload fail.
+    Each notification includes the page you were on (without anything after the <code>?</code> in the
+    address bar), the site that referred you (if any), and your browser and operating system family.
     We have configured it not to set cookies, not to remember anything about you between visits, not to
     store your IP address, not to silently record the buttons you click or text you type, not to record
     a video of your session, not to run pop-up surveys, not to record your screen or window size, and not to capture

--- a/frontend/src/routes/(legal)/privacy/+page.svelte
+++ b/frontend/src/routes/(legal)/privacy/+page.svelte
@@ -102,7 +102,7 @@
     a video of your session, not to run pop-up surveys, not to record your screen or window size, and not to capture
     marketing or ad-tracking tags from the address bar (things like <code>utm_source</code> or
     <code>gclid</code>) or the search terms that brought you here from Google or Bing. A temporary ID
-    groups records from the same browser tab together and is forgotten when you close the tab.
+    groups activities from the same browser tab together and is forgotten when you close the tab.
   </li>
 </ul>
 

--- a/frontend/src/routes/(legal)/privacy/+page.svelte
+++ b/frontend/src/routes/(legal)/privacy/+page.svelte
@@ -97,8 +97,18 @@
     email addresses, request bodies, and query strings are stripped before delivery. Does not use cookie
     tracking or record browser sessions.
   </li>
+  <li>
+    <strong><a href="https://posthog.com" target="_blank" rel="noopener">PostHog</a></strong> — receives
+    pageview counts so we can understand which parts of the site are used and where contributors get stuck.
+    We have configured it not to set cookies, not to use local storage, not to store your IP address,
+    not to autocapture clicks or form input, not to record browser sessions, not to run surveys, not to
+    record screen or viewport dimensions, not to capture URL query strings, not to capture campaign or
+    click-tracking parameters (UTM, gclid, fbclid, and similar), and not to capture search-engine referral
+    keywords. What it does receive: the path of the page you visited (no query string), the referring
+    site's origin and path, and browser and operating system family derived from your user-agent string.
+    A session identifier is held in memory only and is discarded when you close the tab.
+  </li>
 </ul>
-<!-- TODO: Add any analytics services if applicable -->
 
 <h2>Your Rights</h2>
 <p>

--- a/frontend/src/routes/(legal)/privacy/+page.svelte
+++ b/frontend/src/routes/(legal)/privacy/+page.svelte
@@ -73,32 +73,26 @@
 </p>
 <ul>
   <li>
-    <strong><a href="https://workos.com" target="_blank" rel="noopener">WorkOS</a></strong> — handles
-    sign-in and authentication.
+    <strong><a href="https://workos.com">WorkOS</a></strong> — handles sign-in and authentication.
   </li>
   <li>
-    <strong><a href="https://railway.com" target="_blank" rel="noopener">Railway</a></strong> — hosts
-    the application.
+    <strong><a href="https://railway.com">Railway</a></strong> — hosts the application.
   </li>
   <li>
-    <strong><a href="https://bunny.net" target="_blank" rel="noopener">Bunny CDN</a></strong> — serves
-    images and other media.
+    <strong><a href="https://bunny.net">Bunny CDN</a></strong> — serves images and other media.
   </li>
   <li>
-    <strong
-      ><a href="https://www.idrive.com/e2/" target="_blank" rel="noopener">iDrive e2</a></strong
-    >
-    — stores uploaded files.
+    <strong><a href="https://www.idrive.com/e2/">iDrive e2</a></strong> — stores uploaded files.
   </li>
   <li>
-    <strong><a href="https://sentry.io" target="_blank" rel="noopener">Sentry</a></strong> — receives
+    <strong><a href="https://sentry.io">Sentry</a></strong> — receives
     error reports when something breaks in your browser or on our servers, so we can fix it. Reports include
     your account ID and username if you're signed in; personally identifying information like IP addresses,
     email addresses, request bodies, and query strings are stripped before delivery. Does not use cookie
     tracking or record browser sessions.
   </li>
   <li>
-    <strong><a href="https://posthog.com" target="_blank" rel="noopener">PostHog</a></strong> — receives
+    <strong><a href="https://posthog.com">PostHog</a></strong> — receives
     pageview counts so we can understand which parts of the site are used and where contributors get stuck.
     We have configured it not to set cookies, not to use local storage, not to store your IP address,
     not to autocapture clicks or form input, not to record browser sessions, not to run surveys, not to

--- a/frontend/src/routes/(legal)/privacy/+page.svelte
+++ b/frontend/src/routes/(legal)/privacy/+page.svelte
@@ -97,7 +97,7 @@
     time you do specific actions like visit a page, successfully save an edit, or have an upload fail.
     Each notification includes the page you were on (without anything after the <code>?</code> in the
     address bar), the site that referred you (if any), and your browser and operating system family.
-    We have configured it not to set cookies, not to remember anything about you between visits, not to
+    We have configured PostHog not to set cookies, not to remember anything about you between visits, not to
     store your IP address, not to silently record the buttons you click or text you type, not to record
     a video of your session, not to run pop-up surveys, not to record your screen or window size, and not to capture
     marketing or ad-tracking tags from the address bar (things like <code>utm_source</code> or

--- a/frontend/src/routes/(legal)/privacy/+page.svelte
+++ b/frontend/src/routes/(legal)/privacy/+page.svelte
@@ -92,15 +92,17 @@
     tracking or record browser sessions.
   </li>
   <li>
-    <strong><a href="https://posthog.com">PostHog</a></strong> — receives
-    pageview counts so we can understand which parts of the site are used and where contributors get stuck.
-    We have configured it not to set cookies, not to use local storage, not to store your IP address,
-    not to autocapture clicks or form input, not to record browser sessions, not to run surveys, not to
-    record screen or viewport dimensions, not to capture URL query strings, not to capture campaign or
-    click-tracking parameters (UTM, gclid, fbclid, and similar), and not to capture search-engine referral
-    keywords. What it does receive: the path of the page you visited (no query string), the referring
-    site's origin and path, and browser and operating system family derived from your user-agent string.
-    A session identifier is held in memory only and is discarded when you close the tab.
+    <strong><a href="https://posthog.com">PostHog</a></strong> — helps us understand which parts of
+    the site are used and where contributors get stuck, so we can improve them. It receives a record each
+    time you visit a page, and may in future also record specific actions like a successful edit or a
+    failed upload. Each record includes the page you were on (without anything after the <code>?</code>
+    in the address bar), the site that referred you (if any), and your browser and operating system family.
+    We have configured it not to set cookies, not to remember anything about you between visits, not to
+    store your IP address, not to silently record the buttons you click or text you type, not to record
+    a video of your session, not to run pop-up surveys, not to record your screen or window size, and not to capture
+    marketing or ad-tracking tags from the address bar (things like <code>utm_source</code> or
+    <code>gclid</code>) or the search terms that brought you here from Google or Bing. A temporary ID
+    groups records from the same browser tab together and is forgotten when you close the tab.
   </li>
 </ul>
 


### PR DESCRIPTION
## Summary
Updated the site's privacy policy to document PostHog analytics integration.

## Changes
- **Added PostHog entry** to the third-party services list with an explanation of:
  - What data PostHog collects (page visits, specific user actions like saves and upload failures)
  - What data is included in notifications (page URL without query params, referrer, browser/OS info)
  - Privacy-preserving configurations (no cookies, no session memory, no IP storage, no silent tracking, no surveys, no screen recording, no marketing tag capture)
  - How temporary session IDs work (grouped per browser tab, cleared on tab close)