### PR TITLE
refactor(provenance): rate-limit via decorators

### DIFF
--- a/backend/apps/catalog/api/corporate_entities.py
+++ b/backend/apps/catalog/api/corporate_entities.py
@@ -17,7 +17,7 @@ from apps.core.authz.types import Activity
 from apps.core.models import active_status_q
 from apps.core.schemas import RateLimitErrorSchema, ValidationErrorSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
-from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 from apps.provenance.schemas import RichTextSchema
 
 from ..models import (
@@ -177,12 +177,11 @@ def list_corporate_entities(
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_corporate_entity_claims(
     request: HttpRequest, public_id: str, data: CorporateEntityClaimPatchSchema
 ) -> CorporateEntityDetailSchema:
     """Assert per-field claims from the authenticated user, then re-resolve."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     if not data.fields and data.aliases is None:
         raise_form_error("No changes provided.")
 

--- a/backend/apps/catalog/api/entity_crud.py
+++ b/backend/apps/catalog/api/entity_crud.py
@@ -48,7 +48,7 @@ from apps.provenance.models import ChangeSetAction
 from apps.provenance.rate_limits import (
     CREATE_RATE_LIMIT_SPEC,
     DELETE_RATE_LIMIT_SPEC,
-    check_and_record,
+    rate_limited,
 )
 from apps.provenance.schemas import ChangeSetInputSchema
 
@@ -173,8 +173,6 @@ def register_entity_delete_restore[ModelT: CatalogModel, SchemaT: Schema](
     def _delete(
         request: HttpRequest, public_id: str, data: ChangeSetInputSchema
     ) -> DeleteResponseSchema | Status[SoftDeleteBlockedSchema | AlreadyDeletedSchema]:
-        check_and_record(request.user, DELETE_RATE_LIMIT_SPEC)
-
         obj = get_object_or_404(
             model_cls.objects.active(), **{public_id_field: public_id}
         )
@@ -227,7 +225,9 @@ def register_entity_delete_restore[ModelT: CatalogModel, SchemaT: Schema](
         )
 
     _delete.__name__ = f"{entity_label.lower()}_delete"
-    _delete = requires(Activity.CATALOG_DELETE)(_delete)
+    _delete = requires(Activity.CATALOG_DELETE)(
+        rate_limited(DELETE_RATE_LIMIT_SPEC)(_delete)
+    )
     router.post(
         "/{path:public_id}/delete/",
         auth=django_auth,
@@ -242,8 +242,6 @@ def register_entity_delete_restore[ModelT: CatalogModel, SchemaT: Schema](
     def _restore(
         request: HttpRequest, public_id: str, data: ChangeSetInputSchema
     ) -> SchemaT | Status[ErrorDetailSchema]:
-        check_and_record(request.user, CREATE_RATE_LIMIT_SPEC)
-
         # Bypass .active() — we're looking for soft-deleted rows.
         obj = get_object_or_404(model_cls, **{public_id_field: public_id})
         if obj.status != "deleted":
@@ -276,7 +274,9 @@ def register_entity_delete_restore[ModelT: CatalogModel, SchemaT: Schema](
     # Restore consumes the create rate-limit bucket (it reintroduces a record),
     # so it is classified as CATALOG_CREATE even though the underlying
     # ``execute_claims`` writes action=EDIT. See docs/RecordLifecycle.md.
-    _restore = requires(Activity.CATALOG_CREATE)(_restore)
+    _restore = requires(Activity.CATALOG_CREATE)(
+        rate_limited(CREATE_RATE_LIMIT_SPEC)(_restore)
+    )
     router.post(
         "/{path:public_id}/restore/",
         auth=django_auth,
@@ -420,8 +420,6 @@ def register_entity_create[ModelT: CatalogModel, SchemaT: Schema](
         data: EntityCreateInputSchema,
         parent: CatalogModel | None = None,
     ) -> Status[SchemaT]:
-        check_and_record(request.user, CREATE_RATE_LIMIT_SPEC)
-
         scope_filter = (
             scope_filter_builder(data, parent)
             if scope_filter_builder is not None
@@ -501,7 +499,9 @@ def register_entity_create[ModelT: CatalogModel, SchemaT: Schema](
             return _do_create(request, data, parent=parent)
 
         _create_parented.__name__ = f"{entity_label.lower()}_create{op_id_suffix}"
-        _create_parented = requires(Activity.CATALOG_CREATE)(_create_parented)
+        _create_parented = requires(Activity.CATALOG_CREATE)(
+            rate_limited(CREATE_RATE_LIMIT_SPEC)(_create_parented)
+        )
         router.post(
             f"/{{path:parent_public_id}}/{route_suffix}/",
             auth=django_auth,
@@ -521,7 +521,9 @@ def register_entity_create[ModelT: CatalogModel, SchemaT: Schema](
             return _do_create(request, data)
 
         _create_unparented.__name__ = f"{entity_label.lower()}_create{op_id_suffix}"
-        _create_unparented = requires(Activity.CATALOG_CREATE)(_create_unparented)
+        _create_unparented = requires(Activity.CATALOG_CREATE)(
+            rate_limited(CREATE_RATE_LIMIT_SPEC)(_create_unparented)
+        )
         router.post(
             "/",
             auth=django_auth,

--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -18,7 +18,7 @@ from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
 from apps.core.schemas import RateLimitErrorSchema, ValidationErrorSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
-from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 from apps.provenance.schemas import RichTextSchema
 
 from ..models import Franchise, MachineModel, Title
@@ -129,12 +129,11 @@ def _serialize_franchise_detail(franchise: Franchise) -> FranchiseDetailSchema:
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_franchise_claims(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> FranchiseDetailSchema:
     """Assert per-field claims from the authenticated user, then re-resolve."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     franchise = get_object_or_404(
         Franchise.objects.active(), **{Franchise.public_id_field: public_id}
     )

--- a/backend/apps/catalog/api/gameplay_features.py
+++ b/backend/apps/catalog/api/gameplay_features.py
@@ -16,7 +16,7 @@ from apps.core.schemas import RateLimitErrorSchema, ValidationErrorSchema
 from apps.media.helpers import all_media
 from apps.media.schemas import UploadedMediaSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
-from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 from apps.provenance.schemas import RichTextSchema
 
 from ..models import GameplayFeature
@@ -142,12 +142,11 @@ def list_gameplay_features(
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_gameplay_feature_claims(
     request: HttpRequest, public_id: str, data: HierarchyClaimPatchSchema
 ) -> GameplayFeatureDetailSchema:
     """Assert per-field claims from the authenticated user, then re-resolve."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     if not data.fields and data.parents is None and data.aliases is None:
         raise_form_error("No changes provided.")
 

--- a/backend/apps/catalog/api/locations_write.py
+++ b/backend/apps/catalog/api/locations_write.py
@@ -39,7 +39,7 @@ from pydantic import ConfigDict, field_validator
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
 from apps.core.schemas import RateLimitErrorSchema, ValidationErrorSchema
-from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 from apps.provenance.schemas import ChangeSetInputSchema
 
 from ..models import CatalogModel, Location
@@ -283,6 +283,7 @@ register_entity_create(
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_location_claims(
     request: HttpRequest, public_id: str, data: LocationPatchClaimSchema
 ) -> LocationDetailSchema:
@@ -295,8 +296,6 @@ def patch_location_claims(
     it; that's tracked in a follow-up that teaches ``NameEditor`` a
     name-only mode.
     """
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     loc = get_object_or_404(
         Location.objects.active(), **{Location.public_id_field: public_id}
     )

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -35,7 +35,7 @@ from apps.provenance.rate_limits import (
     CREATE_RATE_LIMIT_SPEC,
     DELETE_RATE_LIMIT_SPEC,
     EDIT_RATE_LIMIT_SPEC,
-    check_and_record,
+    rate_limited,
 )
 from apps.provenance.schemas import (
     AttributionSchema,
@@ -976,12 +976,11 @@ _SELF_REF_FIELDS = frozenset({"variant_of", "converted_from", "remake_of"})
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_model_claims(
     request: HttpRequest, public_id: str, data: ModelClaimPatchSchema
 ) -> ModelDetailSchema:
     """Assert per-field claims from the authenticated user, then re-resolve the model."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     pm = get_object_or_404(
         MachineModel.objects.active().prefetch_related(
             "themes",
@@ -1097,6 +1096,7 @@ def model_delete_preview(
     tags=["private"],
 )
 @requires(Activity.CATALOG_DELETE)
+@rate_limited(DELETE_RATE_LIMIT_SPEC)
 def delete_model(
     request: HttpRequest, public_id: str, data: ChangeSetInputSchema
 ) -> DeleteResponseSchema | Status[SoftDeleteBlockedSchema | AlreadyDeletedSchema]:
@@ -1109,8 +1109,6 @@ def delete_model(
     points here, …) would be left dangling. Never cascades to the parent
     Title — orphan Titles are supported by spec.
     """
-    check_and_record(request.user, DELETE_RATE_LIMIT_SPEC)
-
     pm = get_object_or_404(
         MachineModel.objects.active(), **{MachineModel.public_id_field: public_id}
     )
@@ -1148,6 +1146,7 @@ def delete_model(
     tags=["private"],
 )
 @requires(Activity.CATALOG_CREATE)
+@rate_limited(CREATE_RATE_LIMIT_SPEC)
 def restore_model(
     request: HttpRequest, public_id: str, data: ChangeSetInputSchema
 ) -> ModelDetailSchema | Status[ErrorDetailSchema]:
@@ -1157,8 +1156,6 @@ def restore_model(
     delete ChangeSet). Shares the ``create`` rate-limit bucket. The parent
     Title is untouched — consistent with delete's no-cascade-to-parent rule.
     """
-    check_and_record(request.user, CREATE_RATE_LIMIT_SPEC)
-
     # Bypass .active() — we're looking for soft-deleted models.
     pm = get_object_or_404(MachineModel, **{MachineModel.public_id_field: public_id})
     if pm.status != "deleted":

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -25,7 +25,7 @@ from apps.core.schemas import RateLimitErrorSchema, ValidationErrorSchema
 from apps.media.helpers import all_media
 from apps.media.schemas import UploadedMediaSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
-from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 from apps.provenance.schemas import RichTextSchema
 
 from ..cache import get_cached_response, manufacturers_all_key, set_cached_response
@@ -505,12 +505,11 @@ def list_all_manufacturers(
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_manufacturer_claims(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> ManufacturerDetailSchema:
     """Assert per-field claims from the authenticated user, then re-resolve."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     mfr = get_object_or_404(
         Manufacturer.objects.active(), **{Manufacturer.public_id_field: public_id}
     )

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -36,7 +36,7 @@ from apps.provenance.rate_limits import (
     CREATE_RATE_LIMIT_SPEC,
     DELETE_RATE_LIMIT_SPEC,
     EDIT_RATE_LIMIT_SPEC,
-    check_and_record,
+    rate_limited,
 )
 from apps.provenance.schemas import ChangeSetInputSchema, RichTextSchema
 
@@ -323,12 +323,11 @@ def list_all_people(
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_person_claims(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> PersonDetailSchema:
     """Assert per-field claims from the authenticated user, then re-resolve."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     person = get_object_or_404(
         Person.objects.active(), **{Person.public_id_field: public_id}
     )
@@ -359,6 +358,7 @@ def patch_person_claims(
     tags=["private"],
 )
 @requires(Activity.CATALOG_CREATE)
+@rate_limited(CREATE_RATE_LIMIT_SPEC)
 def create_person(
     request: HttpRequest, data: EntityCreateInputSchema
 ) -> Status[PersonDetailSchema]:
@@ -372,8 +372,6 @@ def create_person(
 
     Rate-limited per user on the shared ``create`` bucket. Staff bypass.
     """
-    check_and_record(request.user, CREATE_RATE_LIMIT_SPEC)
-
     # Introspect the model's field rather than using MAX_CATALOG_NAME_LENGTH
     # directly — Person.name happens to be capped at 200, while Title/Model
     # are 300, and the shared constant is a ceiling not a floor. Mismatch
@@ -475,6 +473,7 @@ def person_delete_preview(
     tags=["private"],
 )
 @requires(Activity.CATALOG_DELETE)
+@rate_limited(DELETE_RATE_LIMIT_SPEC)
 def delete_person(
     request: HttpRequest, public_id: str, data: ChangeSetInputSchema
 ) -> (
@@ -488,8 +487,6 @@ def delete_person(
     rationale. Also defers to the generic PROTECT walker for any future
     blockers (none expected today).
     """
-    check_and_record(request.user, DELETE_RATE_LIMIT_SPEC)
-
     person = get_object_or_404(
         Person.objects.active(), **{Person.public_id_field: public_id}
     )
@@ -545,6 +542,7 @@ def delete_person(
     tags=["private"],
 )
 @requires(Activity.CATALOG_CREATE)
+@rate_limited(CREATE_RATE_LIMIT_SPEC)
 def restore_person(
     request: HttpRequest, public_id: str, data: ChangeSetInputSchema
 ) -> PersonDetailSchema | Status[ErrorDetailSchema]:
@@ -553,8 +551,6 @@ def restore_person(
     Shares the ``create`` rate-limit bucket (Restore is semantically a
     re-create). Person has no lifecycle children, so nothing cascades.
     """
-    check_and_record(request.user, CREATE_RATE_LIMIT_SPEC)
-
     # Bypass .active() — we're looking for soft-deleted people.
     person = get_object_or_404(Person, **{Person.public_id_field: public_id})
     if person.status != "deleted":

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -18,7 +18,7 @@ from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
 from apps.core.schemas import RateLimitErrorSchema, ValidationErrorSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
-from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 from apps.provenance.schemas import RichTextSchema
 
 from ..models import Credit, MachineModel, Series, Title
@@ -180,12 +180,11 @@ def list_series(request: HttpRequest) -> list[SeriesListItemSchema]:
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_series_claims(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> SeriesDetailSchema:
     """Assert per-field claims from the authenticated user, then re-resolve."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     series = get_object_or_404(
         Series.objects.active(), **{Series.public_id_field: public_id}
     )

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -25,7 +25,7 @@ from apps.provenance.helpers import active_claims, claims_prefetch
 from apps.provenance.rate_limits import (
     CREATE_RATE_LIMIT_SPEC,
     EDIT_RATE_LIMIT_SPEC,
-    check_and_record,
+    rate_limited,
 )
 from apps.provenance.schemas import RichTextSchema
 
@@ -232,12 +232,11 @@ def list_all_systems(request: HttpRequest) -> list[SystemListItemSchema]:
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_system_claims(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> SystemDetailSchema:
     """Assert per-field claims from the authenticated user, then re-resolve."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     system = get_object_or_404(
         System.objects.active(), **{System.public_id_field: public_id}
     )
@@ -267,6 +266,7 @@ def patch_system_claims(
     tags=["private"],
 )
 @requires(Activity.CATALOG_CREATE)
+@rate_limited(CREATE_RATE_LIMIT_SPEC)
 def create_system(
     request: HttpRequest, data: SystemCreateSchema
 ) -> Status[SystemDetailSchema]:
@@ -280,8 +280,6 @@ def create_system(
     required non-URL-nested FK (manufacturer) which the shared registrar
     doesn't express. Uses the same building blocks.
     """
-    check_and_record(request.user, CREATE_RATE_LIMIT_SPEC)
-
     name_field = System._meta.get_field("name")
     assert isinstance(name_field, models.Field)
     assert name_field.max_length is not None

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -19,7 +19,7 @@ from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
 from apps.core.schemas import RateLimitErrorSchema, ValidationErrorSchema
 from apps.provenance.helpers import claims_prefetch
-from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 from apps.provenance.schemas import RichTextSchema
 
 from ..models import (
@@ -186,9 +186,12 @@ def _patch_taxonomy(  # noqa: UP047
     public_id: str,
     data: ClaimPatchSchema,
 ) -> TaxonomySchema:
-    """Shared PATCH handler for all taxonomy entities."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
+    """Shared PATCH handler for all taxonomy entities.
 
+    Each calling route is decorated with ``@rate_limited(EDIT_RATE_LIMIT_SPEC)``
+    — keeping the bucket charge on the public route (not in this helper)
+    so the inventory walker can read the marker off ``op.view_func``.
+    """
     obj = get_object_or_404(
         model_class.objects.active(), **{model_class.public_id_field: public_id}
     )
@@ -339,6 +342,7 @@ def _bulk_title_counts_for_subgenerations(
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_technology_generation(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> TaxonomySchema:
@@ -398,6 +402,7 @@ def list_display_types(request: HttpRequest) -> list[DisplayTypeListItemSchema]:
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_display_type(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> TaxonomySchema:
@@ -422,6 +427,7 @@ technology_subgenerations_router = Router(tags=["technology-subgenerations"])
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_technology_subgeneration(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> TaxonomySchema:
@@ -446,6 +452,7 @@ display_subtypes_router = Router(tags=["display-subtypes"])
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_display_subtype(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> TaxonomySchema:
@@ -476,6 +483,7 @@ def list_cabinets(request: HttpRequest) -> list[TaxonomyWithTitleCountSchema]:
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_cabinet(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> TaxonomySchema:
@@ -508,6 +516,7 @@ def list_game_formats(request: HttpRequest) -> list[TaxonomyWithTitleCountSchema
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_game_format(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> TaxonomySchema:
@@ -571,11 +580,10 @@ def list_reward_types(request: HttpRequest) -> list[TaxonomyWithTitleCountSchema
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_reward_type(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> RewardTypeDetailSchema:
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     obj = get_object_or_404(
         RewardType.objects.active(), **{RewardType.public_id_field: public_id}
     )
@@ -613,6 +621,7 @@ def list_tags(request: HttpRequest) -> list[TaxonomyWithTitleCountSchema]:
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_tag(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> TaxonomySchema:
@@ -757,11 +766,10 @@ def list_credit_roles(request: HttpRequest) -> list[TaxonomySchema]:
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_credit_role(
     request: HttpRequest, public_id: str, data: ClaimPatchSchema
 ) -> CreditRoleDetailSchema:
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     obj = get_object_or_404(
         CreditRole.objects.active(), **{CreditRole.public_id_field: public_id}
     )

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -15,7 +15,7 @@ from apps.core.authz.types import Activity
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.schemas import RateLimitErrorSchema, ValidationErrorSchema
 from apps.provenance.helpers import active_claims, claims_prefetch
-from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 from apps.provenance.schemas import RichTextSchema
 
 from ..models import MachineModel, Theme
@@ -152,12 +152,11 @@ def list_themes(request: HttpRequest) -> list[ThemeListItemSchema]:
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_theme_claims(
     request: HttpRequest, public_id: str, data: HierarchyClaimPatchSchema
 ) -> ThemeDetailSchema:
     """Assert per-field claims from the authenticated user, then re-resolve."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     if not data.fields and data.parents is None and data.aliases is None:
         raise_form_error("No changes provided.")
 

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -49,7 +49,7 @@ from apps.provenance.rate_limits import (
     CREATE_RATE_LIMIT_SPEC,
     DELETE_RATE_LIMIT_SPEC,
     EDIT_RATE_LIMIT_SPEC,
-    check_and_record,
+    rate_limited,
 )
 from apps.provenance.schemas import (
     ChangeSetInputSchema,
@@ -977,12 +977,11 @@ def list_all_titles(request: HttpRequest) -> HttpResponse:
     tags=["private"],
 )
 @requires(Activity.CATALOG_EDIT)
+@rate_limited(EDIT_RATE_LIMIT_SPEC)
 def patch_title_claims(
     request: HttpRequest, public_id: str, data: TitleClaimPatchSchema
 ) -> TitleDetailSchema:
     """Assert title-owned claims and return the refreshed title detail."""
-    check_and_record(request.user, EDIT_RATE_LIMIT_SPEC)
-
     if not data.fields and data.abbreviations is None:
         raise_form_error("No changes provided.")
 
@@ -1035,6 +1034,7 @@ def patch_title_claims(
     tags=["private"],
 )
 @requires(Activity.CATALOG_CREATE)
+@rate_limited(CREATE_RATE_LIMIT_SPEC)
 def create_title(
     request: HttpRequest, data: EntityCreateInputSchema
 ) -> Status[TitleDetailSchema]:
@@ -1047,8 +1047,6 @@ def create_title(
 
     Rate-limited per user. Staff bypass.
     """
-    check_and_record(request.user, CREATE_RATE_LIMIT_SPEC)
-
     name = validate_name(data.name, max_length=MAX_CATALOG_NAME_LENGTH)
     slug = validate_slug_format(data.slug)
     _assert_title_name_available(name)
@@ -1082,6 +1080,7 @@ def create_title(
     tags=["private"],
 )
 @requires(Activity.CATALOG_CREATE)
+@rate_limited(CREATE_RATE_LIMIT_SPEC)
 def create_model(
     request: HttpRequest, title_public_id: str, data: EntityCreateInputSchema
 ) -> Status[ModelDetailSchema]:
@@ -1097,8 +1096,6 @@ def create_model(
     titles can legitimately share a model name (e.g. "Pro"). Slug
     uniqueness is global — the ``/models/{public_id}`` URL pattern requires it.
     """
-    check_and_record(request.user, CREATE_RATE_LIMIT_SPEC)
-
     title = get_object_or_404(
         Title.objects.active(), **{Title.public_id_field: title_public_id}
     )
@@ -1193,6 +1190,7 @@ def title_delete_preview(
     tags=["private"],
 )
 @requires(Activity.CATALOG_DELETE)
+@rate_limited(DELETE_RATE_LIMIT_SPEC)
 def delete_title(
     request: HttpRequest, public_id: str, data: ChangeSetInputSchema
 ) -> TitleDeleteResponseSchema | Status[SoftDeleteBlockedSchema | AlreadyDeletedSchema]:
@@ -1204,8 +1202,6 @@ def delete_title(
     active PROTECT referrer outside the cascade tree would be left
     dangling; the response body lists the referrers so the UI can explain.
     """
-    check_and_record(request.user, DELETE_RATE_LIMIT_SPEC)
-
     title = get_object_or_404(
         Title.objects.active(), **{Title.public_id_field: public_id}
     )
@@ -1248,6 +1244,7 @@ def delete_title(
     tags=["private"],
 )
 @requires(Activity.CATALOG_CREATE)
+@rate_limited(CREATE_RATE_LIMIT_SPEC)
 def restore_title(
     request: HttpRequest, public_id: str, data: ChangeSetInputSchema
 ) -> TitleDetailSchema | Status[ErrorDetailSchema]:
@@ -1259,8 +1256,6 @@ def restore_title(
     or the original delete ChangeSet is undone. Shares the ``create``
     rate-limit bucket (Restore is semantically a re-create).
     """
-    check_and_record(request.user, CREATE_RATE_LIMIT_SPEC)
-
     # Bypass .active() — we're looking for soft-deleted titles.
     title = get_object_or_404(Title, **{Title.public_id_field: public_id})
     if title.status != "deleted":

--- a/backend/apps/core/tests/test_openapi_boundaries.py
+++ b/backend/apps/core/tests/test_openapi_boundaries.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import re
 
 import pytest
 from ninja import Schema
 
+from apps.core.authz.route_walker import iter_operations
+from apps.provenance.rate_limits import get_rate_limit_spec
 from config.api import api
 
 ALLOWED_SUFFIXES = ("Schema", "Ref")
@@ -145,4 +148,49 @@ class TestMutatingEndpointsHave4xx:
             "error responses (ValidationErrorSchema, RateLimitErrorSchema, "
             "etc.) or add to NO_4XX_ALLOWLIST with justification: "
             f"{violations}"
+        )
+
+
+class TestRateLimitedEndpointsDeclare429:
+    """Every ``@rate_limited`` route must advertise ``429: RateLimitErrorSchema``.
+
+    The decorator can raise ``RateLimitExceededError`` → 429 at request
+    time, but the OpenAPI response map is hand-written on
+    ``@router.<verb>(... response={...})`` and the decorator can't
+    fabricate it. This boundary test makes the omission visible.
+    """
+
+    # `iter_operations` yields paths with Ninja's typed-converter syntax
+    # (`{path:public_id}`); OpenAPI strips the converter prefix
+    # (`{public_id}`). Match the OpenAPI form.
+    _STRIP_CONVERTER = re.compile(r"\{[^:}]+:([^}]+)\}")
+
+    def test_rate_limited_routes_declare_429(self):
+        paths = api.get_openapi_schema()["paths"]
+        missing: list[str] = []
+        for method, path, view in iter_operations(api):
+            if get_rate_limit_spec(view) is None:
+                continue
+            full_path = f"/api{self._STRIP_CONVERTER.sub(r'{\1}', path)}"
+            method_lc = method.lower()
+            responses = paths.get(full_path, {}).get(method_lc, {}).get("responses", {})
+            # Ninja keys the responses dict by int when registered via
+            # `response={429: ...}`; the rendered JSON OpenAPI doc keys
+            # by string. ``get_openapi_schema()`` returns the live dict
+            # (int keys today) — accept either so a future Ninja
+            # normalization doesn't silently report "missing 429"
+            # everywhere.
+            entry = responses.get(429) or responses.get("429") or {}
+            schema_ref = (
+                entry.get("content", {}).get("application/json", {}).get("schema", {})
+            )
+            ref = schema_ref.get("$ref", "")
+            if not ref.endswith("/RateLimitErrorSchema"):
+                missing.append(
+                    f"{method} {full_path} → {view.__module__}.{view.__qualname__}"
+                )
+        assert not missing, (
+            "These @rate_limited routes don't declare "
+            "`429: RateLimitErrorSchema` in their response map:\n  "
+            + "\n  ".join(missing)
         )

--- a/backend/apps/core/tests/test_route_inventory.py
+++ b/backend/apps/core/tests/test_route_inventory.py
@@ -24,9 +24,18 @@ from apps.core.authz.markers import (
     GATED_INLINE_ATTR,
     PUBLIC_ATTR,
     get_gated_inline_activity,
+    get_required_activity,
 )
 from apps.core.authz.route_walker import iter_operations
 from apps.core.authz.types import Activity
+from apps.provenance.rate_limits import (
+    CREATE_RATE_LIMIT_SPEC,
+    DELETE_RATE_LIMIT_SPEC,
+    EDIT_RATE_LIMIT_SPEC,
+    RateLimitSpec,
+    get_rate_limit_exempt_reason,
+    get_rate_limit_spec,
+)
 from config.api import api
 
 # `op.methods` from Ninja is uppercase. Do NOT reuse the lowercase
@@ -177,4 +186,77 @@ def test_gated_inline_routes_call_enforce_or_check() -> None:
         "@gated_inline routes whose body never calls enforce()/check() — "
         "the marker is informational; the view body must invoke the "
         "policy or the route is silently ungated:\n  " + "\n  ".join(missing)
+    )
+
+
+# Activities whose mutating routes MUST carry @rate_limited (or
+# @rate_limit_exempt). The mapping below dictates which bucket each
+# activity charges — adding a new activity here forces every matching
+# route to declare a bucket or an exemption, and is a deliberate policy
+# decision rather than an emergent default.
+EXPECTED_BUCKET_FOR_ACTIVITY: dict[Activity, RateLimitSpec] = {
+    Activity.CATALOG_CREATE: CREATE_RATE_LIMIT_SPEC,
+    Activity.CATALOG_EDIT: EDIT_RATE_LIMIT_SPEC,
+    Activity.CATALOG_DELETE: DELETE_RATE_LIMIT_SPEC,
+}
+
+
+def _route_activity(view: object) -> Activity | None:
+    """Return the rate-limit-relevant activity stamped on the view, if any.
+
+    Walks both ``@requires`` and ``@gated_inline``. Today's relevant set
+    (CATALOG_CREATE/EDIT/DELETE) only overlaps with ``@requires`` routes;
+    consulting both anyway future-proofs us against adding e.g.
+    CITATION_EDIT when some citation routes are gated inline.
+    """
+    return get_required_activity(view) or get_gated_inline_activity(view)
+
+
+def test_rate_limit_relevant_routes_are_classified() -> None:
+    """Every mutating route gated by a rate-limit-relevant activity
+    must carry @rate_limited(spec) or @rate_limit_exempt(reason), and
+    the spec must match the bucket the activity dictates.
+
+    Mirrors ``test_every_mutating_route_is_classified`` — presence of a
+    rate-limit marker on the route is mandatory; correctness of the
+    bucket is mandatory too (catches the
+    ``@rate_limited(CREATE_RATE_LIMIT_SPEC)``-on-an-edit-route typo).
+    """
+    unclassified: list[str] = []
+    wrong_bucket: list[str] = []
+    for method, path, view in iter_operations(api):
+        if method not in MUTATING_METHODS:
+            continue
+        activity = _route_activity(view)
+        if activity is None or activity not in EXPECTED_BUCKET_FOR_ACTIVITY:
+            continue
+
+        route_id = f"{method} {path} → {view.__module__}.{view.__qualname__}"
+        spec = get_rate_limit_spec(view)
+        exempt_reason = get_rate_limit_exempt_reason(view)
+
+        if spec is None and exempt_reason is None:
+            unclassified.append(f"{route_id} (activity={activity.value})")
+            continue
+        if spec is not None and exempt_reason is not None:
+            wrong_bucket.append(
+                f"{route_id}: route is both @rate_limited and "
+                f"@rate_limit_exempt — pick one"
+            )
+            continue
+        if spec is not None:
+            expected = EXPECTED_BUCKET_FOR_ACTIVITY[activity]
+            if spec != expected:
+                wrong_bucket.append(
+                    f"{route_id}: activity={activity.value} expects "
+                    f"bucket={expected.bucket!r}, got bucket={spec.bucket!r}"
+                )
+
+    assert not unclassified, (
+        "Rate-limit-relevant mutating routes missing @rate_limited / "
+        "@rate_limit_exempt:\n  " + "\n  ".join(unclassified)
+    )
+    assert not wrong_bucket, (
+        "Rate-limit bucket disagrees with route activity (or route is "
+        "double-stamped):\n  " + "\n  ".join(wrong_bucket)
     )

--- a/backend/apps/provenance/rate_limits.py
+++ b/backend/apps/provenance/rate_limits.py
@@ -16,17 +16,31 @@ Semantics:
   predicate is no longer this file's concern. Look in
   ``core/authz/rules.py`` to change who is exempt.
 * Both successful and validation-rejected attempts consume a slot. The
-  consuming call is :func:`check_and_record` and endpoints invoke it once at
-  the top of the request.
+  consuming call is :func:`check_and_record`; mutating routes invoke it
+  declaratively via :func:`rate_limited` (once per request, before the
+  route body runs), or — for inline cases — at the top of the body.
 * 429 refusals do NOT consume a slot. If a rejection bumped the horizon
   forward on every retry, the window would never drain.
+
+Inventory contract (see ``apps/core/tests/test_route_inventory.py``):
+the rate-limit bucket a route consumes is dictated 1:1 by the route's
+``@requires`` (or ``@gated_inline``) activity — ``CATALOG_CREATE`` →
+``CREATE_RATE_LIMIT_SPEC``, ``CATALOG_EDIT`` → ``EDIT_RATE_LIMIT_SPEC``,
+``CATALOG_DELETE`` → ``DELETE_RATE_LIMIT_SPEC``. There is no override
+table; the inventory test fails if a route's stamped spec disagrees
+with its activity. To exempt a mutating route gated by one of these
+activities, stamp ``@rate_limit_exempt(reason)`` instead.
 """
 
 from __future__ import annotations
 
+import functools
 import math
 import time
+import types
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TypeVar, cast
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.core.cache import cache
@@ -144,3 +158,95 @@ def check_and_record(
 def reset_for_user(user: AbstractBaseUser, bucket: str) -> None:
     """Test helper: clear a user's bucket."""
     cache.delete(_cache_key(user.pk, bucket))
+
+
+# ── Decorators ───────────────────────────────────────────────────────
+#
+# Mirror ``apps.core.authz.markers``: a wrapping decorator that both
+# enforces at request time and stamps a marker the inventory walker can
+# read off the wrapped callable. The ``FunctionType`` rebuild trick is
+# the same one ``@requires`` uses — Ninja resolves forward-ref
+# annotations through ``view.__globals__``, and a plain wrapper would
+# carry *this* module's globals, breaking annotation resolution for
+# closure-built views (e.g. the ``entity_crud`` factory).
+
+F = TypeVar("F", bound=Callable[..., object])
+
+RATE_LIMITED_ATTR = "_rate_limit_spec"
+RATE_LIMIT_EXEMPT_ATTR = "_rate_limit_exempt"
+
+
+def rate_limited(spec: RateLimitSpec) -> Callable[[F], F]:
+    """Wrap the view to consume one slot in `spec` and stamp the marker.
+
+    Must be inside ``@router.<verb>`` (Ninja registers the wrapped
+    callable). Either order relative to ``@requires`` works at runtime
+    — markers propagate through ``update_wrapper``'s ``__dict__`` copy
+    in both directions; pick one order per file for readability.
+    """
+
+    def decorator(func: F) -> F:
+        # Promote ``check_and_record`` from a global into a closure cell.
+        # Load-bearing: the wrapper below is rebuilt with ``func.__globals__``
+        # (the view's module), which doesn't import ``check_and_record`` —
+        # a bare global reference would NameError at request time. Mirrors
+        # ``_enforce = enforce`` in ``apps.core.authz.markers.requires``.
+        _check_and_record = check_and_record
+
+        def template(request, *args, **kwargs):  # type: ignore[no-untyped-def]
+            _check_and_record(request.user, spec)
+            return func(request, *args, **kwargs)
+
+        # See ``apps.core.authz.markers.requires`` for the rationale —
+        # rebuild the wrapper with the wrapped function's globals so
+        # Ninja's forward-ref annotation resolution still works for
+        # closure-built views.
+        wrapper = types.FunctionType(
+            template.__code__,
+            func.__globals__,
+            name=template.__name__,
+            argdefs=template.__defaults__,
+            closure=template.__closure__,
+        )
+        functools.update_wrapper(wrapper, func)
+        setattr(wrapper, RATE_LIMITED_ATTR, spec)
+        return cast(F, wrapper)
+
+    return decorator
+
+
+def rate_limit_exempt(reason: str) -> Callable[[F], F]:
+    """Declare a mutating route as deliberately not rate-limited.
+
+    `reason` is required and must be non-empty after `.strip()` — an
+    empty or whitespace-only rationale fails at decoration time so a
+    missing reason can't slip into the inventory output. Mirrors
+    ``@public_mutation``.
+    """
+    if not isinstance(reason, str) or not reason.strip():
+        raise ValueError(
+            "@rate_limit_exempt requires a non-empty reason string. "
+            "The reason is captured in the inventory output so a future "
+            "reviewer can audit 'do we still want this exempt?'."
+        )
+
+    def decorator(func: F) -> F:
+        setattr(func, RATE_LIMIT_EXEMPT_ATTR, reason)
+        return func
+
+    return decorator
+
+
+# ── Typed marker read accessors ──────────────────────────────────────
+
+
+def get_rate_limit_spec(view: object) -> RateLimitSpec | None:
+    """Return the ``RateLimitSpec`` stamped by ``@rate_limited``, or ``None``."""
+    value = getattr(view, RATE_LIMITED_ATTR, None)
+    return value if isinstance(value, RateLimitSpec) else None
+
+
+def get_rate_limit_exempt_reason(view: object) -> str | None:
+    """Return the rationale stamped by ``@rate_limit_exempt``, or ``None``."""
+    value = getattr(view, RATE_LIMIT_EXEMPT_ATTR, None)
+    return value if isinstance(value, str) else None

--- a/backend/apps/provenance/tests/test_rate_limits.py
+++ b/backend/apps/provenance/tests/test_rate_limits.py
@@ -9,12 +9,19 @@ import pytest
 from django.core.cache import cache
 
 from apps.accounts.test_factories import make_user
+from apps.core.authz.markers import get_required_activity, requires
+from apps.core.authz.types import Activity
 from apps.provenance.rate_limits import (
     CREATE_RATE_LIMIT_SPEC,
     DELETE_RATE_LIMIT_SPEC,
+    EDIT_RATE_LIMIT_SPEC,
     RateLimitExceededError,
     RateLimitSpec,
     check_and_record,
+    get_rate_limit_exempt_reason,
+    get_rate_limit_spec,
+    rate_limit_exempt,
+    rate_limited,
     reset_for_user,
 )
 
@@ -148,6 +155,122 @@ class TestBucketConfig:
             check_and_record(user, DELETE_RATE_LIMIT_SPEC)
         reset_for_user(user, CREATE_RATE_LIMIT_SPEC.bucket)
         reset_for_user(user, DELETE_RATE_LIMIT_SPEC.bucket)
+
+
+class TestEditBucketConfig:
+    def test_edit_bucket_is_60_per_hour(self):
+        assert EDIT_RATE_LIMIT_SPEC.bucket == "edit"
+        assert EDIT_RATE_LIMIT_SPEC.limit == 60
+        assert EDIT_RATE_LIMIT_SPEC.window_seconds == 3_600
+
+    def test_edit_bucket_is_independent_of_create_and_delete(self, user):
+        for _ in range(CREATE_RATE_LIMIT_SPEC.limit):
+            check_and_record(user, CREATE_RATE_LIMIT_SPEC)
+        for _ in range(DELETE_RATE_LIMIT_SPEC.limit):
+            check_and_record(user, DELETE_RATE_LIMIT_SPEC)
+        # Filling create + delete leaves edit fully available.
+        check_and_record(user, EDIT_RATE_LIMIT_SPEC)
+        reset_for_user(user, CREATE_RATE_LIMIT_SPEC.bucket)
+        reset_for_user(user, DELETE_RATE_LIMIT_SPEC.bucket)
+        reset_for_user(user, EDIT_RATE_LIMIT_SPEC.bucket)
+
+
+class _Req:
+    """Minimal request stand-in carrying ``.user`` only."""
+
+    def __init__(self, user):
+        self.user = user
+
+
+class TestRateLimitedDecorator:
+    """Unit tests for the @rate_limited decorator itself."""
+
+    def test_charges_the_bucket_per_request(self, user):
+        spec = RateLimitSpec(bucket="dec_charge", limit=2, window_seconds=60)
+
+        @rate_limited(spec)
+        def view(request):
+            return "ok"
+
+        try:
+            assert view(_Req(user)) == "ok"
+            assert view(_Req(user)) == "ok"
+            with pytest.raises(RateLimitExceededError) as exc:
+                view(_Req(user))
+            assert exc.value.bucket == "dec_charge"
+        finally:
+            reset_for_user(user, spec.bucket)
+
+    def test_stamps_marker_readable_via_accessor(self):
+        spec = RateLimitSpec(bucket="dec_stamp", limit=1, window_seconds=60)
+
+        @rate_limited(spec)
+        def view(request):
+            return None
+
+        assert get_rate_limit_spec(view) is spec
+
+    def test_stacking_with_requires_propagates_both_markers(self):
+        """Pin the `update_wrapper.__dict__` propagation the inventory
+        walker relies on. If a future refactor of ``@requires`` drops
+        ``WRAPPER_UPDATES`` (the ``__dict__`` copy), the outer marker
+        would silently disappear and only this test would catch it."""
+        spec = RateLimitSpec(bucket="dec_stack", limit=1, window_seconds=60)
+
+        @requires(Activity.CATALOG_EDIT)
+        @rate_limited(spec)
+        def view_a(request):
+            return None
+
+        @rate_limited(spec)
+        @requires(Activity.CATALOG_EDIT)
+        def view_b(request):
+            return None
+
+        # Both orders: the outermost callable carries BOTH markers.
+        for view in (view_a, view_b):
+            assert get_required_activity(view) == Activity.CATALOG_EDIT
+            assert get_rate_limit_spec(view) is spec
+
+
+class TestRateLimitExemptDecorator:
+    def test_stamps_reason_readable_via_accessor(self):
+        @rate_limit_exempt("undo inverts an existing changeset")
+        def view(request):
+            return None
+
+        assert get_rate_limit_exempt_reason(view) == (
+            "undo inverts an existing changeset"
+        )
+
+    def test_stacking_with_requires_propagates_both_markers(self):
+        """Unlike ``@rate_limited``, ``@rate_limit_exempt`` doesn't wrap —
+        it just ``setattr``s on the original function. When stacked under
+        ``@requires`` (which rebuilds the function via ``FunctionType``),
+        the exempt marker must still reach the outermost callable via
+        ``update_wrapper``'s ``__dict__`` copy. Pin that, so the first
+        caller doesn't trip a silent regression."""
+
+        @requires(Activity.CATALOG_EDIT)
+        @rate_limit_exempt("test")
+        def view(request):
+            return None
+
+        assert get_required_activity(view) == Activity.CATALOG_EDIT
+        assert get_rate_limit_exempt_reason(view) == "test"
+
+    def test_empty_reason_rejected_at_decoration_time(self):
+        with pytest.raises(ValueError, match="non-empty reason"):
+
+            @rate_limit_exempt("")
+            def view_a(request):
+                return None
+
+        with pytest.raises(ValueError, match="non-empty reason"):
+
+            @rate_limit_exempt("   ")
+            def view_b(request):
+                return None
 
 
 # Silence time.sleep warnings in case any test uses real time.


### PR DESCRIPTION
## Summary

This closes the structural gap that permitted the edit-bucket-not-wired bug fixed in #452: wiring is now declarative and CI-enforced.

This replaces 27 imperative `check_and_record(...)` calls at the top of catalog mutating routes with `@rate_limited(spec)` decorators, and adds an inventory test that fails if a mutating route gated by `CATALOG_CREATE`/`EDIT`/`DELETE` is missing a rate-limit marker or carries the wrong bucket. 

- `@rate_limited(spec)` / `@rate_limit_exempt(reason)` mirror `@requires` / `@public_mutation` (FunctionType rebuild + `update_wrapper`, typed accessors).
- New `test_rate_limit_relevant_routes_are_classified` enforces 1:1 `activity → bucket`; no override table. Walks both `@requires` and `@gated_inline`.
- New OpenAPI boundary check asserts every `@rate_limited` route declares `429: RateLimitErrorSchema`.
- Stacking unit tests pin `update_wrapper.__dict__` marker propagation for both `@rate_limited` (wrapping) and `@rate_limit_exempt` (setattr-only).
- Migration covers 20 PATCH-claim + 7 create/delete/restore routes across 13 catalog modules. `entity_crud.py` factory wraps `_create_*` / `_delete` / `_restore` programmatically.

## Test plan

- [x] `make mypy` — clean (420 files)
- [x] `make lint` — clean
- [x] `make test` — 2871 backend + 1282 frontend pass
- [x] `make api-gen` + `make quality` — clean
- [x] Inventory test red→green during dev: 27 routes flagged red, all green post-migration
- [x] OpenAPI boundary test caught two real bugs during dev (Ninja path-converter syntax, int response keys)
- [ ] Manual: PATCH a record 61 times as non-staff → 61st returns 429 with `bucket: "edit"`; staff bypass
- [ ] Manual: delete + restore a record → restore consumes **create** bucket, not edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)