### PR TITLE
docs(seo): add SEO plan docs

### DIFF
--- a/docs/plans/seo/CanonicalUrl.md
+++ b/docs/plans/seo/CanonicalUrl.md
@@ -1,0 +1,94 @@
+# Canonical URL
+
+This is the plan for emitting `<link rel="canonical" href="...">` on every indexable page, so search engines consolidate ranking signals on one authoritative URL when the same content is reachable via multiple paths (trailing-slash variants, query-string variants, scheme/host variants).
+
+Addresses the "canonical URLs" concern in [`SearchEngines.md`](SearchEngines.md).
+
+## Scope — what this plan does and doesn't cover
+
+**In scope:** a `<link rel="canonical">` tag in the root layout, pointing to the normalized URL for the current page.
+
+**Out of scope (already handled elsewhere):**
+
+- **Single-Model-Title duplication.** The `/models/[slug]` route already 301-redirects to the Title route when the parent Title has exactly one Model. A 301 collapses the duplicate at the HTTP layer and consolidates signals on the target; canonical tags are not load-bearing for this case. `ModelSitemapFeed` also excludes these Models per [`Sitemap.md`](Sitemap.md).
+- **Slug renames.** Handled by 301 redirects in the slug-edit flow per the "URL stability across slug changes" concern in [`SearchEngines.md`](SearchEngines.md).
+- **Faceted/paginated listing URLs** (`?page=2`, `?manufacturer=stern`). Tracked as a separate concern in [`SearchEngines.md`](SearchEngines.md); the canonical strategy there (canonicalize filters back to the base listing vs. `noindex` filter combinations) needs its own decision and may end up using this same `<link rel="canonical">` mechanism with route-specific rules.
+
+What's left for this plan: mechanical canonicalization — strip the query string, normalize the trailing slash, ensure the canonical href uses the production origin (not the request host).
+
+## Dependency
+
+None hard. Slots in alongside [`NoindexMeta.md`](NoindexMeta.md) — both are root-layout `<svelte:head>` SEO tags driven by `page.url` / `page.route.id`. Land either order.
+
+## Goals
+
+- Every indexable page emits exactly one `<link rel="canonical">` pointing to the normalized URL.
+- Canonical href always uses `SITE_ORIGIN`, never the request host — so a request to a preview origin or an unexpected hostname still points search engines at production.
+- Query strings are stripped by default; routes that legitimately use query params for distinct content opt in.
+- Non-indexable routes don't emit a canonical (they're already `noindex` per [`NoindexMeta.md`](NoindexMeta.md); a canonical would be noise).
+
+## Mechanism
+
+Inject in the root `+layout.svelte` next to the noindex meta. Both are driven by the same `page` state.
+
+```svelte
+<!-- frontend/src/routes/+layout.svelte -->
+<script lang="ts">
+  import { page } from '$app/state';
+  import { isIndexable } from '$lib/route-metadata';
+  import { canonicalUrl } from '$lib/seo/canonical';
+
+  let indexable = $derived(isIndexable(page.route.id));
+  let canonical = $derived(indexable ? canonicalUrl(page.url, page.route.id) : null);
+</script>
+
+<svelte:head>
+  {#if canonical}
+    <link rel="canonical" href={canonical} />
+  {/if}
+  <!-- noindex meta from NoindexMeta.md -->
+</svelte:head>
+```
+
+`canonicalUrl(url, routeId)` lives in `frontend/src/lib/seo/canonical.ts`:
+
+- Replace the origin with `SITE_ORIGIN` (read via `$env/static/public` so it's available in CSR too — the SSR-only `$env/static/private` would break client-side rerenders).
+- Normalize the trailing slash to the project's convention (no trailing slash, matching SvelteKit defaults).
+- Drop the query string and fragment by default.
+- Per-route opt-in for preserved query params: a small `CANONICAL_QUERY_PARAMS` map keyed by route ID listing the params that contribute to canonical identity (e.g. paginated listings might keep `?page=`). Empty by default; populated only when a route needs it.
+
+## What gets a canonical
+
+Every route where `isIndexable(routeId) === true`. Non-indexable routes get `noindex` instead and don't need a canonical.
+
+## Gate on `ALLOW_SEARCH_ENGINE_INDEXING`?
+
+No. Same reasoning as [`NoindexMeta.md`](NoindexMeta.md) § "Gate on `ALLOW_SEARCH_ENGINE_INDEXING`?" — on non-prod deploys, robots.txt's `Disallow: /` already keeps crawlers out; the canonical tag is harmless redundancy. Unconditional emission keeps local testing trivial.
+
+## Tests
+
+`frontend/src/routes/+layout.dom.test.ts` (or a new `canonical.dom.test.ts`):
+
+- Render an indexable route with no query string → canonical equals `${SITE_ORIGIN}${pathname}`.
+- Render an indexable route with a query string → canonical strips the query.
+- Render an indexable route reached via a non-prod request host → canonical still uses `SITE_ORIGIN`.
+- Render a non-indexable route → no `<link rel="canonical">` is present.
+
+Unit tests for `canonicalUrl()` cover trailing-slash normalization and the per-route query-param allowlist when one is added.
+
+## Implementation order
+
+1. `frontend/src/lib/seo/canonical.ts` — pure function, unit-tested.
+2. Add the `<svelte:head>` block to `frontend/src/routes/+layout.svelte`.
+3. DOM test per § "Tests".
+4. Verify locally: `curl -s localhost:5173/titles | grep canonical` and `curl -s 'localhost:5173/titles?foo=bar' | grep canonical` both show the canonical path with no query.
+
+## Considered alternatives
+
+- **Use `page.url.href` directly.** Rejected: bakes in the request host and query string, so a request to a preview origin or with a tracking param would emit a wrong canonical.
+- **Per-page `<svelte:head>` blocks in each indexable route.** Rejected for the same reason as in [`NoindexMeta.md`](NoindexMeta.md): centralizing in the root layout means a new route inherits correct behavior without per-page wiring.
+- **Fold into `NoindexMeta.md` and rename it `HeadSeoTags.md`.** Considered — same mechanism, same test file, both driven by `isIndexable()`. Rejected to keep each plan single-purpose and matching the existing `seo/` directory pattern.
+
+## Open questions
+
+None.

--- a/docs/plans/seo/NoindexMeta.md
+++ b/docs/plans/seo/NoindexMeta.md
@@ -1,0 +1,92 @@
+# Noindex Meta Tag
+
+This is the plan for injecting `<meta name="robots" content="noindex">` on every non-indexable route, so user-facing pages we don't want in search results (`/login`, `/search`, `/style-lab`, `*/edit`, etc.) stay out of Google's index even when crawlers reach them via inbound links.
+
+Addresses the "keeping non-indexable user-facing pages out of the index" concern in [`SearchEngines.md`](SearchEngines.md); see that doc for how this fits with robots.txt and sitemap.
+
+## Dependency
+
+This plan consumes [`RouteWalking.md`](RouteWalking.md) — the per-route `searchEngineInclusion` export, the walker primitives in `frontend/src/lib/route-metadata.ts`, and the `isIndexable(routeId)` predicate. Land that first.
+
+## Why per-page noindex, not robots.txt `Disallow`
+
+Per [Google's current guidance](https://developers.google.com/search/docs/crawling-indexing/block-indexing): robots.txt is for crawl-traffic management, not index exclusion. A page `Disallow`-ed in robots.txt can still appear in search results (URL + anchor text, no snippet) if anything links to it. The recommended mechanism for "do not index this page" is per-page `<meta name="robots" content="noindex">`.
+
+The two are also mutually exclusive: if a URL is `Disallow`-ed in robots.txt, Googlebot can't crawl it and so never sees the `noindex` meta. So for user-facing pages we explicitly want crawled (so the meta is seen) but not indexed.
+
+See [`SearchEngines.md`](SearchEngines.md) § "Why the split between robots.txt and noindex" for the full mapping.
+
+## Goals
+
+- Every non-indexable user-facing page emits `<meta name="robots" content="noindex">` in its `<head>`.
+- The decision is driven by the same `isIndexable(routeId)` predicate the sitemap uses — no parallel list, no drift.
+- Adding a new non-indexable route requires only the existing `searchEngineInclusion = 'excluded'` export; the meta tag follows automatically.
+
+## Mechanism
+
+Inject in the root `+layout.svelte` so it covers every route:
+
+```svelte
+<!-- frontend/src/routes/+layout.svelte -->
+<script lang="ts">
+  import { page } from '$app/state';
+  import { isIndexable } from '$lib/route-metadata';
+
+  let noindex = $derived(!isIndexable(page.route.id));
+</script>
+
+<svelte:head>
+  {#if noindex}
+    <meta name="robots" content="noindex" />
+  {/if}
+</svelte:head>
+
+<!-- ...existing layout body... -->
+```
+
+Notes:
+
+- `page.route.id` is the SvelteKit route ID (e.g. `/titles/[slug]`), which is the same shape `isIndexable()` already operates on — no translation needed.
+- Auth-gated routes get the meta tag too. They're already invisible to crawlers (the layout redirects unauthenticated requests), but defense in depth is cheap: if anything ever serves an auth-gated page bytes to a logged-out crawler, the meta still says noindex.
+- Use `<meta name="robots">`, not `<meta name="googlebot">` — the generic form covers Google, Bing, and other compliant crawlers in one tag.
+
+## What gets the meta tag
+
+Every route where `isIndexable(routeId) === false`. With current routes:
+
+- Auth-gated (anything under a `requireCapability` layout): `/a/*`, plus catalog edit subroutes once they have such a layout.
+- Declared `searchEngineInclusion = 'excluded'`: `/login`, `/signup`, `/verify-email`, `/auth/*`, `/search`, `/kiosk/*`, `/style-lab`, `/api-docs`, `/_sentry_test`, `/changesets/*`, `/review/*`, and the catalog edit subroutes (`/*/edit`, `/*/edit-history`, `/*/sources`, `/*/new`) until/unless they get a `requireCapability` layout.
+
+The list isn't enumerated in this doc — it's whatever `isIndexable()` returns false for, and the route-walking test (per [`RouteWalking.md`](RouteWalking.md)) already enforces that every route declares its classification.
+
+## Gate on `ALLOW_SEARCH_ENGINE_INDEXING`?
+
+No. The meta tag should be emitted on every deploy regardless of whether indexing is allowed at the deploy level. Reasoning:
+
+- On non-prod deploys (`ALLOW_SEARCH_ENGINE_INDEXING != "true"`), robots.txt already says `Disallow: /` and crawlers shouldn't be looking at any page. The meta is redundant but harmless.
+- Tying the meta to the env var adds a branch to the layout for no behavioral benefit and one more failure mode (e.g. forgetting to thread the var into SSR context).
+- Keeping the meta unconditional makes local testing trivial: visit any non-indexable route and view source.
+
+## Tests
+
+`frontend/src/routes/+layout.dom.test.ts` (or a new `noindex-meta.dom.test.ts` alongside):
+
+- Render the layout for an indexable route (`/titles`) and assert no `<meta name="robots">` is present.
+- Render for a non-indexable declared route (`/login`) and assert `<meta name="robots" content="noindex">` is present.
+- Render for an auth-gated route (`/a/dashboard`) and assert the meta is present.
+
+The test parameterizes over the same anchor routes used in `RouteWalking.md`'s sanity check — keeps both tests honest if the route classifications drift.
+
+## Implementation order
+
+1. Add the `<svelte:head>` block to `frontend/src/routes/+layout.svelte`. Roughly five lines.
+2. Add the dom test per § "Tests".
+3. Verify locally: `curl -s localhost:5173/login | grep robots` shows the meta; same for `/titles` shows nothing.
+
+That's the whole PR. Tiny.
+
+## Considered alternatives
+
+- **`X-Robots-Tag: noindex` HTTP response header instead of a meta tag.** Equivalent in effect; required for non-HTML responses (PDFs, images). For HTML pages we control, the meta tag is simpler — no SvelteKit `setHeaders` plumbing, just markup. Revisit if we ever serve non-HTML responses that need excluding.
+- **Per-route `<svelte:head>` blocks in each excluded page.** Rejected: would silently miss any new non-indexable route until a reviewer noticed. Centralizing the decision in the root layout means "well-classified" automatically implies "correctly headed."
+- **Folding into `Robots.md`.** Rejected: different mechanism (HTML markup vs. text file), different consumer (per-request render vs. static file), different testing surface. Sharing the `isIndexable()` predicate is enough integration.

--- a/docs/plans/seo/Robots.md
+++ b/docs/plans/seo/Robots.md
@@ -1,0 +1,109 @@
+# robots.txt
+
+This is the plan for introducing `robots.txt` to the project. SvelteKit owns public pages, so the file lives there as a `+server.ts` endpoint. Two jobs: gate non-prod deploys from crawlers entirely (via the `ALLOW_SEARCH_ENGINE_INDEXING` env var), and tell crawlers not to fetch non-page server endpoints (`/api/`, `/djadmin/`, `/_sentry_test`).
+
+Addresses the "gating non-prod deploys" and "crawler traffic for non-page paths" concerns in [`SearchEngines.md`](SearchEngines.md); per-page index exclusion lives in [`NoindexMeta.md`](NoindexMeta.md), and the affirmative "what to index" signal lives in [`Sitemap.md`](Sitemap.md).
+
+## Dependency
+
+This plan consumes [`RouteWalking.md`](RouteWalking.md) — the route-metadata primitive that other consumers in the SEO strategy share. robots.txt itself only needs the env-var gate and a small static list of non-page paths, but landing on top of RouteWalking keeps the directory's dependency story straight.
+
+## Scope — what robots.txt is and isn't for
+
+Per [Google's current guidance](https://developers.google.com/search/docs/crawling-indexing/robots/intro): **robots.txt is for managing crawl traffic, not for keeping pages out of the index.** A URL `Disallow`-ed in robots.txt can still appear in Google results (URL + anchor text, no snippet) if anything links to it. The recommended mechanism for "do not index this page" is per-page `<meta name="robots" content="noindex">`, covered in [`NoindexMeta.md`](NoindexMeta.md).
+
+Concretely:
+
+- **In scope for robots.txt:**
+  - Non-prod deploys → `Disallow: /` to keep crawlers off the deploy entirely (preview/staging have no external inbound links, so crawl-block is sufficient).
+  - Non-page server endpoints (`/api/`, `/djadmin/`, `/_sentry_test`) → `Disallow:` to prevent crawl traffic against them.
+- **Out of scope (handled in `NoindexMeta.md`):** user-facing pages we want kept out of the index (`/login`, `/signup`, `/search`, `/kiosk/*`, `/*/edit`, …). These are real pages with potential inbound links; we want crawlers to fetch them (so they see the `noindex` meta) but not index them. Putting them in robots.txt `Disallow` would actively prevent the noindex from working.
+
+## Goals
+
+- Don't accidentally index preview/staging deploys — a missing or wrong flag must fail safe (un-indexed), not leak.
+- Keep crawlers off non-page server endpoints.
+- Keep robots.txt small and static — the production body is a fixed list of server-endpoint paths, not a derived projection of the route tree.
+
+## 1. Per-deployment indexability signal
+
+Whether a given deploy should be crawled is a deploy-identity question, and the answer needs to stay correct as we add environments (preview, staging, future prod-like services). The constraints we're designing against:
+
+- **Preview/staging must not leak into Google.** A preview deploy with an `https://` origin and `DEBUG=false` looks production-shaped to any heuristic — sniffing `SITE_ORIGIN` for a hostname or keying off `NODE_ENV` will silently misclassify it.
+- **Read-time default must be off.** If the flag is ever read without being set — local dev, a misconfigured env, an emergency rollback that drops env vars — the safe outcome is "not indexable." Production is the one place that opts in.
+- **Deploys must declare intent.** A new preview service that ships without the flag set is exactly the leak we're trying to prevent. The read-time default protects against accidents at runtime; a deploy-time check forces the operator to make the call before the service goes live.
+- **Typos must fail safe.** `"True"` or `"1"` quietly disabling indexing on prod is a much better failure than the reverse.
+- **The signal has to be readable from SvelteKit (Node).** `robots.txt` is a SvelteKit endpoint, so the source of truth needs to be available without a Django round-trip per request.
+
+A single opt-in env var satisfies all four — production explicitly turns it on, every other environment (local dev, preview, staging, future services) inherits the safe default with no config.
+
+### Mechanism
+
+- `ALLOW_SEARCH_ENGINE_INDEXING` — an env var, set by a human operator in each environment's config (Railway's service settings for deployed envs, a developer's local `.env` for local dev). Nothing auto-detects or auto-populates the value. Read-time default when unset is off. Operators set it to `true` on the production Railway service, `false` on every other deployed environment (preview, staging), and either value (or unset) locally — only set locally when a developer wants to test the corresponding `robots.txt` output.
+- Read via a tiny `lib/server/search-engine-indexable.ts` helper so the rule is single-sourced (and reusable by the sitemap endpoint in [`Sitemap.md`](Sitemap.md)). Parse strictly: only the literal string `"true"` enables indexing; anything else (including `""`, `"1"`, `"yes"`, `"True"`) is treated as off.
+- Document in `.env.example` as commented-out, with a note that local dev defaults to off and only needs setting for testing.
+- A deploy check (see § 3) enforces the stronger rule under `manage.py check --deploy`: the value MUST be present and MUST be the literal `"true"` or `"false"`. Local `make dev` never trips this — the requirement applies only to real deploys, where forgetting to declare intent on a new preview service is the failure mode we care about.
+
+## 2. robots.txt contents
+
+> **Do not add user-facing routes (`/login`, `/search`, `/*/edit`, etc.) to this list** — they're handled by per-page `noindex` meta per [`NoindexMeta.md`](NoindexMeta.md). Adding a `Disallow:` for them blocks crawling, which means Googlebot never sees the `noindex` and the URL can still appear in results via inbound links.
+
+When `ALLOW_SEARCH_ENGINE_INDEXING != "true"`:
+
+```text
+User-agent: *
+Disallow: /
+```
+
+When `ALLOW_SEARCH_ENGINE_INDEXING == "true"`:
+
+```text
+User-agent: *
+Disallow: /api/
+Disallow: /djadmin/
+Disallow: /_sentry_test
+```
+
+The production list is intentionally short: only paths that are server endpoints (not user-facing pages). User-facing non-indexable pages — `/login`, `/signup`, `/search`, `/kiosk/*`, `/*/edit`, etc. — are kept out of the index via per-page `<meta name="robots" content="noindex">` per [`NoindexMeta.md`](NoindexMeta.md), not via robots.txt `Disallow`. Putting them here would block crawlers from ever seeing the `noindex` meta, leaving them visible in search results via inbound links.
+
+The `Sitemap:` line is intentionally absent in this PR; [`Sitemap.md`](Sitemap.md) adds it once `/sitemap.xml` exists.
+
+### Deployment routing
+
+No Caddyfile changes needed. The current `@django` matcher in `Caddyfile` only catches `/api`, `/djadmin`, `/media`, `/static`, so `/robots.txt` routes to SvelteKit (Node, port 3000) by default.
+
+## 3. Deploy validation — `ALLOW_SEARCH_ENGINE_INDEXING`
+
+Validated at the earliest point it's consumed (deploy/runtime). Pattern and conventions per `docs/DeployChecks.md`.
+
+Frontend env vars are validated in Python because backend and frontend share the Railway env (per `docs/DeployChecks.md` § "Frontend checks belong in Python"). Add to `backend/apps/core/checks.py` (alongside `check_observability_env`):
+
+- **`ALLOW_SEARCH_ENGINE_INDEXING`** — `@register(Tags.security, deploy=True)` check that errors when `ALLOW_SEARCH_ENGINE_INDEXING` is empty, and errors when set to anything other than the literal `"true"` or `"false"`. Every deployed environment must declare its intent (catches the new-preview-service-leaks-into-Google failure mode) and the strict-shape rule catches typos like `"True"` or `"1"` that would silently leave production un-indexed. Local dev is unaffected: the check is `deploy=True`, so it only runs under `manage.py check --deploy`. New error ids `core.E303` (missing) and `core.E304` (malformed).
+
+Tests in `backend/apps/core/tests/test_checks.py` (matching the existing pattern): one test per error id — flip the env state, assert the message id appears (or doesn't).
+
+The check is deploy-gated (`deploy=True`), so it only runs under `manage.py check --deploy` — i.e., Railway's `preDeployCommand`. Reproduce locally per `docs/DeployChecks.md` § "Running deploy checks locally".
+
+## 4. Tests
+
+- **Backend (pytest):** one test per `core.E303` / `core.E304` error id in `apps/core/tests/test_checks.py`.
+- **Frontend (vitest):** `robots.txt` returns the `Disallow: /` body when `ALLOW_SEARCH_ENGINE_INDEXING != "true"`, and the production body (with the three non-page disallows) when `== "true"`. Snapshot test of both bodies.
+
+## 5. Implementation order
+
+1. Add `ALLOW_SEARCH_ENGINE_INDEXING` to `.env.example` (commented-out, with a note that it's only needed for local testing) and write `lib/server/search-engine-indexable.ts`.
+2. Add the `ALLOW_SEARCH_ENGINE_INDEXING` deploy check in `apps/core/checks.py`, with tests. Verify locally per `docs/DeployChecks.md` § "Running deploy checks locally".
+3. `frontend/src/routes/robots.txt/+server.ts` — gate on `ALLOW_SEARCH_ENGINE_INDEXING`, emit the appropriate static body. Frontend test per § 4.
+4. Verify locally: `curl localhost:5173/robots.txt` with and without `ALLOW_SEARCH_ENGINE_INDEXING=true` in `.env`.
+5. Set `ALLOW_SEARCH_ENGINE_INDEXING=true` on the production Railway service and `ALLOW_SEARCH_ENGINE_INDEXING=false` on every preview/staging service (separate manual step — not part of the PR). The deploy check refuses promotion if any deployed env leaves the value unset or sets it to anything other than `"true"` or `"false"`.
+
+## Considered alternatives
+
+- **Constance config instead of env var.** Rejected: robots.txt is served by SvelteKit (Node), so a Django/constance value would need an API hop per request. Constance also has no per-environment visibility concept, loses the deploy-refusal gate (every env gets the default), and a single admin click on a security-adjacent toggle leaves no audit trail. Env var changes show up in Railway's deploy history.
+- **Sniff `SITE_ORIGIN` hostname or key off `NODE_ENV`/`DEBUG`.** Rejected: preview/staging services run with `DEBUG=false` and an `https://` origin, so any heuristic silently misclassifies them. An explicit flag stays correct as we add environments.
+- **Required env var everywhere (including local dev).** Considered. Rejected: forces every developer to set a var they don't care about for local work. Defaulting to off at read time keeps local ergonomic; the deploy-time check still forces every real env to declare intent.
+- **Derive the production `Disallow:` list from the route tree.** Considered. Rejected after switching to the noindex-meta strategy for user-facing pages: the remaining production disallows are non-page server endpoints (`/api/`, `/djadmin/`, `/_sentry_test`), which don't live in the SvelteKit route tree anyway. A small static list is more honest than a derivation that walks a tree to find three paths.
+
+## Open questions
+
+None.

--- a/docs/plans/seo/RouteWalking.md
+++ b/docs/plans/seo/RouteWalking.md
@@ -1,0 +1,129 @@
+# Route Metadata and Walking
+
+Plan for introducing route-metadata primitives — `frontend/src/lib/route-metadata.ts` — and the first piece of metadata that lives there: a per-route `searchEngineInclusion` classification, plus walker utilities and tests that enforce it.
+
+The route-metadata primitive is consumed by the SEO strategy (see [`SearchEngines.md`](SearchEngines.md)), but is independently valuable as an auth-gating enforcement test — it pays off even if no SEO work ever happens.
+
+## Why
+
+Two unrelated-looking problems share a root cause: there's no machine-readable answer for "what kind of route is this?"
+
+1. **Search-engine inclusion is implicit.** Is `/search` supposed to be in Google's index? `/style-lab`? `/login`? Today the answers live in reviewer attention and conventions. A new route silently inherits "yes" by default; if you forgot to think about it, the sitemap ships it.
+2. **Auth gating is declared, but nothing enforces "is the right mechanism used?"** `requireCapability` is the canonical helper, but nothing stops someone from rolling a one-off `if (!locals.user) throw redirect(...)` inside `+page.server.ts`. The mistake is invisible until a security audit.
+
+Making the search-engine signal explicit on every route — and adding a test that cross-checks the auth mechanism against the layout chain — closes both gaps with one small piece of machinery. This work is independently valuable: the auth-mechanism enforcement is a security guardrail that pays off even if no SEO work ever happens. (The follow-on work in [`Robots.md`](Robots.md) and [`Sitemap.md`](Sitemap.md) consumes it as a dependency.)
+
+The file is named `route-metadata.ts` because we'll likely add more per-route metadata over time (canonical tags, SSR overrides, custom analytics flags, etc.); the search-engine classification is just the first.
+
+## The two orthogonal signals
+
+Each piece of information lives in exactly one place — no parallel systems, no redundant declarations.
+
+- **`requireCapability` in a `+layout.server.ts`** = the route is gated. This is what the codebase already uses today; nothing changes about the auth mechanism itself. The walker reads this to determine that a route is auth-gated.
+- **`export const searchEngineInclusion` on a route or layout file** = whether the route should appear in search-engine indexes. Two values: `'included'` or `'excluded'`. Layouts let descendants inherit.
+
+The two axes are independent at the declaration layer. Consumers (sitemap, robots.txt) compose them via the `isIndexable()` predicate, which returns `true` only when the route is included AND not gated.
+
+## The `SearchEngineInclusion` type
+
+```ts
+// frontend/src/lib/route-metadata.ts
+export type SearchEngineInclusion = "included" | "excluded";
+
+export const SEARCH_ENGINE_INCLUSION_VALUES = ["included", "excluded"] as const;
+```
+
+## Where the `searchEngineInclusion` exports go
+
+Inheritance does most of the work. Set the default at the top-level layout:
+
+```ts
+// frontend/src/routes/+layout.ts
+export const searchEngineInclusion = "included" as const;
+```
+
+Override at leaves where they differ:
+
+```ts
+// frontend/src/routes/login/+page.server.ts
+export const searchEngineInclusion = "excluded" as const;
+```
+
+```ts
+// frontend/src/routes/style-lab/+page.ts
+export const searchEngineInclusion = "excluded" as const;
+```
+
+Routes that today only have `+page.svelte` need a `+page.ts` added to carry the export. Trivial — one-line file.
+
+**Gated routes don't need this export.** Routes under a `requireCapability` layout (today: `/a/*`; catalog edit subroutes once they have such a layout) are inherently excluded from search engines — there's no point declaring `searchEngineInclusion = 'excluded'` on them. The walker treats them as excluded by virtue of being auth-gated. Declaring it anyway would be a contradiction the test catches (see below).
+
+For catalog edit subroutes (`/titles/[slug]/edit`, `/sources`, `/edit-history`, `/new`), the path forward is to put `requireCapability` on the section's `+layout.server.ts` (or add one). Once that layout exists, the entire subtree is auth-gated — no per-route `searchEngineInclusion` declaration needed anywhere in it.
+
+## Walker primitives
+
+`frontend/src/lib/route-metadata.ts` exposes composable utilities the test and downstream consumers all share:
+
+```ts
+export function allRoutes(): RouteId[];
+export function searchEngineInclusionFor(id: RouteId): SearchEngineInclusion;
+export function isAuthGated(id: RouteId): boolean; // via requireCapability ancestor
+export function isIndexable(id: RouteId): boolean; // composite: !isAuthGated && included
+export function layoutChain(id: RouteId): string[]; // ancestor +layout(.server)?.ts paths
+export function hasAncestorImport(id: RouteId, module: string): boolean;
+```
+
+`isIndexable()` is the composite predicate consumers actually want:
+
+```ts
+export function isIndexable(id: RouteId): boolean {
+  if (isAuthGated(id)) return false;
+  return searchEngineInclusionFor(id) === "included";
+}
+```
+
+Internally the walker wraps `import.meta.glob('/src/routes/**/+*')`. Roughly 100 lines.
+
+## The test (`route-metadata.test.ts`)
+
+A route is well-formed iff **exactly one** of these is true:
+
+1. It has a `requireCapability` ancestor (auth-gated). No `searchEngineInclusion` export anywhere in its chain.
+2. It has a `searchEngineInclusion` export (one of `SEARCH_ENGINE_INCLUSION_VALUES`) somewhere in its chain. No `requireCapability` ancestor.
+
+The test enumerates `allRoutes()` and asserts each route falls cleanly into one of the two cases. Two failure modes:
+
+- **Both signals present** → contradiction. "You declared `searchEngineInclusion` on a route that's auth-gated. Auth-gated routes are inherently excluded; drop the declaration."
+- **Neither signal present** → unclassified. "Either gate this route via `requireCapability` or declare its `searchEngineInclusion`."
+
+Bi-directional auth-mechanism enforcement falls out of this naturally. The same layout-chain inspection that determines `isAuthGated()` IS the auth gate, so they can't drift. A one-off `if (!locals.user) throw redirect(...)` in some `+page.server.ts` won't register as an auth gate — that route will fail the test as "unclassified" until either `requireCapability` is added or a `searchEngineInclusion` export is declared.
+
+**Anchor sanity check.** A small set of known-stable routes (`/`, `/titles`, `/titles/[slug]`, `/about`, `/login`, `/a/dashboard`) must appear in `allRoutes()` and resolve to the expected combination of `searchEngineInclusionFor()` / `isAuthGated()` values. Defends against "walker silently returned nothing, so all assertions trivially pass." Self-documenting; a magic-number count threshold would catch the same case less precisely and would rot on intentional route consolidation.
+
+Implementation note for the auth detection: static text-match scan of `+layout.server.ts` files for the `require-capability.server` import. Cheap and adequate at current size. If a future second auth mechanism is introduced, this is the canonical place to recognize it — updating the walker is a deliberate decision rather than a silent broadening.
+
+## Refactor existing route-walking
+
+One existing test walks the route tree for an adjacent purpose and should consume the walker:
+
+- **`frontend/src/lib/api/catalog-meta.test.ts`** uses `import.meta.glob('/src/routes/**/+*')` to discover detail routes and assert each is mapped in `CATALOG_META`. Refactor to consume `allRoutes()` (and a helper that recognizes catalog-detail patterns). One walker, one set of bugs.
+
+Out of scope — don't refactor these:
+
+- **`frontend/src/lib/focus-mode.ts`** (`MINIMAL_SHELL_EXACT_PATHS`, `FOCUS_EXACT_PATHS`, `isFocusModePath()`) classify routes by UI chrome, a different axis. Some paths overlap (`/signup`, `/auth/error`, `/kiosk`, `*/edit` suffixes) but binding two axes together when they happen to overlap creates a future "they diverged" headache. Revisit only if they actually drift.
+- **`frontend/src/lib/frontDoors.ts`** is a UI-shell concern; unrelated.
+
+## What this enables downstream
+
+- **`robots.txt`** — see [`Robots.md`](Robots.md). Derives `Disallow:` lines from `isIndexable()` over the route tree.
+- **`sitemap.xml`** — see [`Sitemap.md`](Sitemap.md). Feeds `isIndexable()` into super-sitemap's `excludeRoutePatterns`.
+- **Future per-route metadata** — the same file (`route-metadata.ts`) is the natural home for additional per-route signals (canonical URL overrides, SSR exceptions, analytics tags, etc.). Same walker primitives, new exports.
+- **Future cross-cutting tests** — e.g. "every catalog detail route has an `edit-history` and `sources` subroute," "every included route renders a `<link rel='canonical'>`." Reusable walker, ad-hoc composition.
+
+## Implementation order
+
+1. Write `frontend/src/lib/route-metadata.ts`: the `SearchEngineInclusion` type, walker primitives (`allRoutes`, `searchEngineInclusionFor`, `layoutChain`, `hasAncestorImport`), and `isIndexable` / `isAuthGated` predicates.
+2. Add `export const searchEngineInclusion` to route files for the non-gated routes only. Top-level `+layout.ts` defaults to `'included'`; non-indexable routes (`/login`, `/signup`, `/verify-email`, `/auth/error`, `/search`, `/kiosk`, `/api-docs`, `/style-lab`, `/_sentry_test`) override to `'excluded'`. Gated routes get nothing — `requireCapability` already declares them. Add `+page.ts` files where they don't exist yet.
+3. Add the route-metadata vitest test: every route is well-formed (exactly one of "gated" or "declares `searchEngineInclusion`"); anchor sanity. It'll initially fail until the exports are filled in — that's the point.
+4. Refactor `frontend/src/lib/api/catalog-meta.test.ts` to consume the walker (`allRoutes()` + a catalog-detail predicate) instead of doing its own `import.meta.glob` traversal.
+5. Open PR. The follow-on SEO work in [`Robots.md`](Robots.md) (first) and [`Sitemap.md`](Sitemap.md) (second) can be opened as drafts on top of this branch.

--- a/docs/plans/seo/SearchEngines.md
+++ b/docs/plans/seo/SearchEngines.md
@@ -1,0 +1,95 @@
+# Search Engine Strategy
+
+This is a hub document about how the project interacts with search engines -- such as which deploys are crawlable, which pages on a crawlable deploy belong in the index, how we tell crawlers about them, how the data on each page is presented in results.
+
+## The concerns
+
+## Per-route metadata
+
+Several consumers — sitemap, noindex meta, and any future per-route enforcement (canonical declaration, title/description presence) — read from the same per-route classification:
+
+```ts
+isIndexable(routeId): boolean
+```
+
+defined in [`RouteWalking.md`](RouteWalking.md). The predicate composes the per-route `searchEngineInclusion` export with the auth-gating layout-chain check. Each consumer applies it differently — sitemap filters _in_, noindex injects _out_, robots.txt mostly ignores it (its scope is server endpoints, not pages) — but they can't drift, because there's only one source.
+
+### Server-side rendering
+
+Public routes must render meaningful HTML server-side, not depend on client-side hydration to become visible to crawlers. A public route that flips to CSR-only is effectively non-indexable.
+
+#### SSR routes done
+
+Detail pages (`/titles/[slug]`, `/models/[slug]`, and the rest of the catalog detail routes) declare `ssr = true` on their `+layout.ts`. Edit subroutes correctly declare `ssr = false` — non-indexable, so it doesn't matter.
+
+#### SSR routes not yet done
+
+##### Catalog listing pages are CSR-only
+
+[`/titles/+page.ts:2`](frontend/src/routes/titles/+page.ts#L2),[`/manufacturers/+page.ts:2`](frontend/src/routes/manufacturers/+page.ts#L2), [`/corporate-entities/+page.ts:2`](frontend/src/routes/corporate-entities/+page.ts#L2), and the rest of the listings export `ssr = false`.
+
+This was a deliberate performance choice; the listings hydrate a large client-side slug (e.g. all titles) so filtering/sorting is instant — but the cost is that they currently don't render meaningful HTML for crawlers. Fixing isn't just flipping the flag: the page's data-loading and rendering model is built around having the full dataset client-side.
+
+Fixing this isn't urgent; the listing pages are not super important for driving search traffic, unlike detail pages.
+
+Either the SSR path needs a different (lighter) data shape, or the page architecture changes, or we accept the tradeoff and mark listings `searchEngineInclusion = 'excluded'`, relying on the sitemap of detail pages for discovery. Decision still open.
+
+##### `/users/[username]` is CSR-only
+
+([`+page.ts:6`](frontend/src/routes/users/[username]/+page.ts#L6)). Smaller scope than listings; likely just needs an SSR path.
+
+##### No enforcement test
+
+There's nothing today that catches a regression where someone adds `ssr = false` to a new indexable route. The check is exactly the kind of route-tree property `RouteWalking.md` is built for: walk the layout chain, assert every indexable route has SSR enabled. Belongs there as a follow-up.
+
+### ✅ DONE: 404 status integrity
+
+A "not found" page must return HTTP 404, not 200 with apologetic copy ("soft-404"). Soft-404s confuse search indexing — it sees the 200 and may index the apology page. Entity loaders throw `error(404, …)` (e.g. `frontend/src/routes/models/[slug]/+layout.server.ts`) and `frontend/src/routes/+error.svelte` renders the response; the constraint is to keep using these rather than rolling custom not-found rendering in `+page.svelte`.
+
+### Gating staging deploys
+
+Staging environments should never appear in Google, regardless of what links to them. See [`Robots.md`](Robots.md).
+
+### Excluding pages from crawling
+
+Server endpoints like `/api/`, `/djadmin/`, and `/_sentry_test` aren't user-facing pages and shouldn't be crawled at all — fetches against them waste crawl budget and load the backend with no SEO benefit.
+
+See [`Robots.md`](Robots.md).
+
+### Excluding pages from search indexes
+
+Routes like `/login`, `/search`, `/style-lab`, `/kiosk/*`, and `/*/edit` are real pages that crawlers can reach via inbound links — but they shouldn't appear in search results. Per [Google's guidance](https://developers.google.com/search/docs/crawling-indexing/block-indexing), robots.txt is the wrong tool for this (see § "Why the split between robots.txt and noindex" below).
+
+See [`NoindexMeta.md`](NoindexMeta.md).
+
+### Per-page title and description
+
+Every indexable route needs a unique, meaningful `<title>` and `<meta name="description">`. The title drives the clickable SERP heading; the description drives the snippet underneath. Generic or duplicated values across pages dilute ranking and click-through. The route-walking primitive could enforce that every indexable route declares both.
+
+### Canonical URLs
+
+Multiple URLs can serve the same or near-identical content: trailing-slash variants, query-string variants, scheme/host variants. Without `<link rel="canonical">`, Google picks one to index and may pick wrong, splitting ranking signals across duplicates. (The Single-Model-Title case where Title and Model pages show the same content is already collapsed by a 301 redirect on `/models/[slug]`, so canonical tags aren't load-bearing there.)
+
+See [`CanonicalUrl.md`](CanonicalUrl.md).
+
+### Aiding search engine discovery
+
+A sitemap enumerates every indexable URL with its `lastmod` timestamp. This helps crawlers find pages they might otherwise miss (especially ones with few inbound links) and prioritize re-crawls when content changes. It doesn't make a page indexable on its own — indexing is default-on for any crawled, non-noindex page — but it accelerates discovery and signals freshness.
+
+See [`Sitemap.md`](Sitemap.md).
+
+### URL stability across slug changes
+
+The catalog supports slug edits. Without `301` redirects from the old slug to the new one, every rename silently discards accumulated SEO equity (inbound links, ranking history) and creates broken bookmarks. The mechanism belongs in the slug-edit flow itself, not in a separate SEO mechanism.
+
+### Structured data
+
+JSON-LD or microdata using schema.org types — `Product`-like schemas for Models, `Person` for designers and artists, `Organization` for manufacturers, `BreadcrumbList` for navigation. Google uses these for rich results: knowledge panels, carousels, breadcrumb display in SERPs. High-leverage for a domain catalog like this, but only valuable if maintained accurately per entity type.
+
+### Faceted and paginated listing URLs
+
+Listing pages like `/titles?manufacturer=stern&era=ss&page=2` can multiply into thousands of low-value URL combinations, wasting crawl budget and creating thin/duplicate content problems. Strategies include: canonicalizing filtered/paginated views back to the base listing, applying `noindex` to filter combinations, or restricting which combinations are linkable.
+
+### Search Console operations
+
+Verifying the production property, submitting the sitemap URL, monitoring index-coverage reports, and watching for manual actions or security warnings. Operational rather than architectural — belongs in an ops runbook rather than a code-design doc.

--- a/docs/plans/seo/Sitemap.md
+++ b/docs/plans/seo/Sitemap.md
@@ -1,0 +1,302 @@
+# sitemap.xml
+
+This is the plan for introducing `sitemap.xml` to the project. SvelteKit owns public pages, so the file lives there as a `+server.ts` endpoint. The frontend uses [`super-sitemap`](https://github.com/jasongitmail/super-sitemap) for XML rendering, and discovers dynamic-route slugs from a Django-side registry of per-entity sitemap feeds.
+
+Addresses the "aiding search engine discovery" concern in [`SearchEngines.md`](SearchEngines.md); see that doc for how this fits with robots.txt and the per-page noindex meta.
+
+This PR builds on [`Robots.md`](Robots.md), which already shipped the `ALLOW_SEARCH_ENGINE_INDEXING` env var, the `lib/server/search-engine-indexable.ts` helper, and the deploy-time validation. It also adds the `Sitemap: ${SITE_ORIGIN}/sitemap.xml` line to the existing `robots.txt`.
+
+## Dependencies
+
+- [`RouteWalking.md`](RouteWalking.md) — provides `allRoutes()`, `isIndexable(routeId)`, and the per-route `searchEngineInclusion` exports.
+- [`Robots.md`](Robots.md) — provides the `ALLOW_SEARCH_ENGINE_INDEXING` env var, `lib/server/search-engine-indexable.ts`, and the deploy-time validation that prevents preview/staging from leaking. The sitemap endpoint reuses the same helper rather than re-reading the env var.
+
+Throughout this doc, `isIndexable(routeId)` refers to the predicate defined in `RouteWalking.md` (true when the route declares `searchEngineInclusion = 'included'` AND is not auth-gated).
+
+## Goals
+
+- Tell crawlers what to index (the public catalog).
+- Give search engines accurate `<lastmod>` per catalog page so they can prioritize re-crawls.
+- Adding a new indexable entity type should be a one-file backend change with no frontend touch.
+
+## 1. Backend — sitemap feed registry
+
+Catalog (and any future indexable-content app) shouldn't have to know about a "sitemap" concept beyond "here are my feeds." We use the registration pattern AppBoundaries.md prescribes for cross-app composition:
+
+> _"registration hooks, where a generic subsystem lets another app register behavior without becoming coupled to it"_
+
+### Layout
+
+**`apps/core/sitemap/`** — generic subsystem. No imports from other apps.
+
+```python
+# apps/core/sitemap/registry.py
+from collections.abc import Iterable
+from datetime import datetime
+from typing import NamedTuple, Protocol
+
+class SitemapEntry(NamedTuple):
+    slug: str
+    updated_at: datetime
+
+class SitemapFeed(Protocol):
+    kind: str             # 'titles', 'models', 'taxonomy_themes', ...
+    route_pattern: str    # SvelteKit route ID, e.g. '/titles/[slug]'
+    def entries(self) -> Iterable[SitemapEntry]: ...
+    def max_updated_at(self) -> datetime | None: ...
+
+_REGISTRY: dict[str, SitemapFeed] = {}
+
+def register_sitemap_feed(feed: SitemapFeed) -> None:
+    """Called from each app's AppConfig.ready(). Raises on duplicate kind."""
+
+def get_sitemap_feed(kind: str) -> SitemapFeed | None: ...
+def all_registered_feeds() -> list[SitemapFeed]: ...
+```
+
+```python
+# apps/core/sitemap/api.py
+from apps.core.rate_limits import RateLimitSpec, check_and_record_ip
+
+SITEMAP_FEED_RATE_LIMIT = RateLimitSpec(
+    bucket="sitemap_feed",
+    limit=120,
+    window_seconds=60,
+)
+
+@router.get("/sitemap/")
+def list_feeds(request) -> list[SitemapFeedSummarySchema]:
+    """Discovery endpoint — frontend reads this to know what feeds exist."""
+    check_and_record_ip(request, SITEMAP_FEED_RATE_LIMIT)
+    return [
+        SitemapFeedSummarySchema(
+            kind=f.kind,
+            route_pattern=f.route_pattern,
+            max_updated_at=f.max_updated_at(),
+        )
+        for f in all_registered_feeds()
+    ]
+
+@router.get("/sitemap/{kind}/")
+def get_feed(request, kind: str) -> list[SitemapEntrySchema]:
+    check_and_record_ip(request, SITEMAP_FEED_RATE_LIMIT)
+    feed = get_sitemap_feed(kind)
+    if feed is None:
+        raise Http404
+    return list(feed.entries())
+```
+
+**`apps/catalog/sitemap_feeds.py`** — catalog's plug-ins.
+
+```python
+from apps.core.sitemap import SitemapEntry, register_sitemap_feed
+from apps.catalog.models import Title, MachineModel, Manufacturer, ...
+
+class TitleSitemapFeed:
+    kind = "titles"
+    route_pattern = "/titles/[slug]"
+    def entries(self):
+        return (Title.objects
+            .only("slug", "updated_at")
+            .order_by("slug")
+            .iterator())
+    def max_updated_at(self):
+        return Title.objects.aggregate(Max("updated_at"))["updated_at__max"]
+
+class ModelSitemapFeed:
+    kind = "models"
+    route_pattern = "/models/[slug]"
+    def entries(self):
+        # Single-Model-Title rule: exclude Models whose parent Title has exactly one Model.
+        # The UI collapses single-Model Titles into the Model page (per docs/SingleModelTitles.md),
+        # so the Title slug is canonical and indexing both routes would split signals.
+        return (MachineModel.objects
+            .annotate(_sibling_count=Count("title__models"))
+            .filter(_sibling_count__gt=1)
+            .only("slug", "updated_at")
+            .order_by("slug")
+            .iterator())
+    def max_updated_at(self): ...
+
+# ...one class per indexable entity type (Manufacturer, Person, System, Series,
+# Franchise, Location — path-variant — plus each taxonomy type)
+
+register_sitemap_feed(TitleSitemapFeed())
+register_sitemap_feed(ModelSitemapFeed())
+# ...
+```
+
+```python
+# apps/catalog/apps.py
+class CatalogConfig(AppConfig):
+    def ready(self):
+        from apps.catalog import sitemap_feeds  # noqa: F401 — registers on import
+```
+
+### Why this shape
+
+- **Boundary respect.** Core defines the Protocol and dispatch; doesn't import catalog. Catalog imports core (already legal) and registers itself. Future non-catalog apps (kiosk, hypothetical blog) plug in without touching core or catalog.
+- **Dynamic discovery.** Frontend reads `GET /api/sitemap/` once per render to learn what feeds exist. Adding a new entity type is a one-file backend change.
+- **Rate limiting.** Each feed query is a DB hit; without protection, a fanout abuser could drive real load. Reuses `apps/core/rate_limits.py`'s existing IP-keyed limiter. 120/min is comfortable for the ~15-call fanout per `/sitemap.xml` render (real crawlers fetch maybe daily), tight enough to deflect abuse.
+- **Public reads — no auth gate.** No `Activity` needed; these are public, non-mutating, and contain only data already on the indexable detail pages.
+- **No lifecycle filter needed today** (no soft-delete or draft state exists). Add one if/when `RecordLifecycle.md` introduces non-live states.
+
+Typed schemas (`SitemapEntrySchema`, `SitemapFeedSummarySchema`) live in `apps/core/sitemap/schemas.py`. Set `Cache-Control: public, max-age=3600` on both endpoints. Run `make api-gen` after.
+
+## 2. Frontend — super-sitemap
+
+The frontend uses [`super-sitemap`](https://github.com/jasongitmail/super-sitemap) for XML rendering. It handles escaping, `lastmod` formatting, and sitemap-index splitting (auto-flips to a `<sitemapindex>` if total URLs cross 50k). Pin to `super-sitemap@^1.0.12` — zero runtime dependencies, healthy maintenance (~40k downloads/month, single-maintainer with consistent cadence over 18+ months).
+
+### Wiring
+
+```ts
+// frontend/src/routes/sitemap.xml/+server.ts
+import * as sitemap from "super-sitemap";
+import { SITE_ORIGIN } from "$env/static/private";
+import { allRoutes, isIndexable } from "$lib/route-metadata";
+
+export const GET = async ({ fetch }) => {
+  const feeds = await fetch("/api/sitemap/").then((r) => r.json());
+  const paramValues = Object.fromEntries(
+    feeds.map(({ kind, route_pattern }) => [
+      route_pattern,
+      async () => {
+        const entries = await fetch(`/api/sitemap/${kind}/`).then((r) =>
+          r.json(),
+        );
+        return entries.map((e) => ({
+          values: [e.slug],
+          lastmod: e.updated_at,
+        }));
+      },
+    ]),
+  );
+
+  return sitemap.response({
+    origin: SITE_ORIGIN,
+    excludeRoutePatterns: allRoutes()
+      .filter((id) => !isIndexable(id))
+      .map(routeIdToRegex),
+    paramValues,
+  });
+};
+```
+
+That's the whole endpoint. Adding a new entity type requires zero changes here — `GET /api/sitemap/` reports the new feed, the loop wires it into `paramValues` automatically.
+
+### Why super-sitemap
+
+- **Debuggability win.** XML correctness (escaping, `lastmod` formatting, index-vs-urlset switching) is annoying to verify by hand. With the library, the debugging surface shrinks from "is our XML right?" to "does our config produce what we expect?" — and the latter is straightforward to test.
+- **Boring tech in scope.** Sitemap protocol is stable; we don't need innovation here.
+- **Library doesn't conflict with rate limiting.** It's just an XML-response helper at the SvelteKit layer; rate limiting lives at the Django endpoint where it belongs.
+
+### One subtlety to handle
+
+`super-sitemap`'s `paramValues` callbacks fail the whole sitemap render if any throws. If a backend feed returns 429 during a fetch, the entire `/sitemap.xml` returns 5xx to the crawler. Mitigations:
+
+- The 120/min rate limit + 1-hour `Cache-Control` make this vanishingly rare in practice.
+- If we see it in production, wrap each callback in try/catch returning `[]` (better: last-known-good cached entries) so the sitemap degrades gracefully rather than failing whole.
+
+Start with the simple version; harden only if observed.
+
+### Gate on `ALLOW_SEARCH_ENGINE_INDEXING`
+
+Reuse the `lib/server/search-engine-indexable.ts` helper from `Robots.md`. When `ALLOW_SEARCH_ENGINE_INDEXING != "true"`, return `404 Not Found` for `/sitemap.xml` — a non-indexable deploy has nothing to advertise. The robots.txt-side `Disallow: /` already keeps crawlers out; the 404 is defense in depth.
+
+## 3. Add `Sitemap:` line to robots.txt
+
+The `robots.txt` endpoint shipped in [`Robots.md`](Robots.md) does not yet emit a `Sitemap:` line. Once `/sitemap.xml` exists, append it to the indexable-mode body:
+
+```text
+Sitemap: ${SITE_ORIGIN}/sitemap.xml
+```
+
+One-line additive change. Update the existing robots vitest to assert the line is present iff `ALLOW_SEARCH_ENGINE_INDEXING == "true"`.
+
+## 4. What goes in the sitemap
+
+**In:**
+
+- `/`
+- `/about`, `/about/people`
+- `/legal/privacy`, `/legal/terms`, `/legal/licensing`
+- All catalog listing pages: `/titles`, `/models`, `/manufacturers`, `/people`, `/systems`, `/series`, `/franchises`, `/locations`, plus taxonomy listings
+- All catalog detail pages with their `updated_at` as `lastmod`, except:
+  - **Single-Model Titles** — when a Title has exactly one Model, include the Title route and **exclude** the Model route. The UI collapses single-Model Titles into the Model page (per `docs/SingleModelTitles.md`), but the Title slug is the canonical URL; indexing both would split signals and create duplicate-content noise. Enforced in `ModelSitemapFeed.entries()`.
+
+**Out:**
+
+- `/style-lab`, `/api-docs`, `/search`, `/kiosk`, `/_sentry_test`, `/auth/error`
+- Anything auth-gated — recognized by `requireCapability` in the layout chain; non-indexable routes are excluded by `isIndexable(routeId)`; never enumerated by hand
+- Models whose parent Title has exactly one Model (see above)
+
+## 5. Startup validation — `SITE_ORIGIN`
+
+`SITE_ORIGIN` is consumed at _both_ build time (baked into prerendered meta tags) and deploy/runtime (sitemap URLs and the `Sitemap:` line in robots.txt), so it needs gates at both phases. Pattern and conventions per `docs/BuildChecks.md` and `docs/DeployChecks.md`.
+
+### Build-phase check
+
+Today `frontend/svelte.config.js:40` falls back to `'http://localhost:5173'` when `SITE_ORIGIN` is unset. That fallback is the right behavior for `make dev`, but in a production build it silently bakes `localhost` URLs into prerendered HTML — exactly the failure mode we want a refusal gate for.
+
+Approach: keep the dev fallback, but fail the build when a production indicator is present (e.g. `RAILWAY_GIT_COMMIT_SHA` is set, which the project already treats as the "real build" signal — see the same file at line 34 / 37). If `RAILWAY_GIT_COMMIT_SHA` is set and `SITE_ORIGIN` is empty or doesn't shape-match an `https://` origin, throw with a clear message. Non-zero exit at this stage fails `pnpm build` and Railway refuses the image (per `docs/BuildChecks.md` § "What fails the build for free").
+
+Add `SITE_ORIGIN` to `Dockerfile` `ARG` declarations alongside the existing build-time vars (the file already lists `RAILWAY_GIT_COMMIT_SHA`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`), and set it on the Railway service. Per `docs/BuildChecks.md` § "What requires explicit wiring", a missing `ARG` silently turns the consumer into a no-op — so this is a two-step change.
+
+### Deploy-phase check
+
+Frontend env vars are validated in Python because backend and frontend share the Railway env (per `docs/DeployChecks.md` § "Frontend checks belong in Python"). Add to `backend/apps/core/checks.py` (alongside `check_observability_env` and the `ALLOW_SEARCH_ENGINE_INDEXING` check from `Robots.md`):
+
+- **`SITE_ORIGIN`** — `@register(Tags.security, deploy=True)` check that errors when `SITE_ORIGIN` is empty in non-DEBUG. Shape-validate it as an `https://` origin with a netloc and no path/trailing slash (reuse the `urlparse` pattern from `_is_valid_dsn`). New error ids `core.E301` (missing) and `core.E302` (malformed). Catches the case where the build had a value but the running container does not.
+
+Tests in `backend/apps/core/tests/test_checks.py`: one test per error id — flip the env state, assert the message id appears (or doesn't).
+
+The check is deploy-gated (`deploy=True`), so it only runs under `manage.py check --deploy` — i.e., Railway's `preDeployCommand`. Reproduce locally per `docs/DeployChecks.md` § "Running deploy checks locally".
+
+## 6. Tests
+
+- **Backend (pytest):**
+  - `apps/core/tests/test_sitemap_registry.py` — registry mechanics: register, lookup, list, duplicate-kind raises. Uses a fake feed; doesn't import catalog.
+  - `apps/core/tests/test_sitemap_api.py` — dispatch endpoint: 200 with expected shape for a registered kind, 404 for an unknown kind, listing endpoint returns the registered feeds, rate-limit returns 429 with `Retry-After` past the threshold.
+  - `apps/catalog/tests/test_sitemap_feeds.py` — each catalog feed's queryset shape, ordering, `max_updated_at` matches newest row. Includes the single-Model-Title exclusion test for `ModelSitemapFeed`.
+  - One test per `core.E301` / `core.E302` error id in `apps/core/tests/test_checks.py`.
+  - **XSD validation** — fetch `/sitemap.xml` via an in-process test client and validate the response against the sitemaps.org XSD using `xmllint --noout --schema`. Catches schema drift on every CI run.
+- **Frontend (vitest):**
+  - `sitemap.xml/+server.ts` builds super-sitemap's `paramValues` correctly from a mocked `/api/sitemap/` response.
+  - `sitemap.xml/+server.ts` returns 404 when `ALLOW_SEARCH_ENGINE_INDEXING != "true"`.
+  - Existing robots.txt test extended to assert the `Sitemap:` line is present iff `ALLOW_SEARCH_ENGINE_INDEXING == "true"`.
+
+## 7. Implementation order
+
+1. Add the `SITE_ORIGIN` build-phase guard in `frontend/svelte.config.js` (throw when `RAILWAY_GIT_COMMIT_SHA` is set and `SITE_ORIGIN` is empty/malformed). Declare `SITE_ORIGIN` as an `ARG` in `Dockerfile`.
+2. Add the `SITE_ORIGIN` deploy check in `apps/core/checks.py`, with tests. Verify locally per `docs/DeployChecks.md` § "Running deploy checks locally".
+3. `apps/core/sitemap/registry.py` — `SitemapEntry`, `SitemapFeed` Protocol, `register_sitemap_feed` / `get_sitemap_feed` / `all_registered_feeds`. Tests with a fake feed.
+4. `apps/core/sitemap/api.py` — dispatch endpoint at `/api/sitemap/{kind}/`, listing endpoint at `/api/sitemap/`, IP rate limiting via `apps.core.rate_limits`. Tests for 200 / 404 / 429 paths.
+5. `apps/catalog/sitemap_feeds.py` — `TitleSitemapFeed`, `ModelSitemapFeed` (with single-Model-Title filter), and the rest of the catalog feeds. Tests per feed.
+6. `apps/catalog/apps.py` — trigger registration in `AppConfig.ready()`.
+7. `make api-gen`.
+8. `pnpm add super-sitemap@~1.0.12`.
+9. `frontend/src/routes/sitemap.xml/+server.ts` — wire super-sitemap to `/api/sitemap/` + `/api/sitemap/{kind}/`, with `excludeRoutePatterns` derived from the manifest. Gate on `ALLOW_SEARCH_ENGINE_INDEXING` via the helper from `Robots.md`.
+10. Append the `Sitemap:` line to `frontend/src/routes/robots.txt/+server.ts` (indexable-mode only). Extend the existing robots test.
+11. Add the XSD validation test (backend pytest, fetches its own endpoint and pipes through `xmllint`).
+12. Verify locally: `curl localhost:5173/sitemap.xml`, validate with `xmllint --noout --schema`.
+
+### Deployment routing
+
+No Caddyfile changes needed. The current `@django` matcher in `Caddyfile` only catches `/api`, `/djadmin`, `/media`, `/static`, so `/sitemap.xml` routes to SvelteKit (Node, port 3000) by default.
+
+## Considered alternatives
+
+- **Hand-rolled XML rendering.** Considered to avoid a third-party dependency. Rejected: the library's value isn't lines saved (it's only ~80), it's that XML correctness (escaping, `lastmod` formatting, sitemap-index splitting) becomes the library's problem to debug rather than ours.
+- **New `apps/sitemap/` Django app.** Considered. Rejected per `docs/AppBoundaries.md`: a new app should own a distinct concept, and sitemap feeds are thin projections over existing catalog data with no domain of their own.
+- **Hand-rolled sitemap index from day one.** Considered for "future-proofing" against the 50k-URLs-per-file cap. Rejected: super-sitemap auto-flips from `<urlset>` to `<sitemapindex>` when needed, the catalog is years from 50k.
+- **Per-route hardcoded sitemap config on the frontend.** Rejected: hardcoding means adding a new entity type requires touching the frontend, defeating the registration pattern's main benefit.
+
+## Open questions
+
+1. **Production hostname** — confirm `SITE_ORIGIN` in production (presumably `https://flipcommons.org`?) so the `Sitemap:` line is right.
+
+## Resolved
+
+- **People pages** (`/people/[slug]`) — catalog persons (designers, artists, etc.). Indexable; included in the sitemap.
+- **Soft-delete / draft state** — none exist today. No lifecycle-based filter needed in the sitemap feeds; revisit if/when drafts or soft-delete are introduced.
+- **Single-Model Titles** — include the Title route; exclude the Model route. Title slug is canonical; indexing both would split signals.


### PR DESCRIPTION
## Summary

Adds planning docs for SEO work under `docs/plans/seo/`: canonical URLs, noindex meta, robots.txt, route walking, search engine submission, and sitemap.

## Test plan

- [ ] Skim each doc renders correctly on GitHub