### PR TITLE
fix(authz): authenticate the delete confirmation screen

### DIFF
--- a/frontend/src/lib/delete-preview-loader.server.test.ts
+++ b/frontend/src/lib/delete-preview-loader.server.test.ts
@@ -45,17 +45,19 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+const capableMe = ok({ is_authenticated: true, capabilities: { 'catalog.delete': true } });
+
 describe('loadDeletePreview', () => {
   // #420: must forward `request` so /me/ sees the user's cookie over SSR.
   it('forwards (fetch, url, request) to createServerClient', async () => {
-    GET.mockResolvedValueOnce(ok({ is_authenticated: true })).mockResolvedValueOnce(ok({}));
+    GET.mockResolvedValueOnce(capableMe).mockResolvedValueOnce(ok({}));
     await loadDeletePreview(args());
     expect(createServerClient).toHaveBeenCalledWith(fetchStub, url, request);
   });
 
   it('returns the preview body and public_id on success', async () => {
     const preview = { name: 'Theme', changeset_count: 3 };
-    GET.mockResolvedValueOnce(ok({ is_authenticated: true })).mockResolvedValueOnce(ok(preview));
+    GET.mockResolvedValueOnce(capableMe).mockResolvedValueOnce(ok(preview));
 
     const result = await loadDeletePreview(args());
 
@@ -67,7 +69,7 @@ describe('loadDeletePreview', () => {
   });
 
   it('redirects anonymous users to /login (via shared auth helper)', async () => {
-    GET.mockResolvedValueOnce(ok({ is_authenticated: false }));
+    GET.mockResolvedValueOnce(ok({ is_authenticated: false, capabilities: {} }));
 
     await expect(loadDeletePreview(args())).rejects.toMatchObject({
       status: 302,
@@ -75,8 +77,19 @@ describe('loadDeletePreview', () => {
     });
   });
 
+  it('redirects authenticated-but-uncapable users to /verify-email', async () => {
+    GET.mockResolvedValueOnce(
+      ok({ is_authenticated: true, capabilities: { 'catalog.delete': false } }),
+    );
+
+    await expect(loadDeletePreview(args())).rejects.toMatchObject({
+      status: 302,
+      location: '/verify-email',
+    });
+  });
+
   it('redirects to the fallback URL on 404', async () => {
-    GET.mockResolvedValueOnce(ok({ is_authenticated: true })).mockResolvedValueOnce(fail(404));
+    GET.mockResolvedValueOnce(capableMe).mockResolvedValueOnce(fail(404));
 
     await expect(loadDeletePreview(args({ public_id: 'missing' }))).rejects.toMatchObject({
       status: 302,
@@ -85,7 +98,7 @@ describe('loadDeletePreview', () => {
   });
 
   it('throws on other non-OK responses', async () => {
-    GET.mockResolvedValueOnce(ok({ is_authenticated: true })).mockResolvedValueOnce(fail(500));
+    GET.mockResolvedValueOnce(capableMe).mockResolvedValueOnce(fail(500));
 
     await expect(loadDeletePreview(args())).rejects.toThrow(/500/);
   });

--- a/frontend/src/lib/delete-preview-loader.server.ts
+++ b/frontend/src/lib/delete-preview-loader.server.ts
@@ -1,6 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import { createServerClient } from '$lib/api/server';
-import { loadAuthenticatedMe } from '$lib/api/load-me.server';
+import { requireCapability } from '$lib/require-capability.server';
 import type { paths } from '$lib/api/schema';
 
 // Entity-segment union derived from the schema's delete-preview routes.
@@ -43,9 +43,10 @@ export async function loadDeletePreview<E extends DeletePreviewEntity>({
   public_id: string;
 }> {
   const endpoint = `/api/${entity}/{public_id}/delete-preview/`;
-  const client = createServerClient(fetch, url, request);
 
-  await loadAuthenticatedMe(client, 'loadDeletePreview');
+  await requireCapability({ fetch, url, request, activity: 'catalog.delete' });
+
+  const client = createServerClient(fetch, url, request);
 
   // openapi-fetch can't resolve a typed response for a path it sees as a
   // dynamic string, so the casts are localized here. `entity` is already


### PR DESCRIPTION
## Summary

- Replace the bare \`loadAuthenticatedMe\` check in [delete-preview-loader.server.ts](frontend/src/lib/delete-preview-loader.server.ts) with \`requireCapability({ activity: 'catalog.delete' })\`. Any logged-in user could previously trigger the SSR delete-preview fetch (the backend would reject the actual DELETE, but the preview leaked through the gate).
- Uncapable users now redirect to \`/verify-email\` before the SSR call, matching how \`*/edit*\` and \`*/new\` are gated.
- Once \`route-metadata.ts\` lands ([docs/plans/seo/RouteWalking.md](docs/plans/seo/RouteWalking.md)), \`*/delete\` is classified as auth-gated via the same \`require-capability.server\` import scan — no special-case bucket needed.

## Test plan

- [x] \`pnpm vitest run src/lib/delete-preview-loader.server.test.ts\` — added an uncapable-user → \`/verify-email\` case; existing anonymous → \`/login\` and happy-path cases still pass
- [x] \`svelte-check\` clean
- [ ] Manual: as a non-staff authenticated user, hit \`/titles/[slug]/delete\` and confirm the redirect to \`/verify-email\` (previously got the preview page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)