### PR TITLE
refactor(authz): route /kiosk/edit gate through requireCapability

### DIFF
--- a/frontend/src/routes/kiosk/edit/+layout.server.ts
+++ b/frontend/src/routes/kiosk/edit/+layout.server.ts
@@ -1,12 +1,8 @@
-import { redirect } from '@sveltejs/kit';
-import { resolve } from '$app/paths';
-import { createServerClient } from '$lib/api/server';
-import { loadAuthenticatedMe } from '$lib/api/load-me.server';
+import { requireCapability } from '$lib/require-capability.server';
 import type { LayoutServerLoad } from './$types';
 
+// Single auth gate for the kiosk-edit SPA area. Any page that lands
+// under `/kiosk/edit/*` inherits this gate; do not re-implement per-page.
 export const load: LayoutServerLoad = async ({ fetch, url, request }) => {
-  const client = createServerClient(fetch, url, request);
-  const me = await loadAuthenticatedMe(client, 'kiosk/edit gate');
-  if (!me.capabilities?.['kiosk.edit']) throw redirect(302, resolve('/'));
-  return {};
+  await requireCapability({ fetch, url, request, activity: 'kiosk.edit' });
 };

--- a/frontend/src/routes/kiosk/edit/layout-server.test.ts
+++ b/frontend/src/routes/kiosk/edit/layout-server.test.ts
@@ -1,83 +1,43 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { GET, createServerClient } = vi.hoisted(() => {
-  const get = vi.fn();
-  return {
-    GET: get,
-    createServerClient: vi.fn(() => ({ GET: get })),
-  };
-});
+const requireCapability = vi.fn();
 
-vi.mock('$lib/api/server', () => ({ createServerClient }));
-vi.mock('$app/paths', () => ({ resolve: (p: string) => p }));
+vi.mock('$lib/require-capability.server', () => ({
+  requireCapability: (...args: unknown[]) => requireCapability(...args),
+}));
 
-import { load } from './+layout.server';
+const { load } = await import('./+layout.server');
 
-function makeEvent() {
-  const url = new URL('http://localhost/kiosk/edit');
-  const request = new Request(url, { headers: { cookie: 'sessionid=abc' } });
-  return {
-    fetch: globalThis.fetch,
-    url,
-    request,
-  };
+function makeEvent(url: URL) {
+  const fetchStub = (() => undefined) as unknown as typeof globalThis.fetch;
+  const request = new Request(url);
+  return { fetch: fetchStub, url, request };
 }
 
-async function expectRedirectTo(target: string) {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await load(makeEvent() as any);
-    throw new Error('expected redirect, got nothing thrown');
-  } catch (e) {
-    // SvelteKit's `redirect` helper throws an object with status + location.
-    expect((e as { status: number }).status).toBe(302);
-    expect((e as { location: string }).location).toBe(target);
-  }
-}
-
-describe('/kiosk/edit auth gate', () => {
+describe('/kiosk/edit +layout.server.ts load', () => {
   beforeEach(() => {
-    GET.mockReset();
-    createServerClient.mockClear();
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    requireCapability.mockReset();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+  it('gates the kiosk-edit area through requireCapability with kiosk.edit', async () => {
+    requireCapability.mockResolvedValueOnce(undefined);
+    const event = makeEvent(new URL('http://localhost/kiosk/edit'));
 
-  it('forwards the incoming request to createServerClient (cookie plumbing)', async () => {
-    GET.mockResolvedValue({
-      data: { is_authenticated: true, capabilities: { 'kiosk.edit': true } },
+    await load(event as unknown as Parameters<typeof load>[0]);
+
+    expect(requireCapability).toHaveBeenCalledWith({
+      fetch: event.fetch,
+      url: event.url,
+      request: event.request,
+      activity: 'kiosk.edit',
     });
-    const event = makeEvent();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await load(event as any);
-    expect(createServerClient).toHaveBeenCalledWith(event.fetch, event.url, event.request);
   });
 
-  it('redirects anon to /login (via shared auth helper)', async () => {
-    GET.mockResolvedValue({ data: { is_authenticated: false, capabilities: {} } });
-    await expectRedirectTo('/login');
-  });
+  it('propagates the redirect/error thrown by requireCapability', async () => {
+    const denied = Object.assign(new Error('redirect'), { status: 302, location: '/login' });
+    requireCapability.mockRejectedValueOnce(denied);
+    const event = makeEvent(new URL('http://localhost/kiosk/edit'));
 
-  it('redirects authed user without kiosk.edit to /', async () => {
-    GET.mockResolvedValue({
-      data: { is_authenticated: true, capabilities: { 'kiosk.edit': false } },
-    });
-    await expectRedirectTo('/');
-  });
-
-  it('redirects authed user with missing kiosk.edit key to /', async () => {
-    GET.mockResolvedValue({ data: { is_authenticated: true, capabilities: {} } });
-    await expectRedirectTo('/');
-  });
-
-  it('lets users with kiosk.edit through', async () => {
-    GET.mockResolvedValue({
-      data: { is_authenticated: true, capabilities: { 'kiosk.edit': true } },
-    });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await expect(load(makeEvent() as any)).resolves.toEqual({});
+    await expect(load(event as unknown as Parameters<typeof load>[0])).rejects.toBe(denied);
   });
 });


### PR DESCRIPTION
## Summary
- `/kiosk/edit` had a hand-rolled auth gate that called `loadAuthenticatedMe` and checked `capabilities['kiosk.edit']` directly, bypassing `$lib/require-capability.server`. Switched it to the shared helper so the route matches the convention used by `/admin` and every catalog edit route.
- Test rewritten in the same style as `routes/admin/layout-server.test.ts` (mock `requireCapability`, assert it's called with the right activity).

## Why
The SEO plan's auth-gate scan (see `docs/plans/seo/RouteWalking.md`) detects gated routes by scanning `+layout.server.ts` files for the `$lib/require-capability.server` import. The hand-rolled gate was invisible to that scan.

## Behavior change
Authed users without `kiosk.edit` now redirect to `/verify-email` (was `/`). Same target as `/admin/*` and all catalog edit routes. Anonymous users still redirect to `/login` via `loadAuthenticatedMe`, unchanged.

## Test plan
- [x] `pnpm exec vitest run src/routes/kiosk/edit/layout-server.test.ts`
- [ ] Hit `/kiosk/edit` while signed out → `/login`
- [ ] Hit `/kiosk/edit` as an authed user without `kiosk.edit` → `/verify-email`
- [ ] Hit `/kiosk/edit` as an authed user with `kiosk.edit` → page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)