### PR TITLE
refactor(seo): add route classification walker

### DIFF
--- a/docs/plans/seo/CanonicalUrl.md
+++ b/docs/plans/seo/CanonicalUrl.md
@@ -29,17 +29,27 @@ None hard. Slots in alongside [`NoindexMeta.md`](NoindexMeta.md) — both are ro
 
 ## Mechanism
 
-Inject in the root `+layout.svelte` next to the noindex meta. Both are driven by the same `page` state.
+`route-metadata.server.ts` is a server-only module (see [`NoindexMeta.md`](NoindexMeta.md) for why), so the indexable flag is computed in the root `+layout.server.ts` alongside `noindex` and rides down as load data. The `+layout.svelte` then computes the canonical URL from `page.url` only when the flag says it should:
+
+```ts
+// frontend/src/routes/+layout.server.ts (the same file NoindexMeta.md adds)
+import { isSearchEngineIndexable } from "$lib/route-metadata.server";
+import type { LayoutServerLoad } from "./$types";
+
+export const load: LayoutServerLoad = ({ route }) => {
+  const indexable = isSearchEngineIndexable(route.id);
+  return { noindex: !indexable, indexable };
+};
+```
 
 ```svelte
 <!-- frontend/src/routes/+layout.svelte -->
 <script lang="ts">
   import { page } from '$app/state';
-  import { isIndexable } from '$lib/route-metadata';
   import { canonicalUrl } from '$lib/seo/canonical';
 
-  let indexable = $derived(isIndexable(page.route.id));
-  let canonical = $derived(indexable ? canonicalUrl(page.url, page.route.id) : null);
+  let { data, children } = $props();
+  let canonical = $derived(data.indexable ? canonicalUrl(page.url, page.route.id) : null);
 </script>
 
 <svelte:head>
@@ -59,7 +69,7 @@ Inject in the root `+layout.svelte` next to the noindex meta. Both are driven by
 
 ## What gets a canonical
 
-Every route where `isIndexable(routeId) === true`. Non-indexable routes get `noindex` instead and don't need a canonical.
+Every route where `isSearchEngineIndexable(routeId) === true`. Non-indexable routes get `noindex` instead and don't need a canonical.
 
 ## Gate on `ALLOW_SEARCH_ENGINE_INDEXING`?
 
@@ -87,7 +97,7 @@ Unit tests for `canonicalUrl()` cover trailing-slash normalization and the per-r
 
 - **Use `page.url.href` directly.** Rejected: bakes in the request host and query string, so a request to a preview origin or with a tracking param would emit a wrong canonical.
 - **Per-page `<svelte:head>` blocks in each indexable route.** Rejected for the same reason as in [`NoindexMeta.md`](NoindexMeta.md): centralizing in the root layout means a new route inherits correct behavior without per-page wiring.
-- **Fold into `NoindexMeta.md` and rename it `HeadSeoTags.md`.** Considered — same mechanism, same test file, both driven by `isIndexable()`. Rejected to keep each plan single-purpose and matching the existing `seo/` directory pattern.
+- **Fold into `NoindexMeta.md` and rename it `HeadSeoTags.md`.** Considered — same mechanism, same test file, both driven by `isSearchEngineIndexable()`. Rejected to keep each plan single-purpose and matching the existing `seo/` directory pattern.
 
 ## Open questions
 

--- a/docs/plans/seo/NoindexMeta.md
+++ b/docs/plans/seo/NoindexMeta.md
@@ -6,7 +6,7 @@ Addresses the "keeping non-indexable user-facing pages out of the index" concern
 
 ## Dependency
 
-This plan consumes [`RouteWalking.md`](RouteWalking.md) — the per-route `searchEngineInclusion` export, the walker primitives in `frontend/src/lib/route-metadata.ts`, and the `isIndexable(routeId)` predicate. Land that first.
+This plan consumes [`RouteWalking.md`](RouteWalking.md) — the walker primitives in `frontend/src/lib/route-metadata.server.ts` and the `isSearchEngineIndexable(routeId)` predicate. Land that first.
 
 ## Why per-page noindex, not robots.txt `Disallow`
 
@@ -19,45 +19,55 @@ See [`SearchEngines.md`](SearchEngines.md) § "Why the split between robots.txt 
 ## Goals
 
 - Every non-indexable user-facing page emits `<meta name="robots" content="noindex">` in its `<head>`.
-- The decision is driven by the same `isIndexable(routeId)` predicate the sitemap uses — no parallel list, no drift.
-- Adding a new non-indexable route requires only the existing `searchEngineInclusion = 'excluded'` export; the meta tag follows automatically.
+- The decision is driven by the same `isSearchEngineIndexable(routeId)` predicate the sitemap uses — no parallel list, no drift.
+- Adding a new non-indexable route requires only adding it to `SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS` (or letting the catalog convention classify it); the meta tag follows automatically.
 
 ## Mechanism
 
-Inject in the root `+layout.svelte` so it covers every route:
+`route-metadata.server.ts` is a server-only module — its `?raw` glob would balloon the client bundle if imported into a `.svelte` file. So the predicate runs in the root `+layout.server.ts` and the result rides down as load data:
+
+```ts
+// frontend/src/routes/+layout.server.ts (new file)
+import { isSearchEngineIndexable } from "$lib/route-metadata.server";
+import type { LayoutServerLoad } from "./$types";
+
+export const load: LayoutServerLoad = ({ route }) => {
+  return { noindex: !isSearchEngineIndexable(route.id) };
+};
+```
 
 ```svelte
 <!-- frontend/src/routes/+layout.svelte -->
 <script lang="ts">
-  import { page } from '$app/state';
-  import { isIndexable } from '$lib/route-metadata';
-
-  let noindex = $derived(!isIndexable(page.route.id));
+  let { data, children } = $props();
 </script>
 
 <svelte:head>
-  {#if noindex}
+  {#if data.noindex}
     <meta name="robots" content="noindex" />
   {/if}
 </svelte:head>
 
-<!-- ...existing layout body... -->
+{@render children?.()}
+<!-- ...rest of existing layout body... -->
 ```
 
 Notes:
 
-- `page.route.id` is the SvelteKit route ID (e.g. `/titles/[slug]`), which is the same shape `isIndexable()` already operates on — no translation needed.
+- `route.id` on the server load event is the SvelteKit route ID (e.g. `/titles/[slug]`), which is the same shape `isSearchEngineIndexable()` already operates on — no translation needed.
+- Adding a root `+layout.server.ts` must NOT import `$lib/require-capability.server` — the auth-gate scan in `route-metadata.server.ts` throws at module load if a root gate is detected (it would silently make every non-catalog route non-indexable).
 - Auth-gated routes get the meta tag too. They're already invisible to crawlers (the layout redirects unauthenticated requests), but defense in depth is cheap: if anything ever serves an auth-gated page bytes to a logged-out crawler, the meta still says noindex.
 - Use `<meta name="robots">`, not `<meta name="googlebot">` — the generic form covers Google, Bing, and other compliant crawlers in one tag.
 
 ## What gets the meta tag
 
-Every route where `isIndexable(routeId) === false`. With current routes:
+Every route where `isSearchEngineIndexable(routeId) === false`. With current routes:
 
-- Auth-gated (anything under a `requireCapability` layout): `/a/*`, plus catalog edit subroutes once they have such a layout.
-- Declared `searchEngineInclusion = 'excluded'`: `/login`, `/signup`, `/verify-email`, `/auth/*`, `/search`, `/kiosk/*`, `/style-lab`, `/api-docs`, `/_sentry_test`, `/changesets/*`, `/review/*`, and the catalog edit subroutes (`/*/edit`, `/*/edit-history`, `/*/sources`, `/*/new`) until/unless they get a `requireCapability` layout.
+- Auth-gated (anything under a `requireCapability` layout): `/admin/*`, `/kiosk/edit/*`, and all catalog `*/edit` subroutes.
+- Listed non-indexable (entries in `SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS`): `/login`, `/signup`, `/verify-email`, `/auth/error`, `/search`, `/kiosk`, `/style-lab`, `/api-docs`, `/_sentry_test`, `/changesets`, `/review`, `/users/[username]`.
+- Catalog non-indexable kinds (`catalog-listing`, `catalog-new`, `catalog-delete`) for every entity.
 
-The list isn't enumerated in this doc — it's whatever `isIndexable()` returns false for, and the route-walking test (per [`RouteWalking.md`](RouteWalking.md)) already enforces that every route declares its classification.
+The list isn't enumerated in this doc — it's whatever `isSearchEngineIndexable()` returns false for, and the route-walking test (per [`RouteWalking.md`](RouteWalking.md)) already enforces that every route classifies.
 
 ## Gate on `ALLOW_SEARCH_ENGINE_INDEXING`?
 
@@ -71,17 +81,18 @@ No. The meta tag should be emitted on every deploy regardless of whether indexin
 
 `frontend/src/routes/+layout.dom.test.ts` (or a new `noindex-meta.dom.test.ts` alongside):
 
-- Render the layout for an indexable route (`/titles`) and assert no `<meta name="robots">` is present.
-- Render for a non-indexable declared route (`/login`) and assert `<meta name="robots" content="noindex">` is present.
-- Render for an auth-gated route (`/a/dashboard`) and assert the meta is present.
+- Render the layout for an indexable route (`/titles/[slug]`) and assert no `<meta name="robots">` is present.
+- Render for a listed non-indexable route (`/login`) and assert `<meta name="robots" content="noindex">` is present.
+- Render for an auth-gated route (`/admin/dashboard`) and assert the meta is present.
 
 The test parameterizes over the same anchor routes used in `RouteWalking.md`'s sanity check — keeps both tests honest if the route classifications drift.
 
 ## Implementation order
 
-1. Add the `<svelte:head>` block to `frontend/src/routes/+layout.svelte`. Roughly five lines.
-2. Add the dom test per § "Tests".
-3. Verify locally: `curl -s localhost:5173/login | grep robots` shows the meta; same for `/titles` shows nothing.
+1. Create `frontend/src/routes/+layout.server.ts` with the noindex load. Verify the auth-gate scan still passes (the new file imports `route-metadata.server`, not `require-capability.server`, so it's fine).
+2. Add the `<svelte:head>` block to `frontend/src/routes/+layout.svelte` reading `data.noindex`.
+3. Add the dom test per § "Tests".
+4. Verify locally: `curl -s localhost:5173/login | grep robots` shows the meta; same for `/titles/medieval-madness` shows nothing.
 
 That's the whole PR. Tiny.
 
@@ -89,4 +100,5 @@ That's the whole PR. Tiny.
 
 - **`X-Robots-Tag: noindex` HTTP response header instead of a meta tag.** Equivalent in effect; required for non-HTML responses (PDFs, images). For HTML pages we control, the meta tag is simpler — no SvelteKit `setHeaders` plumbing, just markup. Revisit if we ever serve non-HTML responses that need excluding.
 - **Per-route `<svelte:head>` blocks in each excluded page.** Rejected: would silently miss any new non-indexable route until a reviewer noticed. Centralizing the decision in the root layout means "well-classified" automatically implies "correctly headed."
-- **Folding into `Robots.md`.** Rejected: different mechanism (HTML markup vs. text file), different consumer (per-request render vs. static file), different testing surface. Sharing the `isIndexable()` predicate is enough integration.
+- **Computing `noindex` in `+layout.svelte` directly.** Rejected — would require importing `route-metadata.server.ts` into a client-bundle file, which SvelteKit blocks (rightly: the module's `?raw` glob would ship server source as strings to the browser).
+- **Folding into `Robots.md`.** Rejected: different mechanism (HTML markup vs. text file), different consumer (per-request render vs. static file), different testing surface. Sharing the `isSearchEngineIndexable()` predicate is enough integration.

--- a/docs/plans/seo/RouteWalking.md
+++ b/docs/plans/seo/RouteWalking.md
@@ -1,129 +1,257 @@
 # Route Metadata and Walking
 
-Plan for introducing route-metadata primitives — `frontend/src/lib/route-metadata.ts` — and the first piece of metadata that lives there: a per-route `searchEngineInclusion` classification, plus walker utilities and tests that enforce it.
+Plan for the shared classification machinery — `frontend/src/lib/route-metadata.server.ts` — that answers "is this route indexable?" for sitemap, robots, noindex meta, canonical, SSR enforcement and title/description enforcement. Those consumers live downstream and are described in [`SearchEngines.md`](SearchEngines.md).
 
-The route-metadata primitive is consumed by the SEO strategy (see [`SearchEngines.md`](SearchEngines.md)), but is independently valuable as an auth-gating enforcement test — it pays off even if no SEO work ever happens.
+The headline design choice: **derive indexability from the catalog entity registry where possible, declare it per-route only for the small set of routes that can't be derived.** This follows the project's [model-driven metadata](../model_driven_metadata/ModelDrivenMetadata.md) discipline — the catalog model is the source of truth, not parallel per-route declarations.
 
 ## Why
 
-Two unrelated-looking problems share a root cause: there's no machine-readable answer for "what kind of route is this?"
+Two facts about the route tree make per-route co-located classification the wrong shape:
 
-1. **Search-engine inclusion is implicit.** Is `/search` supposed to be in Google's index? `/style-lab`? `/login`? Today the answers live in reviewer attention and conventions. A new route silently inherits "yes" by default; if you forgot to think about it, the sitemap ships it.
-2. **Auth gating is declared, but nothing enforces "is the right mechanism used?"** `requireCapability` is the canonical helper, but nothing stops someone from rolling a one-off `if (!locals.user) throw redirect(...)` inside `+page.server.ts`. The mistake is invisible until a security audit.
+1. **Most routes are catalog routes.** The entity registry has 20 entries today. Each one has a detail route, a listing route and edit / delete / edit-history / sources / new subroutes. That's ~140 catalog routes vs. ~14 non-catalog ones. Their indexability is a class fact, not a per-route fact: every detail page is indexable, every edit subroute isn't. Co-locating an export on each one would be ~140 mechanical declarations that all say the same thing — and adding a new catalog entity would mean remembering to add five more. That's exactly the "code expansion instead of declaration" smell [ModelDrivenMetadata.md](../model_driven_metadata/ModelDrivenMetadata.md) is fighting.
+2. **A small set of routes are outside the catalog convention.** `/`, `/about`, `/(legal)/*`, `/login`, `/signup`, `/verify-email`, `/auth/error`, `/search`, `/style-lab`, `/api-docs`, `/kiosk/*`, `/users/[username]`, `/_sentry_test`. Their indexability isn't derivable from any registry — it's a per-route product decision. (`/__health` is a `+server.ts` endpoint, not a page — `allRoutes()` doesn't enumerate it and the classifier never sees it.)
 
-Making the search-engine signal explicit on every route — and adding a test that cross-checks the auth mechanism against the layout chain — closes both gaps with one small piece of machinery. This work is independently valuable: the auth-mechanism enforcement is a security guardrail that pays off even if no SEO work ever happens. (The follow-on work in [`Robots.md`](Robots.md) and [`Sitemap.md`](Sitemap.md) consumes it as a dependency.)
+The right split: catalog routes inherit class-level answers from the existing entity registry ([`catalog-meta.ts`](frontend/src/lib/api/catalog-meta.ts)); the rest get short hand-maintained allowlists. The walker exists mainly to enforce "every route fits into exactly one bucket" — catching anything that slips through unclassified.
 
-The file is named `route-metadata.ts` because we'll likely add more per-route metadata over time (canonical tags, SSR overrides, custom analytics flags, etc.); the search-engine classification is just the first.
+The auth-gate check the walker needs anyway (gated routes aren't indexable) covers `/admin/*` and `/kiosk/edit/*` for free.
 
-## The two orthogonal signals
+## Invariants
 
-Each piece of information lives in exactly one place — no parallel systems, no redundant declarations.
+The design MUST satisfy these two properties:
 
-- **`requireCapability` in a `+layout.server.ts`** = the route is gated. This is what the codebase already uses today; nothing changes about the auth mechanism itself. The walker reads this to determine that a route is auth-gated.
-- **`export const searchEngineInclusion` on a route or layout file** = whether the route should appear in search-engine indexes. Two values: `'included'` or `'excluded'`. Layouts let descendants inherit.
+1. **Adding a new catalog entity requires zero SEO declarations.** Once the entity ships in `CATALOG_META`, detail / listing / edit-history / sources / edit / new / delete routes all classify correctly without any human-authored per-route metadata. Any design that requires the contributor to remember to add an SEO declaration alongside their new entity violates this invariant.
+2. **Adding a non-catalog route forces an explicit classification decision.** The walker test fails until the route appears in `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`, `SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS`, or under a non-catalog auth-gated layout (today `/admin/*` and `/kiosk/edit/*`). There is no silent default — an unclassified route is a test failure, not an "implicitly included" or "implicitly excluded" route.
 
-The two axes are independent at the declaration layer. Consumers (sitemap, robots.txt) compose them via the `isIndexable()` predicate, which returns `true` only when the route is included AND not gated.
+The first invariant comes from the [model-driven metadata](../model_driven_metadata/ModelDrivenMetadata.md) discipline: parallel hand-maintained per-route declarations are exactly the drift surface model-driven design eliminates. The second invariant comes from the SEO consequences of "wrong default": a route silently included that shouldn't be leaks into the index and is expensive to remove (Google caches removed pages for months); a route silently excluded that shouldn't be costs traffic invisibly. Both directions of failure are slow to detect; forcing the decision at PR time is cheap by comparison.
 
-## The `SearchEngineInclusion` type
+## The classification
 
-```ts
-// frontend/src/lib/route-metadata.ts
-export type SearchEngineInclusion = "included" | "excluded";
+Catalog routes are classified by **URL pattern** against the `entity_type_plural` values in `CATALOG_META`. Auth-gated areas outside the catalog (`/admin/*` and `/kiosk/edit/*` today) are classified by **import scan**. Everything else comes from short hand-maintained allowlists.
 
-export const SEARCH_ENGINE_INCLUSION_VALUES = ["included", "excluded"] as const;
-```
+| Bucket                       | How it's recognized                                                                                                                                               | Indexable?                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Catalog: listing**         | `/{plural}`                                                                                                                                                       | No, **for now** — low search value (fast-changing list view, detail pages are the SEO surface) and CSR-only today because listings hydrate the full entity slug client-side. We'll likely flip to indexable once the SSR data-shape problem is solved; the cost of staying non-indexable in the meantime is small because the sitemap of detail pages covers discovery. See [`SearchEngines.md`](SearchEngines.md). |
+| **Catalog: detail**          | `/{plural}/[public-id]`                                                                                                                                           | Yes                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Catalog: edit-history**    | `/{plural}/[public-id]/edit-history`                                                                                                                              | Yes                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Catalog: sources**         | `/{plural}/[public-id]/sources`                                                                                                                                   | Yes                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Catalog: edit**            | `/{plural}/[public-id]/edit` (with optional `/[section]`). Gated by convention (`catalog.edit`).                                                                  | No                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **Catalog: new**             | `/{plural}/new`, `/{plural}/[public-id]/new` and nested-create patterns like `/{plural}/[public-id]/{nested-plural}/new`. Gated by convention (`catalog.create`). | No                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **Catalog: delete**          | `/{plural}/[public-id]/delete`. Gated by convention (`catalog.delete`) via the shared `loadDeletePreview` helper.                                                 | No                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **Auth-gated (non-catalog)** | Any ancestor `+layout.server.ts` imports `$lib/require-capability.server`. Today: `/admin/*`, `/kiosk/edit/*`.                                                    | No                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **Listed indexable**         | Route ID appears in `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`                                                                                                           | Yes                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Listed non-indexable**     | Route ID appears in `SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS`                                                                                                       | No                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
-## Where the `searchEngineInclusion` exports go
+`{plural}` matches any `entity_type_plural` value from `CATALOG_META`. `[public-id]` is the entity's public identifier and may contain slashes — most entities use a single path segment (`/titles/medieval-madness`), but Location uses a multi-segment hierarchical path (`/locations/usa/il/chicago/logan-arcade`). The matcher accepts both forms. New catalog entities light up every row automatically as soon as they appear in the registry — this is how Invariant 1 is satisfied. The walker-test "every route is classified" rule is how Invariant 2 is enforced.
 
-Inheritance does most of the work. Set the default at the top-level layout:
+`/models/[slug]` classifies as `catalog-detail` (indexable) like every other detail route; the existing 301 redirect on single-model Titles handles the Title↔Model duplicate at request time, so the walker doesn't need to know about the collapse rule.
 
-```ts
-// frontend/src/routes/+layout.ts
-export const searchEngineInclusion = "included" as const;
-```
+### Nested listings under a catalog detail
 
-Override at leaves where they differ:
+A handful of routes are shaped like `/{plural}/[public-id]/{nested-plural}` — a page that lists entities related to a parent. Today only `/manufacturers/[slug]/systems` exists as a real page (has its own `+page.svelte`, SSR via the `[slug]/+layout.ts` ancestor). `/titles/[slug]/models` and `/manufacturers/[slug]/corporate-entities` are directory-only — they exist solely to host `/new` underneath — so they have no page file (neither `+page.svelte` nor `+page@*.svelte`) and don't appear in `allRoutes()`.
 
-```ts
-// frontend/src/routes/login/+page.server.ts
-export const searchEngineInclusion = "excluded" as const;
-```
+With N=1, we don't introduce a `catalog-nested-listing` class. A regex for that pattern would have to carve out `edit` / `edit-history` / `sources` / `delete` / `new` as exclusions — more machinery than one route warrants. Instead, `/manufacturers/[slug]/systems` lives in `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS` as a deliberate per-route product decision. Revisit when a second nested listing ships.
 
-```ts
-// frontend/src/routes/style-lab/+page.ts
-export const searchEngineInclusion = "excluded" as const;
-```
-
-Routes that today only have `+page.svelte` need a `+page.ts` added to carry the export. Trivial — one-line file.
-
-**Gated routes don't need this export.** Routes under a `requireCapability` layout (today: `/a/*`; catalog edit subroutes once they have such a layout) are inherently excluded from search engines — there's no point declaring `searchEngineInclusion = 'excluded'` on them. The walker treats them as excluded by virtue of being auth-gated. Declaring it anyway would be a contradiction the test catches (see below).
-
-For catalog edit subroutes (`/titles/[slug]/edit`, `/sources`, `/edit-history`, `/new`), the path forward is to put `requireCapability` on the section's `+layout.server.ts` (or add one). Once that layout exists, the entire subtree is auth-gated — no per-route `searchEngineInclusion` declaration needed anywhere in it.
-
-## Walker primitives
-
-`frontend/src/lib/route-metadata.ts` exposes composable utilities the test and downstream consumers all share:
+## The module
 
 ```ts
-export function allRoutes(): RouteId[];
-export function searchEngineInclusionFor(id: RouteId): SearchEngineInclusion;
-export function isAuthGated(id: RouteId): boolean; // via requireCapability ancestor
-export function isIndexable(id: RouteId): boolean; // composite: !isAuthGated && included
-export function layoutChain(id: RouteId): string[]; // ancestor +layout(.server)?.ts paths
-export function hasAncestorImport(id: RouteId, module: string): boolean;
-```
+// frontend/src/lib/route-metadata.server.ts
+import { CATALOG_META, type CatalogEntityKey } from "$lib/api/catalog-meta";
 
-`isIndexable()` is the composite predicate consumers actually want:
+// Route IDs (SvelteKit page.route.id form — groups like (legal) and params
+// like [username] preserved). NOT URLs — /(legal)/privacy, not /privacy.
+// `satisfies readonly RouteId[]` pins entries to SvelteKit's generated
+// RouteId union, catching typos and stale entries at compile time.
+export const SEARCH_ENGINE_INDEXABLE_ROUTE_IDS = [
+  "/",
+  "/about",
+  "/about/people",
+  "/(legal)/privacy",
+  "/(legal)/terms",
+  "/(legal)/licensing",
+  "/manufacturers/[slug]/systems",
+] as const satisfies readonly RouteId[];
 
-```ts
-export function isIndexable(id: RouteId): boolean {
-  if (isAuthGated(id)) return false;
-  return searchEngineInclusionFor(id) === "included";
+// Route IDs (SvelteKit page.route.id form — groups and params preserved).
+// NOT URLs — /users/[username], not /users/moses.
+export const SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS = [
+  "/login",
+  "/signup",
+  "/verify-email",
+  "/auth/error",
+  "/search",
+  "/style-lab",
+  "/api-docs",
+  // Low search value while user pages are an activity stream rather than a
+  // stable profile. Revisit if user pages grow real profile content.
+  "/users/[username]",
+  "/changesets",
+  "/review",
+  "/kiosk",
+  "/_sentry_test",
+] as const satisfies readonly RouteId[];
+
+export type RouteClass =
+  | { kind: "catalog-listing"; entity: CatalogEntityKey }
+  | { kind: "catalog-detail"; entity: CatalogEntityKey }
+  | { kind: "catalog-edit-history"; entity: CatalogEntityKey }
+  | { kind: "catalog-sources"; entity: CatalogEntityKey }
+  | { kind: "catalog-edit"; entity: CatalogEntityKey }
+  | { kind: "catalog-new"; entity: CatalogEntityKey }
+  | { kind: "catalog-delete"; entity: CatalogEntityKey }
+  | { kind: "auth-gated" } // non-catalog, via import scan
+  | { kind: "listed-indexable" }
+  | { kind: "listed-non-indexable" }
+  | { kind: "unclassified" };
+
+export function classifyRoute(id: RouteId): RouteClass {
+  // 1. Try catalog patterns against every CATALOG_META[*].entity_type_plural
+  // 2. Try non-catalog auth-gate (ancestor +layout.server.ts imports $lib/require-capability.server)
+  // 3. Try the two listed allowlists
+  // 4. Fall through to 'unclassified'
+}
+
+export function isSearchEngineIndexable(id: RouteId): boolean {
+  const c = classifyRoute(id);
+  switch (c.kind) {
+    case "catalog-detail":
+    case "catalog-edit-history":
+    case "catalog-sources":
+    case "listed-indexable":
+      return true;
+    case "catalog-listing": // non-indexable for now (low search value + CSR-only); revisit when listing SSR lands
+    case "catalog-edit":
+    case "catalog-new":
+    case "catalog-delete":
+    case "auth-gated":
+    case "listed-non-indexable":
+      return false;
+    case "unclassified":
+      // Throw, don't soft-fail. The every-route-classified vitest test is
+      // the primary gate (run in CI before deploy); on the rare slip-through,
+      // a loud 500 on the affected route is the right failure mode. A silent
+      // `return false` with a `console.error` is the worst of both worlds:
+      // pages that should be indexed silently aren't, and the log line in a
+      // server stream rarely gets read until traffic drops.
+      throw new Error(`Route ${id} is unclassified. Add it to a catalog convention, an auth-gated layout, or one of the SEARCH_ENGINE_*_ROUTE_IDS allowlists.`);
+  }
+}
+
+// Enumerates page-bearing route IDs — every route with a +page.svelte OR
+// +page@*.svelte (reset-layout form, used by every catalog /delete page and
+// the nested-create pages). A naïve `+page.svelte` glob silently excludes
+// 22 of 157 page routes. +server.ts endpoints are excluded: non-HTML
+// responses, no meta-tag surface. Directory-only routes (e.g.
+// /titles/[slug]/models, which exists solely to host /new underneath) are
+// also excluded since they have no +page.svelte and SvelteKit never serves
+// them as a page.
+export function allRoutes(): RouteId[] {
+  /* import.meta.glob('/src/routes/**/+page*.svelte') — then strip the
+     @-suffix from the filename to recover the route ID. */
 }
 ```
 
-Internally the walker wraps `import.meta.glob('/src/routes/**/+*')`. Roughly 100 lines.
+Public surface: `classifyRoute`, `isSearchEngineIndexable`, `allRoutes`, the two `SEARCH_ENGINE_*_ROUTE_IDS` constants (consumed by the sitemap), and the `RouteClass` / `CatalogRouteClass` types plus the `isCatalogRoute` type guard (consumed by the catalog-meta and convention tests). Pattern-match helpers and the auth-gate import-scan stay file-private.
+
+Catalog pattern-matching is straightforward: walk `CATALOG_META`, build a regex per `entity_type_plural`, match against `routeId`. The `[public-id]` slot realizes as `[slug]` at the SvelteKit level for most entities and as `[...path]` for Location; the matcher handles both. Nested-create routes (e.g. `/titles/[public-id]/models/new`, `/manufacturers/[public-id]/corporate-entities/new`) are recognized as `catalog-new` for the inner entity.
+
+Non-catalog auth-gate detection: scan every ancestor `+layout.server.ts` for a `$lib/require-capability.server` import. The scan matches `/admin/+layout.server.ts`, `/kiosk/edit/+layout.server.ts`, and every `/{plural}/[slug]/edit/+layout.server.ts`. The catalog-edit hits are redundant with the catalog-pattern bucket: classification tries catalog patterns first, so catalog-edit routes are claimed before this scan ever fires. After catalog-pattern matching, the routes the scan effectively catches are `/admin/*` and `/kiosk/edit/*` (and `/kiosk/edit` itself — see prefix-match note below). A new non-catalog gated area (say `/ops/*`) is covered by the same rule — no allowlist needed.
+
+## Enforcing the convention
+
+The catalog classification trusts that `catalog-edit` / `catalog-new` / `catalog-delete` routes are actually gated. That trust needs its own enforcement, separate from the walker:
+
+A small test (lives next to the walker) asserts the gate is in place for every catalog entity:
+
+- For each `CATALOG_META[*].entity_type_plural`:
+  - The `edit` route's `+layout.server.ts` imports `$lib/require-capability.server` and calls `requireCapability({ activity: 'catalog.edit', ... })`.
+  - The `new` route's `+page.server.ts` (and any nested-create page) imports `$lib/require-capability.server` and uses `activity: 'catalog.create'`.
+  - The `delete` route's `+page.server.ts` imports `$lib/delete-preview-loader.server` (the helper that calls `requireCapability({ activity: 'catalog.delete' })`).
+
+Cheap text-match scan. Fails loudly if someone adds a catalog entity without wiring its standard auth gates. The walker stays simple because gate-presence is enforced in a separate, narrowly-scoped test rather than encoded as walker knowledge.
+
+## Performance
+
+`isSearchEngineIndexable(routeId)` runs on every SSR request that injects a noindex meta tag, so per-request cost matters. Every lookup is O(small) and touches no filesystem:
+
+- **Catalog pattern match.** Regex against a small precomputed set of patterns derived from `CATALOG_META` at module load.
+- **Non-catalog auth-gate.** A precomputed set of gated route-ID prefixes: `/admin`, `/kiosk/edit`, and every `/{plural}/[slug]/edit` (the catalog-edit ones are dead code in practice since catalog-pattern matching runs first, but the set has them). Prefixes are in SvelteKit pattern form (literal `[slug]` / `[...path]` brackets) — same shape as `page.route.id`, so no URL normalization needed. The match is `routeId === prefix || routeId.startsWith(prefix + '/')`, **not** a plain `startsWith(prefix + '/')` — the latter misses the layout's own page (e.g. the route ID for `/kiosk/edit/+page.svelte` is `/kiosk/edit`, with no trailing slash). Built via `import.meta.glob('/src/routes/**/+layout.server.ts', { eager: true, query: '?raw', import: 'default' })` — Vite resolves this at **build time** and bakes each matched layout's source into the SSR bundle as a top-level string-literal `const`. At module load, one pass over the matched strings substring-checks for `from '$lib/require-capability.server'` and computes the prefix set. No filesystem I/O at runtime. Do NOT implement this with `fs.readFile` / `fs.readdir` at module load — that pays real I/O on every cold worker start and breaks when the SSR bundle is deployed without the source tree.
+- **Listed allowlist.** `Set.has(routeId)` against the two `SEARCH_ENGINE_*_ROUTE_IDS` constants.
+
+The `import.meta.glob('/src/routes/**/+*')` walk is resolved by Vite at **build time**, not request time. It exists only to enumerate the route tree for:
+
+- The vitest tests (every-route-classified, indexable-routes-are-SSR, anchor sanity, catalog-auth-convention).
+- The sitemap generator at build time (or whenever it regenerates).
+
+SvelteKit provides `page.route.id` already in pattern form (`/titles/[slug]`, not `/titles/medieval-madness`), so there's no URL parsing at request time either — the input string is already what the walker expects.
 
 ## The test (`route-metadata.test.ts`)
 
-A route is well-formed iff **exactly one** of these is true:
+The walker exists to enforce three things:
 
-1. It has a `requireCapability` ancestor (auth-gated). No `searchEngineInclusion` export anywhere in its chain.
-2. It has a `searchEngineInclusion` export (one of `SEARCH_ENGINE_INCLUSION_VALUES`) somewhere in its chain. No `requireCapability` ancestor.
+1. **Every route is classified.** Walk `allRoutes()`, call `classifyRoute()` on each and assert no `unclassified` results. New routes fail until they're either gated, follow a catalog convention or appear in one of the two listed allowlists.
+2. **Every indexable route is SSR-enabled.** Walk `allRoutes()`, filter to `isSearchEngineIndexable(routeId) === true`, and for each one assert the route resolves to `ssr === true` after walking its config ancestor chain. SvelteKit's resolution rule: walk from leaf up through ancestors, take the first `export const ssr = X` declaration found in any of `+page.ts` / `+page.js` / `+page.server.ts` / `+layout.ts` / `+layout.js` / `+layout.server.ts` at that level, default to `true` if none. (The `.server.ts` variants matter: catalog `[slug]/edit/+layout.server.ts` is exactly where `ssr = false` lives today.) Same raw-source trick as the auth-gate scan — bake source into the bundle at build time via `import.meta.glob('?raw')`, scan for `export const ssr = (true|false)` with a regex. Fails loudly if someone flips `ssr = false` on a layout that contains an indexable page, or adds a new indexable route without giving it SSR.
+3. **Anchor sanity.** A small table of stable route IDs resolves to the expected `RouteClass` and `isSearchEngineIndexable()` values. Inputs are in **route-pattern form** — the same shape `page.route.id` has at runtime and the same shape `classifyRoute()` takes — not resolved URLs. That keeps the test exercising the real input shape, lets the `RouteId` type catch typos and renames at compile time, and avoids reimplementing SvelteKit's matcher (which would be wrong on `[...path]`):
 
-The test enumerates `allRoutes()` and asserts each route falls cleanly into one of the two cases. Two failure modes:
+   ```ts
+   // Anchors use route-pattern form (page.route.id), not resolved URLs.
+   const ANCHORS: Array<[RouteId, RouteClass["kind"], boolean]> = [
+     ["/", "listed-indexable", true],
+     ["/about", "listed-indexable", true],
+     ["/titles", "catalog-listing", false],
+     ["/titles/[slug]", "catalog-detail", true],
+     ["/titles/[slug]/edit-history", "catalog-edit-history", true],
+     ["/titles/[slug]/edit", "catalog-edit", false],
+     ["/locations/[...path]", "catalog-detail", true],
+     ["/login", "listed-non-indexable", false],
+     ["/admin/dashboard", "auth-gated", false],
+     // Pins the prefix-match off-by-one: /kiosk/edit is the layout's own
+     // page (no trailing slash), not just a parent of /kiosk/edit/[id].
+     ["/kiosk/edit", "auth-gated", false],
+   ];
+   ```
 
-- **Both signals present** → contradiction. "You declared `searchEngineInclusion` on a route that's auth-gated. Auth-gated routes are inherently excluded; drop the declaration."
-- **Neither signal present** → unclassified. "Either gate this route via `requireCapability` or declare its `searchEngineInclusion`."
+   Defends against "walker returned nothing, so all assertions trivially pass." Self-documenting; a magic-number count threshold would catch the same case less precisely and would rot on intentional consolidation.
 
-Bi-directional auth-mechanism enforcement falls out of this naturally. The same layout-chain inspection that determines `isAuthGated()` IS the auth gate, so they can't drift. A one-off `if (!locals.user) throw redirect(...)` in some `+page.server.ts` won't register as an auth gate — that route will fail the test as "unclassified" until either `requireCapability` is added or a `searchEngineInclusion` export is declared.
+4. **The two allowlists are disjoint.** A short assertion that no route ID appears in both `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS` and `SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS`. Two separate `as const` arrays are more readable than a single map, but TypeScript can't catch double-entry at compile time; this test does.
 
-**Anchor sanity check.** A small set of known-stable routes (`/`, `/titles`, `/titles/[slug]`, `/about`, `/login`, `/a/dashboard`) must appear in `allRoutes()` and resolve to the expected combination of `searchEngineInclusionFor()` / `isAuthGated()` values. Defends against "walker silently returned nothing, so all assertions trivially pass." Self-documenting; a magic-number count threshold would catch the same case less precisely and would rot on intentional route consolidation.
+That's the whole walker-test surface. The separate `catalog-auth-convention.test.ts` (see [Enforcing the convention](#enforcing-the-convention)) covers gate-presence; the two tests together cover both "every route is classified" and "every convention-gated catalog route actually has its gate."
 
-Implementation note for the auth detection: static text-match scan of `+layout.server.ts` files for the `require-capability.server` import. Cheap and adequate at current size. If a future second auth mechanism is introduced, this is the canonical place to recognize it — updating the walker is a deliberate decision rather than a silent broadening.
+## Refactor: fold the existing route walker into this module
 
-## Refactor existing route-walking
+[`frontend/src/lib/api/catalog-meta.test.ts`](frontend/src/lib/api/catalog-meta.test.ts) already walks the route tree via `import.meta.glob('/src/routes/**/+*')` to enforce that every `CATALOG_META` key has detail and edit-history / sources subroutes. The `route-metadata` walker needs the same enumeration. Two changes:
 
-One existing test walks the route tree for an adjacent purpose and should consume the walker:
+- Move the `import.meta.glob` walk into `route-metadata.server.ts`'s `allRoutes()`.
+- Have `catalog-meta.test.ts` consume `allRoutes()` + `classifyRoute()` instead of doing its own glob + regex. The `ROUTE_DIR_TO_KEY` / `UNMAPPED_ROUTE_DIRS` / `DEFERRED_KEYS` structure becomes redundant: catalog membership now comes from `CATALOG_META` and the route-class match, not a parallel hand-maintained map.
 
-- **`frontend/src/lib/api/catalog-meta.test.ts`** uses `import.meta.glob('/src/routes/**/+*')` to discover detail routes and assert each is mapped in `CATALOG_META`. Refactor to consume `allRoutes()` (and a helper that recognizes catalog-detail patterns). One walker, one set of bugs.
+The module is suffixed `.server.ts` because it uses `import.meta.glob('/src/routes/**/+layout.server.ts', { eager: true, query: '?raw' })` to scan auth-gate imports. Vite inlines each matched file's source as a string literal at build time, and SvelteKit's normal "you can't import a `.server.ts` from client code" check doesn't apply to `?raw` (it's a string, not a module). Without the `.server` suffix on this module, any client-side importer would ship every `+layout.server.ts` and `+page.server.ts` source string into the browser bundle. Downstream consumers (noindex meta injection, canonical URL helper, etc.) should compute the boolean in a server load and pass it down as data — not call `isSearchEngineIndexable()` from a `.svelte` file.
 
-Out of scope — don't refactor these:
+Out of scope — don't touch:
 
-- **`frontend/src/lib/focus-mode.ts`** (`MINIMAL_SHELL_EXACT_PATHS`, `FOCUS_EXACT_PATHS`, `isFocusModePath()`) classify routes by UI chrome, a different axis. Some paths overlap (`/signup`, `/auth/error`, `/kiosk`, `*/edit` suffixes) but binding two axes together when they happen to overlap creates a future "they diverged" headache. Revisit only if they actually drift.
-- **`frontend/src/lib/frontDoors.ts`** is a UI-shell concern; unrelated.
+- [`frontend/src/lib/focus-mode.ts`](frontend/src/lib/focus-mode.ts) (`MINIMAL_SHELL_EXACT_PATHS`, `FOCUS_EXACT_PATHS`) classifies routes by UI chrome, a different axis. Some paths overlap (`/signup`, `/auth/error`, `/kiosk`, `*/edit`) but binding two axes together creates a future "they diverged" headache. Revisit only if they actually drift.
+- [`frontend/src/lib/frontDoors.ts`](frontend/src/lib/frontDoors.ts) is a UI-shell concern; unrelated.
 
 ## What this enables downstream
 
-- **`robots.txt`** — see [`Robots.md`](Robots.md). Derives `Disallow:` lines from `isIndexable()` over the route tree.
-- **`sitemap.xml`** — see [`Sitemap.md`](Sitemap.md). Feeds `isIndexable()` into super-sitemap's `excludeRoutePatterns`.
-- **Future per-route metadata** — the same file (`route-metadata.ts`) is the natural home for additional per-route signals (canonical URL overrides, SSR exceptions, analytics tags, etc.). Same walker primitives, new exports.
-- **Future cross-cutting tests** — e.g. "every catalog detail route has an `edit-history` and `sources` subroute," "every included route renders a `<link rel='canonical'>`." Reusable walker, ad-hoc composition.
+Full consumer list lives in [`SearchEngines.md`](SearchEngines.md); short version:
+
+- **`robots.txt`** — see [`Robots.md`](Robots.md). Server-endpoint disallows, mostly orthogonal to route classification.
+- **`sitemap.xml`** — see [`Sitemap.md`](Sitemap.md). Enumerates per-entity URLs from `CATALOG_META` + entity data: the detail page plus an `/edit-history` and `/sources` URL per entity. Adds the entries from `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`. The walker's `isSearchEngineIndexable()` is the filter for any include/exclude question.
+- **`<meta name="robots" content="noindex">`** — see [`NoindexMeta.md`](NoindexMeta.md). Layout-level injection driven by `isSearchEngineIndexable(page.route.id)`.
+- **Canonical URL** — see [`CanonicalUrl.md`](CanonicalUrl.md). Catalog detail derives the canonical from the entity's `link_url_pattern`; listed indexable routes derive it from the route ID.
+- **Title/description presence test** — every indexable route declares a meaningful `<title>` and `<meta name="description">`. Catalog detail derives both from entity data; listed indexable routes declare them in the page.
+
+(The SSR-enforcement test ships in `route-metadata.test.ts` itself — see "The test" above — not as a downstream consumer.)
 
 ## Implementation order
 
-1. Write `frontend/src/lib/route-metadata.ts`: the `SearchEngineInclusion` type, walker primitives (`allRoutes`, `searchEngineInclusionFor`, `layoutChain`, `hasAncestorImport`), and `isIndexable` / `isAuthGated` predicates.
-2. Add `export const searchEngineInclusion` to route files for the non-gated routes only. Top-level `+layout.ts` defaults to `'included'`; non-indexable routes (`/login`, `/signup`, `/verify-email`, `/auth/error`, `/search`, `/kiosk`, `/api-docs`, `/style-lab`, `/_sentry_test`) override to `'excluded'`. Gated routes get nothing — `requireCapability` already declares them. Add `+page.ts` files where they don't exist yet.
-3. Add the route-metadata vitest test: every route is well-formed (exactly one of "gated" or "declares `searchEngineInclusion`"); anchor sanity. It'll initially fail until the exports are filled in — that's the point.
-4. Refactor `frontend/src/lib/api/catalog-meta.test.ts` to consume the walker (`allRoutes()` + a catalog-detail predicate) instead of doing its own `import.meta.glob` traversal.
-5. Open PR. The follow-on SEO work in [`Robots.md`](Robots.md) (first) and [`Sitemap.md`](Sitemap.md) (second) can be opened as drafts on top of this branch.
+1. Write `frontend/src/lib/route-metadata.server.ts`: types, `allRoutes()`, `classifyRoute()` (catalog pattern-match + non-catalog import-scan + listed allowlists), `isSearchEngineIndexable()`.
+2. Add `route-metadata.test.ts`: every-route-classified + anchor sanity + disjoint allowlists + SSR-enforcement (every indexable route resolves to `ssr === true` after walking the config-file ancestor chain). Expect the unclassified check to surface genuinely-unclassified routes during development — that's the point.
+3. Add `catalog-auth-convention.test.ts` (next to the walker): for every `CATALOG_META` entity, assert the standard `edit` / `new` / `delete` route files exist and import the expected gating helpers.
+4. Refactor `catalog-meta.test.ts` to consume `allRoutes()` + `classifyRoute()`; drop `ROUTE_DIR_TO_KEY` / `UNMAPPED_ROUTE_DIRS`.
+5. Open PR. The follow-on work in [`Robots.md`](Robots.md), [`Sitemap.md`](Sitemap.md), [`NoindexMeta.md`](NoindexMeta.md) and [`CanonicalUrl.md`](CanonicalUrl.md) can stack on top.
+
+## Deliberately not in this plan
+
+- **Per-route `searchEngineInclusion` exports.** An earlier draft co-located a yes/no export on every `+page.ts`. Dropped because it conflicts with model-driven metadata: ~140 of those declarations would be mechanical reproductions of class-level facts and a new catalog entity would silently slip through unless someone remembered to add five more.
+- **Auth-mechanism enforcement.** An earlier draft folded in a test that flagged ad-hoc `if (!locals.user) throw redirect(...)` blocks. Real concern, separate scope — should ship as its own grep-based test if it ships at all, not bundled here.
+- **A general per-route metadata layer.** The module is named `route-metadata.server.ts` only because the test file naturally pairs with it; resist adding speculative per-route fields. Add them when there's a real second consumer.

--- a/docs/plans/seo/SearchEngines.md
+++ b/docs/plans/seo/SearchEngines.md
@@ -2,17 +2,54 @@
 
 This is a hub document about how the project interacts with search engines -- such as which deploys are crawlable, which pages on a crawlable deploy belong in the index, how we tell crawlers about them, how the data on each page is presented in results.
 
-## The concerns
+## Single source of truth: `isSearchEngineIndexable(routeId)`
 
-## Per-route metadata
+One function answers "should search engines index this route?" for every consumer in the SEO stack:
 
-Several consumers — sitemap, noindex meta, and any future per-route enforcement (canonical declaration, title/description presence) — read from the same per-route classification:
+- **Sitemap** filters routes _in_ — only `isSearchEngineIndexable() === true` routes appear.
+- **`<meta name="robots" content="noindex">`** is injected _out_ — only `isSearchEngineIndexable() === false` routes get the tag.
+- **Canonical URL, SSR-enabled, title/description-present** enforcement tests all gate on the same predicate.
+
+They can't drift because they all read from one source. The predicate is defined in [`RouteWalking.md`](RouteWalking.md); its classification is **derived from the catalog entity registry where possible, declared per-route only for routes outside the catalog convention**. This applies the project's [model-driven metadata](../model_driven_metadata/ModelDrivenMetadata.md) discipline to the SEO surface — the catalog model is the source of truth, parallel per-route declarations would be drift waiting to happen.
+
+### How to make a route (non-)indexable
+
+The answer depends on whether you're adding a new **instance of an existing catalog pattern**, a new **catalog pattern itself**, or a **non-catalog route**.
+
+**New instance of an existing catalog pattern.** Adding a new entity to `CATALOG_META` (or adding the standard subroutes for an entity that's already there) — nothing to do. The seven catalog patterns (`listing`, `detail`, `edit-history`, `sources`, `edit`, `new`, `delete`) already cover the entity's routes. `isSearchEngineIndexable()` lights up correctly with zero SEO declarations.
+
+**New catalog pattern.** Adding a subroute that doesn't fit any existing pattern (a hypothetical `*/comments`, `*/related-titles`, etc.) — edit `frontend/src/lib/route-metadata.server.ts`: add a `kind: 'catalog-<name>'` to the `RouteClass` union, match it in `classifyRoute()`, decide its indexability in `isSearchEngineIndexable()` and — if it's auth-gated — add it to the convention test. This is rare; the existing patterns cover the catalog's CRUD + audit surface.
+
+**Non-catalog route** (`/login`, `/about`, `/some-new-page`) — add the route ID to exactly one of two allowlists in `frontend/src/lib/route-metadata.server.ts`:
+
+- `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS` — should appear in search results.
+- `SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS` — shouldn't.
+
+For non-catalog and new-catalog-pattern routes, the walker test fails until the route is classified, so the choice is forced — there's no silent default. See [`RouteWalking.md`](RouteWalking.md) for the full classification table.
+
+#### Worked example: marking `/login` non-indexable
+
+Add the route ID to the non-indexable list:
 
 ```ts
-isIndexable(routeId): boolean
+// frontend/src/lib/route-metadata.server.ts
+const SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS = [
+  "/login", // ← add here
+  "/signup",
+  // ...
+] as const;
 ```
 
-defined in [`RouteWalking.md`](RouteWalking.md). The predicate composes the per-route `searchEngineInclusion` export with the auth-gating layout-chain check. Each consumer applies it differently — sitemap filters _in_, noindex injects _out_, robots.txt mostly ignores it (its scope is server endpoints, not pages) — but they can't drift, because there's only one source.
+That's the only file you touch. Effects cascade automatically:
+
+- `isSearchEngineIndexable('/login')` returns `false`.
+- The sitemap omits `/login`. Sitemaps list pages we _want_ indexed; non-indexable routes don't appear.
+- The root layout injects `<meta name="robots" content="noindex">` into `/login`'s HTML so crawlers reaching it via inbound links (password-reset emails, OAuth redirects, etc.) don't index it.
+- The SSR-on-indexable, title-and-description-on-indexable and canonical-on-indexable enforcement tests skip `/login` — they only apply to indexable routes.
+
+A common confusion worth heading off: a non-indexable route gets a meta tag _and_ is excluded from the sitemap. Both, not either-or. The sitemap is "please crawl these"; the noindex tag is "if you do reach this anyway, don't index it." Different signals, both needed.
+
+## The concerns
 
 ### Server-side rendering
 
@@ -32,15 +69,11 @@ This was a deliberate performance choice; the listings hydrate a large client-si
 
 Fixing this isn't urgent; the listing pages are not super important for driving search traffic, unlike detail pages.
 
-Either the SSR path needs a different (lighter) data shape, or the page architecture changes, or we accept the tradeoff and mark listings `searchEngineInclusion = 'excluded'`, relying on the sitemap of detail pages for discovery. Decision still open.
-
-##### `/users/[username]` is CSR-only
-
-([`+page.ts:6`](frontend/src/routes/users/[username]/+page.ts#L6)). Smaller scope than listings; likely just needs an SSR path.
+**Decision for now:** listings classify as non-indexable. The sitemap of detail pages covers discovery, so the cost of staying out of the index is small. We'll revisit when the listing data-shape problem is solved (a lighter SSR data path, or a page-architecture change) — at that point the classification flips by adding listings to the indexable side of the table in [`RouteWalking.md`](RouteWalking.md), no other changes needed.
 
 ##### No enforcement test
 
-There's nothing today that catches a regression where someone adds `ssr = false` to a new indexable route. The check is exactly the kind of route-tree property `RouteWalking.md` is built for: walk the layout chain, assert every indexable route has SSR enabled. Belongs there as a follow-up.
+There's nothing today that catches a regression where someone adds `ssr = false` to a new indexable route. The check is exactly the kind of route-tree property [`RouteWalking.md`](RouteWalking.md) is built for: walk the layout chain, assert every indexable route has SSR enabled. Ships as part of `route-metadata.test.ts` — see [`RouteWalking.md`](RouteWalking.md) § The test.
 
 ### ✅ DONE: 404 status integrity
 

--- a/docs/plans/seo/Sitemap.md
+++ b/docs/plans/seo/Sitemap.md
@@ -8,10 +8,10 @@ This PR builds on [`Robots.md`](Robots.md), which already shipped the `ALLOW_SEA
 
 ## Dependencies
 
-- [`RouteWalking.md`](RouteWalking.md) — provides `allRoutes()`, `isIndexable(routeId)`, and the per-route `searchEngineInclusion` exports.
+- [`RouteWalking.md`](RouteWalking.md) — provides `allRoutes()`, `isSearchEngineIndexable(routeId)`, and the `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS` constant in `frontend/src/lib/route-metadata.server.ts`.
 - [`Robots.md`](Robots.md) — provides the `ALLOW_SEARCH_ENGINE_INDEXING` env var, `lib/server/search-engine-indexable.ts`, and the deploy-time validation that prevents preview/staging from leaking. The sitemap endpoint reuses the same helper rather than re-reading the env var.
 
-Throughout this doc, `isIndexable(routeId)` refers to the predicate defined in `RouteWalking.md` (true when the route declares `searchEngineInclusion = 'included'` AND is not auth-gated).
+Throughout this doc, `isSearchEngineIndexable(routeId)` refers to the predicate defined in `RouteWalking.md` — true when the route is a `catalog-detail` / `catalog-edit-history` / `catalog-sources` route or appears in `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`; false otherwise.
 
 ## Goals
 
@@ -153,36 +153,47 @@ The frontend uses [`super-sitemap`](https://github.com/jasongitmail/super-sitema
 // frontend/src/routes/sitemap.xml/+server.ts
 import * as sitemap from "super-sitemap";
 import { SITE_ORIGIN } from "$env/static/private";
-import { allRoutes, isIndexable } from "$lib/route-metadata";
+import { allRoutes, isSearchEngineIndexable } from "$lib/route-metadata.server";
+
+// Every entity's detail page has two indexable sibling subroutes —
+// /edit-history and /sources — that share the same slug. One loader serves
+// all three pattern keys; super-sitemap renders one URL per (pattern, slug)
+// combination. Keep this list aligned with the indexable catalog-* kinds
+// in route-metadata.server.ts; if a new indexable subroute lands (or one
+// flips to non-indexable), update both places.
+const INDEXABLE_CATALOG_SUBROUTE_SUFFIXES = [
+  "",
+  "/edit-history",
+  "/sources",
+] as const;
 
 export const GET = async ({ fetch }) => {
   const feeds = await fetch("/api/sitemap/").then((r) => r.json());
-  const paramValues = Object.fromEntries(
-    feeds.map(({ kind, route_pattern }) => [
-      route_pattern,
-      async () => {
-        const entries = await fetch(`/api/sitemap/${kind}/`).then((r) =>
-          r.json(),
-        );
-        return entries.map((e) => ({
-          values: [e.slug],
-          lastmod: e.updated_at,
-        }));
-      },
-    ]),
-  );
+
+  const paramValues: Record<string, () => Promise<sitemap.ParamValues>> = {};
+  for (const { kind, route_pattern } of feeds) {
+    const loader = async () => {
+      const entries = await fetch(`/api/sitemap/${kind}/`).then((r) =>
+        r.json(),
+      );
+      return entries.map((e) => ({ values: [e.slug], lastmod: e.updated_at }));
+    };
+    for (const suffix of INDEXABLE_CATALOG_SUBROUTE_SUFFIXES) {
+      paramValues[`${route_pattern}${suffix}`] = loader;
+    }
+  }
 
   return sitemap.response({
     origin: SITE_ORIGIN,
     excludeRoutePatterns: allRoutes()
-      .filter((id) => !isIndexable(id))
+      .filter((id) => !isSearchEngineIndexable(id))
       .map(routeIdToRegex),
     paramValues,
   });
 };
 ```
 
-That's the whole endpoint. Adding a new entity type requires zero changes here — `GET /api/sitemap/` reports the new feed, the loop wires it into `paramValues` automatically.
+That's the whole endpoint. Adding a new entity type requires zero changes here — `GET /api/sitemap/` reports the new feed, the loop wires it into `paramValues` for detail + edit-history + sources automatically.
 
 ### Why super-sitemap
 
@@ -220,14 +231,15 @@ One-line additive change. Update the existing robots vitest to assert the line i
 - `/`
 - `/about`, `/about/people`
 - `/legal/privacy`, `/legal/terms`, `/legal/licensing`
-- All catalog listing pages: `/titles`, `/models`, `/manufacturers`, `/people`, `/systems`, `/series`, `/franchises`, `/locations`, plus taxonomy listings
-- All catalog detail pages with their `updated_at` as `lastmod`, except:
+- All catalog detail pages with their `updated_at` as `lastmod`, plus per-entity `/edit-history` and `/sources` URLs (every `catalog-detail` / `catalog-edit-history` / `catalog-sources` route classifies as indexable), except:
   - **Single-Model Titles** — when a Title has exactly one Model, include the Title route and **exclude** the Model route. The UI collapses single-Model Titles into the Model page (per `docs/SingleModelTitles.md`), but the Title slug is the canonical URL; indexing both would split signals and create duplicate-content noise. Enforced in `ModelSitemapFeed.entries()`.
 
 **Out:**
 
 - `/style-lab`, `/api-docs`, `/search`, `/kiosk`, `/_sentry_test`, `/auth/error`
-- Anything auth-gated — recognized by `requireCapability` in the layout chain; non-indexable routes are excluded by `isIndexable(routeId)`; never enumerated by hand
+- Catalog listing pages (`/titles`, `/models`, `/manufacturers`, etc.) — non-indexable today per [`RouteWalking.md`](RouteWalking.md) (low search value + CSR-only); discoverability is covered by the catalog detail entries above. Revisit when listing SSR lands.
+- Catalog `/new` and `/delete` subroutes — non-indexable.
+- Anything auth-gated — recognized by `requireCapability` in the layout chain; non-indexable routes are excluded by `isSearchEngineIndexable(routeId)`; never enumerated by hand
 - Models whose parent Title has exactly one Model (see above)
 
 ## 5. Startup validation — `SITE_ORIGIN`
@@ -261,7 +273,7 @@ The check is deploy-gated (`deploy=True`), so it only runs under `manage.py chec
   - One test per `core.E301` / `core.E302` error id in `apps/core/tests/test_checks.py`.
   - **XSD validation** — fetch `/sitemap.xml` via an in-process test client and validate the response against the sitemaps.org XSD using `xmllint --noout --schema`. Catches schema drift on every CI run.
 - **Frontend (vitest):**
-  - `sitemap.xml/+server.ts` builds super-sitemap's `paramValues` correctly from a mocked `/api/sitemap/` response.
+  - `sitemap.xml/+server.ts` builds super-sitemap's `paramValues` correctly from a mocked `/api/sitemap/` response, including the fan-out: a single backend feed produces param entries under three pattern keys (detail + `/edit-history` + `/sources`) with the same slug list.
   - `sitemap.xml/+server.ts` returns 404 when `ALLOW_SEARCH_ENGINE_INDEXING != "true"`.
   - Existing robots.txt test extended to assert the `Sitemap:` line is present iff `ALLOW_SEARCH_ENGINE_INDEXING == "true"`.
 

--- a/frontend/src/lib/api/catalog-meta.test.ts
+++ b/frontend/src/lib/api/catalog-meta.test.ts
@@ -1,122 +1,75 @@
 import { describe, it, expect } from 'vitest';
+import { catalogRoutesByEntity } from '../route-metadata.server';
 import { CATALOG_META, type CatalogEntityKey } from './catalog-meta';
 
-// Maps SvelteKit route directory → CATALOG_META key + the dynamic-segment
-// shape its detail routes use. Most entities use single-segment `[slug]`;
-// Location uses `[...path]` because its public_id is a multi-segment
-// `location_path` (e.g. `usa/il/chicago`). Every detail route that
-// corresponds to a registry entity must be listed here.
-type RouteSegment = '[slug]' | '[...path]';
-const ROUTE_DIR_TO_KEY: Record<string, { key: CatalogEntityKey; segment: RouteSegment }> = {
-  titles: { key: 'title', segment: '[slug]' },
-  models: { key: 'model', segment: '[slug]' },
-  manufacturers: { key: 'manufacturer', segment: '[slug]' },
-  franchises: { key: 'franchise', segment: '[slug]' },
-  series: { key: 'series', segment: '[slug]' },
-  people: { key: 'person', segment: '[slug]' },
-  cabinets: { key: 'cabinet', segment: '[slug]' },
-  'display-types': { key: 'display-type', segment: '[slug]' },
-  'display-subtypes': { key: 'display-subtype', segment: '[slug]' },
-  'game-formats': { key: 'game-format', segment: '[slug]' },
-  'reward-types': { key: 'reward-type', segment: '[slug]' },
-  tags: { key: 'tag', segment: '[slug]' },
-  'technology-generations': { key: 'technology-generation', segment: '[slug]' },
-  'technology-subgenerations': { key: 'technology-subgeneration', segment: '[slug]' },
-  'corporate-entities': { key: 'corporate-entity', segment: '[slug]' },
-  'gameplay-features': { key: 'gameplay-feature', segment: '[slug]' },
-  systems: { key: 'system', segment: '[slug]' },
-  themes: { key: 'theme', segment: '[slug]' },
-  'credit-roles': { key: 'credit-role', segment: '[slug]' },
-  locations: { key: 'location', segment: '[...path]' },
-};
+// Every linkable entity must have detail + edit-history + sources routes.
+// edit-history/ and sources/ are thin wrappers over $lib/provenance-loaders
+// and $lib/components, but each entity still needs its own +page.server.ts +
+// +page.svelte so the files live under the entity's shared +layout.server.ts
+// — otherwise navigating to edit-history re-runs the entity load. The cost
+// of forgetting is an invisible UX gap (see credit-role, missing for an
+// unknown period). This test catches it.
+//
+// Classification trust: route-metadata.test.ts already enforces that every
+// page-bearing route classifies into exactly one bucket. So if a catalog
+// route directory exists, it MUST classify as one of the catalog-* kinds —
+// no risk of a route slipping past as 'unclassified' here.
 
-// Route directories that intentionally do NOT map to a CATALOG_META entry.
-// Add to this list when introducing a route that should not be registry-managed.
-const UNMAPPED_ROUTE_DIRS = new Set<string>([]);
+// The +page.server.ts files for edit-history and sources do the actual data
+// loading (loadEditHistory / loadSources from $lib/provenance-loaders). If
+// the server file is deleted, the route still classifies — the +page.svelte
+// is what classification looks at — but the page would render with missing
+// `data.evidence` / `data.sources` and crash at runtime.
+const PAGE_SERVER_SOURCES = import.meta.glob('/src/routes/**/+page.server.ts', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>;
 
-// CATALOG_META keys whose frontend routes are deferred. The backend registers
-// these (via LinkableModel) but the SvelteKit routes don't exist yet.
-const DEFERRED_KEYS = new Set<CatalogEntityKey>([]);
+const detailRoutes = catalogRoutesByEntity((cls) => cls.kind === 'catalog-detail');
+const editHistoryRoutes = catalogRoutesByEntity((cls) => cls.kind === 'catalog-edit-history');
+const sourcesRoutes = catalogRoutesByEntity((cls) => cls.kind === 'catalog-sources');
 
 describe('catalog-meta vs route tree', () => {
-  it('every detail route directory is either mapped or explicitly unmapped', async () => {
-    // Vite's `import.meta.glob` treats `[slug]` / `[...path]` as glob
-    // character classes, so a pattern like `[...path]` matches a single
-    // character rather than the literal SvelteKit param directory. Cast a
-    // broader net and filter to detail-route paths in JS.
-    const allRoutes = import.meta.glob('/src/routes/**/+*', { eager: false });
-    const detailRouteRe = /\/src\/routes\/([^/]+)\/\[(?:slug|\.\.\.path)\]/;
-    const routeDirs = new Set(
-      Object.keys(allRoutes)
-        .map((p) => p.match(detailRouteRe)?.[1])
-        .filter((d): d is string => typeof d === 'string'),
-    );
-
-    for (const dir of routeDirs) {
-      const mapped = dir in ROUTE_DIR_TO_KEY;
-      const unmapped = UNMAPPED_ROUTE_DIRS.has(dir);
+  it.each(Object.keys(CATALOG_META) as CatalogEntityKey[])(
+    '%s has a catalog-detail route',
+    (key) => {
       expect(
-        mapped || unmapped,
-        `Route directory "${dir}" has a detail route but is not in ROUTE_DIR_TO_KEY or UNMAPPED_ROUTE_DIRS. ` +
-          `Either add it to CATALOG_META + ROUTE_DIR_TO_KEY or mark it explicitly unmapped.`,
+        detailRoutes.has(key),
+        `CATALOG_META contains "${key}" but no route classifies as catalog-detail for it. ` +
+          `Either add the /${CATALOG_META[key].entity_type_plural}/[slug] (or [...path]) route, ` +
+          `or remove the entity from CATALOG_META.`,
       ).toBe(true);
+    },
+  );
 
-      if (mapped) {
-        const { key } = ROUTE_DIR_TO_KEY[dir];
-        expect(CATALOG_META).toHaveProperty(key);
+  it.each(Object.keys(CATALOG_META) as CatalogEntityKey[])(
+    '%s has a catalog-edit-history route with a +page.server.ts loader',
+    (key) => {
+      const ids = editHistoryRoutes.get(key) ?? [];
+      expect(ids, `No catalog-edit-history route for ${key}`).not.toHaveLength(0);
+      for (const id of ids) {
+        const path = `/src/routes${id}/+page.server.ts`;
+        expect(
+          PAGE_SERVER_SOURCES[path],
+          `${path} is missing — the /edit-history page exists but its loader doesn't, so data.evidence will be undefined at runtime.`,
+        ).toBeDefined();
       }
-    }
-  });
+    },
+  );
 
-  it('every entity_type_plural matches the expected route directory', () => {
-    for (const [dir, { key }] of Object.entries(ROUTE_DIR_TO_KEY)) {
-      if (key in CATALOG_META) {
-        expect(CATALOG_META[key].entity_type_plural).toBe(dir);
+  it.each(Object.keys(CATALOG_META) as CatalogEntityKey[])(
+    '%s has a catalog-sources route with a +page.server.ts loader',
+    (key) => {
+      const ids = sourcesRoutes.get(key) ?? [];
+      expect(ids, `No catalog-sources route for ${key}`).not.toHaveLength(0);
+      for (const id of ids) {
+        const path = `/src/routes${id}/+page.server.ts`;
+        expect(
+          PAGE_SERVER_SOURCES[path],
+          `${path} is missing — the /sources page exists but its loader doesn't, so data.sources will be undefined at runtime.`,
+        ).toBeDefined();
       }
-    }
-  });
-
-  it('every CATALOG_META key maps to a known route directory', () => {
-    // Guards against the generator emitting a key that has no corresponding
-    // frontend route — without this, CatalogEntityKey widens silently and
-    // helpers produce URLs that route to nothing.
-    const knownKeys = new Set(Object.values(ROUTE_DIR_TO_KEY).map((entry) => entry.key));
-    for (const key of Object.keys(CATALOG_META) as CatalogEntityKey[]) {
-      if (DEFERRED_KEYS.has(key)) continue;
-      expect(
-        knownKeys,
-        `CATALOG_META contains "${key}" but no route directory maps to it. ` +
-          `Add the mapping to ROUTE_DIR_TO_KEY and create the corresponding route.`,
-      ).toContain(key);
-    }
-  });
-
-  // Every linkable entity must have edit-history/ and sources/ subroutes.
-  // These are thin wrappers over $lib/provenance-loaders and $lib/components,
-  // but each entity still needs its own +page.server.ts + +page.svelte so the
-  // files live under the entity's shared +layout.server.ts — otherwise
-  // navigating to edit-history re-runs the entity load. The cost of this
-  // requirement is ~10 lines of boilerplate per entity; the cost of forgetting
-  // is an invisible UX gap (see credit-role, missing for an unknown period).
-  describe.each(['edit-history', 'sources'])('%s subroute', (subroute) => {
-    // See note above on Vite glob bracket handling — broaden the pattern
-    // and trust the assertion's exact-path lookup (`toHaveProperty`) to
-    // pick the right files.
-    const files = import.meta.glob('/src/routes/**/+page.*', { eager: false });
-
-    const segmentByKey = new Map<CatalogEntityKey, RouteSegment>(
-      Object.values(ROUTE_DIR_TO_KEY).map((entry) => [entry.key, entry.segment]),
-    );
-
-    it.each((Object.keys(CATALOG_META) as CatalogEntityKey[]).filter((k) => !DEFERRED_KEYS.has(k)))(
-      '%s has +page.server.ts and +page.svelte',
-      (key) => {
-        const plural = CATALOG_META[key].entity_type_plural;
-        const segment = segmentByKey.get(key) ?? '[slug]';
-        const base = `/src/routes/${plural}/${segment}/${subroute}`;
-        expect(files).toHaveProperty(`${base}/+page.server.ts`);
-        expect(files).toHaveProperty(`${base}/+page.svelte`);
-      },
-    );
-  });
+    },
+  );
 });

--- a/frontend/src/lib/catalog-auth-convention.test.ts
+++ b/frontend/src/lib/catalog-auth-convention.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { CATALOG_META, type CatalogEntityKey } from './api/catalog-meta';
+import { catalogRoutesByEntity } from './route-metadata.server';
+
+// The route-metadata walker classifies /{plural}/[public-id]/edit (and
+// /new, /delete) by URL pattern, not by reading auth gates. This test is
+// the other half: for every catalog page route classified by the walker,
+// assert the conventional gate file exists at the expected path and
+// imports the expected helper.
+//
+// The test is driven by classified page routes — not by an inventory of
+// existing server files — so deleting a +page.server.ts (leaving its
+// +page.svelte to render ungated) fails the test directly.
+
+const SERVER_SOURCES = {
+  ...(import.meta.glob('/src/routes/**/+layout.server.ts', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>),
+  ...(import.meta.glob('/src/routes/**/+page.server.ts', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>),
+};
+
+// Build per-entity registries of page routes by kind. catalog-edit is
+// restricted to /edit (the layout's own page); /edit/[section] also
+// classifies as catalog-edit but inherits the same +layout.server.ts gate
+// and shouldn't be re-checked.
+const newRoutesByEntity = catalogRoutesByEntity((cls) => cls.kind === 'catalog-new');
+const deleteRoutesByEntity = catalogRoutesByEntity((cls) => cls.kind === 'catalog-delete');
+const editRoutesByEntity = catalogRoutesByEntity(
+  (cls, id) => cls.kind === 'catalog-edit' && id.endsWith('/edit'),
+);
+
+describe('catalog auth-gate convention', () => {
+  for (const key of Object.keys(CATALOG_META) as CatalogEntityKey[]) {
+    describe(key, () => {
+      it('every /edit route has a +layout.server.ts gated with catalog.edit', () => {
+        const ids = editRoutesByEntity.get(key) ?? [];
+        expect(ids, `No catalog-edit page route classified for ${key}`).not.toHaveLength(0);
+        for (const id of ids) {
+          const path = `/src/routes${id}/+layout.server.ts`;
+          const src = SERVER_SOURCES[path];
+          expect(
+            src,
+            `${path} is missing — the /edit page exists but its layout server gate doesn't`,
+          ).toBeDefined();
+          expect(src, `${path} must import $lib/require-capability.server`).toMatch(
+            /from\s+['"]\$lib\/require-capability\.server['"]/,
+          );
+          expect(src, `${path} must use activity catalog.edit`).toMatch(
+            /activity:\s*['"]catalog\.edit['"]/,
+          );
+        }
+      });
+
+      it('every /delete route has a +page.server.ts using the shared delete-preview loader', () => {
+        const ids = deleteRoutesByEntity.get(key) ?? [];
+        expect(ids, `No catalog-delete page route classified for ${key}`).not.toHaveLength(0);
+        for (const id of ids) {
+          const path = `/src/routes${id}/+page.server.ts`;
+          const src = SERVER_SOURCES[path];
+          expect(
+            src,
+            `${path} is missing — the /delete page exists but its server gate doesn't`,
+          ).toBeDefined();
+          expect(src, `${path} must import $lib/delete-preview-loader.server`).toMatch(
+            /from\s+['"]\$lib\/delete-preview-loader\.server['"]/,
+          );
+        }
+      });
+
+      it('every /new route has a +page.server.ts gated with catalog.create', () => {
+        const ids = newRoutesByEntity.get(key) ?? [];
+        expect(ids, `No catalog-new page route classified for ${key}`).not.toHaveLength(0);
+        for (const id of ids) {
+          const path = `/src/routes${id}/+page.server.ts`;
+          const src = SERVER_SOURCES[path];
+          expect(
+            src,
+            `${path} is missing — the /new page exists but its server gate doesn't`,
+          ).toBeDefined();
+          expect(src, `${path} must import $lib/require-capability.server`).toMatch(
+            /from\s+['"]\$lib\/require-capability\.server['"]/,
+          );
+          expect(src, `${path} must use activity catalog.create`).toMatch(
+            /activity:\s*['"]catalog\.create['"]/,
+          );
+        }
+      });
+    });
+  }
+});

--- a/frontend/src/lib/route-metadata.server.ts
+++ b/frontend/src/lib/route-metadata.server.ts
@@ -1,0 +1,265 @@
+/**
+ * Single source of truth for "is this route indexable by search engines?".
+ */
+
+import type { RouteId } from '$app/types';
+import { CATALOG_META, type CatalogEntityKey } from '$lib/api/catalog-meta';
+
+/**
+ * Non-catalog routes that should be indexed by search engines.
+ *
+ * Values are SvelteKit `page.route.id` form (`[slug]` params and `(group)`
+ * directories preserved), NOT resolved URLs — `/(legal)/privacy`, not `/privacy`.
+ */
+export const SEARCH_ENGINE_INDEXABLE_ROUTE_IDS = [
+  '/',
+  '/about',
+  '/about/people',
+  '/(legal)/privacy',
+  '/(legal)/terms',
+  '/(legal)/licensing',
+  // Per-route product decision: a nested catalog listing under the
+  // manufacturer detail. The only route of this shape today; see
+  // RouteWalking.md § "Nested listings under a catalog detail".
+  '/manufacturers/[slug]/systems',
+] as const satisfies readonly RouteId[];
+
+/**
+ * Non-catalog routes that should NOT be indexed by search engines.
+ *
+ * Values are SvelteKit `page.route.id` form (`[slug]` params preserved),
+ * NOT resolved URLs — `/users/[username]`, not `/users/moses`.
+ */
+export const SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS = [
+  '/login',
+  '/signup',
+  '/verify-email',
+  '/auth/error',
+  '/search',
+  '/style-lab',
+  '/api-docs',
+  // Low search value while user pages are an activity stream rather than a
+  // stable profile. Revisit if user pages grow real profile content.
+  '/users/[username]',
+  '/changesets',
+  '/review',
+  '/kiosk',
+  '/_sentry_test',
+] as const satisfies readonly RouteId[];
+
+/** Classification of a SvelteKit route for search engine indexing purposes. */
+export type RouteClass =
+  | { kind: 'catalog-listing'; entity: CatalogEntityKey }
+  | { kind: 'catalog-detail'; entity: CatalogEntityKey }
+  | { kind: 'catalog-edit-history'; entity: CatalogEntityKey }
+  | { kind: 'catalog-sources'; entity: CatalogEntityKey }
+  | { kind: 'catalog-edit'; entity: CatalogEntityKey }
+  | { kind: 'catalog-new'; entity: CatalogEntityKey }
+  | { kind: 'catalog-delete'; entity: CatalogEntityKey }
+  | { kind: 'auth-gated' } // non-catalog, via import scan
+  | { kind: 'listed-indexable' }
+  | { kind: 'listed-non-indexable' }
+  | { kind: 'unclassified' };
+
+/** `RouteClass` variants that carry an `entity` reference. */
+export type CatalogRouteClass = Extract<RouteClass, { entity: CatalogEntityKey }>;
+
+/** Type guard for `CatalogRouteClass`. */
+export function isCatalogRoute(cls: RouteClass): cls is CatalogRouteClass {
+  return 'entity' in cls;
+}
+
+// Index: entity_type_plural → CATALOG_META key. Built once at module load.
+const PLURAL_TO_KEY: ReadonlyMap<string, CatalogEntityKey> = new Map(
+  Object.entries(CATALOG_META).map(([key, meta]) => [
+    meta.entity_type_plural,
+    key as CatalogEntityKey,
+  ]),
+);
+
+// Matches both /{plural}/[slug]/... and /{plural}/[...path]/... in route-pattern form.
+// CONVENTION: every catalog entity's detail param is named `[slug]` (or
+// `[...path]` for Location's multi-segment public_id). A new entity using a
+// different param name (e.g. `[id]`, `[handle]`) will fall through to
+// `unclassified` — the fix is to rename the param to `[slug]` or extend
+// this regex. The convention keeps the matcher trivial.
+const PUBLIC_ID_SEGMENT_RE = /^\[(?:slug|\.\.\.path)\]$/;
+
+const INDEXABLE_SET: ReadonlySet<string> = new Set(SEARCH_ENGINE_INDEXABLE_ROUTE_IDS);
+const NON_INDEXABLE_SET: ReadonlySet<string> = new Set(SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS);
+
+// Precomputed at module load: route-ID prefixes whose +layout.server.ts
+// (or any ancestor's) imports $lib/require-capability.server. Vite resolves
+// the glob at build time and inlines each layout's source as a string, so
+// no filesystem I/O happens at runtime.
+const AUTH_GATED_PREFIXES: ReadonlySet<string> = buildAuthGatedPrefixes();
+
+function buildAuthGatedPrefixes(): ReadonlySet<string> {
+  const modules = import.meta.glob('/src/routes/**/+layout.server.ts', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>;
+  const prefixes = new Set<string>();
+  for (const [path, source] of Object.entries(modules)) {
+    if (!/from\s+['"]\$lib\/require-capability\.server['"]/.test(source)) continue;
+    // /src/routes/admin/+layout.server.ts → /admin
+    const prefix = path.replace(/^\/src\/routes/, '').replace(/\/\+layout\.server\.ts$/, '');
+    if (prefix === '') {
+      // Root +layout.server.ts gating everything would silently make every
+      // non-catalog route auth-gated (and therefore non-indexable) with no
+      // direct test failure pointing at this file. Refuse to load.
+      throw new Error(
+        'route-metadata: root +layout.server.ts must not import $lib/require-capability.server. ' +
+          'Move the gate to a more specific layout (e.g. /admin/+layout.server.ts).',
+      );
+    }
+    prefixes.add(prefix);
+  }
+  return prefixes;
+}
+
+function classifyCatalog(id: string): RouteClass | null {
+  // /(legal)/privacy → segments = ['(legal)', 'privacy'] — won't match any plural, returns null.
+  const segments = id === '/' ? [] : id.slice(1).split('/');
+  if (segments.length === 0) return null;
+
+  const key = PLURAL_TO_KEY.get(segments[0]);
+  if (!key) return null;
+
+  // /{plural}
+  if (segments.length === 1) return { kind: 'catalog-listing', entity: key };
+
+  // /{plural}/new
+  if (segments.length === 2 && segments[1] === 'new') {
+    return { kind: 'catalog-new', entity: key };
+  }
+
+  // From here on, the second segment must be a public-id slot.
+  if (!PUBLIC_ID_SEGMENT_RE.test(segments[1])) return null;
+
+  const tail = segments.slice(2);
+
+  // /{plural}/[public-id]
+  if (tail.length === 0) return { kind: 'catalog-detail', entity: key };
+
+  if (tail.length === 1) {
+    switch (tail[0]) {
+      case 'edit-history':
+        return { kind: 'catalog-edit-history', entity: key };
+      case 'sources':
+        return { kind: 'catalog-sources', entity: key };
+      case 'edit':
+        return { kind: 'catalog-edit', entity: key };
+      case 'delete':
+        return { kind: 'catalog-delete', entity: key };
+      case 'new':
+        return { kind: 'catalog-new', entity: key };
+    }
+    return null;
+  }
+
+  // /{plural}/[public-id]/edit/[section]. The param name `[section]` is
+  // a hardcoded convention — a different name would fall through.
+  if (tail.length === 2 && tail[0] === 'edit' && tail[1] === '[section]') {
+    return { kind: 'catalog-edit', entity: key };
+  }
+
+  // Nested-create: /{outer-plural}/[public-id]/{inner-plural}/new
+  if (tail.length === 2 && tail[1] === 'new') {
+    const inner = PLURAL_TO_KEY.get(tail[0]);
+    if (inner) return { kind: 'catalog-new', entity: inner };
+  }
+
+  return null;
+}
+
+// Pure prefix-match against the auth-gate set. Used by classifyRoute AFTER
+// classifyCatalog has had its chance — catalog-edit routes also match the
+// prefix set (their layouts gate too) but get claimed as catalog-edit first.
+function matchesAuthGatePrefix(id: string): boolean {
+  for (const prefix of AUTH_GATED_PREFIXES) {
+    if (id === prefix || id.startsWith(prefix + '/')) return true;
+  }
+  return false;
+}
+
+/** Classify a SvelteKit route ID into an search engine indexing bucket. */
+export function classifyRoute(id: RouteId): RouteClass {
+  const catalog = classifyCatalog(id);
+  if (catalog) return catalog;
+  if (matchesAuthGatePrefix(id)) return { kind: 'auth-gated' };
+  if (INDEXABLE_SET.has(id)) return { kind: 'listed-indexable' };
+  if (NON_INDEXABLE_SET.has(id)) return { kind: 'listed-non-indexable' };
+  return { kind: 'unclassified' };
+}
+
+/**
+ * Whether a route should be exposed to search engines.
+ *
+ * @throws if the route is unclassified.
+ */
+export function isSearchEngineIndexable(id: RouteId): boolean {
+  const c = classifyRoute(id);
+  switch (c.kind) {
+    case 'catalog-detail':
+    case 'catalog-edit-history':
+    case 'catalog-sources':
+    case 'listed-indexable':
+      return true;
+    case 'catalog-listing':
+    case 'catalog-edit':
+    case 'catalog-new':
+    case 'catalog-delete':
+    case 'auth-gated':
+    case 'listed-non-indexable':
+      return false;
+    case 'unclassified':
+      throw new Error(
+        `Route ${id} is unclassified. Add it to a catalog convention, an auth-gated layout, or one of the SEARCH_ENGINE_*_ROUTE_IDS allowlists in route-metadata.server.ts.`,
+      );
+  }
+}
+
+/**
+ * Enumerate every route ID that has a `+page.svelte`.
+ *
+ * Excludes `+server.ts`-only endpoints (like `/__health`) and directory-only
+ * routes that exist solely as containers for nested routes (like
+ * `/titles/[slug]/models`, which has no `+page.svelte` of its own).
+ */
+export function allRoutes(): RouteId[] {
+  // Match both +page.svelte and +page@*.svelte (the reset-layout form, used
+  // by every catalog /delete page and the nested-create pages). Both
+  // resolve to the same route ID — the @-suffix only changes which layout
+  // chain renders the page, not the URL. A naïve glob of +page.svelte
+  // would silently exclude 22 of 157 page routes from classification.
+  const pages = import.meta.glob('/src/routes/**/+page*.svelte', { eager: false });
+  return Object.keys(pages)
+    .map((p) => {
+      const trimmed = p.replace(/^\/src\/routes/, '').replace(/\/\+page[^/]*\.svelte$/, '');
+      return trimmed === '' ? '/' : trimmed;
+    })
+    .sort() as RouteId[];
+}
+
+/**
+ * Group page routes by entity. Walks `allRoutes()`, classifies each one,
+ * keeps the catalog-* routes that satisfy `predicate`, and buckets them by
+ * the owning entity. `predicate` receives both the classification and the
+ * route ID so callers can filter on either (e.g. catalog-edit routes that
+ * end in `/edit` to skip `/edit/[section]`).
+ */
+export function catalogRoutesByEntity(
+  predicate: (cls: CatalogRouteClass, id: RouteId) => boolean,
+): Map<CatalogEntityKey, RouteId[]> {
+  const out = new Map<CatalogEntityKey, RouteId[]>();
+  for (const id of allRoutes()) {
+    const cls = classifyRoute(id);
+    if (!isCatalogRoute(cls) || !predicate(cls, id)) continue;
+    const arr = out.get(cls.entity) ?? [];
+    arr.push(id);
+    out.set(cls.entity, arr);
+  }
+  return out;
+}

--- a/frontend/src/lib/route-metadata.test.ts
+++ b/frontend/src/lib/route-metadata.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import type { RouteId } from '$app/types';
+import {
+  classifyRoute,
+  isCatalogRoute,
+  isSearchEngineIndexable,
+  allRoutes,
+  SEARCH_ENGINE_INDEXABLE_ROUTE_IDS,
+  SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS,
+  type RouteClass,
+} from './route-metadata.server';
+import type { CatalogEntityKey } from './api/catalog-meta';
+
+// SvelteKit's ssr resolution rule: walk leaf-to-root through the
+// +page.ts / +page.server.ts / +layout.ts / +layout.server.ts chain; the
+// first `export const ssr = X` declaration wins, defaulting to true if none.
+// This lives in the test file (not route-metadata.server.ts) because it's
+// only called by the indexable-routes-are-SSR test below — the runtime
+// hot path doesn't need it, and inlining 30+ raw config-file sources via
+// import.meta.glob('?raw') is wasted memory on the server for non-test code.
+const SSR_CONFIG_SOURCES = {
+  ...(import.meta.glob('/src/routes/**/+page.ts', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>),
+  ...(import.meta.glob('/src/routes/**/+page.js', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>),
+  ...(import.meta.glob('/src/routes/**/+page.server.ts', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>),
+  ...(import.meta.glob('/src/routes/**/+layout.ts', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>),
+  ...(import.meta.glob('/src/routes/**/+layout.js', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>),
+  ...(import.meta.glob('/src/routes/**/+layout.server.ts', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }) as Record<string, string>),
+};
+
+// Within a single route level we check files in this order:
+//   +page.ts → +page.js → +page.server.ts → +layout.ts → +layout.js → +layout.server.ts
+// matching SvelteKit's universal-over-server precedence for page options at
+// the same level. First match wins; we don't merge or look for conflicts —
+// this codebase has at most one `ssr =` declaration per route, so the
+// question "what if both .ts and .server.ts disagree at the same level"
+// hasn't come up.
+function resolveSsr(id: RouteId): boolean {
+  const segments = id === '/' ? [] : id.slice(1).split('/');
+  for (let i = segments.length; i >= 0; i--) {
+    const level = i === 0 ? '' : '/' + segments.slice(0, i).join('/');
+    const isLeaf = i === segments.length;
+    const candidates: string[] = [];
+    if (isLeaf) {
+      candidates.push(
+        `/src/routes${level}/+page.ts`,
+        `/src/routes${level}/+page.js`,
+        `/src/routes${level}/+page.server.ts`,
+      );
+    }
+    candidates.push(
+      `/src/routes${level}/+layout.ts`,
+      `/src/routes${level}/+layout.js`,
+      `/src/routes${level}/+layout.server.ts`,
+    );
+    for (const path of candidates) {
+      const src = SSR_CONFIG_SOURCES[path];
+      if (src === undefined) continue;
+      const m = src.match(/export\s+const\s+ssr\s*=\s*(true|false)\b/);
+      if (m) return m[1] === 'true';
+    }
+  }
+  return true;
+}
+
+describe('route-metadata', () => {
+  it('every route is classified', () => {
+    const unclassified = allRoutes().filter((id) => classifyRoute(id).kind === 'unclassified');
+    expect(
+      unclassified,
+      `Add each route to a catalog convention, an auth-gated layout, or one of the two ` +
+        `SEARCH_ENGINE_*_ROUTE_IDS allowlists in route-metadata.server.ts.`,
+    ).toEqual([]);
+  });
+
+  it('every indexable route resolves to ssr === true', () => {
+    const indexable = allRoutes().filter((id) => isSearchEngineIndexable(id));
+    const nonSsr = indexable.filter((id) => !resolveSsr(id));
+    expect(
+      nonSsr,
+      `Indexable routes must be SSR-rendered. Either flip ssr back to true on the ancestor ` +
+        `that disabled it, or remove the route from SEARCH_ENGINE_INDEXABLE_ROUTE_IDS.`,
+    ).toEqual([]);
+  });
+
+  it('the two allowlists are disjoint', () => {
+    const indexable = new Set<string>(SEARCH_ENGINE_INDEXABLE_ROUTE_IDS);
+    const overlap = SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS.filter((id) => indexable.has(id));
+    expect(overlap, 'A route ID cannot appear in both allowlists').toEqual([]);
+  });
+
+  // Anchor sanity. Inputs are in route-pattern form (the shape page.route.id
+  // has at runtime). Defends against "walker returned nothing, so all
+  // assertions trivially pass." The fourth slot is the expected entity for
+  // catalog rows; null for non-catalog rows. Checking entity catches
+  // PLURAL_TO_KEY swaps that would leave the kind right but the entity wrong.
+  type Anchor = readonly [RouteId, RouteClass['kind'], boolean, CatalogEntityKey | null];
+  const ANCHORS: ReadonlyArray<Anchor> = [
+    ['/', 'listed-indexable', true, null],
+    ['/about', 'listed-indexable', true, null],
+    ['/about/people', 'listed-indexable', true, null],
+    ['/(legal)/privacy', 'listed-indexable', true, null],
+    ['/manufacturers/[slug]/systems', 'listed-indexable', true, null],
+    ['/titles', 'catalog-listing', false, 'title'],
+    ['/titles/[slug]', 'catalog-detail', true, 'title'],
+    ['/titles/[slug]/edit-history', 'catalog-edit-history', true, 'title'],
+    ['/titles/[slug]/sources', 'catalog-sources', true, 'title'],
+    ['/titles/[slug]/edit', 'catalog-edit', false, 'title'],
+    ['/titles/[slug]/edit/[section]', 'catalog-edit', false, 'title'],
+    ['/titles/[slug]/delete', 'catalog-delete', false, 'title'],
+    ['/titles/new', 'catalog-new', false, 'title'],
+    ['/titles/[slug]/models/new', 'catalog-new', false, 'model'],
+    ['/manufacturers/[slug]/corporate-entities/new', 'catalog-new', false, 'corporate-entity'],
+    ['/locations/[...path]', 'catalog-detail', true, 'location'],
+    ['/locations/[...path]/edit', 'catalog-edit', false, 'location'],
+    ['/login', 'listed-non-indexable', false, null],
+    ['/users/[username]', 'listed-non-indexable', false, null],
+    ['/admin', 'auth-gated', false, null],
+    ['/admin/dashboard', 'auth-gated', false, null],
+    // Pins the prefix-match off-by-one: /kiosk/edit is the layout's own
+    // page (no trailing slash), not just a parent of /kiosk/edit/[id].
+    ['/kiosk/edit', 'auth-gated', false, null],
+    ['/kiosk/edit/[id]', 'auth-gated', false, null],
+  ];
+
+  it.each(ANCHORS)(
+    'classifies %s as %s (indexable=%s, entity=%s)',
+    (id, kind, indexable, entity) => {
+      const cls = classifyRoute(id);
+      expect(cls.kind).toBe(kind);
+      expect(isSearchEngineIndexable(id)).toBe(indexable);
+      if (entity === null) {
+        expect(isCatalogRoute(cls)).toBe(false);
+      } else {
+        // Two-step check so a regression to a non-catalog kind reports
+        // "expected false to be true" (clear), not "expected false to be
+        // 'title'" from a short-circuited `cls && cls.entity` expression.
+        expect(isCatalogRoute(cls)).toBe(true);
+        if (isCatalogRoute(cls)) expect(cls.entity).toBe(entity);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Introduces the route-classification walker that every downstream search engine indexing concern (sitemap, noindex meta, canonical URL, SSR enforcement, title/description presence) will gate on. No user-facing behavior change yet — this is infrastructure for the follow-on PRs described in `docs/plans/seo/`.

- New module `frontend/src/lib/route-metadata.server.ts` — `classifyRoute`, `isSearchEngineIndexable`, `allRoutes`, `catalogRoutesByEntity`, and supporting types/guards. Catalog routes classify by URL pattern against `CATALOG_META`; non-catalog routes go through two short hand-maintained allowlists; auth-gated areas are caught by an import scan over `+layout.server.ts` files. Throws on `unclassified` — CI catches drift before deploy.
- Module is `.server.ts` because its `?raw` glob would otherwise inline server-file source into the client bundle. Downstream consumers (noindex meta, canonical URL) compute the boolean in a server load and pass it down as data.
- Three test files: `route-metadata.test.ts` (every-route-classified, indexable→SSR, disjoint allowlists, per-route anchors with entity), `catalog-auth-convention.test.ts` (every classified catalog edit/new/delete page has the expected gate file with the expected helper import), and refactored `catalog-meta.test.ts` (drops the parallel `ROUTE_DIR_TO_KEY` map; also asserts every catalog `/edit-history` and `/sources` route has its `+page.server.ts` loader).
- Plan docs (`RouteWalking.md`, `SearchEngines.md`, `NoindexMeta.md`, `Sitemap.md`, `CanonicalUrl.md`) updated to match: predicate name, `.server.ts` filename, full public surface, and the server-load handoff pattern for noindex/canonical.

## Test plan

- [x] `pnpm vitest run` — 1383/1383 pass.
- [x] `pnpm check` — 0 svelte-check errors.
- [x] `pnpm lint` — clean.
- [x] Manually verified the new tests catch the regressions they're designed for:
  - Deleted `/locations/[...path]/new/+page.server.ts` → `catalog-auth-convention.test.ts` fails with the missing-gate message.
  - Deleted `/titles/[slug]/sources/+page.server.ts` → `catalog-meta.test.ts` fails with the missing-loader message.