### PR TITLE
feat(seo): prevent search engines from indexing routes that shouldn't be

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,10 @@ The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). D
 - `<slot>` → use `{@render children()}` snippets
 - `$$props` / `$$restProps` → use `$props()` with rest syntax
 
+### TypeScript declaration comments use `/** */`
+
+Use JSDoc `/** */` (not `//`) for comments on TypeScript functions, classes, types, and exported constants, so they appear in IDE hover tooltips.
+
 ### No `:global` in Svelte styles
 
 NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,10 @@ The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). D
 - `<slot>` → use `{@render children()}` snippets
 - `$$props` / `$$restProps` → use `$props()` with rest syntax
 
+### TypeScript declaration comments use `/** */`
+
+Use JSDoc `/** */` (not `//`) for comments on TypeScript functions, classes, types, and exported constants, so they appear in IDE hover tooltips.
+
 ### No `:global` in Svelte styles
 
 NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -171,6 +171,10 @@ The frontend uses **Svelte 5 runes mode** (`runes: true` in compiler options). D
 - `<slot>` → use `{@render children()}` snippets
 - `$$props` / `$$restProps` → use `$props()` with rest syntax
 
+### TypeScript declaration comments use `/** */`
+
+Use JSDoc `/** */` (not `//`) for comments on TypeScript functions, classes, types, and exported constants, so they appear in IDE hover tooltips.
+
 ### No `:global` in Svelte styles
 
 NEVER use `:global` in Svelte component styles without explicit approval from the user. Scoped styles are the default and preferred approach. We rearchitect components rather than use `:global`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ For setup and common commands, start with the repository [README](../README.md).
 
 ## Frontend Development
 
+- [Typescript.md](Typescript.md) frontend TypeScript conventions.
 - [Svelte.md](Svelte.md) Svelte 5 authoring conventions and rendering strategy.
 - [SSRConversion.md](SSRConversion.md) workflow for converting routes from CSR to SSR.
 - [DetailLayoutPatterns.md](DetailLayoutPatterns.md) detail-page layout patterns.

--- a/docs/Svelte.md
+++ b/docs/Svelte.md
@@ -2,6 +2,8 @@
 
 This document defines how to think about and develop SvelteKit pages in this project.
 
+For language-level TypeScript conventions that apply across the frontend, see [Typescript.md](Typescript.md).
+
 ## Authoring Conventions
 
 You MUST use Svelte 5 runes mode. Use modern Svelte 5 patterns, not legacy Svelte 4 syntax:

--- a/docs/Typescript.md
+++ b/docs/Typescript.md
@@ -1,0 +1,21 @@
+# TypeScript Development
+
+Conventions for TypeScript in the frontend.
+
+For Svelte-specific patterns see [Svelte.md](Svelte.md).
+
+## Use JSDoc for declaration comments
+
+When a named declaration warrants a comment — function, class, type, interface, exported constant, even an object property — use `/** */` so editors surface it in hover tooltips and signature help. Single-line `//` comments don't appear in IDE popups.
+
+```ts
+/** Resolve an href that may be internal or external; falls back to the raw string. */
+export function resolveHref(href: string): string {
+  // ...
+}
+
+/** Maximum length of a username, mirrored from the backend validator. */
+export const USERNAME_MAX_LENGTH = 32;
+```
+
+The bar for writing a comment is unchanged — most declarations don't need one. But when you do write one, use the format that shows up where readers look. Inline `//` comments inside a function body are still fine; they're for the next person editing the code, not for callers.

--- a/docs/plans/seo/CanonicalUrl.md
+++ b/docs/plans/seo/CanonicalUrl.md
@@ -6,7 +6,7 @@ Addresses the "canonical URLs" concern in [`SearchEngines.md`](SearchEngines.md)
 
 ## Scope — what this plan does and doesn't cover
 
-**In scope:** a `<link rel="canonical">` tag in the root layout, pointing to the normalized URL for the current page.
+**In scope:** a `<link rel="canonical">` tag injected into every indexable page's `<head>`, pointing to the normalized URL for the current page.
 
 **Out of scope (already handled elsewhere):**
 
@@ -15,10 +15,6 @@ Addresses the "canonical URLs" concern in [`SearchEngines.md`](SearchEngines.md)
 - **Faceted/paginated listing URLs** (`?page=2`, `?manufacturer=stern`). Tracked as a separate concern in [`SearchEngines.md`](SearchEngines.md); the canonical strategy there (canonicalize filters back to the base listing vs. `noindex` filter combinations) needs its own decision and may end up using this same `<link rel="canonical">` mechanism with route-specific rules.
 
 What's left for this plan: mechanical canonicalization — strip the query string, normalize the trailing slash, ensure the canonical href uses the production origin (not the request host).
-
-## Dependency
-
-None hard. Slots in alongside [`NoindexMeta.md`](NoindexMeta.md) — both are root-layout `<svelte:head>` SEO tags driven by `page.url` / `page.route.id`. Land either order.
 
 ## Goals
 
@@ -29,47 +25,47 @@ None hard. Slots in alongside [`NoindexMeta.md`](NoindexMeta.md) — both are ro
 
 ## Mechanism
 
-`route-metadata.server.ts` is a server-only module (see [`NoindexMeta.md`](NoindexMeta.md) for why), so the indexable flag is computed in the root `+layout.server.ts` alongside `noindex` and rides down as load data. The `+layout.svelte` then computes the canonical URL from `page.url` only when the flag says it should:
+A `handle` hook (`canonicalHandle` in `frontend/src/hooks.server.ts`) added to the existing `sequence()` alongside `noindexHandle`. It computes the canonical URL from `event.url` + `event.route.id` and string-inserts the tag into the rendered HTML's `<head>` via `transformPageChunk` — exactly mirroring how `noindexHandle` injects the noindex meta tag (see [`NoindexMeta.md`](NoindexMeta.md) § "Mechanism" for the architectural rationale; the same reasoning applies here):
 
 ```ts
-// frontend/src/routes/+layout.server.ts (the same file NoindexMeta.md adds)
-import { isSearchEngineIndexable } from "$lib/route-metadata.server";
-import type { LayoutServerLoad } from "./$types";
+export const canonicalHandle: Handle = async ({ event, resolve }) => {
+  if (!shouldIndex(event.route.id)) return resolve(event);
 
-export const load: LayoutServerLoad = ({ route }) => {
-  const indexable = isSearchEngineIndexable(route.id);
-  return { noindex: !indexable, indexable };
+  const canonical = canonicalUrl(event.url, event.route.id);
+  const tag = `<link rel="canonical" href="${escapeHtmlAttribute(canonical)}" />`;
+  return resolve(event, {
+    transformPageChunk: ({ html }) =>
+      html.replace("</head>", `${tag}\n</head>`),
+  });
 };
+
+export const handle = sequence(
+  Sentry.sentryHandle(),
+  noindexHandle,
+  canonicalHandle,
+);
 ```
 
-```svelte
-<!-- frontend/src/routes/+layout.svelte -->
-<script lang="ts">
-  import { page } from '$app/state';
-  import { canonicalUrl } from '$lib/seo/canonical';
-
-  let { data, children } = $props();
-  let canonical = $derived(data.indexable ? canonicalUrl(page.url, page.route.id) : null);
-</script>
-
-<svelte:head>
-  {#if canonical}
-    <link rel="canonical" href={canonical} />
-  {/if}
-  <!-- noindex meta from NoindexMeta.md -->
-</svelte:head>
-```
+`shouldIndex(id)` is already defined in `hooks.server.ts` for the noindex case — same predicate, opposite direction. Reuse it directly: a route is canonical-eligible iff it's indexable. Null and unclassified routes (`+server.ts` endpoints) get neither signal.
 
 `canonicalUrl(url, routeId)` lives in `frontend/src/lib/seo/canonical.ts`:
 
-- Replace the origin with `SITE_ORIGIN` (read via `$env/static/public` so it's available in CSR too — the SSR-only `$env/static/private` would break client-side rerenders).
+- Replace the origin with `SITE_ORIGIN` (read via `$env/static/public`; the value is also referenced by the canonical itself, so co-locating with public env keeps it grep-able).
 - Normalize the trailing slash to the project's convention (no trailing slash, matching SvelteKit defaults).
 - Drop the query string and fragment by default.
 - Per-route opt-in for preserved query params: a small `CANONICAL_QUERY_PARAMS` map keyed by route ID listing the params that contribute to canonical identity (e.g. paginated listings might keep `?page=`). Empty by default; populated only when a route needs it.
 
+`escapeHtmlAttribute(s)` is a small utility (likely co-located with `canonicalUrl`) that escapes `&`, `<`, `>`, `"`, `'` for safe insertion into an HTML attribute value. The canonical URL is built from `event.url.pathname`, which can contain user-controlled dynamic-segment values (`[slug]`, `[...path]`); even though SvelteKit's routing constrains what can match, escaping at the insertion site is the right defensive layer — same reason we URL-encode at every boundary even when we "know" the input.
+
+Notes:
+
+- **Separate hook, not folded into `noindexHandle`.** Noindex fires on non-indexable; canonical fires on indexable; they never both fire for the same route. Keeping them as independent hooks in the `sequence()` keeps each one's responsibility scannable and lets the tests be split cleanly. The extra `transformPageChunk` pass is negligible.
+- **`transformPageChunk` string-replaces `</head>`.** Same pattern noindex uses; the head reliably appears in the first chunk so the replace is single-pass and unambiguous.
+- **`ssr=false` routes get the canonical on the initial response.** The hook fires for every request including the static-shell response, so the canonical tag lands on the first response (not deferred to a later `__data.json` fetch the way a layout-load implementation would be). Mirror of the same property `noindexHandle` provides.
+
 ## What gets a canonical
 
-Every route where `isSearchEngineIndexable(routeId) === true`. Non-indexable routes get `noindex` instead and don't need a canonical.
+Every route where `isSearchEngineIndexable(routeId) === true`. Non-indexable routes get `noindex` instead and don't need a canonical. Unclassified routes (`+server.ts` endpoints like `/__health`) also get neither — they're not pages and would never be indexed regardless.
 
 ## Gate on `ALLOW_SEARCH_ENGINE_INDEXING`?
 
@@ -77,27 +73,38 @@ No. Same reasoning as [`NoindexMeta.md`](NoindexMeta.md) § "Gate on `ALLOW_SEAR
 
 ## Tests
 
-`frontend/src/routes/+layout.dom.test.ts` (or a new `canonical.dom.test.ts`):
+`frontend/src/hooks-canonical.server.test.ts` mirrors the structure of `hooks-noindex.server.test.ts`: import `canonicalHandle`, run it against a stubbed `event`/`resolve`, capture the `transformPageChunk` invocation, assert on the rendered HTML and headers.
 
-- Render an indexable route with no query string → canonical equals `${SITE_ORIGIN}${pathname}`.
-- Render an indexable route with a query string → canonical strips the query.
-- Render an indexable route reached via a non-prod request host → canonical still uses `SITE_ORIGIN`.
-- Render a non-indexable route → no `<link rel="canonical">` is present.
+Cases:
 
-Unit tests for `canonicalUrl()` cover trailing-slash normalization and the per-route query-param allowlist when one is added.
+- Indexable route (`/`, `/about`, `/titles/[slug]`) with no query string → response body contains `<link rel="canonical" href="${SITE_ORIGIN}${pathname}" />`.
+- Indexable route with a query string → canonical strips the query.
+- Indexable route reached via a non-prod request host (e.g. `preview.example.com`) → canonical still uses `SITE_ORIGIN`.
+- Non-indexable route (`/login`, `/admin/dashboard`, `/titles/[slug]/edit`) → no `<link rel="canonical">` in the body, `resolve` called without options.
+- `route.id === null` (404) → no canonical.
+- Unclassified route (`/__health`) → no canonical, no crash.
+- Per-route query-param allowlist: when `CANONICAL_QUERY_PARAMS` lists `page` for a route, the canonical preserves `?page=2` but still strips other params.
+
+Unit tests for `canonicalUrl()` cover trailing-slash normalization, query-param allowlist application, and the `SITE_ORIGIN` override in isolation from the hook plumbing.
 
 ## Implementation order
 
-1. `frontend/src/lib/seo/canonical.ts` — pure function, unit-tested.
-2. Add the `<svelte:head>` block to `frontend/src/routes/+layout.svelte`.
-3. DOM test per § "Tests".
-4. Verify locally: `curl -s localhost:5173/titles | grep canonical` and `curl -s 'localhost:5173/titles?foo=bar' | grep canonical` both show the canonical path with no query.
+1. `frontend/src/lib/seo/canonical.ts` — pure `canonicalUrl()` + `escapeHtmlAttribute()` functions, unit-tested.
+2. Add `canonicalHandle` to `frontend/src/hooks.server.ts` and append it to the `sequence()` after `noindexHandle`.
+3. Add `frontend/src/hooks-canonical.server.test.ts` per § "Tests".
+4. Verify locally:
+   - `curl -s localhost:5173/titles/medieval-madness | grep canonical` shows `<link rel="canonical" href="${SITE_ORIGIN}/titles/medieval-madness" />`.
+   - `curl -s 'localhost:5173/titles/medieval-madness?foo=bar' | grep canonical` shows the same canonical (no query).
+   - `curl -s localhost:5173/login | grep canonical` shows nothing.
+   - `curl -s localhost:5173/__health | grep canonical` shows nothing.
 
 ## Considered alternatives
 
-- **Use `page.url.href` directly.** Rejected: bakes in the request host and query string, so a request to a preview origin or with a tracking param would emit a wrong canonical.
-- **Per-page `<svelte:head>` blocks in each indexable route.** Rejected for the same reason as in [`NoindexMeta.md`](NoindexMeta.md): centralizing in the root layout means a new route inherits correct behavior without per-page wiring.
-- **Fold into `NoindexMeta.md` and rename it `HeadSeoTags.md`.** Considered — same mechanism, same test file, both driven by `isSearchEngineIndexable()`. Rejected to keep each plan single-purpose and matching the existing `seo/` directory pattern.
+- **Layout-load implementation (`+layout.server.ts` returns `{ indexable, canonical }`, root `+layout.svelte` reads `data.canonical` in a `<svelte:head>` block).** Rejected for the same reason `NoindexMeta.md` rejected it: pushes `indexable`/`canonical` fields into every page's `PageData` type, forcing every test that constructs a literal `data` fixture to add them. Also fails to emit the canonical on the initial response for `ssr=false` routes (SvelteKit serves the static shell without running layout loads; the data lands only on the deferred `__data.json` fetch). The hook approach has neither problem.
+- **Fold into `noindexHandle`.** Considered — both hooks read `shouldIndex(event.route.id)` and both inject into `</head>` via `transformPageChunk`. Rejected to keep each hook single-responsibility: noindex and canonical are complementary signals (exactly one fires per route), and splitting them keeps each one's intent obvious in the `sequence()` and lets the test files name what they cover. The cost (one extra `transformPageChunk` pass on indexable routes) is invisible.
+- **Use `event.url.href` directly.** Rejected: bakes in the request host and query string, so a request to a preview origin or with a tracking param would emit a wrong canonical. The `canonicalUrl()` helper exists precisely to strip these.
+- **Per-page `<svelte:head>` blocks in each indexable route.** Rejected: would silently miss any new indexable route until a reviewer noticed. Centralizing in a hook means a new route inherits correct behavior automatically.
+- **Fold into `NoindexMeta.md` and rename it `HeadSeoTags.md`.** Considered — same mechanism, both driven by `isSearchEngineIndexable()`. Rejected to keep each plan single-purpose and matching the existing `seo/` directory pattern. The implementation files (`hooks.server.ts`, the two hook tests) share a directory and a helper; the plans don't need to.
 
 ## Open questions
 

--- a/docs/plans/seo/NoindexMeta.md
+++ b/docs/plans/seo/NoindexMeta.md
@@ -1,65 +1,83 @@
-# Noindex Meta Tag
+# Noindex Signals
 
-This is the plan for injecting `<meta name="robots" content="noindex">` on every non-indexable route, so user-facing pages we don't want in search results (`/login`, `/search`, `/style-lab`, `*/edit`, etc.) stay out of Google's index even when crawlers reach them via inbound links.
+This is the plan for emitting noindex on every non-indexable route, so user-facing pages we don't want in search results (`/login`, `/search`, `/style-lab`, `*/edit`, etc.) stay out of search engine indexes even when crawlers reach them via inbound links.
+
+## Status: ✅ Implemented
+
+This plan has been implemented.
+
+## Key design decision
+
+We emit two signals together:
+
+- `<meta name="robots" content="noindex" />` in the page `<head>`.
+- `X-Robots-Tag: noindex` HTTP response header.
+
+Both come from a single `handle` hook (`noindexHandle` in `hooks.server.ts`) that reads the `isSearchEngineIndexable()` predicate, so they can't disagree. They cover each other's blind spots:
+
+- The header reaches crawlers on non-HTML responses where a meta tag isn't possible (e.g. `__data.json` fetches that SvelteKit issues for `ssr=false` routes).
+- The meta tag survives infrastructure that strips response headers (CDN edge rules, proxies, archive snapshots).
 
 Addresses the "keeping non-indexable user-facing pages out of the index" concern in [`SearchEngines.md`](SearchEngines.md); see that doc for how this fits with robots.txt and sitemap.
 
-## Dependency
+## Why noindex signals, not robots.txt `Disallow`
 
-This plan consumes [`RouteWalking.md`](RouteWalking.md) — the walker primitives in `frontend/src/lib/route-metadata.server.ts` and the `isSearchEngineIndexable(routeId)` predicate. Land that first.
+Per [Google's current guidance](https://developers.google.com/search/docs/crawling-indexing/block-indexing): robots.txt is for crawl-traffic management, not index exclusion. A page `Disallow`-ed in robots.txt can still appear in search results (URL + anchor text, no snippet) if anything links to it. The recommended mechanism for "do not index this page" is a per-page noindex signal — meta tag or `X-Robots-Tag` header.
 
-## Why per-page noindex, not robots.txt `Disallow`
-
-Per [Google's current guidance](https://developers.google.com/search/docs/crawling-indexing/block-indexing): robots.txt is for crawl-traffic management, not index exclusion. A page `Disallow`-ed in robots.txt can still appear in search results (URL + anchor text, no snippet) if anything links to it. The recommended mechanism for "do not index this page" is per-page `<meta name="robots" content="noindex">`.
-
-The two are also mutually exclusive: if a URL is `Disallow`-ed in robots.txt, Googlebot can't crawl it and so never sees the `noindex` meta. So for user-facing pages we explicitly want crawled (so the meta is seen) but not indexed.
+The two are also mutually exclusive: if a URL is `Disallow`-ed in robots.txt, Googlebot can't crawl it and so never sees the `noindex` signal. So for user-facing pages we explicitly want crawled (so the signal is seen) but not indexed.
 
 See [`SearchEngines.md`](SearchEngines.md) § "Why the split between robots.txt and noindex" for the full mapping.
 
 ## Goals
 
-- Every non-indexable user-facing page emits `<meta name="robots" content="noindex">` in its `<head>`.
+- Every non-indexable user-facing page emits noindex via **both** the meta tag in its `<head>` and the `X-Robots-Tag` response header.
 - The decision is driven by the same `isSearchEngineIndexable(routeId)` predicate the sitemap uses — no parallel list, no drift.
-- Adding a new non-indexable route requires only adding it to `SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS` (or letting the catalog convention classify it); the meta tag follows automatically.
+- Adding a new non-indexable route requires only adding it to `SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS` (or letting the catalog convention classify it); both signals follow automatically.
 
 ## Mechanism
 
-`route-metadata.server.ts` is a server-only module — its `?raw` glob would balloon the client bundle if imported into a `.svelte` file. So the predicate runs in the root `+layout.server.ts` and the result rides down as load data:
+`route-metadata.server.ts` is server-only (its `?raw` glob would balloon the client bundle), so the predicate has to run server-side. We put it in a `handle` hook added to the existing `sequence()` in `frontend/src/hooks.server.ts`:
 
 ```ts
-// frontend/src/routes/+layout.server.ts (new file)
-import { isSearchEngineIndexable } from "$lib/route-metadata.server";
-import type { LayoutServerLoad } from "./$types";
-
-export const load: LayoutServerLoad = ({ route }) => {
-  return { noindex: !isSearchEngineIndexable(route.id) };
+export const noindexHandle: Handle = async ({ event, resolve }) => {
+  if (!shouldIndex(event.route.id)) {
+    const response = await resolve(event, {
+      transformPageChunk: ({ html }) =>
+        html.replace(
+          "</head>",
+          '<meta name="robots" content="noindex" />\n</head>',
+        ),
+    });
+    response.headers.set("X-Robots-Tag", "noindex");
+    return response;
+  }
+  return resolve(event);
 };
-```
 
-```svelte
-<!-- frontend/src/routes/+layout.svelte -->
-<script lang="ts">
-  let { data, children } = $props();
-</script>
+function shouldIndex(id: RouteId | null): boolean {
+  if (id === null) return false; // unmatched URLs (404).
+  try {
+    return isSearchEngineIndexable(id);
+  } catch {
+    // Unclassified routes are +server.ts endpoints (e.g. /__health) —
+    // see notes below for why we swallow rather than crash.
+    return false;
+  }
+}
 
-<svelte:head>
-  {#if data.noindex}
-    <meta name="robots" content="noindex" />
-  {/if}
-</svelte:head>
-
-{@render children?.()}
-<!-- ...rest of existing layout body... -->
+export const handle = sequence(Sentry.sentryHandle(), noindexHandle);
 ```
 
 Notes:
 
-- `route.id` on the server load event is the SvelteKit route ID (e.g. `/titles/[slug]`), which is the same shape `isSearchEngineIndexable()` already operates on — no translation needed.
-- Adding a root `+layout.server.ts` must NOT import `$lib/require-capability.server` — the auth-gate scan in `route-metadata.server.ts` throws at module load if a root gate is detected (it would silently make every non-catalog route non-indexable).
-- Auth-gated routes get the meta tag too. They're already invisible to crawlers (the layout redirects unauthenticated requests), but defense in depth is cheap: if anything ever serves an auth-gated page bytes to a logged-out crawler, the meta still says noindex.
-- Use `<meta name="robots">`, not `<meta name="googlebot">` — the generic form covers Google, Bing, and other compliant crawlers in one tag.
+- **Why `handle`, not a layout `load`.** A root `+layout.server.ts` would put `noindex` into `PageData`, forcing every page test that constructs a literal `data` fixture to add the field. The hook stays out of `PageData` entirely. It also covers responses the layout load wouldn't reach (see next bullet).
+- **`ssr=false` routes are covered on the initial response.** The hook fires for every request including the static-shell page response, so both the X-Robots-Tag header and the injected meta tag land on the first response — not deferred to the post-hydration `__data.json` fetch the way a layout-load implementation would be.
+- **`transformPageChunk` string-replaces `</head>`.** SvelteKit renders the document head before any body streaming, so `</head>` reliably appears in the first chunk. This is the same pattern used in the wild for CSP nonce injection, analytics shim insertion, etc.
+- **Why the `try/catch` on the predicate.** `isSearchEngineIndexable()` throws on unclassified routes — a deliberate guardrail that makes new `+page.svelte` routes fail loudly in `route-metadata.test.ts` until they're classified. But `allRoutes()` only enumerates `+page.svelte` files, so `+server.ts` endpoints (today just `/__health`) are _outside_ that test's coverage and would be unclassified at runtime. Without the catch, the hook would crash the liveness probe on every deploy. Defaulting unclassified routes to noindex is safe: they're not HTML pages, so accidentally signaling noindex doesn't hurt anything.
+- **Auth-gated routes get noindex too.** They're already invisible to crawlers (the layout redirects unauthenticated requests), but defense in depth is cheap: if anything ever serves an auth-gated page's bytes to a logged-out crawler, the signals still say noindex.
+- Use `<meta name="robots">` (not `<meta name="googlebot">`) and `X-Robots-Tag: noindex` (not `X-Robots-Tag: googlebot: noindex`) — the generic forms cover Google, Bing, and other compliant crawlers in one signal.
 
-## What gets the meta tag
+## What gets the noindex signals
 
 Every route where `isSearchEngineIndexable(routeId) === false`. With current routes:
 
@@ -71,34 +89,37 @@ The list isn't enumerated in this doc — it's whatever `isSearchEngineIndexable
 
 ## Gate on `ALLOW_SEARCH_ENGINE_INDEXING`?
 
-No. The meta tag should be emitted on every deploy regardless of whether indexing is allowed at the deploy level. Reasoning:
+No. Both signals are emitted on every deploy regardless of whether indexing is allowed at the deploy level. Reasoning:
 
-- On non-prod deploys (`ALLOW_SEARCH_ENGINE_INDEXING != "true"`), robots.txt already says `Disallow: /` and crawlers shouldn't be looking at any page. The meta is redundant but harmless.
-- Tying the meta to the env var adds a branch to the layout for no behavioral benefit and one more failure mode (e.g. forgetting to thread the var into SSR context).
-- Keeping the meta unconditional makes local testing trivial: visit any non-indexable route and view source.
+- On non-prod deploys (`ALLOW_SEARCH_ENGINE_INDEXING != "true"`), robots.txt already says `Disallow: /` and crawlers shouldn't be looking at any page. The noindex signals are redundant but harmless.
+- Tying them to the env var adds a branch to the hook for no behavioral benefit and one more failure mode.
+- Keeping them unconditional makes local testing trivial: visit any non-indexable route and view source / check headers.
 
 ## Tests
 
-`frontend/src/routes/+layout.dom.test.ts` (or a new `noindex-meta.dom.test.ts` alongside):
+`frontend/src/hooks-noindex.server.test.ts` imports `noindexHandle` and parameterizes over anchor routes from each bucket. For each routeId it calls the handle with a stubbed `event` and a `resolve` that captures the `transformPageChunk` invocation and returns a fake HTML response, then asserts:
 
-- Render the layout for an indexable route (`/titles/[slug]`) and assert no `<meta name="robots">` is present.
-- Render for a listed non-indexable route (`/login`) and assert `<meta name="robots" content="noindex">` is present.
-- Render for an auth-gated route (`/admin/dashboard`) and assert the meta is present.
-
-The test parameterizes over the same anchor routes used in `RouteWalking.md`'s sanity check — keeps both tests honest if the route classifications drift.
+- Indexable (`/`, `/about`, `/titles/[slug]`) → `resolve` called without options, response has no `X-Robots-Tag`, response body has no `name="robots"` meta tag.
+- Listed non-indexable (`/login`, `/search`, `/users/[username]`), auth-gated (`/admin/dashboard`, `/kiosk/edit`), catalog non-indexable kinds (`/titles`, `/titles/new`, `/titles/[slug]/edit`, `/titles/[slug]/delete`), and `route.id === null` → header set, body contains the meta tag, `resolve` called with a `transformPageChunk` function.
+- Unclassified routes (`/__health`, the only `+server.ts` endpoint today) → header set, no crash. Pins the `try/catch` behavior so a future refactor that "cleans up" the catch surfaces here instead of crashing the liveness probe in production.
 
 ## Implementation order
 
-1. Create `frontend/src/routes/+layout.server.ts` with the noindex load. Verify the auth-gate scan still passes (the new file imports `route-metadata.server`, not `require-capability.server`, so it's fine).
-2. Add the `<svelte:head>` block to `frontend/src/routes/+layout.svelte` reading `data.noindex`.
-3. Add the dom test per § "Tests".
-4. Verify locally: `curl -s localhost:5173/login | grep robots` shows the meta; same for `/titles/medieval-madness` shows nothing.
+1. Add `noindexHandle` to `frontend/src/hooks.server.ts`, add it to the `sequence()`, and export it for testing.
+2. Add `frontend/src/hooks-noindex.server.test.ts` per § "Tests".
+3. Verify locally:
+   - `curl -sI localhost:5173/login | grep -i x-robots-tag` shows the header.
+   - `curl -s localhost:5173/login | grep robots` shows the meta.
+   - Both checks against an SSR'd indexable route (e.g. `/titles/medieval-madness`) show nothing.
+   - For an `ssr=false` listing (e.g. `/titles`), the initial page response now has **both** the header AND the meta tag (the hook covers static-shell responses that a layout load wouldn't).
 
 That's the whole PR. Tiny.
 
 ## Considered alternatives
 
-- **`X-Robots-Tag: noindex` HTTP response header instead of a meta tag.** Equivalent in effect; required for non-HTML responses (PDFs, images). For HTML pages we control, the meta tag is simpler — no SvelteKit `setHeaders` plumbing, just markup. Revisit if we ever serve non-HTML responses that need excluding.
-- **Per-route `<svelte:head>` blocks in each excluded page.** Rejected: would silently miss any new non-indexable route until a reviewer noticed. Centralizing the decision in the root layout means "well-classified" automatically implies "correctly headed."
-- **Computing `noindex` in `+layout.svelte` directly.** Rejected — would require importing `route-metadata.server.ts` into a client-bundle file, which SvelteKit blocks (rightly: the module's `?raw` glob would ship server source as strings to the browser).
-- **Folding into `Robots.md`.** Rejected: different mechanism (HTML markup vs. text file), different consumer (per-request render vs. static file), different testing surface. Sharing the `isSearchEngineIndexable()` predicate is enough integration.
+- **Layout-load implementation (`+layout.server.ts` that returns `{ noindex }`, root `+layout.svelte` with `<svelte:head>{#if data.noindex}…</svelte:head>`).** Rejected: pushes a `noindex` field into every page's `PageData` type, forcing every test that constructs a literal `data` fixture to add `noindex: boolean` — ~13 unrelated test files in this codebase. Also fails to set headers on the initial page response for `ssr=false` routes (SvelteKit serves the static shell without running layout loads; the header lands only on the deferred `__data.json` fetch).
+- **Meta tag only, no `X-Robots-Tag` header.** Rejected: the meta tag can't appear in non-HTML responses (e.g. `__data.json`), and the header is what survives proxies that translate or rewrite HTML.
+- **Header only, no meta tag.** Rejected: header-stripping infrastructure (CDNs, archive snapshots) would silently disable the only signal. The meta tag survives that.
+- **Per-route `<svelte:head>` blocks in each excluded page.** Rejected: would silently miss any new non-indexable route until a reviewer noticed. Centralizing the decision in the hook means "well-classified" automatically implies "correctly signaled."
+- **Computing `noindex` client-side.** Rejected — would require importing `route-metadata.server.ts` into a client-bundle file, which SvelteKit blocks (rightly: the module's `?raw` glob would ship server source as strings to the browser).
+- **Folding into `Robots.md`.** Rejected: different mechanism (per-page signal vs. static text file), different consumer (per-request render vs. crawler bootstrap), different testing surface. Sharing the `isSearchEngineIndexable()` predicate is enough integration.

--- a/docs/plans/seo/Robots.md
+++ b/docs/plans/seo/Robots.md
@@ -4,13 +4,9 @@ This is the plan for introducing `robots.txt` to the project. SvelteKit owns pub
 
 Addresses the "gating non-prod deploys" and "crawler traffic for non-page paths" concerns in [`SearchEngines.md`](SearchEngines.md); per-page index exclusion lives in [`NoindexMeta.md`](NoindexMeta.md), and the affirmative "what to index" signal lives in [`Sitemap.md`](Sitemap.md).
 
-## Dependency
+## What robots.txt is and isn't for
 
-This plan consumes [`RouteWalking.md`](RouteWalking.md) — the route-metadata primitive that other consumers in the SEO strategy share. robots.txt itself only needs the env-var gate and a small static list of non-page paths, but landing on top of RouteWalking keeps the directory's dependency story straight.
-
-## Scope — what robots.txt is and isn't for
-
-Per [Google's current guidance](https://developers.google.com/search/docs/crawling-indexing/robots/intro): **robots.txt is for managing crawl traffic, not for keeping pages out of the index.** A URL `Disallow`-ed in robots.txt can still appear in Google results (URL + anchor text, no snippet) if anything links to it. The recommended mechanism for "do not index this page" is per-page `<meta name="robots" content="noindex">`, covered in [`NoindexMeta.md`](NoindexMeta.md).
+Per [Google's current guidance](https://developers.google.com/search/docs/crawling-indexing/robots/intro) (Bing and others behave similarly): **robots.txt is for managing crawl traffic, not for keeping pages out of the index.** A URL `Disallow`-ed in robots.txt can still appear in search results (URL + anchor text, no snippet) if anything links to it. The recommended mechanism for "do not index this page" is per-page `<meta name="robots" content="noindex">`, covered in [`NoindexMeta.md`](NoindexMeta.md).
 
 Concretely:
 
@@ -29,7 +25,7 @@ Concretely:
 
 Whether a given deploy should be crawled is a deploy-identity question, and the answer needs to stay correct as we add environments (preview, staging, future prod-like services). The constraints we're designing against:
 
-- **Preview/staging must not leak into Google.** A preview deploy with an `https://` origin and `DEBUG=false` looks production-shaped to any heuristic — sniffing `SITE_ORIGIN` for a hostname or keying off `NODE_ENV` will silently misclassify it.
+- **Preview/staging must not leak into any search engine index.** A preview deploy with an `https://` origin and `DEBUG=false` looks production-shaped to any heuristic — sniffing `SITE_ORIGIN` for a hostname or keying off `NODE_ENV` will silently misclassify it.
 - **Read-time default must be off.** If the flag is ever read without being set — local dev, a misconfigured env, an emergency rollback that drops env vars — the safe outcome is "not indexable." Production is the one place that opts in.
 - **Deploys must declare intent.** A new preview service that ships without the flag set is exactly the leak we're trying to prevent. The read-time default protects against accidents at runtime; a deploy-time check forces the operator to make the call before the service goes live.
 - **Typos must fail safe.** `"True"` or `"1"` quietly disabling indexing on prod is a much better failure than the reverse.
@@ -46,7 +42,7 @@ A single opt-in env var satisfies all four — production explicitly turns it on
 
 ## 2. robots.txt contents
 
-> **Do not add user-facing routes (`/login`, `/search`, `/*/edit`, etc.) to this list** — they're handled by per-page `noindex` meta per [`NoindexMeta.md`](NoindexMeta.md). Adding a `Disallow:` for them blocks crawling, which means Googlebot never sees the `noindex` and the URL can still appear in results via inbound links.
+> **Do not add user-facing routes (`/login`, `/search`, `/*/edit`, etc.) to this list** — they're handled by per-page `noindex` meta per [`NoindexMeta.md`](NoindexMeta.md). Adding a `Disallow:` for them blocks crawling, which means crawlers never see the `noindex` and the URL can still appear in results via inbound links.
 
 When `ALLOW_SEARCH_ENGINE_INDEXING != "true"`:
 
@@ -78,7 +74,7 @@ Validated at the earliest point it's consumed (deploy/runtime). Pattern and conv
 
 Frontend env vars are validated in Python because backend and frontend share the Railway env (per `docs/DeployChecks.md` § "Frontend checks belong in Python"). Add to `backend/apps/core/checks.py` (alongside `check_observability_env`):
 
-- **`ALLOW_SEARCH_ENGINE_INDEXING`** — `@register(Tags.security, deploy=True)` check that errors when `ALLOW_SEARCH_ENGINE_INDEXING` is empty, and errors when set to anything other than the literal `"true"` or `"false"`. Every deployed environment must declare its intent (catches the new-preview-service-leaks-into-Google failure mode) and the strict-shape rule catches typos like `"True"` or `"1"` that would silently leave production un-indexed. Local dev is unaffected: the check is `deploy=True`, so it only runs under `manage.py check --deploy`. New error ids `core.E303` (missing) and `core.E304` (malformed).
+- **`ALLOW_SEARCH_ENGINE_INDEXING`** — `@register(Tags.security, deploy=True)` check that errors when `ALLOW_SEARCH_ENGINE_INDEXING` is empty, and errors when set to anything other than the literal `"true"` or `"false"`. Every deployed environment must declare its intent (catches the new-preview-service-leaks-into-search-indexes failure mode) and the strict-shape rule catches typos like `"True"` or `"1"` that would silently leave production un-indexed. Local dev is unaffected: the check is `deploy=True`, so it only runs under `manage.py check --deploy`. New error ids `core.E303` (missing) and `core.E304` (malformed).
 
 Tests in `backend/apps/core/tests/test_checks.py` (matching the existing pattern): one test per error id — flip the env state, assert the message id appears (or doesn't).
 

--- a/docs/plans/seo/RouteWalking.md
+++ b/docs/plans/seo/RouteWalking.md
@@ -2,6 +2,12 @@
 
 Plan for the shared classification machinery — `frontend/src/lib/route-metadata.server.ts` — that answers "is this route indexable?" for sitemap, robots, noindex meta, canonical, SSR enforcement and title/description enforcement. Those consumers live downstream and are described in [`SearchEngines.md`](SearchEngines.md).
 
+## Status: ✅ Implemented
+
+This plan has been implemented.
+
+## Key design element
+
 The headline design choice: **derive indexability from the catalog entity registry where possible, declare it per-route only for the small set of routes that can't be derived.** This follows the project's [model-driven metadata](../model_driven_metadata/ModelDrivenMetadata.md) discipline — the catalog model is the source of truth, not parallel per-route declarations.
 
 ## Why
@@ -22,7 +28,7 @@ The design MUST satisfy these two properties:
 1. **Adding a new catalog entity requires zero SEO declarations.** Once the entity ships in `CATALOG_META`, detail / listing / edit-history / sources / edit / new / delete routes all classify correctly without any human-authored per-route metadata. Any design that requires the contributor to remember to add an SEO declaration alongside their new entity violates this invariant.
 2. **Adding a non-catalog route forces an explicit classification decision.** The walker test fails until the route appears in `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`, `SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS`, or under a non-catalog auth-gated layout (today `/admin/*` and `/kiosk/edit/*`). There is no silent default — an unclassified route is a test failure, not an "implicitly included" or "implicitly excluded" route.
 
-The first invariant comes from the [model-driven metadata](../model_driven_metadata/ModelDrivenMetadata.md) discipline: parallel hand-maintained per-route declarations are exactly the drift surface model-driven design eliminates. The second invariant comes from the SEO consequences of "wrong default": a route silently included that shouldn't be leaks into the index and is expensive to remove (Google caches removed pages for months); a route silently excluded that shouldn't be costs traffic invisibly. Both directions of failure are slow to detect; forcing the decision at PR time is cheap by comparison.
+The first invariant comes from the [model-driven metadata](../model_driven_metadata/ModelDrivenMetadata.md) discipline: parallel hand-maintained per-route declarations are exactly the drift surface model-driven design eliminates. The second invariant comes from the SEO consequences of "wrong default": a route silently included that shouldn't be leaks into search indexes and is expensive to remove (every major engine caches removed pages for months); a route silently excluded that shouldn't be costs traffic invisibly. Both directions of failure are slow to detect; forcing the decision at PR time is cheap by comparison.
 
 ## The classification
 
@@ -223,7 +229,7 @@ That's the whole walker-test surface. The separate `catalog-auth-convention.test
 - Move the `import.meta.glob` walk into `route-metadata.server.ts`'s `allRoutes()`.
 - Have `catalog-meta.test.ts` consume `allRoutes()` + `classifyRoute()` instead of doing its own glob + regex. The `ROUTE_DIR_TO_KEY` / `UNMAPPED_ROUTE_DIRS` / `DEFERRED_KEYS` structure becomes redundant: catalog membership now comes from `CATALOG_META` and the route-class match, not a parallel hand-maintained map.
 
-The module is suffixed `.server.ts` because it uses `import.meta.glob('/src/routes/**/+layout.server.ts', { eager: true, query: '?raw' })` to scan auth-gate imports. Vite inlines each matched file's source as a string literal at build time, and SvelteKit's normal "you can't import a `.server.ts` from client code" check doesn't apply to `?raw` (it's a string, not a module). Without the `.server` suffix on this module, any client-side importer would ship every `+layout.server.ts` and `+page.server.ts` source string into the browser bundle. Downstream consumers (noindex meta injection, canonical URL helper, etc.) should compute the boolean in a server load and pass it down as data — not call `isSearchEngineIndexable()` from a `.svelte` file.
+The module is suffixed `.server.ts` because it uses `import.meta.glob('/src/routes/**/+layout.server.ts', { eager: true, query: '?raw' })` to scan auth-gate imports. Vite inlines each matched file's source as a string literal at build time, and SvelteKit's normal "you can't import a `.server.ts` from client code" check doesn't apply to `?raw` (it's a string, not a module). Without the `.server` suffix on this module, any client-side importer would ship every `+layout.server.ts` and `+page.server.ts` source string into the browser bundle. Downstream consumers (noindex meta injection, canonical URL helper, etc.) should call `isSearchEngineIndexable()` from a `.server.ts` site (a server `handle` hook, a server load) — not from a `.svelte` file.
 
 Out of scope — don't touch:
 
@@ -236,7 +242,7 @@ Full consumer list lives in [`SearchEngines.md`](SearchEngines.md); short versio
 
 - **`robots.txt`** — see [`Robots.md`](Robots.md). Server-endpoint disallows, mostly orthogonal to route classification.
 - **`sitemap.xml`** — see [`Sitemap.md`](Sitemap.md). Enumerates per-entity URLs from `CATALOG_META` + entity data: the detail page plus an `/edit-history` and `/sources` URL per entity. Adds the entries from `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`. The walker's `isSearchEngineIndexable()` is the filter for any include/exclude question.
-- **`<meta name="robots" content="noindex">`** — see [`NoindexMeta.md`](NoindexMeta.md). Layout-level injection driven by `isSearchEngineIndexable(page.route.id)`.
+- **`<meta name="robots" content="noindex" />`** — see [`NoindexMeta.md`](NoindexMeta.md). Injected by a `handle` hook (`hooks.server.ts`) via `transformPageChunk`, driven by `isSearchEngineIndexable(event.route.id)`. The hook also sets the `X-Robots-Tag` response header.
 - **Canonical URL** — see [`CanonicalUrl.md`](CanonicalUrl.md). Catalog detail derives the canonical from the entity's `link_url_pattern`; listed indexable routes derive it from the route ID.
 - **Title/description presence test** — every indexable route declares a meaningful `<title>` and `<meta name="description">`. Catalog detail derives both from entity data; listed indexable routes declare them in the page.
 

--- a/docs/plans/seo/SearchEngines.md
+++ b/docs/plans/seo/SearchEngines.md
@@ -7,7 +7,7 @@ This is a hub document about how the project interacts with search engines -- su
 One function answers "should search engines index this route?" for every consumer in the SEO stack:
 
 - **Sitemap** filters routes _in_ — only `isSearchEngineIndexable() === true` routes appear.
-- **`<meta name="robots" content="noindex">`** is injected _out_ — only `isSearchEngineIndexable() === false` routes get the tag.
+- **`<meta name="robots" content="noindex" />`** is injected _out_ — only `isSearchEngineIndexable() === false` routes get the tag.
 - **Canonical URL, SSR-enabled, title/description-present** enforcement tests all gate on the same predicate.
 
 They can't drift because they all read from one source. The predicate is defined in [`RouteWalking.md`](RouteWalking.md); its classification is **derived from the catalog entity registry where possible, declared per-route only for routes outside the catalog convention**. This applies the project's [model-driven metadata](../model_driven_metadata/ModelDrivenMetadata.md) discipline to the SEO surface — the catalog model is the source of truth, parallel per-route declarations would be drift waiting to happen.
@@ -44,7 +44,7 @@ That's the only file you touch. Effects cascade automatically:
 
 - `isSearchEngineIndexable('/login')` returns `false`.
 - The sitemap omits `/login`. Sitemaps list pages we _want_ indexed; non-indexable routes don't appear.
-- The root layout injects `<meta name="robots" content="noindex">` into `/login`'s HTML so crawlers reaching it via inbound links (password-reset emails, OAuth redirects, etc.) don't index it.
+- The server `handle` hook injects `<meta name="robots" content="noindex" />` into `/login`'s HTML (and sets the `X-Robots-Tag: noindex` response header) so crawlers reaching it via inbound links (password-reset emails, OAuth redirects, etc.) don't index it.
 - The SSR-on-indexable, title-and-description-on-indexable and canonical-on-indexable enforcement tests skip `/login` — they only apply to indexable routes.
 
 A common confusion worth heading off: a non-indexable route gets a meta tag _and_ is excluded from the sitemap. Both, not either-or. The sitemap is "please crawl these"; the noindex tag is "if you do reach this anyway, don't index it." Different signals, both needed.
@@ -81,7 +81,7 @@ A "not found" page must return HTTP 404, not 200 with apologetic copy ("soft-404
 
 ### Gating staging deploys
 
-Staging environments should never appear in Google, regardless of what links to them. See [`Robots.md`](Robots.md).
+Staging environments should never appear in any search index, regardless of what links to them. See [`Robots.md`](Robots.md).
 
 ### Excluding pages from crawling
 
@@ -91,7 +91,7 @@ See [`Robots.md`](Robots.md).
 
 ### Excluding pages from search indexes
 
-Routes like `/login`, `/search`, `/style-lab`, `/kiosk/*`, and `/*/edit` are real pages that crawlers can reach via inbound links — but they shouldn't appear in search results. Per [Google's guidance](https://developers.google.com/search/docs/crawling-indexing/block-indexing), robots.txt is the wrong tool for this (see § "Why the split between robots.txt and noindex" below).
+Routes like `/login`, `/search`, `/style-lab`, `/kiosk/*`, and `/*/edit` are real pages that crawlers can reach via inbound links — but they shouldn't appear in search results. Per [Google's guidance](https://developers.google.com/search/docs/crawling-indexing/block-indexing) (Bing and other major engines behave the same way), robots.txt is the wrong tool for this (see § "Why the split between robots.txt and noindex" below).
 
 See [`NoindexMeta.md`](NoindexMeta.md).
 
@@ -101,7 +101,7 @@ Every indexable route needs a unique, meaningful `<title>` and `<meta name="desc
 
 ### Canonical URLs
 
-Multiple URLs can serve the same or near-identical content: trailing-slash variants, query-string variants, scheme/host variants. Without `<link rel="canonical">`, Google picks one to index and may pick wrong, splitting ranking signals across duplicates. (The Single-Model-Title case where Title and Model pages show the same content is already collapsed by a 301 redirect on `/models/[slug]`, so canonical tags aren't load-bearing there.)
+Multiple URLs can serve the same or near-identical content: trailing-slash variants, query-string variants, scheme/host variants. Without `<link rel="canonical">`, search engines pick one to index and may pick wrong, splitting ranking signals across duplicates. (The Single-Model-Title case where Title and Model pages show the same content is already collapsed by a 301 redirect on `/models/[slug]`, so canonical tags aren't load-bearing there.)
 
 See [`CanonicalUrl.md`](CanonicalUrl.md).
 
@@ -117,7 +117,7 @@ The catalog supports slug edits. Without `301` redirects from the old slug to th
 
 ### Structured data
 
-JSON-LD or microdata using schema.org types — `Product`-like schemas for Models, `Person` for designers and artists, `Organization` for manufacturers, `BreadcrumbList` for navigation. Google uses these for rich results: knowledge panels, carousels, breadcrumb display in SERPs. High-leverage for a domain catalog like this, but only valuable if maintained accurately per entity type.
+JSON-LD or microdata using schema.org types — `Product`-like schemas for Models, `Person` for designers and artists, `Organization` for manufacturers, `BreadcrumbList` for navigation. Search engines consume these for rich-result features — Google's knowledge panels, carousels and breadcrumb display in SERPs; Bing's equivalents — and the same markup feeds non-search consumers like LLM crawlers. High-leverage for a domain catalog like this, but only valuable if maintained accurately per entity type.
 
 ### Faceted and paginated listing URLs
 

--- a/docs/plans/seo/Sitemap.md
+++ b/docs/plans/seo/Sitemap.md
@@ -8,10 +8,7 @@ This PR builds on [`Robots.md`](Robots.md), which already shipped the `ALLOW_SEA
 
 ## Dependencies
 
-- [`RouteWalking.md`](RouteWalking.md) — provides `allRoutes()`, `isSearchEngineIndexable(routeId)`, and the `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS` constant in `frontend/src/lib/route-metadata.server.ts`.
 - [`Robots.md`](Robots.md) — provides the `ALLOW_SEARCH_ENGINE_INDEXING` env var, `lib/server/search-engine-indexable.ts`, and the deploy-time validation that prevents preview/staging from leaking. The sitemap endpoint reuses the same helper rather than re-reading the env var.
-
-Throughout this doc, `isSearchEngineIndexable(routeId)` refers to the predicate defined in `RouteWalking.md` — true when the route is a `catalog-detail` / `catalog-edit-history` / `catalog-sources` route or appears in `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`; false otherwise.
 
 ## Goals
 

--- a/frontend/src/hooks-noindex.server.test.ts
+++ b/frontend/src/hooks-noindex.server.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RequestEvent, ResolveOptions } from '@sveltejs/kit';
+import type { RouteId } from '$app/types';
+
+// Sentry mocks so importing hooks.server.ts doesn't drag in the real SDK.
+vi.mock('@sentry/sveltekit', () => ({
+  sentryHandle: vi.fn(() => vi.fn()),
+  handleErrorWithSentry: vi.fn(() => vi.fn()),
+}));
+vi.mock('$lib/sentry/handle-error', () => ({ handleServerError: vi.fn() }));
+
+// Spy on sequence() so we can pin membership of the exported `handle`
+// without invoking SvelteKit's runtime request store (which sequence reads
+// internally and which isn't set up in unit tests).
+vi.mock('@sveltejs/kit/hooks', () => ({ sequence: vi.fn(() => vi.fn()) }));
+
+const { sequence } = await import('@sveltejs/kit/hooks');
+const { noindexHandle } = await import('./hooks.server');
+
+function runHandle(
+  routeId: RouteId | null,
+  responseHtml = '<html><head></head><body></body></html>',
+) {
+  const resolve = vi.fn(async (_event: RequestEvent, opts?: ResolveOptions) => {
+    let html = responseHtml;
+    if (opts?.transformPageChunk) {
+      const out = opts.transformPageChunk({ html, done: true });
+      if (typeof out === 'string') html = out;
+    }
+    return new Response(html, { headers: { 'content-type': 'text/html' } });
+  });
+  const event = { route: { id: routeId } } as unknown as RequestEvent;
+  return { resolve, promise: noindexHandle({ event, resolve }) };
+}
+
+describe('noindexHandle', () => {
+  const CASES: ReadonlyArray<readonly [RouteId, boolean]> = [
+    // Indexable.
+    ['/', false],
+    ['/about', false],
+    ['/titles/[slug]', false],
+    // Listed non-indexable.
+    ['/login', true],
+    ['/search', true],
+    ['/users/[username]', true],
+    // Auth-gated (via prefix scan).
+    ['/admin/dashboard', true],
+    ['/kiosk/edit', true],
+    // Catalog non-indexable kinds.
+    ['/titles', true],
+    ['/titles/new', true],
+    ['/titles/[slug]/edit', true],
+    ['/titles/[slug]/delete', true],
+  ];
+
+  it.each(CASES)('classifies %s (noindex=%s)', async (routeId, expectedNoindex) => {
+    const { resolve, promise } = runHandle(routeId);
+    const response = await promise;
+
+    if (expectedNoindex) {
+      expect(response.headers.get('X-Robots-Tag')).toBe('noindex');
+      expect(await response.text()).toContain('<meta name="robots" content="noindex"');
+      expect(resolve).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ transformPageChunk: expect.any(Function) }),
+      );
+    } else {
+      expect(response.headers.get('X-Robots-Tag')).toBeNull();
+      expect(await response.text()).not.toContain('name="robots"');
+      // No options passed at all on the indexable path.
+      expect(resolve).toHaveBeenCalledWith(expect.anything());
+    }
+  });
+
+  it('treats route.id === null (unmatched URLs / 404s) as noindex', async () => {
+    const { promise } = runHandle(null);
+    const response = await promise;
+
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex');
+    expect(await response.text()).toContain('<meta name="robots" content="noindex"');
+  });
+
+  it('treats unclassified routes (+server.ts endpoints like /__health) as noindex without throwing', async () => {
+    // /__health has a +server.ts but no +page.svelte, so it's outside the
+    // route-walking test's coverage and unclassified by isSearchEngineIndexable.
+    // The hook must not crash on these — they hit the prod liveness probe.
+    const { promise } = runHandle('/__health' as RouteId);
+    const response = await promise;
+
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex');
+  });
+
+  it('sets X-Robots-Tag on non-HTML responses without mangling the body', async () => {
+    // The dual-signal rationale: the meta tag is impossible on non-HTML
+    // responses, so the header is the only signal that can land. Stub a JSON
+    // response (no </head>) and assert the body is byte-identical — the
+    // html.replace no-ops correctly when there's nothing to replace, and the
+    // header still fires.
+    const jsonBody = '{"status":"ok"}';
+    const resolve = vi.fn(async (_event: RequestEvent, opts?: ResolveOptions) => {
+      let body = jsonBody;
+      if (opts?.transformPageChunk) {
+        const out = opts.transformPageChunk({ html: body, done: true });
+        if (typeof out === 'string') body = out;
+      }
+      return new Response(body, { headers: { 'content-type': 'application/json' } });
+    });
+    const event = { route: { id: '/__health' as RouteId } } as unknown as RequestEvent;
+
+    const response = await noindexHandle({ event, resolve });
+
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex');
+    expect(await response.text()).toBe(jsonBody);
+  });
+});
+
+describe('exported handle sequence', () => {
+  // The bare `noindexHandle` tests above all import the handle directly.
+  // They'd keep passing if a future edit dropped noindexHandle from
+  // `sequence(...)` — the hook would silently never fire in prod. Pin the
+  // structural claim that noindexHandle is in the sequence.
+  it('passes noindexHandle to sequence()', () => {
+    // Position-agnostic so a future hook added to the sequence (e.g. the
+    // canonical-URL hook from CanonicalUrl.md) doesn't break this assertion.
+    const [args] = vi.mocked(sequence).mock.calls;
+    expect(args).toContain(noindexHandle);
+  });
+});

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,13 +1,58 @@
 import { sequence } from '@sveltejs/kit/hooks';
 import * as Sentry from '@sentry/sveltekit';
+import type { Handle } from '@sveltejs/kit';
+import type { RouteId } from '$app/types';
 import { handleServerError } from '$lib/sentry/handle-error';
+import { isSearchEngineIndexable } from '$lib/route-metadata.server';
 
-// Sentry.init lives in instrumentation.server.ts (load-order-safe site).
-// sentryHandle() provides per-request scope isolation so user data from
-// request N doesn't leak into request N+1, and attaches request context
-// to events. Required even though we're not tracing.
-export const handle = sequence(Sentry.sentryHandle());
+/**
+ * Emits noindex on every non-indexable route via both `X-Robots-Tag:
+ * noindex` (set on the response) and `<meta name="robots" content="noindex">`
+ * (string-inserted into the rendered HTML's `<head>`). Both signals are
+ * needed: the header reaches crawlers on non-HTML responses where a meta
+ * tag isn't possible (e.g. `__data.json` fetches for `ssr=false` routes),
+ * and the meta tag survives infrastructure that strips response headers.
+ */
+export const noindexHandle: Handle = async ({ event, resolve }) => {
+  if (!shouldIndex(event.route.id)) {
+    const response = await resolve(event, {
+      transformPageChunk: ({ html }) =>
+        html.replace('</head>', '<meta name="robots" content="noindex" />\n</head>'),
+    });
+    response.headers.set('X-Robots-Tag', 'noindex');
+    return response;
+  }
+  return resolve(event);
+};
 
-// We pass `handleServerError` explicitly rather than letting Sentry's
-// defaultErrorHandler take over — see lib/sentry/handle-error.ts.
+/**
+ * Returns true if the route should appear in search engine indexes. Unmatched
+ * URLs (`id === null`, i.e. 404s) and unclassified routes return
+ * `false` so the hook stays out of the index by default.
+ */
+function shouldIndex(id: RouteId | null): boolean {
+  if (id === null) return false;
+  try {
+    return isSearchEngineIndexable(id);
+  } catch {
+    // isSearchEngineIndexable throws on unclassified routes. Page routes
+    // can't get here — route-metadata.test.ts enforces classification for
+    // every +page.svelte. So an unclassified id is a +server.ts endpoint
+    // (e.g. /__health) — not an HTML page, safe to default to noindex.
+    return false;
+  }
+}
+
+/**
+ * `sentryHandle()` provides per-request scope isolation so user data from
+ * request N doesn't leak into request N+1, and attaches request context to
+ * events — required even though we're not tracing. (`Sentry.init` itself
+ * lives in `instrumentation.server.ts`, a load-order-safe site.)
+ */
+export const handle = sequence(Sentry.sentryHandle(), noindexHandle);
+
+/**
+ * We pass `handleServerError` explicitly rather than letting Sentry's
+ * `defaultErrorHandler` take over — see `lib/sentry/handle-error.ts`.
+ */
 export const handleError = Sentry.handleErrorWithSentry(handleServerError);


### PR DESCRIPTION
## Summary

This PR tells search engines to not index the pages that shouldn't be in the search engine index.

Emits `<meta name="robots" content="noindex" />` and `X-Robots-Tag: noindex` on every non-indexable route via a `handle` hook in `hooks.server.ts`. Both signals are needed: the header reaches crawlers on non-HTML responses (e.g. `__data.json` fetches SvelteKit issues for `ssr=false` routes), and the meta tag survives infrastructure that strips response headers.

- **Hook, not layout load.** A `+layout.server.ts` implementation would push `noindex` into every page's `PageData` type and miss the initial response for `ssr=false` routes. The hook avoids both.
- **`/__health` safety.** `isSearchEngineIndexable()` throws on unclassified routes (a deliberate guardrail for `+page.svelte`). `+server.ts` endpoints like `/__health` are outside the route-walking test's coverage, so the hook catches and defaults to noindex — safe because they're not HTML pages.
- **Plan docs updated.** `NoindexMeta.md` rewritten around the implementation. `CanonicalUrl.md` rewritten to use the same hook pattern (canonical-URL implementation itself is a follow-up). `RouteWalking.md` and `SearchEngines.md` corrected: noindex is hook-level, not layout-level.

## Test plan

- [ ] CI green (16 new hook tests + existing 1383 frontend tests).
- [ ] `curl -sI http://localhost:5173/login` shows `x-robots-tag: noindex`.
- [ ] `curl -s http://localhost:5173/login | grep robots` shows `<meta name="robots" content="noindex" />`.
- [ ] `curl -sI http://localhost:5173/titles` (an `ssr=false` route) shows `x-robots-tag: noindex` and the meta tag is in the initial HTML.
- [ ] `curl -sI http://localhost:5173/titles/medieval-madness` (indexable) shows no `x-robots-tag` and no robots meta.
- [ ] `curl -sI http://localhost:5173/__health` returns 200 with `x-robots-tag: noindex` (regression check for the unclassified-route crash caught during review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)