### PR TITLE
feat(seo): robots.txt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,12 @@ DJANGO_SUPERUSER_PASSWORD=change-me
 # (canonical URLs, OG tags). Defaults to http://localhost:5173 in dev.
 # SITE_ORIGIN=https://flipcommons.org
 
+# ── Search Engine ──────────────────────────────────────────────────
+# Whether this deployment tells search engines that it is crawlable.
+# Only the literal "true" enables; anything else (including "True")
+# is off. Local dev defaults to off; set to true only when testing.
+# ALLOW_SEARCH_ENGINE_INDEXING=false
+
 # ── WorkOS AuthKit ────────────────────────────────────────────────
 # Required for SSO login. Get these from your WorkOS dashboard.
 # Local dev uses the WorkOS Sandbox environment.

--- a/backend/apps/core/checks.py
+++ b/backend/apps/core/checks.py
@@ -361,3 +361,75 @@ def check_observability_env(
             )
         )
     return messages
+
+
+# The literal env-var values that `isDeploymentSearchEngineIndexable()`
+# accepts. The SvelteKit helper only treats `"true"` as on, but the
+# deploy-time check additionally requires `"false"` as the explicit
+# opt-out — anything else (including unset, `"1"`, `"yes"`, `"True"`)
+# fails so operators must declare intent on every deployed service.
+_ALLOWED_INDEXING_VALUES: frozenset[str] = frozenset({"true", "false"})
+
+
+@register(Tags.security, deploy=True)
+def check_search_engine_indexing_env(
+    app_configs: Sequence[AppConfig] | None,
+    **kwargs: Any,  # noqa: ANN401
+) -> list[CheckMessage]:
+    """Block deploy when ALLOW_SEARCH_ENGINE_INDEXING is missing or malformed.
+
+    The SvelteKit `robots.txt` and (later) `sitemap.xml` endpoints read
+    this env var via `isDeploymentSearchEngineIndexable()` to decide
+    whether to expose crawlable signals. Read-time default is off, so
+    an unset preview won't *leak*; this deploy check exists to force
+    every deployed service (prod, staging, every preview) to *declare*
+    intent — otherwise prod can ship with the var unset, default off,
+    and silently drop out of search indexes for weeks before anyone
+    notices traffic crater.
+
+    Backend and frontend share the Railway env (per `docs/DeployChecks.md`
+    § "Frontend checks belong in Python"), so this check runs server-side
+    and reads `os.environ` directly. It never probes the running service.
+
+    Unlike the sibling `check_observability_env` / `check_rate_limit_proxy_trust`,
+    this check intentionally does NOT short-circuit on ``settings.DEBUG``:
+    reproducing the deploy gate locally per `docs/DeployChecks.md`
+    § "Running deploy checks locally" is part of the contract, and the
+    cost of setting a single bool to verify is nil.
+    """
+    _ = app_configs, kwargs
+    # Read the raw value without stripping: the SvelteKit helper does a
+    # strict `=== 'true'` comparison, so a Railway-input value like
+    # " true " (trailing space) would silently misclassify — pass the
+    # backend check, then read as off at runtime, then prod drops out of
+    # search indexes. Rejecting any whitespace at the check keeps the two
+    # halves of the contract in lockstep.
+    raw = os.environ.get("ALLOW_SEARCH_ENGINE_INDEXING", "")
+    if not raw:
+        return [
+            Error(
+                "ALLOW_SEARCH_ENGINE_INDEXING is empty. Every deployed "
+                "service must declare crawler-indexing intent explicitly.",
+                hint=(
+                    'Set ALLOW_SEARCH_ENGINE_INDEXING="true" on the '
+                    'production Railway service and "false" on every '
+                    "other deployed service (preview, staging)."
+                ),
+                id="core.E301",
+            )
+        ]
+    if raw not in _ALLOWED_INDEXING_VALUES:
+        return [
+            Error(
+                f"ALLOW_SEARCH_ENGINE_INDEXING={raw!r} is not a recognised "
+                'value. Only the literal "true" or "false" is accepted.',
+                hint=(
+                    'Set ALLOW_SEARCH_ENGINE_INDEXING to "true" (production) '
+                    'or "false" (every other deployed service). Values like '
+                    '"1", "yes", or "True" are rejected so a typo cannot '
+                    "silently disable production indexing."
+                ),
+                id="core.E302",
+            )
+        ]
+    return []

--- a/backend/apps/core/tests/test_search_engine_indexing_env_check.py
+++ b/backend/apps/core/tests/test_search_engine_indexing_env_check.py
@@ -1,0 +1,72 @@
+"""Tests for ``apps.core.checks.check_search_engine_indexing_env``.
+
+Guards the deploy-time contract that every deployed service explicitly
+declares its crawler-indexing intent via ``ALLOW_SEARCH_ENGINE_INDEXING``.
+The check ids (``core.E301``, ``core.E302``) are the operator-facing
+contract — pinned here so a rename in the message string doesn't silently
+break log greps.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.core.checks import check_search_engine_indexing_env
+
+MonkeyPatch = pytest.MonkeyPatch
+
+
+class TestSearchEngineIndexingEnvCheck:
+    def test_passes_when_set_to_true(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("ALLOW_SEARCH_ENGINE_INDEXING", "true")
+        assert check_search_engine_indexing_env(app_configs=None) == []
+
+    def test_passes_when_set_to_false(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("ALLOW_SEARCH_ENGINE_INDEXING", "false")
+        assert check_search_engine_indexing_env(app_configs=None) == []
+
+    def test_errors_when_unset(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.delenv("ALLOW_SEARCH_ENGINE_INDEXING", raising=False)
+        messages = check_search_engine_indexing_env(app_configs=None)
+        assert len(messages) == 1
+        assert messages[0].id == "core.E301"
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "   ",  # whitespace only
+            " true ",  # the failure mode the no-strip rule defends
+            "true ",
+            " true",
+            "\ttrue",
+            "true\n",
+            "True",  # capitalised — the SvelteKit helper rejects this
+            "1",
+            "yes",
+            "on",
+            "False",
+            "0",
+            "no",
+            "off",
+            "maybe",
+        ],
+    )
+    def test_errors_when_malformed(
+        self, monkeypatch: MonkeyPatch, bad_value: str
+    ) -> None:
+        # A typo like "True" or a stray space silently disabling production
+        # indexing (because the SvelteKit helper only accepts the literal
+        # "true") is exactly the failure mode the check exists to prevent.
+        monkeypatch.setenv("ALLOW_SEARCH_ENGINE_INDEXING", bad_value)
+        messages = check_search_engine_indexing_env(app_configs=None)
+        assert len(messages) == 1
+        assert messages[0].id == "core.E302"
+
+    def test_accepts_django_kwargs_forward_compat(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ALLOW_SEARCH_ENGINE_INDEXING", "true")
+        assert (
+            check_search_engine_indexing_env(app_configs=None, databases=["default"])
+            == []
+        )

--- a/docs/Hosting.md
+++ b/docs/Hosting.md
@@ -42,7 +42,8 @@ Browser ──→ media.flipcommons.org       → Bunny CDN → iDrive e2 privat
    runs `manage.py check --deploy && manage.py migrate` before the new
    container accepts traffic. `check --deploy` surfaces production-only
    system checks (HSTS, SSL redirect, `core.W001` for missing
-   `RATE_LIMIT_TRUST_PROXY_HEADERS`, etc.); Error-level findings fail the
+   `RATE_LIMIT_TRUST_PROXY_HEADERS`, `core.E301`/`core.E302` for missing or
+   malformed `ALLOW_SEARCH_ENGINE_INDEXING`, etc.); Error-level findings fail the
    deploy, Warning-level findings are visible in logs but non-blocking.
    If anything in the pre-deploy command fails, the old container keeps
    serving.
@@ -128,6 +129,12 @@ This is the second fail-closed layer behind the X-Real-IP-only header choice. Bo
 - **Moving off Railway, or adding a CDN.** The current scheme relies on Railway's edge to populate `X-Real-IP` and strip client-supplied versions of it. Any infra change to the proxy chain — different host, Cloudflare/Bunny in front, enabling Railway's CDN — invalidates that assumption and likely needs a Caddy `trusted_proxies` block plus a re-verification probe.
 - **A new code path reads `X-Forwarded-For`.** Don't. The function in `apps/core/rate_limits.py` is the single sanctioned reader of forwarded client IP. Adding analytics, geoip, or logging that reads XFF reintroduces the parsing-bug class this design deliberately deleted.
 
+## Search-engine indexing
+
+`ALLOW_SEARCH_ENGINE_INDEXING` gates SvelteKit's `robots.txt` body. Set `"true"` on prod, `"false"` on every other deployed service. Only the literal `"true"` enables indexing; anything else is off.
+
+`check --deploy` refuses any deploy where the var is unset (`core.E301`) or not exactly `"true"`/`"false"` (`core.E302`) — so a new Railway service needs the var set before its first deploy.
+
 ## Setup
 
 ### 1. Create Railway project
@@ -142,14 +149,15 @@ automatically via a reference variable.
 
 In the Railway service dashboard:
 
-| Variable                         | Value                                                                         |
-| -------------------------------- | ----------------------------------------------------------------------------- |
-| `SECRET_KEY`                     | Random string: `python -c "import secrets; print(secrets.token_urlsafe(50))"` |
-| `DEBUG`                          | `false`                                                                       |
-| `ALLOWED_HOSTS`                  | Comma-separated hosts, e.g. `flipcommons.org,www.flipcommons.org`             |
-| `CSRF_TRUSTED_ORIGINS`           | Full origins, e.g. `https://flipcommons.org,https://www.flipcommons.org`      |
-| `INTERNAL_API_BASE_URL`          | `http://127.0.0.1:8000`                                                       |
-| `RATE_LIMIT_TRUST_PROXY_HEADERS` | `true` — required in production. See [Client IP trust](#client-ip-trust).     |
+| Variable                         | Value                                                                                     |
+| -------------------------------- | ----------------------------------------------------------------------------------------- |
+| `SECRET_KEY`                     | Random string: `python -c "import secrets; print(secrets.token_urlsafe(50))"`             |
+| `DEBUG`                          | `false`                                                                                   |
+| `ALLOWED_HOSTS`                  | Comma-separated hosts, e.g. `flipcommons.org,www.flipcommons.org`                         |
+| `CSRF_TRUSTED_ORIGINS`           | Full origins, e.g. `https://flipcommons.org,https://www.flipcommons.org`                  |
+| `INTERNAL_API_BASE_URL`          | `http://127.0.0.1:8000`                                                                   |
+| `RATE_LIMIT_TRUST_PROXY_HEADERS` | `true` — required in production. See [Client IP trust](#client-ip-trust).                 |
+| `ALLOW_SEARCH_ENGINE_INDEXING`   | `true` on prod, `false` elsewhere. See [Search-engine indexing](#search-engine-indexing). |
 
 `DATABASE_URL` and `PORT` are set automatically by Railway.
 

--- a/docs/plans/seo/Robots.md
+++ b/docs/plans/seo/Robots.md
@@ -1,8 +1,12 @@
 # robots.txt
 
-This is the plan for introducing `robots.txt` to the project. SvelteKit owns public pages, so the file lives there as a `+server.ts` endpoint. Two jobs: gate non-prod deploys from crawlers entirely (via the `ALLOW_SEARCH_ENGINE_INDEXING` env var), and tell crawlers not to fetch non-page server endpoints (`/api/`, `/djadmin/`, `/_sentry_test`).
+This is the plan for introducing `robots.txt` to the project. SvelteKit owns public pages, so the file lives there as a `+server.ts` endpoint. Two jobs: gate non-prod deploys from crawlers entirely (via the `ALLOW_SEARCH_ENGINE_INDEXING` env var), and tell crawlers not to fetch the `/api/` JSON surface.
 
 Addresses the "gating non-prod deploys" and "crawler traffic for non-page paths" concerns in [`SearchEngines.md`](SearchEngines.md); per-page index exclusion lives in [`NoindexMeta.md`](NoindexMeta.md), and the affirmative "what to index" signal lives in [`Sitemap.md`](Sitemap.md).
+
+## Status: ✅ Implemented
+
+This plan has been implemented.
 
 ## What robots.txt is and isn't for
 
@@ -12,14 +16,15 @@ Concretely:
 
 - **In scope for robots.txt:**
   - Non-prod deploys → `Disallow: /` to keep crawlers off the deploy entirely (preview/staging have no external inbound links, so crawl-block is sufficient).
-  - Non-page server endpoints (`/api/`, `/djadmin/`, `/_sentry_test`) → `Disallow:` to prevent crawl traffic against them.
+  - The `/api/` JSON surface → `Disallow:` as a hygiene signal that this isn't a user-facing page tree.
 - **Out of scope (handled in `NoindexMeta.md`):** user-facing pages we want kept out of the index (`/login`, `/signup`, `/search`, `/kiosk/*`, `/*/edit`, …). These are real pages with potential inbound links; we want crawlers to fetch them (so they see the `noindex` meta) but not index them. Putting them in robots.txt `Disallow` would actively prevent the noindex from working.
+- **Deliberately omitted:** `/djadmin/` and `/_sentry_test`. Listing them here publishes their existence to anyone reading `robots.txt` — `/djadmin/` was renamed from Django's default `/admin/` partly for obscurity, and a public `Disallow:` undoes that. Nothing public links to either path, so well-behaved crawlers won't hit them; non-compliant scrapers ignore `robots.txt` anyway. Not advertising them is the better default.
 
 ## Goals
 
 - Don't accidentally index preview/staging deploys — a missing or wrong flag must fail safe (un-indexed), not leak.
-- Keep crawlers off non-page server endpoints.
-- Keep robots.txt small and static — the production body is a fixed list of server-endpoint paths, not a derived projection of the route tree.
+- Steer crawlers away from the `/api/` JSON surface.
+- Keep robots.txt small and static — and don't use it to advertise endpoints that nothing public links to.
 
 ## 1. Per-deployment indexability signal
 
@@ -36,8 +41,8 @@ A single opt-in env var satisfies all four — production explicitly turns it on
 ### Mechanism
 
 - `ALLOW_SEARCH_ENGINE_INDEXING` — an env var, set by a human operator in each environment's config (Railway's service settings for deployed envs, a developer's local `.env` for local dev). Nothing auto-detects or auto-populates the value. Read-time default when unset is off. Operators set it to `true` on the production Railway service, `false` on every other deployed environment (preview, staging), and either value (or unset) locally — only set locally when a developer wants to test the corresponding `robots.txt` output.
-- Read via a tiny `lib/server/search-engine-indexable.ts` helper so the rule is single-sourced (and reusable by the sitemap endpoint in [`Sitemap.md`](Sitemap.md)). Parse strictly: only the literal string `"true"` enables indexing; anything else (including `""`, `"1"`, `"yes"`, `"True"`) is treated as off.
-- Document in `.env.example` as commented-out, with a note that local dev defaults to off and only needs setting for testing.
+- Read via a tiny `lib/is-deployment-search-engine-indexable.server.ts` helper exporting `isDeploymentSearchEngineIndexable(): boolean`, so the rule is single-sourced (and reusable by the sitemap endpoint in [`Sitemap.md`](Sitemap.md)). Named to contrast with the existing per-route `isSearchEngineIndexable(routeId)` in `lib/route-metadata.server.ts` — that one answers "should this URL be indexed"; this one answers "should this whole deploy be indexed at all". The `search-engine` qualifier in the name leaves room for future indexability axes (internal search, sitemap-only inclusion, etc.) without ambiguity. The helper reads from `$env/dynamic/private` — **not** `$env/static/private`, which would bake the value in at build time and silently misclassify any environment that shares a build artifact. Parse strictly: only the literal string `"true"` enables indexing; anything else (including `""`, `"1"`, `"yes"`, `"True"`) is treated as off.
+- Document in the repo-root `.env.example` (there is no `frontend/.env.example`) as commented-out, with a note that local dev defaults to off and only needs setting for testing.
 - A deploy check (see § 3) enforces the stronger rule under `manage.py check --deploy`: the value MUST be present and MUST be the literal `"true"` or `"false"`. Local `make dev` never trips this — the requirement applies only to real deploys, where forgetting to declare intent on a new preview service is the failure mode we care about.
 
 ## 2. robots.txt contents
@@ -56,13 +61,20 @@ When `ALLOW_SEARCH_ENGINE_INDEXING == "true"`:
 ```text
 User-agent: *
 Disallow: /api/
-Disallow: /djadmin/
-Disallow: /_sentry_test
 ```
 
-The production list is intentionally short: only paths that are server endpoints (not user-facing pages). User-facing non-indexable pages — `/login`, `/signup`, `/search`, `/kiosk/*`, `/*/edit`, etc. — are kept out of the index via per-page `<meta name="robots" content="noindex">` per [`NoindexMeta.md`](NoindexMeta.md), not via robots.txt `Disallow`. Putting them here would block crawlers from ever seeing the `noindex` meta, leaving them visible in search results via inbound links.
+The production list is intentionally minimal. `/djadmin/` and `/_sentry_test` are deliberately omitted — `robots.txt` is world-readable, so listing them advertises their existence (and undoes the obscurity of renaming `/admin/` → `/djadmin/`). Nothing public links to either path, so compliant crawlers won't find them; non-compliant scrapers ignore `robots.txt`, so a `Disallow:` wouldn't stop them anyway.
+
+User-facing non-indexable pages — `/login`, `/signup`, `/search`, `/kiosk/*`, `/*/edit`, etc. — are kept out of the index via per-page `<meta name="robots" content="noindex">` per [`NoindexMeta.md`](NoindexMeta.md), not via robots.txt `Disallow`. Putting them here would block crawlers from ever seeing the `noindex` meta, leaving them visible in search results via inbound links.
 
 The `Sitemap:` line is intentionally absent in this PR; [`Sitemap.md`](Sitemap.md) adds it once `/sitemap.xml` exists.
+
+### Response headers
+
+The `+server.ts` returns the body with:
+
+- `Content-Type: text/plain; charset=utf-8` — the spec-mandated type for `robots.txt`; without it, some crawlers will refuse to parse the response.
+- `Cache-Control: public, max-age=300` — crawlers refetch `robots.txt` frequently; a short cache prevents pointless regeneration. Five minutes is short enough that flipping `ALLOW_SEARCH_ENGINE_INDEXING` and redeploying takes effect promptly.
 
 ### Deployment routing
 
@@ -74,7 +86,9 @@ Validated at the earliest point it's consumed (deploy/runtime). Pattern and conv
 
 Frontend env vars are validated in Python because backend and frontend share the Railway env (per `docs/DeployChecks.md` § "Frontend checks belong in Python"). Add to `backend/apps/core/checks.py` (alongside `check_observability_env`):
 
-- **`ALLOW_SEARCH_ENGINE_INDEXING`** — `@register(Tags.security, deploy=True)` check that errors when `ALLOW_SEARCH_ENGINE_INDEXING` is empty, and errors when set to anything other than the literal `"true"` or `"false"`. Every deployed environment must declare its intent (catches the new-preview-service-leaks-into-search-indexes failure mode) and the strict-shape rule catches typos like `"True"` or `"1"` that would silently leave production un-indexed. Local dev is unaffected: the check is `deploy=True`, so it only runs under `manage.py check --deploy`. New error ids `core.E303` (missing) and `core.E304` (malformed).
+- **`ALLOW_SEARCH_ENGINE_INDEXING`** — `@register(Tags.security, deploy=True)` check that errors when `ALLOW_SEARCH_ENGINE_INDEXING` is empty, and errors when set to anything other than the literal `"true"` or `"false"`. Local dev is unaffected: the check is `deploy=True`, so it only runs under `manage.py check --deploy`. New error ids `core.E301` (missing) and `core.E302` (malformed). This starts a new `core.E3xx` group for security-tag checks, mirroring how `E1xx` clusters observability and `E2xx` clusters build/version.
+
+**Why require it on every deployed env, not just prod.** The read-time default is safe (off), so an unset preview won't leak. But the deploy check can't distinguish prod from preview — there's no `IS_PROD` flag to key off — so the only way to force the _production_ operator to explicitly declare intent is to force _every_ operator to. Without that, prod can ship with the var unset, default off, and silently drop out of search indexes for weeks before anyone notices traffic crater. That's exactly the invisible-silent-failure mode [`DeployAutomation.md`](../../DeployAutomation.md) tells us to refuse: the false-positive cost (set one env var on a new preview service) is negligible; the false-negative cost (prod de-indexed, nobody notices) is catastrophic. Per `DeployChecks.md` § "Assert env-var shape, don't probe services", this check stays in-process and only reads `os.environ` — it does **not** fetch its own `/robots.txt` or otherwise probe the running service.
 
 Tests in `backend/apps/core/tests/test_checks.py` (matching the existing pattern): one test per error id — flip the env state, assert the message id appears (or doesn't).
 
@@ -82,23 +96,24 @@ The check is deploy-gated (`deploy=True`), so it only runs under `manage.py chec
 
 ## 4. Tests
 
-- **Backend (pytest):** one test per `core.E303` / `core.E304` error id in `apps/core/tests/test_checks.py`.
-- **Frontend (vitest):** `robots.txt` returns the `Disallow: /` body when `ALLOW_SEARCH_ENGINE_INDEXING != "true"`, and the production body (with the three non-page disallows) when `== "true"`. Snapshot test of both bodies.
+- **Backend (pytest):** one test per `core.E301` / `core.E302` error id in `apps/core/tests/test_checks.py`.
+- **Frontend (vitest):** `robots.txt` returns the `Disallow: /` body when `ALLOW_SEARCH_ENGINE_INDEXING != "true"`, and the production body (with `Disallow: /api/`) when `== "true"`. Snapshot test of both bodies.
 
 ## 5. Implementation order
 
-1. Add `ALLOW_SEARCH_ENGINE_INDEXING` to `.env.example` (commented-out, with a note that it's only needed for local testing) and write `lib/server/search-engine-indexable.ts`.
+1. Add `ALLOW_SEARCH_ENGINE_INDEXING` to the repo-root `.env.example` (commented-out, with a note that it's only needed for local testing) and write `lib/is-deployment-search-engine-indexable.server.ts`.
 2. Add the `ALLOW_SEARCH_ENGINE_INDEXING` deploy check in `apps/core/checks.py`, with tests. Verify locally per `docs/DeployChecks.md` § "Running deploy checks locally".
-3. `frontend/src/routes/robots.txt/+server.ts` — gate on `ALLOW_SEARCH_ENGINE_INDEXING`, emit the appropriate static body. Frontend test per § 4.
-4. Verify locally: `curl localhost:5173/robots.txt` with and without `ALLOW_SEARCH_ENGINE_INDEXING=true` in `.env`.
-5. Set `ALLOW_SEARCH_ENGINE_INDEXING=true` on the production Railway service and `ALLOW_SEARCH_ENGINE_INDEXING=false` on every preview/staging service (separate manual step — not part of the PR). The deploy check refuses promotion if any deployed env leaves the value unset or sets it to anything other than `"true"` or `"false"`.
+3. `frontend/src/routes/robots.txt/+server.ts` — gate on `isDeploymentSearchEngineIndexable()`, emit the appropriate static body with the headers per § 2. Frontend test per § 4.
+4. Verify locally: `curl -i localhost:5173/robots.txt` with and without `ALLOW_SEARCH_ENGINE_INDEXING=true` in `.env`; check body **and** `Content-Type` / `Cache-Control` headers.
+5. **Set Railway env vars _before_ merging the PR** — `ALLOW_SEARCH_ENGINE_INDEXING=true` on the production service, `=false` on every other deployed service (staging _and_ every existing per-PR preview service, not just the canonical ones). The new deploy check refuses any deploy where the value is unset or malformed, so the first post-merge deploy will fail on any service that hasn't been updated — including in-flight preview deploys for unrelated open PRs. Doing this step before merge keeps the deploy pipeline green; doing it after means a window where every service refuses to promote until an operator catches up.
 
 ## Considered alternatives
 
 - **Constance config instead of env var.** Rejected: robots.txt is served by SvelteKit (Node), so a Django/constance value would need an API hop per request. Constance also has no per-environment visibility concept, loses the deploy-refusal gate (every env gets the default), and a single admin click on a security-adjacent toggle leaves no audit trail. Env var changes show up in Railway's deploy history.
 - **Sniff `SITE_ORIGIN` hostname or key off `NODE_ENV`/`DEBUG`.** Rejected: preview/staging services run with `DEBUG=false` and an `https://` origin, so any heuristic silently misclassifies them. An explicit flag stays correct as we add environments.
 - **Required env var everywhere (including local dev).** Considered. Rejected: forces every developer to set a var they don't care about for local work. Defaulting to off at read time keeps local ergonomic; the deploy-time check still forces every real env to declare intent.
-- **Derive the production `Disallow:` list from the route tree.** Considered. Rejected after switching to the noindex-meta strategy for user-facing pages: the remaining production disallows are non-page server endpoints (`/api/`, `/djadmin/`, `/_sentry_test`), which don't live in the SvelteKit route tree anyway. A small static list is more honest than a derivation that walks a tree to find three paths.
+- **Derive the production `Disallow:` list from the route tree.** Considered. Rejected after switching to the noindex-meta strategy for user-facing pages: the remaining production disallow is the `/api/` JSON surface, which doesn't live in the SvelteKit route tree anyway. A one-line static list is more honest than a derivation.
+- **Also `Disallow: /djadmin/` and `/_sentry_test`.** Rejected: `robots.txt` is world-readable, so listing these advertises endpoints that nothing public links to (and undoes the obscurity of renaming `/admin/` → `/djadmin/`). Compliant crawlers won't find them without a link; non-compliant scrapers ignore `robots.txt`. Silence is the better default.
 
 ## Open questions
 

--- a/docs/plans/seo/Sitemap.md
+++ b/docs/plans/seo/Sitemap.md
@@ -1,20 +1,18 @@
 # sitemap.xml
 
-This is the plan for introducing `sitemap.xml` to the project. SvelteKit owns public pages, so the file lives there as a `+server.ts` endpoint. The frontend uses [`super-sitemap`](https://github.com/jasongitmail/super-sitemap) for XML rendering, and discovers dynamic-route slugs from a Django-side registry of per-entity sitemap feeds.
-
-Addresses the "aiding search engine discovery" concern in [`SearchEngines.md`](SearchEngines.md); see that doc for how this fits with robots.txt and the per-page noindex meta.
-
-This PR builds on [`Robots.md`](Robots.md), which already shipped the `ALLOW_SEARCH_ENGINE_INDEXING` env var, the `lib/server/search-engine-indexable.ts` helper, and the deploy-time validation. It also adds the `Sitemap: ${SITE_ORIGIN}/sitemap.xml` line to the existing `robots.txt`.
-
-## Dependencies
-
-- [`Robots.md`](Robots.md) — provides the `ALLOW_SEARCH_ENGINE_INDEXING` env var, `lib/server/search-engine-indexable.ts`, and the deploy-time validation that prevents preview/staging from leaking. The sitemap endpoint reuses the same helper rather than re-reading the env var.
+This is the plan for introducing `sitemap.xml` to the project.
 
 ## Goals
 
-- Tell crawlers what to index (the public catalog).
+- Let crawlers what is available to be indexed.
 - Give search engines accurate `<lastmod>` per catalog page so they can prioritize re-crawls.
 - Adding a new indexable entity type should be a one-file backend change with no frontend touch.
+
+See [`SearchEngines.md`](SearchEngines.md) for how this fits with robots.txt and the per-page noindex meta.
+
+## Overview
+
+The sitemap will be a SvelteKit `+server.ts` endpoint that renders `/sitemap.xml` via [`super-sitemap`](https://github.com/jasongitmail/super-sitemap), with route slugs supplied by a Django-side registry each app can plug into. Appends a `Sitemap:` line to the existing `frontend/src/routes/robots.txt/+server.ts`.
 
 ## 1. Backend — sitemap feed registry
 
@@ -151,6 +149,7 @@ The frontend uses [`super-sitemap`](https://github.com/jasongitmail/super-sitema
 import * as sitemap from "super-sitemap";
 import { SITE_ORIGIN } from "$env/static/private";
 import { allRoutes, isSearchEngineIndexable } from "$lib/route-metadata.server";
+import { isDeploymentSearchEngineIndexable } from "$lib/is-deployment-search-engine-indexable.server";
 
 // Every entity's detail page has two indexable sibling subroutes —
 // /edit-history and /sources — that share the same slug. One loader serves
@@ -209,11 +208,11 @@ Start with the simple version; harden only if observed.
 
 ### Gate on `ALLOW_SEARCH_ENGINE_INDEXING`
 
-Reuse the `lib/server/search-engine-indexable.ts` helper from `Robots.md`. When `ALLOW_SEARCH_ENGINE_INDEXING != "true"`, return `404 Not Found` for `/sitemap.xml` — a non-indexable deploy has nothing to advertise. The robots.txt-side `Disallow: /` already keeps crawlers out; the 404 is defense in depth.
+Call `isDeploymentSearchEngineIndexable()` from `frontend/src/lib/is-deployment-search-engine-indexable.server.ts`. When it returns false, return `404 Not Found` for `/sitemap.xml` — a non-indexable deploy has nothing to advertise. The robots.txt-side `Disallow: /` already keeps crawlers out; the 404 is defense in depth.
 
 ## 3. Add `Sitemap:` line to robots.txt
 
-The `robots.txt` endpoint shipped in [`Robots.md`](Robots.md) does not yet emit a `Sitemap:` line. Once `/sitemap.xml` exists, append it to the indexable-mode body:
+The existing `robots.txt` endpoint at `frontend/src/routes/robots.txt/+server.ts` does not yet emit a `Sitemap:` line. Once `/sitemap.xml` exists, append it to the indexable-mode body:
 
 ```text
 Sitemap: ${SITE_ORIGIN}/sitemap.xml
@@ -253,11 +252,11 @@ Add `SITE_ORIGIN` to `Dockerfile` `ARG` declarations alongside the existing buil
 
 ### Deploy-phase check
 
-Frontend env vars are validated in Python because backend and frontend share the Railway env (per `docs/DeployChecks.md` § "Frontend checks belong in Python"). Add to `backend/apps/core/checks.py` (alongside `check_observability_env` and the `ALLOW_SEARCH_ENGINE_INDEXING` check from `Robots.md`):
+Frontend env vars are validated in Python because backend and frontend share the Railway env (per `docs/DeployChecks.md` § "Frontend checks belong in Python"). Add to `backend/apps/core/checks.py` (alongside `check_observability_env` and `check_search_engine_indexing_env`):
 
-- **`SITE_ORIGIN`** — `@register(Tags.security, deploy=True)` check that errors when `SITE_ORIGIN` is empty in non-DEBUG. Shape-validate it as an `https://` origin with a netloc and no path/trailing slash (reuse the `urlparse` pattern from `_is_valid_dsn`). New error ids `core.E301` (missing) and `core.E302` (malformed). Catches the case where the build had a value but the running container does not.
+- **`SITE_ORIGIN`** — `@register(Tags.security, deploy=True)` check that errors when `SITE_ORIGIN` is empty in non-DEBUG. Shape-validate it as an `https://` origin with a netloc and no path/trailing slash (reuse the `urlparse` pattern from `_is_valid_dsn`). New error ids `core.E303` (missing) and `core.E304` (malformed) — `core.E301`/`core.E302` are taken by `check_search_engine_indexing_env`. Catches the case where the build had a value but the running container does not.
 
-Tests in `backend/apps/core/tests/test_checks.py`: one test per error id — flip the env state, assert the message id appears (or doesn't).
+Tests in a new `backend/apps/core/tests/test_site_origin_check.py` (matching the one-file-per-check pattern set by `test_search_engine_indexing_env_check.py` and `test_observability_env_check.py`): one test per error id — flip the env state, assert the message id appears (or doesn't).
 
 The check is deploy-gated (`deploy=True`), so it only runs under `manage.py check --deploy` — i.e., Railway's `preDeployCommand`. Reproduce locally per `docs/DeployChecks.md` § "Running deploy checks locally".
 
@@ -267,7 +266,7 @@ The check is deploy-gated (`deploy=True`), so it only runs under `manage.py chec
   - `apps/core/tests/test_sitemap_registry.py` — registry mechanics: register, lookup, list, duplicate-kind raises. Uses a fake feed; doesn't import catalog.
   - `apps/core/tests/test_sitemap_api.py` — dispatch endpoint: 200 with expected shape for a registered kind, 404 for an unknown kind, listing endpoint returns the registered feeds, rate-limit returns 429 with `Retry-After` past the threshold.
   - `apps/catalog/tests/test_sitemap_feeds.py` — each catalog feed's queryset shape, ordering, `max_updated_at` matches newest row. Includes the single-Model-Title exclusion test for `ModelSitemapFeed`.
-  - One test per `core.E301` / `core.E302` error id in `apps/core/tests/test_checks.py`.
+  - One test per `core.E303` / `core.E304` error id in `apps/core/tests/test_site_origin_check.py`.
   - **XSD validation** — fetch `/sitemap.xml` via an in-process test client and validate the response against the sitemaps.org XSD using `xmllint --noout --schema`. Catches schema drift on every CI run.
 - **Frontend (vitest):**
   - `sitemap.xml/+server.ts` builds super-sitemap's `paramValues` correctly from a mocked `/api/sitemap/` response, including the fan-out: a single backend feed produces param entries under three pattern keys (detail + `/edit-history` + `/sources`) with the same slug list.
@@ -284,7 +283,7 @@ The check is deploy-gated (`deploy=True`), so it only runs under `manage.py chec
 6. `apps/catalog/apps.py` — trigger registration in `AppConfig.ready()`.
 7. `make api-gen`.
 8. `pnpm add super-sitemap@~1.0.12`.
-9. `frontend/src/routes/sitemap.xml/+server.ts` — wire super-sitemap to `/api/sitemap/` + `/api/sitemap/{kind}/`, with `excludeRoutePatterns` derived from the manifest. Gate on `ALLOW_SEARCH_ENGINE_INDEXING` via the helper from `Robots.md`.
+9. `frontend/src/routes/sitemap.xml/+server.ts` — wire super-sitemap to `/api/sitemap/` + `/api/sitemap/{kind}/`, with `excludeRoutePatterns` derived from the manifest. Gate on `ALLOW_SEARCH_ENGINE_INDEXING` via `isDeploymentSearchEngineIndexable()`.
 10. Append the `Sitemap:` line to `frontend/src/routes/robots.txt/+server.ts` (indexable-mode only). Extend the existing robots test.
 11. Add the XSD validation test (backend pytest, fetches its own endpoint and pipes through `xmllint`).
 12. Verify locally: `curl localhost:5173/sitemap.xml`, validate with `xmllint --noout --schema`.

--- a/frontend/src/lib/is-deployment-search-engine-indexable.server.ts
+++ b/frontend/src/lib/is-deployment-search-engine-indexable.server.ts
@@ -1,0 +1,16 @@
+import { env } from '$env/dynamic/private';
+
+/**
+ * Gates whether this deploy exposes crawlable robots.txt / sitemap.xml
+ * signals to search engines.
+ *
+ * Read from `$env/dynamic/private` — NOT `$env/static/private`, which
+ * would bake the value in at build time and silently misclassify any
+ * environment that shares a build artifact.
+ *
+ * Wire-format enforcement lives in the `core.E301` / `core.E302` deploy
+ * check (`backend/apps/core/checks.py`).
+ */
+export function isDeploymentSearchEngineIndexable(): boolean {
+  return env.ALLOW_SEARCH_ENGINE_INDEXING === 'true';
+}

--- a/frontend/src/routes/robots.txt/+server.ts
+++ b/frontend/src/routes/robots.txt/+server.ts
@@ -1,0 +1,23 @@
+import { isDeploymentSearchEngineIndexable } from '$lib/is-deployment-search-engine-indexable.server';
+import type { RequestHandler } from './$types';
+
+const DISALLOW_ALL = 'User-agent: *\nDisallow: /\n';
+
+/**
+ * Do NOT add user-facing routes (`/login`, `/search`, `/*\/edit`, …) here —
+ * they're kept out of the index via per-page `<meta name="robots" content="noindex">`
+ * (see `docs/plans/seo/NoindexMeta.md`). A `Disallow:` would block crawlers
+ * from ever fetching the page, so the `noindex` meta would never be seen
+ * and the URL could still appear in results via inbound links.
+ */
+const INDEXABLE_BODY = 'User-agent: *\nDisallow: /api/\n';
+
+const HEADERS: HeadersInit = {
+  'Content-Type': 'text/plain; charset=utf-8',
+  'Cache-Control': 'public, max-age=300',
+};
+
+export const GET: RequestHandler = () => {
+  const body = isDeploymentSearchEngineIndexable() ? INDEXABLE_BODY : DISALLOW_ALL;
+  return new Response(body, { headers: HEADERS });
+};

--- a/frontend/src/routes/robots.txt/robots.test.ts
+++ b/frontend/src/routes/robots.txt/robots.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockEnv } = vi.hoisted(() => ({ mockEnv: {} as Record<string, string> }));
+vi.mock('$env/dynamic/private', () => ({ env: mockEnv }));
+
+import { GET } from './+server';
+
+function callGet(): Response {
+  return GET({} as unknown as Parameters<typeof GET>[0]) as Response;
+}
+
+describe('GET /robots.txt', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+  });
+
+  it('returns the disallow-all body when ALLOW_SEARCH_ENGINE_INDEXING is unset', async () => {
+    const response = callGet();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=300');
+    await expect(response.text()).resolves.toMatchInlineSnapshot(`
+      "User-agent: *
+      Disallow: /
+      "
+    `);
+  });
+
+  it('returns the indexable body when ALLOW_SEARCH_ENGINE_INDEXING="true"', async () => {
+    mockEnv.ALLOW_SEARCH_ENGINE_INDEXING = 'true';
+    const response = callGet();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=300');
+    await expect(response.text()).resolves.toMatchInlineSnapshot(`
+      "User-agent: *
+      Disallow: /api/
+      "
+    `);
+  });
+
+  // Only the literal "true" enables indexing. Anything else fails safe to the
+  // disallow-all body so a typo can't silently expose preview or staging to
+  // crawlers. The deploy-time check (core.E301 / core.E302) refuses any of
+  // these values on a real deploy, but this is the runtime backstop.
+  it.each(['false', 'True', ' true ', 'true ', '1', 'yes', ''])(
+    'returns the disallow-all body for the non-"true" value %p',
+    async (value) => {
+      mockEnv.ALLOW_SEARCH_ENGINE_INDEXING = value;
+      const response = callGet();
+      await expect(response.text()).resolves.toBe('User-agent: *\nDisallow: /\n');
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Introduces a `robots.txt` to help control search engine crawling.

Adds a SvelteKit `/robots.txt` endpoint that returns `Disallow: /` by default and a permissive production body (`Disallow: /api/` only) when `ALLOW_SEARCH_ENGINE_INDEXING="true"`. A new deploy check refuses any deploy where the var is unset or anything other than the literal `"true"`/`"false"`, forcing every deployed service to declare crawler-indexing intent.

- Helper `lib/is-deployment-search-engine-indexable.server.ts` single-sources the rule (reads `$env/dynamic/private`, strict `=== 'true'` comparison) so the sitemap endpoint can reuse it later.
- Backend check `check_search_engine_indexing_env` (new error ids `core.E301` / `core.E302`) is `deploy=True`, runs server-side, never probes the service — matches the in-process pattern documented in `DeployChecks.md`. Intentionally does NOT short-circuit on `DEBUG` so the gate is reproducible locally.
- User-facing non-indexable pages stay out of the index via per-page noindex meta (#459), not via `Disallow:` here — a `Disallow:` would block crawlers from ever seeing the meta.
- `docs/Hosting.md` documents the new env var; `.env.example` documents the local-dev default; `docs/plans/seo/Robots.md` marked Implemented.

## Pre-merge action required

The deploy check refuses any deploy where `ALLOW_SEARCH_ENGINE_INDEXING` is unset. Set it on Railway **before merging** to avoid a gap where in-flight preview deploys for unrelated PRs fail:

- production service → `ALLOW_SEARCH_ENGINE_INDEXING=true`
- every other deployed service (staging + every existing per-PR preview) → `ALLOW_SEARCH_ENGINE_INDEXING=false`

## Test plan

- [ ] `curl -i $URL/robots.txt` on production returns `Disallow: /api/` body with `Content-Type: text/plain; charset=utf-8` and `Cache-Control: public, max-age=300`
- [ ] `curl -i $URL/robots.txt` on a preview returns `Disallow: /` body with the same headers
- [ ] Deploying any service without the env var set fails `check --deploy` with `core.E301`
- [ ] Setting the env var to anything other than `"true"` / `"false"` (including `"True"`, `" true "`, `"1"`) fails with `core.E302`

🤖 Generated with [Claude Code](https://claude.com/claude-code)