### PR TITLE
fix(frontend): allow inline style attrs in CSP; use PostHog ingest host

### DIFF
--- a/frontend/src/lib/analytics/config.test.ts
+++ b/frontend/src/lib/analytics/config.test.ts
@@ -6,7 +6,7 @@ import { config } from './config';
 // is a contract — weakening any option fails this test, which is the point.
 describe('analytics config (locked-down PostHog init)', () => {
   it('uses the US API host', () => {
-    expect(config.api_host).toBe('https://us.posthog.com');
+    expect(config.api_host).toBe('https://us.i.posthog.com');
   });
 
   it('uses heap-only persistence (no cookies, no storage)', () => {

--- a/frontend/src/lib/analytics/config.ts
+++ b/frontend/src/lib/analytics/config.ts
@@ -7,7 +7,7 @@ import type { PostHogConfig } from 'posthog-js';
 // test. See docs/Analytics.md § Privacy posture for the contract this
 // enforces.
 export const config: Partial<PostHogConfig> = {
-  api_host: 'https://us.posthog.com',
+  api_host: 'https://us.i.posthog.com',
   persistence: 'memory', // satisfies "no persistent client-side identity"
   autocapture: false, // satisfies "no autocapture / implicit tracking"
   capture_pageview: 'history_change', // SPA-aware: initial load + every CSR navigation

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -146,8 +146,9 @@ const appHtmlStyleHash = computeAppHtmlStyleHash();
 //     correctly — a wildcard like `*.ingest.sentry.io` would NOT match
 //     those) plus PostHog's api_host. PostHog's external chunk loads
 //     (session-recording.js, surveys.js, /flags) are all disabled in
-//     lib/analytics/config.ts — us.posthog.com is the only host the
-//     SDK actually contacts. When no DSN is configured the Sentry
+//     lib/analytics/config.ts — us.i.posthog.com (the dedicated US
+//     ingestion subdomain that PostHog recommends as api_host) is the
+//     only host the SDK actually contacts. When no DSN is configured the Sentry
 //     entry is omitted; the runtime SDK is also inert in that case.
 //   - `frame-ancestors 'none'` prevents other origins from framing us
 //     (the modern equivalent of X-Frame-Options: DENY in Caddyfile, kept
@@ -168,13 +169,23 @@ const cspReportOnlyDirectives = {
   'default-src': ['self'],
   'script-src': ['self', ...cdnEntry],
   'style-src': ['self', appHtmlStyleHash, ...cdnEntry],
+  // Svelte's `style:` directive (and any hand-written `style="..."`
+  // attribute) compiles to an inline style attribute, which CSP gates
+  // separately under style-src-attr. Without this entry the browser
+  // falls back to style-src — which doesn't permit attribute styles
+  // even with hashes — and every page with e.g. SiteHeader's dynamic
+  // SVG-filter id reports a violation. style-src-attr is much lower
+  // risk than style-src-elem (an attacker can restyle but can't load
+  // a remote stylesheet or inject a <style> block), so 'unsafe-inline'
+  // here is the standard compromise for Svelte/React apps.
+  'style-src-attr': ['unsafe-inline'],
   'img-src': ['self', 'https:', 'data:'],
   'font-src': ['self', ...cdnEntry],
   'connect-src': [
     'self',
     ...cdnEntry,
     ...(sentryOrigin ? [sentryOrigin] : []),
-    'https://us.posthog.com',
+    'https://us.i.posthog.com',
   ],
   'frame-ancestors': ['none'],
   'frame-src': ['none'],


### PR DESCRIPTION
## Summary

Two small CSP/analytics fixes:

- Add `style-src-attr: 'unsafe-inline'` so Svelte's `style:` directive (e.g. SiteHeader's dynamic SVG-filter id) stops triggering CSP report-only violations. Attribute styles aren't covered by hashes; `style-src-attr` is narrower than `style-src-elem` — no remote stylesheet or `<style>` injection risk.
- Switch PostHog `api_host` from `us.posthog.com` (the dashboard) to `us.i.posthog.com` (the dedicated US ingestion subdomain PostHog recommends). Updated in config, the contract test, the CSP `connect-src` entry and the surrounding comment.

## Test plan

- [ ] `make test` passes (analytics config contract test now asserts `us.i.posthog.com`)
- [ ] In a built frontend, PostHog `/capture` requests succeed against `us.i.posthog.com` and aren't blocked by `connect-src`
- [ ] Sentry CSP report-only violations from inline `style="..."` attributes drop to zero on pages using `style:` directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)