### PR TITLE
chore(hsts): advance ratchet to max-age=86400 (1-day soak)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -26,7 +26,7 @@ header {
 	X-Content-Type-Options nosniff
 	Referrer-Policy strict-origin-when-cross-origin
 	X-Frame-Options DENY
-	Strict-Transport-Security "max-age=60"
+	Strict-Transport-Security "max-age=86400"
 }
 
 # Long-cache the self-hosted fonts. SvelteKit's Node adapter serves

--- a/backend/tests/test_caddyfile_hsts.py
+++ b/backend/tests/test_caddyfile_hsts.py
@@ -17,7 +17,7 @@ from django.conf import settings
 def test_caddyfile_emits_hsts() -> None:
     caddyfile = (settings.BASE_DIR.parent / "Caddyfile").read_text()
     assert re.search(
-        r'^\s*Strict-Transport-Security\s+"max-age=60"\s*$',
+        r'^\s*Strict-Transport-Security\s+"max-age=86400"\s*$',
         caddyfile,
         re.MULTILINE,
     ), "Caddyfile must carry Strict-Transport-Security; see docs/Hosting.md § HSTS"

--- a/docs/Hosting.md
+++ b/docs/Hosting.md
@@ -227,8 +227,8 @@ In practice, modern providers cover their own subdomains. `media.flipcommons.org
 
 Three steps, not four — the conventional 1-week intermediate buys ceremony, not signal:
 
-1. **`max-age=60`** — current. The 60s window is too short to be a real soak; this step just verifies the header is emitted correctly (`curl -sI https://flipcommons.org | grep -i strict-transport`). No need to wait long.
-2. **`max-age=86400`** (1 day) — the actual soak. A day of real user traffic with sticky HSTS. If anything is going to break (an HTTP-only resource on the apex, a redirect loop) it surfaces here. Recovery cost is bounded at 24h of lockout for affected users.
+1. **`max-age=60`** — header-emission check. The 60s window is too short to be a real soak; this step just verifies the header is emitted correctly (`curl -sI https://flipcommons.org | grep -i strict-transport` and the same for `https://www.flipcommons.org`). No need to wait long.
+2. **`max-age=86400`** (1 day) — current. The actual soak: a day of real user traffic with sticky HSTS. If anything is going to break (an HTTP-only resource on the apex, a redirect loop) it surfaces here. Recovery cost is bounded at 24h of lockout for affected users.
 3. **`max-age=31536000`** (1 year) — destination value. Edit the `Strict-Transport-Security` line in `Caddyfile`, commit, deploy.
 
 Verify after each step: response includes `Strict-Transport-Security: max-age=N` (no `includeSubDomains`, by design).


### PR DESCRIPTION
## Summary

Step 2 of the HSTS rollout documented in [docs/Hosting.md § HSTS](../blob/main/docs/Hosting.md#hsts). Step 1 (`max-age=60`) confirmed the header reaches the browser on both apex and www; this advances to `max-age=86400` so HSTS actually persists in browser caches for the soak day before the final 1-year step.

- Caddyfile: `Strict-Transport-Security` bumped 60 → 86400
- Pinned test updated to match (test and Caddyfile ratchet together by design)
- Docs: marked step 2 as current; added www to the verify command

Note: the www host already emits HSTS via the site-level `header` block in the Caddyfile — verified in production. The earlier framing of "www was missed" was incorrect; what was actually missing was a max-age long enough for browsers to retain it between visits.

## Test plan

- [ ] After deploy: `curl -sI https://flipcommons.org | grep -i strict-transport` shows `max-age=86400`
- [ ] `curl -sI https://www.flipcommons.org | grep -i strict-transport` shows `max-age=86400`
- [ ] Visit `http://www.flipcommons.org` once over HTTPS, then within 24h visit `http://www.flipcommons.org` again — browser should autocorrect to HTTPS without an HTTP-edge redirect hop
- [ ] Soak ~24h watching for redirect loops or HTTP-only resource breakage; if clean, schedule step 3 (`max-age=31536000`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)