### PR TITLE
feat(seo): sitemap.xml

### DIFF
--- a/docs/plans/seo/Sitemap.md
+++ b/docs/plans/seo/Sitemap.md
@@ -13,34 +13,11 @@ See [`SearchEngines.md`](SearchEngines.md) for how this fits with `robots.txt` a
 
 The sitemap is a SvelteKit `+server.ts` endpoint that renders `/sitemap.xml` via [`super-sitemap`](https://github.com/jasongitmail/super-sitemap). Per-URL `<lastmod>` comes from two sources:
 
-- **Dynamic catalog pages**: a single Django endpoint derives feeds from `LinkableModel` subclasses, returning per-instance `(slug, lastmod)`. The default `lastmod` is the record's own `updated_at`; the single override (`Title`) widens it to include its Models' `updated_at`.
-- **Static pages** (`/`, `/about`, `/legal/*`): a build-time manifest computed from `git log -1 --format=%cI` over each route's source file. The same manifest backs "Last updated: …" footers on legal pages so the user-visible date and the sitemap `lastmod` come from the same value.
+- **Dynamic catalog pages**: a single Django endpoint derives feeds from `LinkableModel` subclasses, returning per-instance `(slug, lastmod)` plus an optional per-kind set of slugs whose `catalog-detail` URL is non-canonical. The default `lastmod` is the record's own `updated_at` filtered to `.active()`; one override (`Title`) widens lastmod to include its Models' `updated_at`. One canonical-URL override (`MachineModel`) marks single-Model-Title members as non-canonical at the detail route — their `/edit-history` and `/sources` URLs still emit.
+- **Static pages** (`/`, `/about`, `/legal/*`): a small hand-maintained map of route ID → date-only `YYYY-MM-DD` (sitemaps.org accepts plain dates for `<lastmod>` — no need to type a fake time). The legal pages already render a "Last updated: …" line under the `<h1>` via the existing `<LastUpdated />` component; the sitemap reads the same constant so the user-visible date and the crawler-visible `<lastmod>` cannot disagree. When a static page's content changes, the author bumps the date in the same diff — same edit, same reviewer.
+- **Non-catalog dynamic routes** (today only `/manufacturers/[slug]/systems`): a tiny `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE` map names the parent entity whose slugs feed each such route. One entry today, growable.
 
 Appends a `Sitemap:` line to the existing `frontend/src/routes/robots.txt/+server.ts`.
-
-## Invariants
-
-The design MUST satisfy these properties:
-
-1. **Adding a new catalog model puts its URLs in the sitemap automatically.** A new catalog model (a `LinkableModel` subclass classified as a catalog entity per [RouteWalking.md](RouteWalking.md)) produces complete `<url>` entries for its detail page, `/edit-history`, and `/sources` — each with a correct `lastmod` — without any human-authored sitemap code. When a catalog model needs to narrow which instances belong in the sitemap (today: `MachineModel`'s single-Model-Title exclusion), the override lives on the model via `sitemap_queryset()` — never in `apps/core/sitemap.py` or the SvelteKit endpoint. The invariant scopes to catalog models specifically: static routes (`/`, `/about`, `/legal/*`) and any future non-catalog dynamic indexable routes (e.g. `/users/[username]` if it flips indexable) are handled through their own mechanisms, but they are not the automation target — the catalog is.
-
-2. **The sitemap URL set equals the indexable route set.** Every route where `isSearchEngineIndexable() === true` produces sitemap `<url>` entries; no route where it returns `false` does. Both directions flow through that single predicate — via `excludeRoutePatterns` for static routes and via `catalogRoutesByEntity()` for per-entity dynamic routes. There is no sitemap-specific allowlist or denylist for either inclusion or exclusion.
-
-3. **Every `<lastmod>` reflects the actual freshness of the page's primary content.**
-   - For catalog pages, the default `lastmod` is the record's own `updated_at`, because the primary content of nearly every catalog detail page comes from the record itself. The single override is `Title`, whose page also renders the list of its Models — its `lastmod` is `Greatest(Title.updated_at, Max(Models.updated_at))`. This naturally covers the Single-Model-Title case, where the Title page collapses to show the lone Model's content: the Model's edits flow into the Title's `lastmod` via the same aggregation.
-   - For static pages, `lastmod` is the last git-commit time on the route's source file, baked into a manifest at build time.
-   - There is no separate "sitemap timestamp" anywhere to keep in sync — catalog `lastmod` staleness is bounded by the 1-hour `Cache-Control`, and static `lastmod` is fixed at deploy.
-
-The first invariant comes from the [model-driven metadata](../model_driven_metadata/ModelDrivenMetadata.md) discipline: a parallel hand-maintained per-model sitemap registry is exactly the drift surface a `LinkableModel` walk eliminates, and an entity silently absent from search is invisible to detect — it just doesn't show up in the traffic that never existed.
-
-The second invariant is what makes the sitemap honest. A URL in `/sitemap.xml` is a "please index this" signal to crawlers; a URL absent from it asks search engines to find the page some other way (links, manual submission). Both failure modes are expensive: a non-indexable URL leaking into the sitemap wastes crawl budget on pages that then emit `noindex`, while an indexable URL missing from it slows discovery by weeks. Making both impossible-by-construction beats catching them after deploy.
-
-The third invariant matters because `lastmod` is the signal Google uses to prioritize re-crawls — a sitemap that lies about freshness (or just stops getting refreshed) loses its main value over a flat URL list. Two failure modes are worth naming:
-
-- A `lastmod` that doesn't move when the page's content changed → search engines re-crawl too late.
-- A `lastmod` that moves when the page's content didn't change → search engines re-crawl wastefully, and eventually learn to distrust the signal.
-
-The "record's own `updated_at`, plus one Title override" rule under-reports on transitive edits (a Manufacturer rename doesn't bump every Title listing it) and that's an accepted tradeoff — Google won't re-crawl every Title because of a Manufacturer typo anyway, and the alternative is an unbounded relationship walker that over-reports on internal non-content edits.
 
 ## 1. Backend — derive feeds from `LinkableModel`
 
@@ -50,37 +27,63 @@ This is the [`_meta` walk](../model_driven_metadata/ModelDrivenMetadata.md#patte
 
 ### What the model already provides
 
-| Feed field | Source on `LinkableModel`                                           |
-| ---------- | ------------------------------------------------------------------- |
-| `kind`     | `entity_type`                                                       |
-| slug field | `public_id_field` (defaults to `"slug"`)                            |
-| `lastmod`  | `_sitemap_lastmod` annotation from `sitemap_queryset()` classmethod |
+| Feed field              | Source on `LinkableModel`                                           |
+| ----------------------- | ------------------------------------------------------------------- |
+| `kind`                  | `entity_type`                                                       |
+| slug field              | `public_id_field` (defaults to `"slug"`)                            |
+| `lastmod`               | `_sitemap_lastmod` annotation from `sitemap_queryset()` classmethod |
+| `detail_excluded_slugs` | `non_canonical_detail_slugs()` classmethod (default: empty)         |
 
 No `route_pattern` is emitted — the frontend already maps `entity_type` → SvelteKit route IDs via `catalogRoutesByEntity()` ([`route-metadata.server.ts`](../../../frontend/src/lib/route-metadata.server.ts)), so emitting SvelteKit-shaped patterns from Python would just duplicate that map.
 
-### Per-model override
+### Per-model overrides — two methods, by category
 
-A single `sitemap_queryset()` classmethod on `LinkableModel` covers all the catalog-page wrinkles, defaulting to the no-special-case shape. One method, not two: see [Considered alternatives](#considered-alternatives) for why `canonical_url_queryset()` was dropped.
+Two classmethods on `LinkableModel`, each covering a distinct concern:
+
+- `sitemap_queryset()` — which **active** rows belong in the sitemap, with their `_sitemap_lastmod`. Used uniformly across `catalog-detail`, `catalog-edit-history`, and `catalog-sources` routes.
+- `non_canonical_detail_slugs()` — within those rows, the subset whose `catalog-detail` URL is non-canonical (the canonical URL lives on a different entity). Applies only to the detail route; `/edit-history` and `/sources` still emit.
+
+The split exists because single-Model-Title MachineModels have a non-canonical detail page (the Title is canonical) but their `/edit-history` and `/sources` are independently canonical per [`SingleModelTitles.md`](../../SingleModelTitles.md). One method that excludes the row entirely would drop those ancillary URLs too. See [Considered alternatives](#considered-alternatives) for the history of this split.
+
+Today every concrete `LinkableModel` subclass also inherits `LifecycleStatusModel` (via [`CatalogModel`](../../../backend/apps/catalog/models/base.py), which combines both) and `TimeStampedModel` (giving it `updated_at`). The defaults below rely on both — `.active()` and `F("updated_at")`. A parity test (see §7) pins the inheritance so a future non-lifecycle `LinkableModel` fails CI rather than crashing at sitemap render.
 
 ```python
 # apps/core/models/mixins.py — extending LinkableModel
 @classmethod
 def sitemap_queryset(cls) -> QuerySet[Self]:
-    """Instances to include in the sitemap, annotated with `_sitemap_lastmod`.
+    """Active rows to include in the sitemap, annotated with `_sitemap_lastmod`.
 
-    Default: every row, with `_sitemap_lastmod = updated_at`. Override to
-    narrow the queryset (e.g. exclude rows whose URL isn't canonical), to
-    widen the lastmod (e.g. aggregate child timestamps), or both.
+    Default: `.active()` rows with `_sitemap_lastmod = updated_at`. Override
+    to widen `lastmod` (e.g. aggregate child timestamps) — not to narrow
+    membership for canonical-URL reasons; use `non_canonical_detail_slugs()`
+    for that.
 
     Return `cls.objects.none()` to opt a `LinkableModel` out of the sitemap
-    entirely — e.g. a through-table entity with no detail page.
+    entirely — e.g. a future through-table entity with no detail page. A
+    `LinkableModel` subclass that doesn't also inherit `LifecycleStatusModel`
+    + `TimeStampedModel` MUST override this method; the parity test in
+    `apps/core/tests/test_sitemap.py` catches that contract at CI time.
     """
     return (
-        cls.objects
+        cls.objects.active()
         .annotate(_sitemap_lastmod=F("updated_at"))
         .only(cls.public_id_field, "updated_at")
         .order_by(cls.public_id_field)
     )
+
+@classmethod
+def non_canonical_detail_slugs(cls) -> Iterable[str]:
+    """Slugs whose `catalog-detail` URL is non-canonical.
+
+    Default: empty. Override when the detail page collapses to a different
+    entity's page in the UI (canonical URL lives elsewhere) — the row stays
+    in `sitemap_queryset()` so `/edit-history` and `/sources` still emit,
+    but its detail URL is omitted from the sitemap.
+
+    Returned slugs must already be members of `sitemap_queryset()`; slugs
+    outside that set are ignored (defensive — they wouldn't appear anyway).
+    """
+    return ()
 ```
 
 The two overrides today:
@@ -89,14 +92,21 @@ The two overrides today:
 # apps/catalog/models/machine_model.py
 class MachineModel(LinkableModel, ...):
     @classmethod
-    def sitemap_queryset(cls):
-        # Single-Model-Title rule: when a Title has exactly one Model, the UI
-        # collapses to the Model page (per docs/SingleModelTitles.md), but the
-        # Title slug is canonical. Indexing both would split signals.
+    def non_canonical_detail_slugs(cls):
+        # Single-Model-Title rule: when a Title has exactly one active Model,
+        # the UI collapses to the Model page (per docs/SingleModelTitles.md),
+        # but the Title slug is the canonical URL for the detail page. The
+        # Model's /edit-history and /sources are independently canonical
+        # (each lists that Model's history / sources, not the Title's), so
+        # they stay in the sitemap via the default `sitemap_queryset()`.
         return (
-            super().sitemap_queryset()
-            .annotate(_sibling_count=Count("title__machine_models"))
-            .filter(_sibling_count__gt=1)
+            cls.objects.active()
+            .annotate(_sibling_count=Count(
+                "title__machine_models",
+                filter=active_status_q("title__machine_models"),
+            ))
+            .filter(_sibling_count=1)
+            .values_list(cls.public_id_field, flat=True)
         )
 ```
 
@@ -107,20 +117,23 @@ class Title(LinkableModel, ...):
     def sitemap_queryset(cls):
         # Title is the only catalog page whose primary content aggregates other
         # catalog entities (the Model list, plus — for single-Model Titles — the
-        # collapsed Model's content). Bump lastmod when any of those change.
+        # collapsed Model's content). Bump lastmod when any Model changes.
         #
-        # Rebuilt from `cls.objects` (rather than `super().sitemap_queryset()`)
-        # to avoid Django's re-annotation footgun: a second `.annotate()` on the
-        # same alias (`_sitemap_lastmod`) doesn't reliably win across Django
-        # versions. `Coalesce` defends against `Max(...) = NULL` for zero-Model
-        # Titles on non-Postgres backends — Postgres' GREATEST already ignores
-        # NULLs, but the explicit fallback is portable.
+        # Rebuilt from `cls.objects.active()` (rather than calling `super()`)
+        # to avoid Django's re-annotation footgun: a second `.annotate()` on
+        # the same alias (`_sitemap_lastmod`) doesn't reliably win across
+        # Django versions. `Coalesce` defends against `Max(...) = NULL` for
+        # Titles with no Models on non-Postgres backends — Postgres' GREATEST
+        # already ignores NULLs, but the explicit fallback is portable.
         return (
-            cls.objects
+            cls.objects.active()
             .annotate(
                 _sitemap_lastmod=Greatest(
                     F("updated_at"),
-                    Coalesce(Max("machine_models__updated_at"), F("updated_at")),
+                    Coalesce(
+                        Max("machine_models__updated_at"),
+                        F("updated_at"),
+                    ),
                 ),
             )
             .only(cls.public_id_field, "updated_at")
@@ -128,7 +141,7 @@ class Title(LinkableModel, ...):
         )
 ```
 
-Note `machine_models` (not `models`) — that's the `related_name` on `MachineModel.title` and `MachineModel.title` is the only FK from `MachineModel` to `Title`. Read directly off `type[LinkableModel]` — no `getattr` fallback (per the [field-on-model antipattern](../model_driven_metadata/ModelDrivenMetadata.md#antipattern-field-on-model)).
+Note `machine_models` (not `models`) — that's the `related_name` on `MachineModel.title` and `MachineModel.title` is the only FK from `MachineModel` to `Title`. `active_status_q("relation")` (from `apps/core/models/mixins.py`) builds the active-or-null `Q` filter for child rows reached through a relation, mirroring `LifecycleQuerySet.active()`'s null-inclusive shape for ingest compatibility. Read directly off `type[LinkableModel]` — no `getattr` fallback (per the [field-on-model antipattern](../model_driven_metadata/ModelDrivenMetadata.md#antipattern-field-on-model)).
 
 ### Derivation + single API endpoint
 
@@ -142,6 +155,7 @@ class SitemapEntry(NamedTuple):
 class SitemapFeed(NamedTuple):
     kind: str
     entries: list[SitemapEntry]
+    detail_excluded_slugs: frozenset[str]
     max_lastmod: datetime | None
 
 def all_sitemap_feeds() -> list[SitemapFeed]:
@@ -160,148 +174,258 @@ def all_sitemap_feeds() -> list[SitemapFeed]:
             continue
         feeds.append(
             SitemapFeed(
-                model.entity_type, entries, max(e.lastmod for e in entries)
+                kind=model.entity_type,
+                entries=entries,
+                detail_excluded_slugs=frozenset(model.non_canonical_detail_slugs()),
+                max_lastmod=max(e.lastmod for e in entries),
             )
         )
     return feeds
 ```
 
-The `is not None` filter and the empty-feed skip together mean `max_lastmod` is always a real datetime — neither `max([])` nor `max([None, ...])` can raise.
+The `is not None` filter and the empty-feed skip together mean `max_lastmod` is always a real datetime — neither `max([])` nor `max([None, ...])` can raise. `detail_excluded_slugs` is a `frozenset` to make the wire shape order-independent and to give the frontend O(1) lookups.
 
 One endpoint returns everything in one shot — no 1+N fan-out, no partial-failure mode:
 
 ```python
-# apps/core/sitemap_api.py
-SITEMAP_RATE_LIMIT = RateLimitSpec(bucket="sitemap", limit=10, window_seconds=60)
+# apps/core/api/sitemap.py
+SITEMAP_CACHE_KEY = "core:sitemap:feeds"
+SITEMAP_CACHE_TTL = 3600  # seconds
 
-@router.get("/sitemap/")
+router = Router()
+
+@router.get("/sitemap/", response=SitemapResponseSchema)
 def get_sitemap(request) -> SitemapResponseSchema:
-    check_and_record_ip(request, SITEMAP_RATE_LIMIT)
-    return SitemapResponseSchema(feeds=all_sitemap_feeds())
+    feeds = cache.get(SITEMAP_CACHE_KEY)
+    if feeds is None:
+        feeds = all_sitemap_feeds()
+        cache.set(SITEMAP_CACHE_KEY, feeds, SITEMAP_CACHE_TTL)
+    return SitemapResponseSchema(feeds=feeds)
 ```
 
-`Cache-Control: public, max-age=3600`. Typed schemas (`SitemapEntrySchema`, `SitemapFeedSchema`, `SitemapResponseSchema`) live in `apps/core/sitemap_schemas.py`. Run `make api-gen` after.
+Wired the same way every other Ninja router in the repo is wired: the router lives in `apps/core/api/sitemap.py` and is exposed by `apps/core/api/__init__.py` as `routers = [("", router)]` (create the `api/` package if it doesn't exist yet). `config/api.py` auto-discovers via `apps.get_app_configs()` looking for `<app>.api.routers` — no extra registration. Typed schemas (`SitemapEntrySchema`, `SitemapFeedSchema`, `SitemapResponseSchema`) live in `apps/core/api/sitemap_schemas.py`. Response sets `Cache-Control: public, max-age=3600`. Run `make api-gen` after.
 
-10/min is sized for the actual workload (crawlers fetch `/sitemap.xml` ~daily, and the SvelteKit endpoint hits this once per render) and pattern-matches the project's other IP-keyed public endpoints (signup availability). It's decorative defense in depth, not a real throttle — but the limiter is the established pattern for public reads.
+No rate limiter. The SvelteKit `/sitemap[[page=integer]].xml` endpoint calls this server-side via `createServerClient(...)` (per [`Svelte.md`](../../Svelte.md)), so from Django's perspective every public hit on the sitemap arrives from the Node container's single IP. An IP-keyed limiter would bucket all crawler traffic — including post-deploy bursts where multiple bots simultaneously cache-miss — under one key and 429 the whole sitemap render. The shared Django cache (`django.core.cache`, configured as `FileBasedCache` at `BASE_DIR/cache` in [`config/settings.py`](../../../backend/config/settings.py); same pattern as [`apps/catalog/cache.py`](../../../backend/apps/catalog/cache.py)) collapses the workload to one full materialization per hour across all worker processes, which is the actual cost ceiling we care about.
 
-**Payload size note.** `all_sitemap_feeds()` materializes every entry in memory before responding. Today (~10k Titles, ~10k Models, 19 LinkableModels) that's small. At catalog scale past ~50k entries per kind, this needs pagination or streaming — same cliff that triggers super-sitemap's auto-flip to `<sitemapindex>` on the frontend side.
+**Wire-shape note.** `SitemapEntrySchema.lastmod` is typed `datetime` in Python; Django Ninja serializes it as an ISO 8601 string in JSON, and the generated TypeScript type is `string`. The SvelteKit consumer passes the string straight through to super-sitemap (which expects ISO strings) — no parsing on either side.
+
+**Payload size note.** `all_sitemap_feeds()` materializes every entry in memory before responding. Today (~10k Titles, ~10k Models, 20 LinkableModels) that's small. At catalog scale past ~50k entries per kind, this needs pagination or streaming — same cliff that triggers super-sitemap's `<sitemapindex>` splitting on the frontend side (which is why the SvelteKit route is named `sitemap[[page=integer]].xml` from day one; see §3).
 
 ### Why this shape
 
-- **One override per wrinkle, no relationship walker.** Catalog pages overwhelmingly render their own record's content. The one exception (Title) gets a one-line `sitemap_queryset()` override; everything else inherits the default. No auto-derivation from Django relationships — walking all FK/M2M relationships over-includes (provenance ChangeSets, audit rows, denormalization caches aren't page content), and walking only `LinkableModel`-targeted relationships under-includes (non-LinkableModel entities like aliases or credit lines often drive page content precisely because they don't have their own page). A "smart" walker would be wrong in both directions; the honest answer is one explicit override for the one entity that actually aggregates.
-- **One method, not two.** `sitemap_queryset()` covers both "which rows" and "what `lastmod`" because that's the only consumer today. A separate `canonical_url_queryset()` was considered for hypothetical future use by canonical-link tags or schema.org `mainEntityOfPage` (see Considered alternatives) — rejected as speculative future-proofing. If a second consumer arrives, split then.
+- **One override per wrinkle, no relationship walker.** Catalog pages overwhelmingly render their own record's content. The one lastmod-aggregation exception (Title) gets a one-line `sitemap_queryset()` override; the one canonical-URL exception (MachineModel) gets a `non_canonical_detail_slugs()` override; everything else inherits both defaults. No auto-derivation from Django relationships — walking all FK/M2M relationships over-includes (provenance ChangeSets, audit rows, denormalization caches aren't page content), and walking only `LinkableModel`-targeted relationships under-includes (non-LinkableModel entities like aliases or credit lines often drive page content precisely because they don't have their own page). A "smart" walker would be wrong in both directions; the honest answer is explicit overrides for the entities that actually aggregate or collapse.
+- **Two methods, split by category.** Membership-and-lastmod (`sitemap_queryset()`) and canonical-URL-at-detail (`non_canonical_detail_slugs()`) are different questions because `/edit-history` and `/sources` are independently canonical even when the detail page collapses. A single-method shape was the first draft and was reopened (see Considered alternatives) once the sitemap surfaced as the canonical-URL consumer. A future `<link rel="canonical">` tag on the rendered HTML would read `non_canonical_detail_slugs()` too.
 - **Sitemap inclusion is implied by being a `LinkableModel`** that has a SvelteKit route for its `entity_type`. A `LinkableModel` without a matching route (today: none; tomorrow potentially through-tables like `MachineModelTag` or `MachineModelRewardType`) emits a Django feed that the frontend silently drops via `catalogRoutesByEntity().get(kind) === undefined`. To explicitly opt out, override `sitemap_queryset()` to return `cls.objects.none()`.
+- **Soft-deleted rows excluded by default.** `sitemap_queryset()` calls `.active()` directly. Every concrete `LinkableModel` today inherits `LifecycleStatusModel` via `CatalogModel`, so `status='deleted'` rows never appear in the sitemap. `MachineModel.non_canonical_detail_slugs()` filters its sibling count with `active_status_q("title__machine_models")` so single-Model detection counts only active siblings. If `status='draft'` or other lifecycle states are added later, narrow `.active()` at the `LifecycleQuerySet` level — the sitemap inherits the change automatically.
 - **No fan-out.** One HTTP call from SvelteKit → Django. super-sitemap fails the whole render if a `paramValues` callback throws, so eliminating the per-feed fetches eliminates that failure mode.
 - **Public reads, no auth gate.** Non-mutating, contains only data already on the indexable detail pages.
-- **Rate-limited** via the existing IP-keyed limiter; 10/min matches the actual crawl cadence and the project's public-endpoint pattern.
-- **No lifecycle filter needed today** (no soft-delete or draft state exists). `sitemap_queryset()` is the natural home if that changes — narrow the queryset to exclude soft-deleted rows.
+- **Cached for 1 hour in the shared file-based cache**, not rate-limited. The endpoint's only public caller is the SvelteKit `/sitemap[[page=integer]].xml` server-side fetch, which arrives from the Node container's single IP — an IP-keyed limiter would 429 the entire sitemap render on post-deploy / post-restart cache-miss bursts. The file-based cache (configured globally in [`config/settings.py`](../../../backend/config/settings.py)) collapses the cost ceiling to one materialization per hour across all Gunicorn workers; that's the actual workload to bound.
 
-## 2. Static pages — build-time `lastmod` manifest
+## 2. Static pages — hand-maintained `lastmod` constants
 
-Static routes (`/`, `/about`, `/about/people`, `/legal/privacy`, `/legal/terms`, `/legal/licensing`) live as committed Svelte files. Their `lastmod` is the file's last git-commit time. A Vite build step walks the static-route source files and emits `frontend/src/lib/static-lastmod.generated.json`:
+Static routes (`/`, `/about`, `/about/people`, `/legal/privacy`, `/legal/terms`, `/legal/licensing`) live as committed Svelte files. There are six of them today, they change roughly 1–2× per year, and the legal pages already display a "Last updated" line under their `<h1>` via the existing [`<LastUpdated />`](../../../frontend/src/lib/components/LastUpdated.svelte) component. The same date is what the sitemap should emit as `<lastmod>`.
 
-```json
-{
-  "/": "2026-03-04T18:22:11+00:00",
-  "/about": "2026-02-19T09:14:03+00:00",
-  "/legal/privacy": "2026-04-11T16:55:00+00:00"
-}
+One hand-maintained map, two readers:
+
+```ts
+// frontend/src/lib/static-lastmod.ts
+import type { RouteId } from "$app/types";
+
+/**
+ * Hand-maintained `YYYY-MM-DD` dates for static pages. Date-only is a valid
+ * `<lastmod>` per sitemaps.org — no fake time component. When the content of
+ * one of these pages changes substantively, bump the date in the same diff.
+ * The legal pages display the corresponding date under their `<h1>` via
+ * `<LastUpdated />`, so a forgotten bump is visible in human review.
+ *
+ * The `satisfies` clause forces every entry to be a known route ID and every
+ * indexable static route to have an entry — `make quality` / `svelte-check`
+ * catches typos and missing routes at build time.
+ */
+export const STATIC_LASTMOD = {
+  "/": "2026-03-04",
+  "/about": "2026-02-19",
+  "/about/people": "2026-02-19",
+  "/(legal)/privacy": "2026-04-11",
+  "/(legal)/terms": "2026-03-22",
+  "/(legal)/licensing": "2026-01-30",
+} as const satisfies Record<StaticIndexableRouteId, string>;
 ```
 
-The set of static routes comes from the same `allRoutes().filter(isSearchEngineIndexable)` walk that drives the sitemap's `excludeRoutePatterns` — minus the routes covered by catalog feeds. There's no hand-maintained list of static pages.
+`StaticIndexableRouteId` is derived from the route classifier: indexable route IDs that are not `catalog-*`, contain no `[param]` / `[...path]` / `[[optional]]` segments, and are not keys of `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE`. All three exclusions matter — `/manufacturers/[slug]/systems` is indexable and non-catalog, but it's a parameterized listed route handled via `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE`, not a static page. Adding a new static indexable route fails the typecheck until `STATIC_LASTMOD` gets an entry; removing or renaming a route fails the typecheck on the old key. No drift surface, no Vite plugin, no `git` calls, no shallow-clone heuristic.
 
-"The source file" for a route is its `+page.svelte` (or `+page.svx` / equivalent leaf component). Changes to shared `+layout.svelte` files don't bump every leaf's `lastmod` — a layout polish isn't a content change to `/legal/privacy`.
+The legal pages keep their current shape:
 
-The manifest is consumed by **two readers**:
+```svelte
+<h1>Privacy Policy</h1>
+<LastUpdated>Last updated: {formatLastUpdated(STATIC_LASTMOD["/(legal)/privacy"])}</LastUpdated>
+```
 
-1. **Sitemap endpoint** uses it to emit `<lastmod>` for static URLs alongside the catalog URLs from the Django feed.
-2. **Legal page components** import it to render `Last updated: {formatDate(manifest['/legal/privacy'])}` in the footer. The user-visible date and the crawler-visible timestamp come from the same value, so they cannot disagree, and a wrong date is much easier to catch when a human sees it on every visit.
+`formatLastUpdated` (new, small) renders `"2026-04-11"` → `"April 11, 2026"` so the user-visible date and the `<lastmod>` value come from the same constant at the same precision — no day-level drift between what readers see and what crawlers receive. Each page references its own key directly — no `page.route.id` runtime lookup, which means the typechecker catches a typo at the call site instead of throwing at render time.
 
-Generated file is gitignored (same pattern as `schema.d.ts`).
+The sitemap endpoint reads `STATIC_LASTMOD` directly (see §3) and emits one `<url>` per entry. If a new static indexable route is added without a `STATIC_LASTMOD` entry, the typecheck fails before the sitemap can render an incomplete set.
 
-### Soft-fail behavior
+### Why hand-maintained beats `git log`
 
-`lastmod` is a crawler hint, not data anyone makes decisions on. The build step does NOT fail when `git` is unavailable or when a listed route's source file has no usable git history. The common failure mode is the build environment, not the source tree: shallow-clone build environments like Railway/Nixpacks ship with a depth-1 clone by default, in which `git log -1 --format=%cI <file>` returns the shallow tip's commit date for every file — silently making every page's `lastmod` identical.
-
-Per route, the build step:
-
-- Tries `git log -1 --format=%cI <file>`.
-- If the result is missing, errors, or matches the shallow-clone tip date across multiple files (heuristic for "shallow clone, not real history"), falls back to the build-time clock and logs a warning naming the route(s) that fell back.
-- Emits the manifest with whatever timestamps it found.
-
-The fallback degrades `lastmod` accuracy on static pages, which is benign: those pages change rarely, and the legal-page footer reading from the same manifest makes any obvious wrongness human-visible. Trading a benign rare drift for a sharp build failure on a crawler hint isn't worth it. If the warning ever fires on a real deploy, the fix is unshallowing the clone or pinning per-page constants — not failing the build retroactively.
+- **Better signal.** `git log -1` over a source file moves on prettier reflows, whitespace fixes, and layout-component refactors that touch the file without changing meaning. A hand-bumped date moves only on substantive content changes — exactly the signal `<lastmod>` is supposed to be.
+- **No deploy-environment fragility.** Railway/Nixpacks ship depth-1 clones by default, in which `git log` returns the shallow tip date for every file. Detecting that needs a heuristic; the heuristic itself is a smell.
+- **No build step to maintain.** Skips the Vite plugin, the generated JSON, the gitignore entry, the soft-fail logic, and the tests for all of that.
+- **The forgotten-bump failure mode is visible.** Legal pages display the date under the `<h1>`. A reviewer who reads the policy diff also reads the date next to it.
+- **Scales fine.** Six pages today. If the static-page count ever grows past ~30 and editors start forgetting bumps, revisit — but the trigger for revisiting is "we observed the failure mode," not "we imagined it."
 
 ## 3. Frontend — super-sitemap
 
-The frontend uses [`super-sitemap`](https://github.com/jasongitmail/super-sitemap) for XML rendering. It handles escaping, `lastmod` formatting, and sitemap-index splitting (auto-flips to a `<sitemapindex>` if total URLs cross 50k). Pin to `super-sitemap@^1.0.12` — zero runtime dependencies, healthy maintenance (~40k downloads/month, single-maintainer with consistent cadence over 18+ months).
+The frontend uses [`super-sitemap`](https://github.com/jasongitmail/super-sitemap) for XML rendering. It handles escaping, `lastmod` formatting, and sitemap-index splitting (when total URLs cross 50k, an index document points at `/sitemap1.xml`, `/sitemap2.xml`, etc. — which only works if the route file is named `sitemap[[page=integer]].xml` and passes `page: params.page`, per the super-sitemap README). Pin to `super-sitemap@^1.0.12` — zero runtime dependencies, healthy maintenance (~40k downloads/month, single-maintainer with consistent cadence over 18+ months).
+
+### Route file: `sitemap[[page=integer]].xml`
+
+The route lives at `frontend/src/routes/sitemap[[page=integer]].xml/+server.ts` from day one, even though today's URL count is well under 50k. The optional `[[page=integer]]` rest-param lets the same endpoint serve `/sitemap.xml` (the index or single urlset) and `/sitemap1.xml`, `/sitemap2.xml`, etc. (per-page urlsets) without a second file. Renaming later when we cross 50k would mean either breaking the canonical `/sitemap.xml` URL or adding a redirect — both avoidable by getting the route shape right upfront. The `=integer` matcher (in `src/params/integer.ts`, pattern `^[1-9]\d*$` to match super-sitemap's own page validation at sitemap.js:105) keeps `/sitemapfoo.xml`, `/sitemap0.xml`, and `/sitemap007.xml` 404ing at the router instead of routing through and getting 400 from super-sitemap.
+
+### Listed-indexable routes that consume a catalog entity's slug
+
+Some indexable routes are dynamic but not classified as `catalog-*` because they aren't the catalog entity's own detail/history/sources page — `/manufacturers/[slug]/systems` is the only one today (per `route-metadata.server.ts`'s `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`). They consume a parent entity's slugs, so the sitemap needs to know which feed feeds which route. A tiny hand-maintained map names the parent:
+
+```ts
+// frontend/src/lib/route-metadata.server.ts (additive)
+export const LISTED_INDEXABLE_ENTITY_SLUG_SOURCE = {
+  "/manufacturers/[slug]/systems": "manufacturer",
+} as const satisfies Partial<Record<RouteId, CatalogEntityKey>>;
+```
+
+The `satisfies` clause forces every key to be a real route ID and every value to be a known `CatalogEntityKey`. One entry today; a parity test (see §7) asserts every key is also in `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS` (so a typo can't silently drop the entry) and that every value has a backend feed. This is the "non-catalog dynamic indexable routes handled through their own mechanism" footnote from invariant #1 — outside the catalog-model automation guarantee, deliberately.
+
+`lastmod` for these routes comes from the parent entity's `_sitemap_lastmod`. That under-reports when the listing's content changes without bumping the parent (e.g. a new System linked to a Manufacturer doesn't bump `Manufacturer.updated_at`) — same accepted tradeoff as the rest of the design. Revisit per-route lastmod widening if/when traffic data shows we're losing re-crawls because of it.
 
 ### Wiring
 
 ```ts
-// frontend/src/routes/sitemap.xml/+server.ts
+// frontend/src/routes/sitemap[[page=integer]].xml/+server.ts
 import * as sitemap from "super-sitemap";
 import { SITE_ORIGIN } from "$env/static/private";
 import {
   allRoutes,
   catalogRoutesByEntity,
+  classifyRoute,
   isSearchEngineIndexable,
+  LISTED_INDEXABLE_ENTITY_SLUG_SOURCE,
 } from "$lib/route-metadata.server";
 import { isDeploymentSearchEngineIndexable } from "$lib/is-deployment-search-engine-indexable.server";
-import staticLastmod from "$lib/static-lastmod.generated.json";
+import { STATIC_LASTMOD } from "$lib/static-lastmod";
+import { createServerClient } from "$lib/api/server";
+import type { RouteId } from "$app/types";
 
-export const GET = async ({ fetch }) => {
+// STATIC_LASTMOD keys are route IDs (may contain `(group)` segments); the
+// `processPaths` callback below receives super-sitemap's already-resolved URLs,
+// so look up by URL form. Built once at module load.
+const STATIC_LASTMOD_BY_URL: ReadonlyMap<string, string> = new Map(
+  Object.entries(STATIC_LASTMOD).map(([routeId, lastmod]) => [
+    stripRouteGroups(routeId),
+    lastmod,
+  ]),
+);
+
+export const GET = async ({ fetch, url, request, params }) => {
   if (!isDeploymentSearchEngineIndexable()) {
     return new Response("Not Found", { status: 404 });
   }
 
-  const { feeds } = await fetch("/api/sitemap/").then((r) => r.json());
+  const client = createServerClient(fetch, url, request);
+  const { data, error } = await client.GET("/api/sitemap/");
+  if (error || !data) {
+    return new Response("Sitemap unavailable", { status: 502 });
+  }
+  const { feeds } = data;
 
   // For each entity, gather all indexable SvelteKit route IDs that share its
   // slug (detail + /edit-history + /sources today; whatever is indexable
-  // tomorrow). `isSearchEngineIndexable()` is the only filter, so a new
-  // indexable subroute lands here automatically — no list to maintain.
-  const indexableRoutesByEntity = catalogRoutesByEntity((_cls, id) =>
-    isSearchEngineIndexable(id),
+  // tomorrow). `safeIsIndexable` swallows classifier throws (see below).
+  const directRoutesByEntity = catalogRoutesByEntity((_cls, id) =>
+    safeIsIndexable(id),
   );
 
-  const paramValues: Record<string, sitemap.ParamValues> = {};
-  for (const { kind, entries } of feeds) {
-    const routeIds = indexableRoutesByEntity.get(kind);
-    if (!routeIds) continue;
-    const values = entries.map((e) => ({
-      values: [e.slug],
-      lastmod: e.lastmod,
-    }));
-    for (const id of routeIds) paramValues[id] = values;
+  // Per-entity listed-indexable routes (e.g. `/manufacturers/[slug]/systems`
+  // under `manufacturer`). Inverted at module-edit time, not request time.
+  const listedRoutesByEntity = new Map<string, RouteId[]>();
+  for (const [routeId, kind] of Object.entries(
+    LISTED_INDEXABLE_ENTITY_SLUG_SOURCE,
+  )) {
+    const arr = listedRoutesByEntity.get(kind) ?? [];
+    arr.push(routeId as RouteId);
+    listedRoutesByEntity.set(kind, arr);
+  }
+
+  const paramValues: sitemap.ParamValues = {};
+  for (const { kind, entries, detail_excluded_slugs } of feeds) {
+    const direct = directRoutesByEntity.get(kind) ?? [];
+    const listed = listedRoutesByEntity.get(kind) ?? [];
+    const excluded = new Set(detail_excluded_slugs);
+    for (const id of [...direct, ...listed]) {
+      const cls = classifyRoute(id);
+      const isDetail = cls.kind === "catalog-detail";
+      const filteredEntries =
+        isDetail && excluded.size
+          ? entries.filter((e) => !excluded.has(e.slug))
+          : entries;
+      paramValues[id] = filteredEntries.map((e) => ({
+        values: [e.slug],
+        lastmod: e.lastmod,
+      }));
+    }
   }
 
   return sitemap.response({
     origin: SITE_ORIGIN,
+    page: params.page,
     excludeRoutePatterns: allRoutes()
-      .filter((id) => !isSearchEngineIndexable(id))
+      .filter((id) => !safeIsIndexable(id))
       .map(routeIdToRegex),
     paramValues,
-    additionalPaths: Object.entries(staticLastmod).map(([path, lastmod]) => ({
-      path,
-      lastmod,
-    })),
+    // Static routes are auto-discovered by super-sitemap walking the routes
+    // tree; we don't enumerate them. `processPaths` attaches `lastmod` to
+    // each one from `STATIC_LASTMOD_BY_URL`. Dynamic-route paths already
+    // carry `lastmod` from `paramValues`, so they pass through unchanged.
+    processPaths: (paths) =>
+      paths.map((p) => {
+        const lastmod = STATIC_LASTMOD_BY_URL.get(p.path);
+        return lastmod ? { ...p, lastmod } : p;
+      }),
+    // Override super-sitemap's default `max-age=0, s-maxage=3600`. We don't
+    // have a shared cache today and we want browsers/crawlers to actually
+    // cache the response for the TTL. Revisit `s-maxage` when a CDN lands.
+    headers: { "Cache-Control": "public, max-age=3600" },
   });
 };
 ```
 
-That's the whole endpoint. Adding a new entity type requires zero changes here — `GET /api/sitemap/` reports the new feed, `catalogRoutesByEntity()` finds its route IDs, the loop wires them into `paramValues`. Adding a new static page is picked up by the manifest build step automatically.
+That's the whole endpoint. Adding a new entity type requires zero changes here — `GET /api/sitemap/` reports the new feed, `catalogRoutesByEntity()` finds its route IDs, the loop wires them into `paramValues`. Adding a new static page requires one line: an entry in `STATIC_LASTMOD`. Adding a new listed-indexable route that consumes a catalog entity's slug requires one line in `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE`.
 
 ### Rest-param routes (`Location`)
 
-`Location.public_id_field = "location_path"` — a slash-separated path like `"manufacturer/title/region/site"` — and its SvelteKit route is `/locations/[...path]` (rest segment). The frontend passes `values: [e.slug]` to super-sitemap regardless of whether the route uses `[slug]` or `[...path]`; the library must substitute the slash-containing string into the rest param without URL-encoding the `/`. Verify behavior against super-sitemap's API and add a targeted test (fixture: a Location with two path segments → expect `/locations/foo/bar` in the output, not `/locations/foo%2Fbar`). If super-sitemap encodes the slashes, the workaround is to split the path into segments and feed `values: e.slug.split("/")` for `[...path]` routes (detected by route ID shape).
+`Location.public_id_field = "location_path"` — a slash-separated path like `"manufacturer/title/region/site"` — and its SvelteKit route is `/locations/[...path]` (rest segment). The frontend passes `values: [e.slug]` to super-sitemap regardless of whether the route uses `[slug]` or `[...path]`. Verified against super-sitemap@1.0.12: the library substitutes via `String.prototype.replace` with no URL-encoding, so `values: ["a/b/c"]` produces `/locations/a/b/c` (literal slashes). No per-route shape branch is needed. A targeted regression test (Location with multi-segment path → expect `/locations/foo/bar`, not `/locations/foo%2Fbar`) belongs in §7 to catch a future library change.
 
 ### Tolerating unclassified routes
 
-`isSearchEngineIndexable()` throws on routes the classifier doesn't recognize — by design, to force route authors to classify intentionally at lint/build time. At request time inside `/sitemap.xml`, that discipline turns into a sharp edge: one stray unclassified route 500s the entire sitemap. Wrap classifier calls inside the endpoint in a try/catch that logs and treats the route as non-indexable (the safer default — leak nothing rather than render nothing). The classifier still throws everywhere else it's called; only the sitemap endpoint downgrades the throw to a log.
+`isSearchEngineIndexable()` throws on routes the classifier doesn't recognize — by design, to force route authors to classify intentionally at lint/build time. At request time inside `/sitemap.xml`, that discipline turns into a sharp edge: one stray unclassified route 500s the entire sitemap. The endpoint calls the classifier at **two** sites — once in the `allRoutes().filter(...)` that builds `excludeRoutePatterns`, and once in the `catalogRoutesByEntity((_cls, id) => ...)` predicate — so introduce a local helper:
+
+```ts
+function safeIsIndexable(id: RouteId): boolean {
+  try {
+    return isSearchEngineIndexable(id);
+  } catch (e) {
+    console.warn(
+      `[sitemap] route ${id} unclassified; treating as non-indexable`,
+      e,
+    );
+    return false;
+  }
+}
+```
+
+and call `safeIsIndexable` at both sites. Returning `false` is the safer default — leak nothing rather than render nothing. The classifier still throws everywhere else it's called; only the sitemap endpoint downgrades the throw to a log.
 
 ### `routeIdToRegex` helper
 
-`excludeRoutePatterns` expects regex strings. SvelteKit route IDs include `[slug]`, `[...path]`, `[[optional]]`, and `(group)` shapes, and the helper must escape `/`, `.`, `[`, `]` literals and translate dynamic segments to wildcard patterns that match what super-sitemap is iterating. Unit-test the helper directly with each shape and against the full `allRoutes()` snapshot — accidentally over- or under-matching here silently drops correct URLs from the sitemap or leaks non-indexable ones in.
+`excludeRoutePatterns` expects regex strings. SvelteKit route IDs include `[slug]`, `[...path]`, `[[optional]]`, and `(group)` shapes. super-sitemap matches `excludeRoutePatterns` against URLs (not route IDs), so the helper must (a) escape `/`, `.`, `[`, `]` literals, (b) translate dynamic segments to wildcard patterns, and (c) **strip `(group)` segments entirely** — the same transform `stripRouteGroups` applies when building `STATIC_LASTMOD_BY_URL`. Both consumers must agree on group handling, or a static route's exclusion regex won't line up with the URL super-sitemap emits for it from auto-discovery. Unit-test the helper directly with each shape and against the full `allRoutes()` snapshot — accidentally over- or under-matching here silently drops correct URLs from the sitemap or leaks non-indexable ones in.
 
 ### Why super-sitemap
 
@@ -311,7 +435,9 @@ That's the whole endpoint. Adding a new entity type requires zero changes here �
 
 ### Response caching
 
-The SvelteKit `/sitemap.xml` response sets `Cache-Control: public, max-age=3600, s-maxage=3600` so crawler probes don't re-render XML in Node every hit. The Django `/api/sitemap/` response sets the same TTL, so the staleness budget is bounded by the longer-lived layer. The two cache lifetimes don't compose multiplicatively — both are wall-clock from the moment each layer warms — but they make repeated crawler hits cheap regardless of layer.
+The SvelteKit `/sitemap.xml` response sets `Cache-Control: public, max-age=3600` by passing explicit `headers` to `sitemap.response()` — super-sitemap@1.0.12's default is `max-age=0, s-maxage=3600` (sitemap.js:117), which we override because (a) we want clients/crawlers to actually cache, not re-validate every hit, and (b) `s-maxage` is a no-op today (Caddy isn't a caching reverse proxy and there's no CDN in front of it). The Django `/api/sitemap/` response sets the same TTL and is also cached in-process for an hour, so the staleness budget is bounded by the longer-lived layer. The two cache lifetimes don't compose multiplicatively — both are wall-clock from the moment each layer warms — but they make repeated crawler hits cheap regardless of layer.
+
+Add `s-maxage` back the same diff that introduces a shared cache layer.
 
 ### Gate on `ALLOW_SEARCH_ENGINE_INDEXING`
 
@@ -331,100 +457,113 @@ One-line additive change. Update the existing robots vitest to assert the line i
 
 **In:**
 
-- `/`, `/about`, `/about/people`, `/legal/privacy`, `/legal/terms`, `/legal/licensing` — `lastmod` from the static manifest (last git-commit on the route's source file).
-- All catalog detail pages with their `_sitemap_lastmod` as `lastmod`, plus per-entity `/edit-history` and `/sources` URLs (every `catalog-detail` / `catalog-edit-history` / `catalog-sources` route classifies as indexable), except:
-  - **Single-Model Titles** — when a Title has exactly one Model, include the Title route and **exclude** the Model route. The UI collapses single-Model Titles into the Model page (per `docs/SingleModelTitles.md`), but the Title slug is the canonical URL; indexing both would split signals and create duplicate-content noise. Enforced via `MachineModel.sitemap_queryset()`. The collapsed Model's edits still bump the Title's `lastmod` because `Title.sitemap_queryset()` aggregates `Max(machine_models__updated_at)`.
+- `/`, `/about`, `/about/people`, `/legal/privacy`, `/legal/terms`, `/legal/licensing` — `lastmod` from the per-route `STATIC_LASTMOD` constant (hand-bumped when the page's content changes; visible to humans on the legal pages via `<LastUpdated />`).
+- All catalog detail pages for active rows, with their `_sitemap_lastmod` as `lastmod`, plus per-entity `/edit-history` and `/sources` URLs (every `catalog-detail` / `catalog-edit-history` / `catalog-sources` route classifies as indexable), except:
+  - **Single-Model Title member Models** — `/models/[slug]` (the catalog-detail route) is **excluded** because the canonical URL is the Title's detail page (the UI collapses to the Model page but the Title slug is canonical per `docs/SingleModelTitles.md`). `/models/[slug]/edit-history` and `/models/[slug]/sources` are **still included** with the Model's own `updated_at` — those pages show the Model's history and sources independently, not the Title's. Implemented via `MachineModel.non_canonical_detail_slugs()`. The Title's own `lastmod` aggregates `Max(machine_models.updated_at)` so the collapsed Model's edits bump the Title's detail-page freshness signal.
+- `/manufacturers/[slug]/systems` — the only listed-indexable dynamic route today. Receives manufacturer slugs via `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE` and the manufacturer's own `_sitemap_lastmod`.
 
 **Out:**
 
 - `/style-lab`, `/api-docs`, `/search`, `/kiosk`, `/_sentry_test`, `/auth/error`
 - Catalog listing pages (`/titles`, `/models`, `/manufacturers`, etc.) — non-indexable today per [`RouteWalking.md`](RouteWalking.md) (low search value + CSR-only); discoverability is covered by the catalog detail entries above. Revisit when listing SSR lands.
 - Catalog `/new` and `/delete` subroutes — non-indexable.
-- Anything auth-gated — recognized by `requireCapability` in the layout chain; non-indexable routes are excluded by `isSearchEngineIndexable(routeId)`; never enumerated by hand
-- Models whose parent Title has exactly one Model (see above)
+- Anything auth-gated — recognized by `requireCapability` in the layout chain; non-indexable routes are excluded by `isSearchEngineIndexable(routeId)`; never enumerated by hand.
+- Soft-deleted catalog rows (`status='deleted'`) — excluded by `.active()` at every queryset entry point.
+- The `catalog-detail` URL for Models whose parent Title has exactly one active Model (see above); their `/edit-history` and `/sources` URLs are still in.
 
-## 6. Prerequisite — `SITE_ORIGIN` build + deploy checks (separate PR)
+## 6. `SITE_ORIGIN` build + deploy checks
 
-`SITE_ORIGIN` is consumed by the sitemap (URLs, robots.txt `Sitemap:` line) and by the prerendered meta tags that already exist. Today `frontend/svelte.config.js:40` falls back to `'http://localhost:5173'` when unset — fine for `make dev`, but a production build silently bakes `localhost` URLs into prerendered HTML.
+`SITE_ORIGIN` is `https://flipcommons.org` in production (apex, no `www`). Consumed by the sitemap (URLs, robots.txt `Sitemap:` line) and by the prerendered meta tags that already exist. Today `frontend/svelte.config.js:40` falls back to `'http://localhost:5173'` when unset — fine for `make dev`, but a production build silently bakes `localhost` URLs into prerendered HTML.
 
-The fix (build-phase refusal gate when `RAILWAY_GIT_COMMIT_SHA` is set but `SITE_ORIGIN` is empty/malformed, plus a deploy check in `apps/core/checks.py` with new error ids `core.E303` / `core.E304`, plus a `Dockerfile` `ARG` for `SITE_ORIGIN`) is **pre-existing env hygiene that the sitemap surfaces, not sitemap work**. Land it in its own PR ahead of this one so the sitemap PR stays focused. The sitemap depends on the build/deploy gates being in place — but bundling them couples sitemap review to deploy-check review and grows the diff surface.
+The fix: build-phase refusal gate when `RAILWAY_GIT_COMMIT_SHA` is set but `SITE_ORIGIN` is empty/malformed, plus a deploy check in `apps/core/checks.py` with new error ids `core.E303` / `core.E304`, plus a `Dockerfile` `ARG` for `SITE_ORIGIN`. Pre-existing env hygiene the sitemap surfaces — but the sitemap can't ship without it, so it lands as the first commit of this PR.
 
 ## 7. Tests
 
 - **Backend (pytest):**
-  - `apps/core/tests/test_sitemap.py` — `all_sitemap_feeds()` walks every concrete `LinkableModel` subclass, builds one feed per kind, entries match `(slug, lastmod)` shape, ordering is by slug, `max_lastmod` matches the newest entry. Parameterized over every concrete `LinkableModel` so a new entity type fires the test and gets reviewed intentionally (per [ModelDrivenMetadata.md](../model_driven_metadata/ModelDrivenMetadata.md#rules-of-thumb): "Parity tests pin derived sets"). Also asserts a model overriding `sitemap_queryset()` to return `.none()` produces no feed entry (opt-out path).
-  - `apps/catalog/tests/test_title_sitemap_lastmod.py` — `Title.sitemap_queryset()` annotates `_sitemap_lastmod = max(Title.updated_at, max(its MachineModels' updated_at))` across: (a) Title-only edit, (b) MachineModel-only edit, (c) both edited, (d) single-Model Title with Model edit, (e) Title with zero MachineModels (annotation falls back to `Title.updated_at` via `Coalesce`).
-  - `apps/core/tests/test_sitemap_api.py` — endpoint returns 200 with the expected shape, rate-limit returns 429 with `Retry-After` past the threshold (10/min).
-  - `apps/catalog/tests/test_machine_model_sitemap_queryset.py` — the single-Model-Title exclusion: `MachineModel.sitemap_queryset()` includes Models whose parent Title has ≥2 `machine_models` and excludes the rest.
+  - `apps/core/tests/test_sitemap.py` — `all_sitemap_feeds()` walks every concrete `LinkableModel` subclass, builds one feed per kind, entries match `(slug, lastmod)` shape, ordering is by slug, `max_lastmod` matches the newest entry, `detail_excluded_slugs` is a `frozenset` (default empty). Parameterized over every concrete `LinkableModel` so a new entity type fires the test and gets reviewed intentionally (per [ModelDrivenMetadata.md](../model_driven_metadata/ModelDrivenMetadata.md#rules-of-thumb): "Parity tests pin derived sets"). Also asserts a model overriding `sitemap_queryset()` to return `.none()` produces no feed entry (opt-out path).
+  - `apps/core/tests/test_sitemap_active_filter.py` — the default `sitemap_queryset()` excludes `status='deleted'` rows for every concrete `LinkableModel` subclass. Soft-deleting a row removes it from the feed across all kinds (parameterized over every `LinkableModel`).
+  - `apps/core/tests/test_linkable_model_lifecycle_parity.py` — every concrete `LinkableModel` subclass inherits `LifecycleStatusModel` and `TimeStampedModel`. The default `sitemap_queryset()` calls `.active()` and reads `updated_at` directly; a future non-lifecycle `LinkableModel` must override `sitemap_queryset()`, and this test makes that contract explicit instead of letting the omission crash at sitemap render.
+  - `apps/catalog/tests/test_title_sitemap_lastmod.py` — `Title.sitemap_queryset()` annotates `_sitemap_lastmod = max(Title.updated_at, max(machine_models.updated_at))` across: (a) Title-only edit, (b) MachineModel-only edit, (c) both edited, (d) single-Model Title with Model edit, (e) Title with zero MachineModels (annotation falls back to `Title.updated_at` via `Coalesce`).
+  - `apps/core/tests/test_sitemap_api.py` — endpoint returns 200 with the expected shape (including `detail_excluded_slugs` per feed); second call within the TTL is served from cache (assert `all_sitemap_feeds` is invoked once across two requests via a spy / mock).
+  - `apps/catalog/tests/test_machine_model_non_canonical.py` — `MachineModel.non_canonical_detail_slugs()` returns exactly the slugs of active Models whose parent Title has exactly one active Model. Cases: (a) Title with two active Models → both slugs absent from the result; (b) Title with one active + one deleted Model → the active Model's slug IS present (the deleted sibling shouldn't keep it canonical); (c) Title with one active Model → that slug IS present; (d) the same Model still appears in `sitemap_queryset()` so its `/edit-history` and `/sources` are not dropped from the feed entries.
   - `apps/catalog/tests/test_location_sitemap.py` — Location's `public_id_field = "location_path"` produces multi-segment slugs (e.g. `"a/b/c"`) in the feed without further encoding.
-  - **Schema validation** — fetch `/sitemap.xml` via an in-process test client and validate the response against the sitemaps.org XSD using `lxml.etree.XMLSchema` (loaded once at module import — no subprocess, no system-binary dependency in CI). XSD is bundled under `backend/tests/fixtures/sitemap.xsd` so the test is offline.
+  - `apps/core/tests/test_entity_type_parity.py` — every concrete `LinkableModel.entity_type` is a member of the frontend's `CatalogEntityKey` set. The sitemap relies on `directRoutesByEntity.get(kind)` matching Python `entity_type` strings against `CatalogEntityKey` exactly; this test pins the cross-language coupling so renaming on either side fails CI rather than silently dropping a kind from the sitemap. Source the frontend set from a checked-in generated file (or a small JSON exported alongside `make api-gen`) — do not duplicate the literal by hand.
 - **Frontend (vitest):**
-  - `sitemap.xml/+server.ts` builds `paramValues` correctly from a mocked `/api/sitemap/` response: a single backend feed for `kind: "title"` lands under every indexable SvelteKit route ID for `title` (detail + `/edit-history` + `/sources` today) with the same slug list and `lastmod`.
-  - `sitemap.xml/+server.ts` substitutes a path-shaped slug (`"a/b/c"`) into a `[...path]` rest route correctly — `/locations/a/b/c`, not `/locations/a%2Fb%2Fc`. Run the rendered XML through XSD validation in the same test so encoding regressions surface as schema errors.
-  - `sitemap.xml/+server.ts` merges static-manifest entries into `additionalPaths` with their build-time `lastmod`.
-  - `sitemap.xml/+server.ts` returns 404 when `ALLOW_SEARCH_ENGINE_INDEXING != "true"`.
-  - `sitemap.xml/+server.ts` sets `Cache-Control: public, max-age=3600, s-maxage=3600` on 200 responses.
-  - `sitemap.xml/+server.ts` does NOT throw when the route classifier would reject an unclassified route — the endpoint logs and skips, so one stray route can't 500 the whole sitemap.
+  - `sitemap[[page=integer]].xml/+server.ts` builds `paramValues` correctly from a mocked `/api/sitemap/` response: a single backend feed for `kind: "title"` lands under every indexable SvelteKit route ID for `title` (detail + `/edit-history` + `/sources` today) with the same slug list and `lastmod`.
+  - **Canonical-URL split** — given a `machine-model` feed where `detail_excluded_slugs = {"sm1"}` and entries are `[{slug:"sm1",lastmod:T1}, {slug:"mm2",lastmod:T2}]`: `paramValues["/models/[slug]"]` includes only `mm2`, but `paramValues["/models/[slug]/edit-history"]` and `paramValues["/models/[slug]/sources"]` include BOTH `sm1` and `mm2` with their own `lastmod`s. This is the load-bearing test for invariant #2.
+  - **Listed-indexable bridge** — given a `manufacturer` feed, `paramValues["/manufacturers/[slug]/systems"]` is populated with the manufacturer slugs and their `lastmod`s, sourced via `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE`. Removing the map entry drops the route from `paramValues`.
+  - `sitemap[[page=integer]].xml/+server.ts` substitutes a path-shaped slug (`"a/b/c"`) into a `[...path]` rest route correctly — `/locations/a/b/c`, not `/locations/a%2Fb%2Fc`. Run the rendered XML through XSD validation in the same test so encoding regressions surface as schema errors.
+  - `processPaths` attaches the right `lastmod` to each auto-discovered static URL from `STATIC_LASTMOD_BY_URL` (one assertion per static route), and leaves dynamic-route paths (which already carry their own `lastmod` from `paramValues`) unchanged.
+  - **Sitemap-index page param plumbing** — when `params.page === undefined`, the endpoint renders a single urlset (or a `<sitemapindex>` if URLs cross 50k); when `params.page === "1"`, it renders page 1 of the urlset. Mock super-sitemap or assert on the `page` argument the wrapper passes through.
+  - `sitemap[[page=integer]].xml/+server.ts` returns 404 when `ALLOW_SEARCH_ENGINE_INDEXING != "true"`.
+  - `sitemap[[page=integer]].xml/+server.ts` returns 502 when the Django client returns an error (resilience: one stray Django outage shouldn't 500 the route).
+  - `sitemap[[page=integer]].xml/+server.ts` sets `Cache-Control: public, max-age=3600` on 200 responses.
+  - `sitemap[[page=integer]].xml/+server.ts` does NOT throw when the route classifier would reject an unclassified route — `safeIsIndexable` logs and treats it as non-indexable, so one stray route can't 500 the whole sitemap.
   - `routeIdToRegex` helper: unit tests for `[slug]`, `[...path]`, `[[optional]]`, `(group)` shapes; snapshot test against the current `allRoutes()` set asserting the regex set excludes exactly the non-indexable routes.
-  - Static-`lastmod` manifest build step: given a fixture route set, emits the expected `{route: lastmod}` shape; falls back to the build-time clock with a warning when `git log` returns nothing or all files share the shallow-tip date (does NOT fail the build).
-  - Legal page components render the "Last updated" footer from the same manifest the sitemap reads.
+  - `STATIC_LASTMOD` parity (`static-lastmod.test.ts`): every static indexable route ID has an entry, every entry corresponds to a real static indexable route, every value matches `YYYY-MM-DD` and parses as a real calendar date. The `satisfies` clause covers the first two at typecheck time; the test pins them at runtime too so the failure has a clear name when it breaks.
+  - `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE` parity: every key is also in `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS` (otherwise the entry is dead); every value is a known `CatalogEntityKey` (the `satisfies` clause covers this at typecheck, the test pins it at runtime). Importantly, no key is a `catalog-*` route ID — those are already handled by `catalogRoutesByEntity()`, so a duplicate here would double-emit URLs.
   - Existing robots.txt test extended to assert the `Sitemap:` line is present iff `ALLOW_SEARCH_ENGINE_INDEXING == "true"`.
 
 ## 8. Implementation order
 
-Prerequisite (separate PR, per §6): `SITE_ORIGIN` build-phase guard, deploy check, and `Dockerfile` `ARG`.
+### Commits
 
-1. Add `LinkableModel.sitemap_queryset()` classmethod with its default (every row, `_sitemap_lastmod = updated_at`, `.only()`, `.order_by()`).
-2. Override `MachineModel.sitemap_queryset()` for the single-Model-Title exclusion (via `Count("title__machine_models")`) and `Title.sitemap_queryset()` for the `Greatest(updated_at, Coalesce(Max("machine_models__updated_at"), updated_at))` aggregation. Tests for both, including the zero-MachineModels case.
-3. `apps/core/sitemap.py` — `SitemapEntry`, `SitemapFeed`, `all_sitemap_feeds()` (filtering None lastmods and skipping empty feeds). Parameterized parity test over every concrete `LinkableModel`, including an opt-out (`sitemap_queryset()` returns `.none()`) assertion.
-4. `apps/core/sitemap_api.py` — single endpoint at `/api/sitemap/`, IP rate limiting (10/min) via `apps.core.rate_limits`, `Cache-Control` headers. Tests for 200 / 429 paths.
+The work below ships as **multiple commits in one PR**, each done by a fresh AI session. **🛑 Do NOT commit until the user explicitly directs the commit.** When a commit's code is ready, stop and wait — the user reviews, then says to commit. No commit happens without explicit go-ahead.
+
+#### ✅ DONE - Commit A: prereqs
+
+`SITE_ORIGIN` prerequisites (per §6). Build-phase refusal gate, deploy check (`core.E303` / `core.E304`), `Dockerfile` `ARG`. No sitemap code yet — just the env hygiene the sitemap depends on. Reviewable as deploy-check work.
+
+#### ✅ DONE - Commit B: backend
+
+Backend feeds + backend sitemap API endpoint (Commit B steps). `LinkableModel.sitemap_queryset()` + `non_canonical_detail_slugs()`, the per-model overrides, `all_sitemap_feeds()`, cached `/api/sitemap/` endpoint, `make api-gen`. Reviewable on its own: tests prove the feeds are right, the endpoint returns the right shape; nothing user-visible yet.
+
+#### ✅ DONE - Commit C: static page timestamps
+
+`STATIC_LASTMOD` + legal page wiring (Commit C step). Hand-maintained map with typed `satisfies`, parity test, and `formatLastUpdated` helper. Wire the legal pages to read from the constant (replacing the current inline "Last updated: March 2026" strings). User-visible: legal-page dates now show the day and come from the same source the sitemap will read.
+
+#### ✅ DONE - Commit D: sitemap
+
+Sitemap frontend endpoint + robots line (Commit D steps). `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE`, super-sitemap wiring (via `createServerClient`, `processPaths`, `page: params.page`, `safeIsIndexable`), `routeIdToRegex`, rest-param handling, robots `Sitemap:` line, XSD validation test. Lights up `/sitemap.xml` (the user-facing URL; the route file is `sitemap[[page=integer]].xml`).
+
+### Steps
+
+#### Commit B — backend feeds + API endpoint
+
+1. Add `LinkableModel.sitemap_queryset()` and `LinkableModel.non_canonical_detail_slugs()` classmethods with their defaults (`.active()` directly, `_sitemap_lastmod = F("updated_at")`, `.only()`, `.order_by()`; non-canonical default is empty tuple). Add a parity test asserting every concrete `LinkableModel` subclass also inherits `LifecycleStatusModel` and `TimeStampedModel` — the default's contract.
+2. Override `MachineModel.non_canonical_detail_slugs()` for the single-Model-Title rule (active sibling count == 1, via `Count("title__machine_models", filter=active_status_q("title__machine_models"))`) and `Title.sitemap_queryset()` for the `Greatest(updated_at, Coalesce(Max("machine_models__updated_at"), updated_at))` aggregation. Tests per §7, including the zero-Models case.
+3. `apps/core/sitemap.py` — `SitemapEntry`, `SitemapFeed` (with `detail_excluded_slugs: frozenset[str]`), `all_sitemap_feeds()` (filtering None lastmods and skipping empty feeds). Parameterized parity test over every concrete `LinkableModel`, including an opt-out (`sitemap_queryset()` returns `.none()`) assertion and a default-active-filter assertion.
+4. `apps/core/api/sitemap.py` + `apps/core/api/__init__.py` (`routers = [("", router)]`) — single endpoint at `/api/sitemap/`, shared `django.core.cache` (file-based per project settings, 1h TTL), `Cache-Control: public, max-age=3600` response header. Typed schemas in `apps/core/api/sitemap_schemas.py` carry `detail_excluded_slugs` as `frozenset[str]` → JSON array. Tests for the 200 path and the cache-hit path (one materialization across two requests).
 5. `make api-gen`.
-6. Build-time static-`lastmod` manifest: Vite plugin / build script that walks the static-route source files, shells `git log -1 --format=%cI`, writes `frontend/src/lib/static-lastmod.generated.json`. Add to `.gitignore`. Soft-fail to the build-time clock with a warning when git history is missing or shallow (per §2). Tests for both the happy path and the fallback path.
-7. Wire legal page components to read from the manifest for their "Last updated" footers.
-8. `pnpm add super-sitemap@~1.0.12`.
-9. `frontend/src/routes/sitemap.xml/+server.ts` — wire super-sitemap to `/api/sitemap/` for catalog URLs and to the static manifest for static URLs, using `catalogRoutesByEntity()` + `isSearchEngineIndexable()` to expand to route IDs. Wrap classifier calls in try/catch (per §3 "Tolerating unclassified routes"). Set `Cache-Control` on responses. Gate on `ALLOW_SEARCH_ENGINE_INDEXING` via `isDeploymentSearchEngineIndexable()`.
-10. Implement and unit-test the `routeIdToRegex` helper (per §3).
-11. Verify rest-param handling against super-sitemap with a Location fixture (per §3); if the library URL-encodes slashes, fall back to `e.slug.split("/")` for rest-shaped routes.
-12. Append the `Sitemap:` line to `frontend/src/routes/robots.txt/+server.ts` (indexable-mode only). Extend the existing robots test.
-13. Add the XSD validation tests (backend pytest + frontend vitest, both using the bundled sitemap XSD).
-14. Verify locally: `curl localhost:5173/sitemap.xml`; spot-check with `xmllint --noout --schema` for ad-hoc inspection (CI uses lxml / a Node XSD validator).
+
+> 🛑 **Stop — do NOT commit until the user explicitly says to.**
+
+#### Commit C — static page timestamps
+
+1. `frontend/src/lib/static-lastmod.ts` — `STATIC_LASTMOD` map (`YYYY-MM-DD` values) + `StaticIndexableRouteId` type + `formatLastUpdated` helper. Parity test (every static indexable route has an entry; every value matches `YYYY-MM-DD` and parses as a real date). Update each legal page's `<LastUpdated>` to read from the constant via `formatLastUpdated(STATIC_LASTMOD["..."])`.
+
+> 🛑 **Stop — do NOT commit until the user explicitly says to.**
+
+#### Commit D — sitemap endpoint + robots line
+
+1. `frontend/src/lib/route-metadata.server.ts` — add `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE` with `/manufacturers/[slug]/systems → manufacturer`. Add parity test (key ∈ `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`; value ∈ `CatalogEntityKey`; key NOT a `catalog-*` route).
+2. `pnpm add super-sitemap@~1.0.12`.
+3. `frontend/src/routes/sitemap[[page=integer]].xml/+server.ts` — note the optional-param route shape (sitemap-index support from day one). Wire super-sitemap to `/api/sitemap/` via `createServerClient` for catalog URLs, expand to route IDs via `catalogRoutesByEntity()` + `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE`, apply `detail_excluded_slugs` only to `catalog-detail` classifications, attach static `lastmod` via `processPaths` reading `STATIC_LASTMOD_BY_URL`. Pass `page: params.page` to `sitemap.response()`. Use `safeIsIndexable` (per §3 "Tolerating unclassified routes"). Set `Cache-Control` on responses. Gate on `ALLOW_SEARCH_ENGINE_INDEXING` via `isDeploymentSearchEngineIndexable()`. Return 502 if the Django client returns an error.
+4. Implement and unit-test the `routeIdToRegex` helper plus `stripRouteGroups` (per §3).
+5. Append the `Sitemap:` line to `frontend/src/routes/robots.txt/+server.ts` (indexable-mode only, pointing to `${SITE_ORIGIN}/sitemap.xml` — the canonical entry point even with the `[[page]]` route shape). Extend the existing robots test.
+6. Add the frontend XSD validation test (vitest, using a bundled sitemap XSD validated by a Node XSD validator), including the Location rest-param regression case (per §3 "Rest-param routes"). XML correctness is the frontend's concern — the backend response is JSON and its shape is already pinned by `SitemapResponseSchema`.
+7. Verify locally: `curl localhost:5173/sitemap.xml`; spot-check with `xmllint --noout --schema` for ad-hoc inspection.
+
+> 🛑 **Stop — do NOT commit until the user explicitly says to.**
 
 ### Deployment routing
 
-No Caddyfile changes needed. The current `@django` matcher in `Caddyfile` only catches `/api`, `/djadmin`, `/media`, `/static`, so `/sitemap.xml` routes to SvelteKit (Node, port 3000) by default.
+No Caddyfile changes needed. The current `@django` matcher in `Caddyfile` only catches `/api`, `/djadmin`, `/media`, `/static`, so `/sitemap.xml`, `/sitemap1.xml`, `/sitemap2.xml`, etc. all route to SvelteKit (Node, port 3000) by default.
 
-## Considered alternatives
+## Follow-ups
 
-- **Per-entity `updated_at` as the only `lastmod` source.** First-draft shape. Rejected: the Title page renders its Models' content; a Model edit changes what the Title page displays but doesn't bump `Title.updated_at`. Crawlers would re-fetch late or not at all on Model edits. The one-line `Title.sitemap_queryset()` override fixes this without introducing a framework.
-- **Auto-derive `lastmod` from Django relationships.** Considered. Rejected: walking all FK/M2M relationships over-includes (provenance ChangeSets, audit rows, denormalization caches aren't page content), and walking only `LinkableModel`-targeted relationships under-includes (non-LinkableModel entities like aliases or credit lines often drive page content precisely because they don't have their own page). The actual page-composition graph isn't well-described by either filter, so a "smart" walker would be wrong in both directions. Catalog pages overwhelmingly render their own record's fields; Title is the one real exception. That's a one-override situation, not a framework.
-- **Touch parent `updated_at` at write time via the ChangeSet pipeline.** Considered. Rejected: pushes the dependency graph into the write path with spooky action at a distance, and the only real dependency in the catalog today is Title→Models. One read-time override is cheaper, more localized, and visible in the model file rather than as a claim-execution side effect.
-- **Per-page-endpoint bulk-`lastmod` functions co-located with `/api/pages/...` endpoints.** Considered. Rejected: more general than the catalog actually needs. Page endpoints today compose mostly from a single root record; only Title meaningfully aggregates. Building a "every page endpoint declares its own lastmod query" framework is overhead for the 95% case where `lastmod = root.updated_at`. Revisit if other page endpoints start aggregating across catalog entities.
-- **`<lastmod>` only on sitemap-index entries (no per-URL `<lastmod>`).** Considered. Rejected: per-URL `lastmod` is the main signal Google uses to prioritize re-crawls. Coarse-grained index-level `lastmod` wouldn't help discover which specific entities changed.
-- **Frontmatter / manual "last updated" constants in static page files.** Considered for static pages. Rejected: forgettable and drifts from reality. `git log` on the source file is automatic, and the legal-page footer reading from the same manifest doubles as informal verification — if the date looks wrong, a human will notice.
-- **Hand-rolled XML rendering.** Considered to avoid a third-party dependency. Rejected: the library's value isn't lines saved (it's only ~80), it's that XML correctness (escaping, `lastmod` formatting, sitemap-index splitting) becomes the library's problem to debug rather than ours.
-- **New `apps/sitemap/` Django app.** Considered. Rejected per `docs/AppBoundaries.md`: a new app should own a distinct concept, and sitemap feeds are thin projections over existing catalog data with no domain of their own.
-- **Hand-rolled sitemap index from day one.** Considered for "future-proofing" against the 50k-URLs-per-file cap. Rejected: super-sitemap auto-flips from `<urlset>` to `<sitemapindex>` when needed, the catalog is years from 50k.
-- **Per-route hardcoded sitemap config on the frontend.** Rejected: hardcoding means adding a new entity type requires touching the frontend.
-- **Separate `canonical_url_queryset()` + `sitemap_queryset()` classmethods.** First-draft shape. Rejected: the two-method split was justified by speculation that a future canonical-link tag or schema.org `mainEntityOfPage` would read the same predicate, but neither consumer exists today. Per CLAUDE.md ("don't design for hypothetical future requirements"), one method covers the one current consumer. The split also actively caused a re-annotation footgun (a `Title.sitemap_queryset()` override calling `super()` and re-annotating `_sitemap_lastmod` doesn't reliably win across Django versions). Collapsing to one method makes the override path direct: rebuild from `cls.objects`, no super-call gotcha. If a second consumer arrives, split then.
-- **Failing the build when `git log` returns nothing for a static-route source file.** First-draft shape. Rejected: shallow-clone build environments (Railway/Nixpacks default to depth-1) silently make every page's `lastmod` the shallow-tip commit date — fail-the-build behavior would either never trigger (because there IS a date, just the wrong one) or trigger spuriously on environments we don't control. `lastmod` is a crawler hint, not data anyone makes decisions on; trading a benign rare drift for a sharp build failure isn't worth it. Soft-fail to the build-time clock with a warning instead (§2 "Soft-fail behavior").
-- **120/min IP rate limit on `/api/sitemap/`.** First-draft shape. Rejected as over-sized: real crawlers fetch `/sitemap.xml` ~daily, and the SvelteKit endpoint is the only other consumer. 10/min still defends against abuse, stays decorative for legitimate traffic, and matches the existing pattern for public IP-keyed endpoints.
-- **Per-model `SitemapFeed` classes registered from `AppConfig.ready()`.** First-draft shape. Rejected per [ModelDrivenMetadata.md](../model_driven_metadata/ModelDrivenMetadata.md): it's a hand-maintained list that enumerates the same model set `LinkableModel.__subclasses__()` already knows, the per-model classes differ only in model import + queryset + ordering, and adding a new catalog model would require a new feed class. The `LinkableModel` walk delivers the same boundary respect (core doesn't import catalog) with zero per-model declarations.
-- **Two endpoints (`GET /api/sitemap/` + `GET /api/sitemap/{kind}/`).** First-draft shape. Rejected: the split only existed so the frontend could "discover" feeds before fetching them, but it always fetches all of them anyway — 1+N HTTP calls per render with no semantic gain. super-sitemap fails the whole render if any `paramValues` callback throws, so eliminating the per-feed fetches also eliminates that partial-failure mode.
-- **`route_pattern` emitted from Python.** First-draft shape. Rejected: the frontend already maps `entity_type` → SvelteKit route IDs via `catalogRoutesByEntity()`. Emitting `'/titles/[slug]'` from Python would duplicate that map and require Python to know about SvelteKit's `[...path]` rest-param shape.
+### Write-time sitemap cache invalidation
 
-## Open questions
+When a user edits or creates a catalog row, the sitemap doesn't reflect that for up to 1h (the `SITEMAP_CACHE_TTL`). By design — keeps the cost ceiling at one materialization per hour per process — but worth revisiting if/when SEO data shows we're losing re-crawls because crawlers see stale `<lastmod>` values.
 
-1. **Production hostname** — confirm `SITE_ORIGIN` in production (presumably `https://flipcommons.org`?) so the `Sitemap:` line is right. Lives in the prerequisite PR (§6), but flagged here so it doesn't get lost.
-2. **super-sitemap rest-param behavior** — verify against the library whether passing `values: ["a/b/c"]` to a `[...path]` route emits `/locations/a/b/c` or `/locations/a%2Fb%2Fc`. If the latter, the Location wiring needs a per-route shape branch (see §3 "Rest-param routes").
-
-## Resolved
-
-- **People pages** (`/people/[slug]`) — catalog persons (designers, artists, etc.). Indexable; included in the sitemap.
-- **Soft-delete / draft state** — none exist today. No lifecycle-based filter needed in the sitemap feeds; revisit if/when drafts or soft-delete are introduced.
-- **Single-Model Titles** — include the Title route; exclude the Model route. Title slug is canonical; indexing both would split signals. The collapsed Model's edits still bump the Title's `lastmod` via `Title.sitemap_queryset()`'s `Max(machine_models__updated_at)`.
-- **`lastmod` source for catalog pages** — default to the record's own `updated_at`; widen via a `sitemap_queryset()` override only where the page renders content from other catalog entities (today: Title's Model list). No relationship walker; no write-time `updated_at` touching.
-- **One method vs. two on `LinkableModel`** — one (`sitemap_queryset()`), covering both narrowing and lastmod widening. `canonical_url_queryset()` was considered for hypothetical future canonical-link / schema.org consumers and rejected as speculative future-proofing (see Considered alternatives).
-- **Static-page `lastmod` from `git log` failure mode** — soft-fail with a warning, never fail the build. Trades benign rare drift on rarely-changing static pages for build-environment robustness. See §2 "Soft-fail behavior".
-- **`SITE_ORIGIN` build + deploy checks** — pre-existing env hygiene the sitemap surfaces; lands in its own PR ahead of the sitemap (see §6).
-- **`lastmod` source for static pages** — build-time manifest from `git log -1 --format=%cI` on the route's source `+page.svelte`. Same manifest backs legal-page "Last updated" footers so the user-visible date and the sitemap `lastmod` cannot disagree.
-- **`lastmod` failure-mode tradeoff** — accept under-reporting on transitive edits (e.g., a Manufacturer rename not bumping every Title listing it). Cheaper than maintaining a relationship walker, and Google won't re-crawl every Title for a Manufacturer typo anyway.
+When we want it: hook a `post_save` / `post_delete` signal on `CatalogModel` that calls `cache.delete(SITEMAP_CACHE_KEY)`. Cheap; the next request re-materializes. The narrower variant (invalidate only on lifecycle / structural edits, not every claim write) is the right level of granularity but adds bookkeeping — start with the broad invalidation and tighten only if materializations become hot.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,8 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.60.0",
     "vite": "^7.3.2",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "xmllint-wasm": "~5.2.0"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
@@ -57,7 +58,8 @@
     "open-props": "^1.7.23",
     "openapi-fetch": "^0.17.0",
     "postcss-jit-props": "^1.0.16",
-    "posthog-js": "^1.376.0"
+    "posthog-js": "^1.376.0",
+    "super-sitemap": "~1.0.12"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       posthog-js:
         specifier: ^1.376.0
         version: 1.376.0
+      super-sitemap:
+        specifier: ~1.0.12
+        version: 1.0.12(svelte@5.55.9(@typescript-eslint/types@8.60.0))
     devDependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.5.4
@@ -114,6 +117,9 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
+      xmllint-wasm:
+        specifier: ~5.2.0
+        version: 5.2.0(@types/node@25.9.1)
 
 packages:
 
@@ -3159,6 +3165,11 @@ packages:
     engines: {node: '>=20.19.0'}
     hasBin: true
 
+  super-sitemap@1.0.12:
+    resolution: {integrity: sha512-C3gfAS1RZxL5bbZGtgnIOitMhfqAt8RmhW8AWTia6c8n9RW3Zx7f/SxVeFWZD0I1nUAx2pkxuWazVtev0Nmb5w==}
+    peerDependencies:
+      svelte: '>=4.0.0 <6.0.0'
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -3451,6 +3462,12 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xmllint-wasm@5.2.0:
+    resolution: {integrity: sha512-GVMuR3ViU8R7sakcVm/4GClMtCV8p7xgjXZlc6GmvPpInIz4V41lmRnjSd4uKhVkf5MZj97wEZkPM4RMAhojuQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@types/node': '>=16'
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -6596,6 +6613,10 @@ snapshots:
       - supports-color
       - typescript
 
+  super-sitemap@1.0.12(svelte@5.55.9(@typescript-eslint/types@8.60.0)):
+    dependencies:
+      svelte: 5.55.9(@typescript-eslint/types@8.60.0)
+
   supports-color@10.2.2: {}
 
   supports-hyperlinks@4.4.0:
@@ -6844,6 +6865,10 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xmllint-wasm@5.2.0(@types/node@25.9.1):
+    dependencies:
+      '@types/node': 25.9.1
 
   xtend@4.0.2: {}
 

--- a/frontend/src/lib/route-metadata.server.ts
+++ b/frontend/src/lib/route-metadata.server.ts
@@ -47,6 +47,28 @@ export const SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS = [
   '/_sentry_test',
 ] as const satisfies readonly RouteId[];
 
+/**
+ * Indexable dynamic routes whose `[slug]` param is fed by a catalog entity's
+ * slugs but whose route ID is NOT a `catalog-*` shape (so it can't be reached
+ * via `catalogRoutesByEntity()`). Maps the route ID to the entity whose
+ * `sitemap_queryset()` supplies its slugs and `lastmod`.
+ *
+ * Today: just `/manufacturers/[slug]/systems` under `manufacturer`. A new
+ * entry must be on a route that is also in `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`
+ * and must NOT name a `catalog-*` route ID (those are already wired through
+ * `catalogRoutesByEntity()` and would double-emit). Parity tests in
+ * `route-metadata.test.ts` pin both invariants at runtime; the
+ * `satisfies` clause pins the key/value types at typecheck.
+ *
+ * `lastmod` for these routes is the parent entity's `_sitemap_lastmod` — an
+ * acknowledged under-report when the listing's content changes without
+ * bumping the parent (e.g. a new System linked to a Manufacturer). Revisit
+ * per-route lastmod widening if/when traffic data shows lost re-crawls.
+ */
+export const LISTED_INDEXABLE_ENTITY_SLUG_SOURCE = {
+  '/manufacturers/[slug]/systems': 'manufacturer',
+} as const satisfies Partial<Record<RouteId, CatalogEntityKey>>;
+
 /** Classification of a SvelteKit route for search engine indexing purposes. */
 export type RouteClass =
   | { kind: 'catalog-listing'; entity: CatalogEntityKey }

--- a/frontend/src/lib/route-metadata.test.ts
+++ b/frontend/src/lib/route-metadata.test.ts
@@ -5,11 +5,12 @@ import {
   isCatalogRoute,
   isSearchEngineIndexable,
   allRoutes,
+  LISTED_INDEXABLE_ENTITY_SLUG_SOURCE,
   SEARCH_ENGINE_INDEXABLE_ROUTE_IDS,
   SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS,
   type RouteClass,
 } from './route-metadata.server';
-import type { CatalogEntityKey } from './api/catalog-meta';
+import { CATALOG_META, type CatalogEntityKey } from './api/catalog-meta';
 
 // SvelteKit's ssr resolution rule: walk leaf-to-root through the
 // +page.ts / +page.server.ts / +layout.ts / +layout.server.ts chain; the
@@ -110,6 +111,40 @@ describe('route-metadata', () => {
     const indexable = new Set<string>(SEARCH_ENGINE_INDEXABLE_ROUTE_IDS);
     const overlap = SEARCH_ENGINE_NON_INDEXABLE_ROUTE_IDS.filter((id) => indexable.has(id));
     expect(overlap, 'A route ID cannot appear in both allowlists').toEqual([]);
+  });
+
+  // The sitemap endpoint uses LISTED_INDEXABLE_ENTITY_SLUG_SOURCE to wire
+  // catalog-entity slugs into non-catalog dynamic routes. Three invariants
+  // matter: (a) keys are real indexable routes (else dead entries silently
+  // drop URLs from the sitemap), (b) values are real CatalogEntityKeys
+  // (else the feed lookup misses), and (c) keys are NOT catalog-* routes
+  // (those go through catalogRoutesByEntity — a duplicate here would
+  // double-emit). The `satisfies` clause covers (a)/(b) at typecheck for
+  // typos; this test pins runtime correctness too so failures have a name.
+  describe('LISTED_INDEXABLE_ENTITY_SLUG_SOURCE', () => {
+    const ENTRIES = Object.entries(LISTED_INDEXABLE_ENTITY_SLUG_SOURCE) as [
+      RouteId,
+      CatalogEntityKey,
+    ][];
+
+    it('is non-empty (else the constant should be deleted, not empty)', () => {
+      expect(ENTRIES.length).toBeGreaterThan(0);
+    });
+
+    it.each(ENTRIES)('%s: route is in SEARCH_ENGINE_INDEXABLE_ROUTE_IDS', (routeId) => {
+      const indexable = new Set<string>(SEARCH_ENGINE_INDEXABLE_ROUTE_IDS);
+      expect(indexable.has(routeId)).toBe(true);
+    });
+
+    it.each(ENTRIES)('%s → %s: entity is a known CatalogEntityKey', (_routeId, entity) => {
+      expect(entity in CATALOG_META).toBe(true);
+    });
+
+    it.each(ENTRIES)('%s: classifies as listed-indexable, not catalog-*', (routeId) => {
+      const cls = classifyRoute(routeId);
+      expect(cls.kind).toBe('listed-indexable');
+      expect(isCatalogRoute(cls)).toBe(false);
+    });
   });
 
   // Anchor sanity. Inputs are in route-pattern form (the shape page.route.id

--- a/frontend/src/lib/sitemap-helpers.test.ts
+++ b/frontend/src/lib/sitemap-helpers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { routeIdToRegex, stripRouteGroups } from './sitemap-helpers';
+import { allRoutes, isSearchEngineIndexable } from './route-metadata.server';
+import type { RouteId } from '$app/types';
+
+describe('stripRouteGroups', () => {
+  it.each([
+    ['/', '/'],
+    ['/about', '/about'],
+    ['/about/people', '/about/people'],
+    ['/(legal)/privacy', '/privacy'],
+    ['/(legal)/terms', '/terms'],
+    ['/(legal)/licensing', '/licensing'],
+    // Defends against a future nested-group shape — super-sitemap strips
+    // every `/(group)` segment, so we should too.
+    ['/(outer)/(inner)/foo', '/foo'],
+    // Group as the only segment: SvelteKit serves at `/`, not `''`.
+    ['/(only)', '/'],
+  ])('strips groups from %s → %s', (input, expected) => {
+    expect(stripRouteGroups(input)).toBe(expected);
+  });
+});
+
+describe('routeIdToRegex', () => {
+  // super-sitemap applies excludeRoutePatterns to route-ID form (with
+  // `[slug]`, `[...path]`, and `(group)` still present), so the regex
+  // should match the route ID literally — no wildcard expansion of
+  // dynamic segments. These anchor tests pin both directions.
+  it.each<[RouteId, string, boolean]>([
+    ['/login', '/login', true],
+    ['/login', '/login/', false],
+    ['/login', '/loginx', false],
+    ['/titles/[slug]/edit', '/titles/[slug]/edit', true],
+    ['/titles/[slug]/edit', '/titles/foo/edit', false],
+    ['/locations/[...path]/edit', '/locations/[...path]/edit', true],
+    ['/locations/[...path]/edit', '/locations/a/b/edit', false],
+    ['/(legal)/privacy', '/(legal)/privacy', true],
+    ['/(legal)/privacy', '/privacy', false],
+    // Optional param — literal, not expanded.
+    ['/sitemap[[page=integer]].xml', '/sitemap[[page=integer]].xml', true],
+  ])('regex for %s matches %s = %s', (id, candidate, expected) => {
+    const re = new RegExp(routeIdToRegex(id));
+    expect(re.test(candidate)).toBe(expected);
+  });
+
+  // Snapshot: the exclude set should be exactly the non-indexable routes,
+  // matched literally against the route-ID-with-groups form that
+  // super-sitemap's filterRoutes() feeds in. A regression that over- or
+  // under-matched here would silently drop correct URLs from the sitemap
+  // or leak non-indexable ones in.
+  it('excludes exactly the non-indexable routes', () => {
+    const excludePatterns = allRoutes()
+      .filter((id) => {
+        try {
+          return !isSearchEngineIndexable(id);
+        } catch {
+          return false;
+        }
+      })
+      .map(routeIdToRegex)
+      .map((p) => new RegExp(p));
+
+    for (const id of allRoutes()) {
+      let isIndexable: boolean;
+      try {
+        isIndexable = isSearchEngineIndexable(id);
+      } catch {
+        isIndexable = false;
+      }
+      const matched = excludePatterns.some((re) => re.test(id));
+      expect(matched, `expected ${id} matched=${matched} for indexable=${isIndexable}`).toBe(
+        !isIndexable,
+      );
+    }
+  });
+});

--- a/frontend/src/lib/sitemap-helpers.ts
+++ b/frontend/src/lib/sitemap-helpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Helpers for the `/sitemap.xml` endpoint, split out for unit-testability.
+ * No SvelteKit-runtime imports here so vitest can import without spinning
+ * up `$env/dynamic/private` or `import.meta.glob`.
+ */
+
+/**
+ * Strip `(group)` segments from a SvelteKit route ID to produce the URL
+ * SvelteKit actually serves. `/(legal)/privacy` → `/privacy`. Used to key
+ * `STATIC_LASTMOD` (which uses route-ID form, with groups) by URL form
+ * (which is what super-sitemap's `processPaths` callback receives).
+ *
+ * Mirrors super-sitemap's own group-stripping pattern (sitemap.js:267) so
+ * the two stay in lockstep — a divergence would mean a static route's
+ * lookup misses and its `<lastmod>` silently disappears from the sitemap.
+ */
+export function stripRouteGroups(routeId: string): string {
+  const stripped = routeId.replaceAll(/\/\([^)]+\)/g, '');
+  return stripped === '' ? '/' : stripped;
+}
+
+/**
+ * Convert a SvelteKit route ID into a regex string for super-sitemap's
+ * `excludeRoutePatterns`.
+ *
+ * Key invariant: super-sitemap applies `excludeRoutePatterns` against
+ * route-ID form (with `[slug]`, `[...path]`, and `(group)` still present)
+ * — NOT against resolved URLs. See `filterRoutes` in `super-sitemap/dist/sitemap.js`:
+ * the patterns run BEFORE the `(group)` strip. So the regex must match the
+ * literal route-ID form, which means we just escape regex metacharacters
+ * and anchor both ends — no `[slug]` → wildcard rewriting needed.
+ */
+export function routeIdToRegex(routeId: string): string {
+  return '^' + routeId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '$';
+}

--- a/frontend/src/params/integer.ts
+++ b/frontend/src/params/integer.ts
@@ -1,0 +1,14 @@
+import type { ParamMatcher } from '@sveltejs/kit';
+
+/**
+ * SvelteKit param matcher for positive integers (no leading zeros) —
+ * enables route shapes like `sitemap[[page=integer]].xml`. Without a
+ * matcher, the optional `[[page]]` rest segment would accept arbitrary
+ * strings (e.g. `/sitemapfoo.xml`), which super-sitemap can't render.
+ *
+ * Pattern mirrors super-sitemap's own page-validation regex (sitemap.js:105):
+ * `/sitemap0.xml` and `/sitemap007.xml` should 404 at the router (route
+ * doesn't exist) rather than route through and get rejected with 400
+ * downstream.
+ */
+export const match: ParamMatcher = (param) => /^[1-9]\d*$/.test(param);

--- a/frontend/src/routes/robots.txt/+server.ts
+++ b/frontend/src/routes/robots.txt/+server.ts
@@ -1,3 +1,4 @@
+import { env } from '$env/dynamic/private';
 import { isDeploymentSearchEngineIndexable } from '$lib/is-deployment-search-engine-indexable.server';
 import type { RequestHandler } from './$types';
 
@@ -10,14 +11,22 @@ const DISALLOW_ALL = 'User-agent: *\nDisallow: /\n';
  * from ever fetching the page, so the `noindex` meta would never be seen
  * and the URL could still appear in results via inbound links.
  */
-const INDEXABLE_BODY = 'User-agent: *\nDisallow: /api/\n';
+const INDEXABLE_BODY_PREFIX = 'User-agent: *\nDisallow: /api/\n';
 
 const HEADERS: HeadersInit = {
   'Content-Type': 'text/plain; charset=utf-8',
   'Cache-Control': 'public, max-age=300',
 };
 
-export const GET: RequestHandler = () => {
-  const body = isDeploymentSearchEngineIndexable() ? INDEXABLE_BODY : DISALLOW_ALL;
+export const GET: RequestHandler = ({ url }) => {
+  if (!isDeploymentSearchEngineIndexable()) {
+    return new Response(DISALLOW_ALL, { headers: HEADERS });
+  }
+  // SITE_ORIGIN at runtime, mirroring the dev fallback pattern in
+  // `frontend/src/lib/api/server.ts`. Railway builds enforce SITE_ORIGIN
+  // at build time (svelte.config.js); the fallback only matters in
+  // `make dev` where the env var may be unset.
+  const origin = env.SITE_ORIGIN?.trim() || url.origin;
+  const body = `${INDEXABLE_BODY_PREFIX}Sitemap: ${origin}/sitemap.xml\n`;
   return new Response(body, { headers: HEADERS });
 };

--- a/frontend/src/routes/robots.txt/robots.test.ts
+++ b/frontend/src/routes/robots.txt/robots.test.ts
@@ -5,8 +5,8 @@ vi.mock('$env/dynamic/private', () => ({ env: mockEnv }));
 
 import { GET } from './+server';
 
-function callGet(): Response {
-  return GET({} as unknown as Parameters<typeof GET>[0]) as Response;
+function callGet(origin = 'http://localhost:5173'): Response {
+  return GET({ url: new URL(origin) } as unknown as Parameters<typeof GET>[0]) as Response;
 }
 
 describe('GET /robots.txt', () => {
@@ -26,8 +26,9 @@ describe('GET /robots.txt', () => {
     `);
   });
 
-  it('returns the indexable body when ALLOW_SEARCH_ENGINE_INDEXING="true"', async () => {
+  it('returns the indexable body with Sitemap line when ALLOW_SEARCH_ENGINE_INDEXING="true"', async () => {
     mockEnv.ALLOW_SEARCH_ENGINE_INDEXING = 'true';
+    mockEnv.SITE_ORIGIN = 'https://flipcommons.org';
     const response = callGet();
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
@@ -35,8 +36,15 @@ describe('GET /robots.txt', () => {
     await expect(response.text()).resolves.toMatchInlineSnapshot(`
       "User-agent: *
       Disallow: /api/
+      Sitemap: https://flipcommons.org/sitemap.xml
       "
     `);
+  });
+
+  it('falls back to the request origin when SITE_ORIGIN is unset', async () => {
+    mockEnv.ALLOW_SEARCH_ENGINE_INDEXING = 'true';
+    const response = callGet('http://localhost:5173');
+    await expect(response.text()).resolves.toContain('Sitemap: http://localhost:5173/sitemap.xml');
   });
 
   // Only the literal "true" enables indexing. Anything else fails safe to the

--- a/frontend/src/routes/sitemap[[page=integer]].xml/+server.ts
+++ b/frontend/src/routes/sitemap[[page=integer]].xml/+server.ts
@@ -1,0 +1,173 @@
+/**
+ * `/sitemap.xml` (and `/sitemap1.xml`, `/sitemap2.xml`, … when the urlset
+ * crosses 50k entries) — see `docs/plans/seo/Sitemap.md`.
+ *
+ * The handler:
+ *   1. Refuses on non-indexable deploys (`ALLOW_SEARCH_ENGINE_INDEXING != "true"`).
+ *   2. Fetches the consolidated `/api/sitemap/` feed from Django.
+ *   3. Wires each feed's slugs into every indexable SvelteKit route ID that
+ *      shares the entity (`catalogRoutesByEntity` + `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE`).
+ *   4. Excludes detail-URL slugs flagged non-canonical (single-Model Title members
+ *      collapse to the Title page) — but keeps `/edit-history` and `/sources`.
+ *   5. Attaches hand-maintained `<lastmod>` to auto-discovered static URLs.
+ *   6. Lets super-sitemap render XML, split into a `<sitemapindex>` if needed.
+ */
+
+import { env } from '$env/dynamic/private';
+import * as sitemap from 'super-sitemap';
+import type { RequestHandler } from './$types';
+import type { RouteId } from '$app/types';
+import {
+  allRoutes,
+  catalogRoutesByEntity,
+  classifyRoute,
+  isSearchEngineIndexable,
+  LISTED_INDEXABLE_ENTITY_SLUG_SOURCE,
+} from '$lib/route-metadata.server';
+import { isDeploymentSearchEngineIndexable } from '$lib/is-deployment-search-engine-indexable.server';
+import { STATIC_LASTMOD } from '$lib/static-lastmod';
+import { stripRouteGroups, routeIdToRegex } from '$lib/sitemap-helpers';
+import { createServerClient } from '$lib/api/server';
+import { CATALOG_META, type CatalogEntityKey } from '$lib/api/catalog-meta';
+
+/**
+ * Type guard for the `feed.kind` wire boundary. Django serializes
+ * `entity_type` as a plain string; the backend `test_entity_type_parity`
+ * suite asserts every Python value is a known `CatalogEntityKey`, but
+ * we cross a typed boundary here, so check rather than cast. An unknown
+ * kind (renamed on the backend, removed on the frontend) is silently
+ * dropped — same outcome as if `.get()` returned undefined.
+ */
+function isCatalogEntityKey(kind: string): kind is CatalogEntityKey {
+  return kind in CATALOG_META;
+}
+
+/**
+ * Throw-tolerant wrapper around `isSearchEngineIndexable`. The classifier
+ * throws on unclassified routes — by design, so route authors classify
+ * intentionally at lint/build time. At request time inside the sitemap
+ * that discipline turns into a sharp edge: one stray unclassified route
+ * 500s the entire response. Return `false` instead so the worst case is a
+ * temporarily missing URL, not a missing sitemap.
+ */
+function safeIsIndexable(id: RouteId): boolean {
+  try {
+    return isSearchEngineIndexable(id);
+  } catch (e) {
+    console.warn(`[sitemap] route ${id} unclassified; treating as non-indexable`, e);
+    return false;
+  }
+}
+
+// --- Module-level memoization ------------------------------------------------
+// `allRoutes()`, the listed map, and STATIC_LASTMOD are stable across
+// requests. Compute the derived structures once at module load rather than
+// rebuilding inside every GET.
+
+// Route IDs that super-sitemap auto-discovers but must NOT emit. Matched
+// against route-ID form (with `[slug]` / `(group)` still present) per
+// super-sitemap's `filterRoutes` semantics — NOT URL form.
+const EXCLUDE_ROUTE_PATTERNS: readonly string[] = allRoutes()
+  .filter((id) => !safeIsIndexable(id))
+  .map(routeIdToRegex);
+
+// catalog-* detail/edit-history/sources route IDs, grouped by entity.
+// `safeIsIndexable` filters to exactly the indexable catalog kinds.
+const DIRECT_ROUTES_BY_ENTITY: ReadonlyMap<CatalogEntityKey, readonly RouteId[]> =
+  catalogRoutesByEntity((_cls, id) => safeIsIndexable(id));
+
+// LISTED_INDEXABLE_ENTITY_SLUG_SOURCE inverted: kind → route IDs.
+const LISTED_ROUTES_BY_ENTITY: ReadonlyMap<CatalogEntityKey, readonly RouteId[]> = (() => {
+  const out = new Map<CatalogEntityKey, RouteId[]>();
+  for (const [routeId, kind] of Object.entries(LISTED_INDEXABLE_ENTITY_SLUG_SOURCE) as [
+    RouteId,
+    CatalogEntityKey,
+  ][]) {
+    const arr = out.get(kind) ?? [];
+    arr.push(routeId);
+    out.set(kind, arr);
+  }
+  return out;
+})();
+
+// STATIC_LASTMOD keys are route IDs (may contain `(group)` segments).
+// super-sitemap's `processPaths` callback receives already-resolved URLs
+// with groups stripped, so look up by URL form.
+const STATIC_LASTMOD_BY_URL: ReadonlyMap<string, string> = new Map(
+  Object.entries(STATIC_LASTMOD).map(([routeId, lastmod]) => [stripRouteGroups(routeId), lastmod]),
+);
+
+// ----------------------------------------------------------------------------
+
+export const GET: RequestHandler = async ({ fetch, url, request, params }) => {
+  if (!isDeploymentSearchEngineIndexable()) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  const client = createServerClient(fetch, url, request);
+  const { data, error } = await client.GET('/api/sitemap/');
+  if (error || !data) {
+    return new Response('Sitemap unavailable', { status: 502 });
+  }
+
+  // Initialize every indexable dynamic route to an empty paramValues entry
+  // FIRST, then overlay feed data. super-sitemap throws on any dynamic route
+  // it discovers in the file tree that lacks a paramValues key — and a
+  // catalog kind with zero active rows produces no Django feed (the backend
+  // skips empty feeds), so the route would otherwise crash the response.
+  // Empty arrays are accepted and produce zero URLs.
+  const paramValues: sitemap.ParamValues = {};
+  for (const routes of DIRECT_ROUTES_BY_ENTITY.values()) {
+    for (const id of routes) paramValues[id] = [];
+  }
+  for (const routes of LISTED_ROUTES_BY_ENTITY.values()) {
+    for (const id of routes) paramValues[id] = [];
+  }
+
+  for (const feed of data.feeds) {
+    if (!isCatalogEntityKey(feed.kind)) continue;
+    const direct = DIRECT_ROUTES_BY_ENTITY.get(feed.kind) ?? [];
+    const listed = LISTED_ROUTES_BY_ENTITY.get(feed.kind) ?? [];
+    if (direct.length === 0 && listed.length === 0) continue;
+
+    const excluded = new Set(feed.detail_excluded_slugs);
+    for (const id of [...direct, ...listed]) {
+      const cls = classifyRoute(id);
+      const isDetail = cls.kind === 'catalog-detail';
+      const entries =
+        isDetail && excluded.size
+          ? feed.entries.filter((e) => !excluded.has(e.slug))
+          : feed.entries;
+      paramValues[id] = entries.map((e) => ({
+        values: [e.slug],
+        lastmod: e.lastmod,
+      }));
+    }
+  }
+
+  // Same fallback pattern as `frontend/src/lib/api/server.ts`. Railway
+  // builds enforce SITE_ORIGIN at build time via svelte.config.js; the
+  // fallback only matters in `make dev` where the env var may be unset.
+  const origin = env.SITE_ORIGIN?.trim() || url.origin;
+
+  return sitemap.response({
+    origin,
+    page: params.page,
+    excludeRoutePatterns: [...EXCLUDE_ROUTE_PATTERNS],
+    paramValues,
+    // Static routes are auto-discovered by super-sitemap walking the routes
+    // tree; `processPaths` attaches `<lastmod>` to each one from
+    // STATIC_LASTMOD_BY_URL. Dynamic-route paths already carry their own
+    // `lastmod` from `paramValues`, so they pass through unchanged.
+    processPaths: (paths) =>
+      paths.map((p) => {
+        const lastmod = STATIC_LASTMOD_BY_URL.get(p.path);
+        return lastmod ? { ...p, lastmod } : p;
+      }),
+    // super-sitemap@1.0.12 defaults to `max-age=0, s-maxage=3600`. We
+    // override because (a) there is no shared cache today (Caddy isn't a
+    // caching reverse proxy, no CDN), so `s-maxage` is a no-op; (b) we want
+    // clients/crawlers to actually cache the response for the TTL.
+    headers: { 'Cache-Control': 'public, max-age=3600' },
+  });
+};

--- a/frontend/src/routes/sitemap[[page=integer]].xml/sitemap.test.ts
+++ b/frontend/src/routes/sitemap[[page=integer]].xml/sitemap.test.ts
@@ -1,0 +1,277 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { validateXML } from 'xmllint-wasm';
+import type { SitemapResponseSchema } from '$lib/api/schema';
+
+const SITEMAP_XSD = readFileSync(
+  fileURLToPath(new URL('../../tests/fixtures/sitemap-0.9.xsd', import.meta.url)),
+  'utf8',
+);
+
+// Mocks must be hoisted ABOVE the route module import. The route file's
+// module-level code runs once at import (it caches `allRoutes()` etc) — by
+// then env + api-client mocks are wired so subsequent requests see them.
+const { mockEnv, mockGet, mockCreateServerClient } = vi.hoisted(() => ({
+  mockEnv: {} as Record<string, string>,
+  mockGet: vi.fn(),
+  mockCreateServerClient: vi.fn(),
+}));
+
+vi.mock('$env/dynamic/private', () => ({ env: mockEnv }));
+vi.mock('$lib/api/server', () => ({
+  createServerClient: mockCreateServerClient,
+}));
+
+import { GET } from './+server';
+
+function callGet(opts: { page?: string; origin?: string } = {}): Promise<Response> {
+  const origin = opts.origin ?? 'http://localhost:5173';
+  return GET({
+    fetch,
+    url: new URL(`${origin}/sitemap${opts.page ? opts.page : ''}.xml`),
+    request: new Request(origin),
+    params: { page: opts.page },
+  } as unknown as Parameters<typeof GET>[0]) as Promise<Response>;
+}
+
+function setApiResponse(body: SitemapResponseSchema) {
+  mockGet.mockResolvedValue({ data: body, error: undefined });
+  mockCreateServerClient.mockReturnValue({ GET: mockGet });
+}
+
+function setApiError() {
+  mockGet.mockResolvedValue({ data: undefined, error: { detail: 'boom' } });
+  mockCreateServerClient.mockReturnValue({ GET: mockGet });
+}
+
+describe('GET /sitemap.xml', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+    mockEnv.ALLOW_SEARCH_ENGINE_INDEXING = 'true';
+    mockEnv.SITE_ORIGIN = 'https://flipcommons.org';
+    mockGet.mockReset();
+    mockCreateServerClient.mockReset();
+    setApiResponse({ feeds: [] });
+  });
+
+  it('returns 404 when ALLOW_SEARCH_ENGINE_INDEXING is not "true"', async () => {
+    delete mockEnv.ALLOW_SEARCH_ENGINE_INDEXING;
+    const response = await callGet();
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 502 when the Django client returns an error', async () => {
+    setApiError();
+    const response = await callGet();
+    expect(response.status).toBe(502);
+  });
+
+  it('overrides super-sitemap default Cache-Control', async () => {
+    const response = await callGet();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('public, max-age=3600');
+  });
+
+  it('renders Title detail/edit-history/sources URLs from a title feed', async () => {
+    setApiResponse({
+      feeds: [
+        {
+          kind: 'title',
+          entries: [
+            { slug: 't1', lastmod: '2026-01-01T00:00:00Z' },
+            { slug: 't2', lastmod: '2026-02-01T00:00:00Z' },
+          ],
+          detail_excluded_slugs: [],
+          max_lastmod: '2026-02-01T00:00:00Z',
+        },
+      ],
+    });
+    const response = await callGet();
+    const xml = await response.text();
+    expect(xml).toContain('https://flipcommons.org/titles/t1');
+    expect(xml).toContain('https://flipcommons.org/titles/t1/edit-history');
+    expect(xml).toContain('https://flipcommons.org/titles/t1/sources');
+    expect(xml).toContain('https://flipcommons.org/titles/t2');
+    expect(xml).toContain('<lastmod>2026-01-01T00:00:00Z</lastmod>');
+    expect(xml).toContain('<lastmod>2026-02-01T00:00:00Z</lastmod>');
+  });
+
+  // Load-bearing test for the canonical-URL invariant: single-Model Title
+  // members are excluded from `/models/[slug]` but kept in /edit-history
+  // and /sources.
+  it('applies detail_excluded_slugs to catalog-detail only', async () => {
+    setApiResponse({
+      feeds: [
+        {
+          kind: 'model',
+          entries: [
+            { slug: 'sm1', lastmod: '2026-01-01T00:00:00Z' },
+            { slug: 'mm2', lastmod: '2026-02-01T00:00:00Z' },
+          ],
+          detail_excluded_slugs: ['sm1'],
+          max_lastmod: '2026-02-01T00:00:00Z',
+        },
+      ],
+    });
+    const response = await callGet();
+    const xml = await response.text();
+    expect(xml).not.toMatch(/<loc>https:\/\/flipcommons\.org\/models\/sm1<\/loc>/);
+    expect(xml).toContain('<loc>https://flipcommons.org/models/mm2</loc>');
+    expect(xml).toContain('<loc>https://flipcommons.org/models/sm1/edit-history</loc>');
+    expect(xml).toContain('<loc>https://flipcommons.org/models/sm1/sources</loc>');
+    expect(xml).toContain('<loc>https://flipcommons.org/models/mm2/edit-history</loc>');
+  });
+
+  it('bridges manufacturer slugs into /manufacturers/[slug]/systems via LISTED_INDEXABLE_ENTITY_SLUG_SOURCE', async () => {
+    setApiResponse({
+      feeds: [
+        {
+          kind: 'manufacturer',
+          entries: [{ slug: 'stern', lastmod: '2026-03-01T00:00:00Z' }],
+          detail_excluded_slugs: [],
+          max_lastmod: '2026-03-01T00:00:00Z',
+        },
+      ],
+    });
+    const response = await callGet();
+    const xml = await response.text();
+    expect(xml).toContain('<loc>https://flipcommons.org/manufacturers/stern</loc>');
+    expect(xml).toContain('<loc>https://flipcommons.org/manufacturers/stern/systems</loc>');
+  });
+
+  // Pins the rest-param ([...path]) substitution: a multi-segment slug
+  // must render with literal slashes, not %2F. If super-sitemap ever
+  // starts URL-encoding param values, this test catches it.
+  it('substitutes a path-shaped Location slug into the rest route literally', async () => {
+    setApiResponse({
+      feeds: [
+        {
+          kind: 'location',
+          entries: [{ slug: 'a/b/c', lastmod: '2026-04-01T00:00:00Z' }],
+          detail_excluded_slugs: [],
+          max_lastmod: '2026-04-01T00:00:00Z',
+        },
+      ],
+    });
+    const response = await callGet();
+    const xml = await response.text();
+    expect(xml).toContain('<loc>https://flipcommons.org/locations/a/b/c</loc>');
+    expect(xml).not.toContain('a%2Fb%2Fc');
+  });
+
+  it('attaches <lastmod> from STATIC_LASTMOD to auto-discovered static URLs', async () => {
+    const response = await callGet();
+    const xml = await response.text();
+    // The static lastmods are hand-maintained; assert the URLs are present
+    // and each one carries a lastmod element nearby.
+    const staticUrls = ['/', '/about', '/about/people', '/privacy', '/terms', '/licensing'];
+    for (const path of staticUrls) {
+      const re = new RegExp(
+        `<loc>https://flipcommons\\.org${path}</loc>\\s*<lastmod>\\d{4}-\\d{2}-\\d{2}</lastmod>`,
+      );
+      expect(xml, `expected <loc>${path}</loc> followed by <lastmod>`).toMatch(re);
+    }
+  });
+
+  it('does not include any non-indexable route in the response', async () => {
+    setApiResponse({ feeds: [] });
+    const response = await callGet();
+    const xml = await response.text();
+    expect(xml).not.toContain('/login');
+    expect(xml).not.toContain('/style-lab');
+    expect(xml).not.toContain('/api-docs');
+    expect(xml).not.toContain('/search');
+    expect(xml).not.toContain('/auth/error');
+  });
+
+  it('falls back to url.origin when SITE_ORIGIN is unset', async () => {
+    delete mockEnv.SITE_ORIGIN;
+    const response = await callGet({ origin: 'http://localhost:5173' });
+    const xml = await response.text();
+    expect(xml).toContain('<loc>http://localhost:5173/</loc>');
+  });
+
+  // page=undefined is the canonical `/sitemap.xml`; page="1" is the first
+  // sitemap-index subpage. Below 50k urls there's only one page so a
+  // request for page="2" should 404 from super-sitemap.
+  it('renders a urlset for page=undefined', async () => {
+    const response = await callGet();
+    const xml = await response.text();
+    expect(xml).toContain('<urlset');
+  });
+
+  it('404s for an out-of-range page index', async () => {
+    const response = await callGet({ page: '99' });
+    expect(response.status).toBe(404);
+  });
+
+  // XSD validation pins XML correctness — well-formedness, element order,
+  // value shapes — against the official sitemaps.org 0.9 schema. Combined
+  // with the Location rest-param regression (multi-segment slug must NOT
+  // be percent-encoded), this catches encoding/structure regressions that
+  // hand-written assertions miss.
+  //
+  // Slug constraint reminder: super-sitemap does NOT XML-escape <loc>
+  // contents (sitemap.js builds the string with template literals). That
+  // works only because catalog slugs are URL-safe alphanumerics/hyphens
+  // — a future slug containing `&`/`<`/`>` would produce invalid XML.
+  // Slug validation is the contract that makes the no-escaping behavior
+  // safe, not anything in this endpoint.
+  it('renders XML that validates against sitemap-0.9.xsd', async () => {
+    setApiResponse({
+      feeds: [
+        {
+          kind: 'title',
+          entries: [
+            { slug: 'foo', lastmod: '2026-01-01T00:00:00Z' },
+            { slug: 'bar-baz', lastmod: '2026-02-01T00:00:00Z' },
+          ],
+          detail_excluded_slugs: [],
+          max_lastmod: '2026-02-01T00:00:00Z',
+        },
+        {
+          kind: 'location',
+          entries: [{ slug: 'a/b/c', lastmod: '2026-04-01T00:00:00Z' }],
+          detail_excluded_slugs: [],
+          max_lastmod: '2026-04-01T00:00:00Z',
+        },
+      ],
+    });
+    const response = await callGet();
+    const xml = await response.text();
+
+    const result = await validateXML({
+      xml: [{ fileName: 'sitemap.xml', contents: xml }],
+      schema: [{ fileName: 'sitemap-0.9.xsd', contents: SITEMAP_XSD }],
+    });
+    expect(
+      result.errors,
+      `Sitemap failed XSD validation:\n${result.rawOutput}\n\nXML:\n${xml}`,
+    ).toEqual([]);
+    expect(result.valid).toBe(true);
+
+    // Pin the rest-param literal-slash invariant here too: an encoding
+    // regression would still pass XSD (the URL would just be different)
+    // but break the actual sitemap consumer contract.
+    expect(xml).toContain('<loc>https://flipcommons.org/locations/a/b/c</loc>');
+    expect(xml).not.toContain('a%2Fb%2Fc');
+  });
+
+  it('drops feeds whose entity has no matching route (silent opt-out)', async () => {
+    setApiResponse({
+      feeds: [
+        {
+          kind: 'nonexistent-entity-kind',
+          entries: [{ slug: 'whatever', lastmod: '2026-01-01T00:00:00Z' }],
+          detail_excluded_slugs: [],
+          max_lastmod: '2026-01-01T00:00:00Z',
+        },
+      ],
+    });
+    const response = await callGet();
+    expect(response.status).toBe(200);
+    const xml = await response.text();
+    expect(xml).not.toContain('/whatever');
+  });
+});

--- a/frontend/src/tests/fixtures/sitemap-0.9.xsd
+++ b/frontend/src/tests/fixtures/sitemap-0.9.xsd
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.sitemaps.org/schemas/sitemap/0.9"
+            xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+            elementFormDefault="qualified">
+  <xsd:annotation>
+    <xsd:documentation>
+      XML Schema for Sitemap files.
+      Last Modifed 2008-03-26
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:element name="urlset">
+    <xsd:annotation>
+      <xsd:documentation>
+        Container for a set of up to 50,000 document elements.
+        This is the root element of the XML file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+        <xsd:element name="url" type="tUrl" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="tUrl">
+    <xsd:annotation>
+      <xsd:documentation>
+        Container for the data needed to describe a document to crawl.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="loc" type="tLoc"/>
+      <xsd:element name="lastmod" type="tLastmod" minOccurs="0"/>
+      <xsd:element name="changefreq" type="tChangeFreq" minOccurs="0"/>
+      <xsd:element name="priority" type="tPriority" minOccurs="0"/>
+      <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="tLoc">
+    <xsd:annotation>
+      <xsd:documentation>
+        REQUIRED: The location URI of a document.
+        The URI must conform to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:anyURI">
+      <xsd:minLength value="12"/>
+      <xsd:maxLength value="2048"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tLastmod">
+    <xsd:annotation>
+      <xsd:documentation>
+        OPTIONAL: The date the document was last modified. The date must conform
+        to the W3C DATETIME format (http://www.w3.org/TR/NOTE-datetime).
+        Example: 2005-05-10
+        Lastmod may also contain a timestamp.
+        Example: 2005-05-10T17:33:30+08:00
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:date"/>
+      </xsd:simpleType>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:dateTime"/>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tChangeFreq">
+    <xsd:annotation>
+      <xsd:documentation>
+        OPTIONAL: Indicates how frequently the content at a particular URL is
+        likely to change. The value "always" should be used to describe
+        documents that change each time they are accessed. The value "never"
+        should be used to describe archived URLs. Please note that web
+        crawlers may not necessarily crawl pages marked "always" more often.
+        Consider this element as a friendly suggestion and not a command.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="always"/>
+      <xsd:enumeration value="hourly"/>
+      <xsd:enumeration value="daily"/>
+      <xsd:enumeration value="weekly"/>
+      <xsd:enumeration value="monthly"/>
+      <xsd:enumeration value="yearly"/>
+      <xsd:enumeration value="never"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tPriority">
+    <xsd:annotation>
+      <xsd:documentation>
+        OPTIONAL: The priority of a particular URL relative to other pages
+        on the same site. The value for this element is a number between
+        0.0 and 1.0 where 0.0 identifies the lowest priority page(s).
+        The default priority of a page is 0.5. Priority is used to select
+        between pages on your site. Setting a priority of 1.0 for all URLs
+        will not help you, as the relative priority of pages on your site
+        is what will be considered.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="0.0"/>
+      <xsd:maxInclusive value="1.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/scripts/dev-frontend
+++ b/scripts/dev-frontend
@@ -1,6 +1,17 @@
 #!/usr/bin/env sh
 set -e
-cd "$(dirname "$0")/../frontend"
+cd "$(dirname "$0")/.."
 
+# Load .env if present (matches scripts/dev-backend). SvelteKit reads
+# `$env/dynamic/private` from process.env; without this, vars set in the
+# monorepo-root .env never reach the Vite dev server (kit.env.dir defaults
+# to cwd = frontend/, which has no .env of its own).
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+cd frontend
 pkill -f "pnpm dev" 2>/dev/null || true
 pnpm dev


### PR DESCRIPTION
## Summary

Introduces `/sitemap.xml` to help search engine crawlers discover the site's content.

It's a SvelteKit `/sitemap[[page=integer]].xml` endpoint that consumes the cached `/api/sitemap/` feed, substitutes catalog slugs into every indexable route via `catalogRoutesByEntity()` + the new `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE` map, applies the single-Model-Title canonical-URL split, and attaches hand-maintained `<lastmod>` to static URLs. robots.txt now advertises the sitemap in indexable mode.

- `integer` param matcher (`^[1-9]\d*$`, mirroring super-sitemap's own page validation) keeps `/sitemap0.xml`, `/sitemap007.xml`, `/sitemapfoo.xml` 404ing at the router instead of 400ing through super-sitemap.
- Bundled `sitemap-0.9.xsd` fixture lets vitest validate the rendered XML against the official schema via `xmllint-wasm`.
- Bonus: `scripts/dev-frontend` now sources the monorepo `.env` (mirrors `scripts/dev-backend`), closing a pre-existing gap that prevented frontend `$env/dynamic/private` from reading repo-root vars in dev.

## Test plan

- [ ] `make test` passes (1452 frontend tests; new coverage: paramValues wiring, canonical-URL split, listed-route bridge, rest-param literal slashes, processPaths static lastmod, page-param plumbing, 404/502 paths, Cache-Control override, safeIsIndexable throw-tolerance, routeIdToRegex parity against the full route set, XSD validation)
- [ ] `make quality` clean (svelte-check, eslint, prettier)
- [ ] Locally: with `ALLOW_SEARCH_ENGINE_INDEXING=true` in `.env`, `curl http://localhost:5173/sitemap.xml` returns a valid `<urlset>` (~150 ms warm response, ~30k URLs)
- [ ] Locally: `curl http://localhost:5173/robots.txt` includes `Sitemap: http://localhost:5173/sitemap.xml`
- [ ] Without indexing enabled, both endpoints behave as before (`Disallow: /` robots; 404 sitemap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)