### PR TITLE
chore(frontend): allow Scalar CDN and fonts in CSP for API docs

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -197,7 +197,12 @@ const appHtmlStyleHash = computeAppHtmlStyleHash();
 const cdnEntry = cdnUrl ? [cdnUrl] : [];
 const cspReportOnlyDirectives = {
   'default-src': ['self'],
-  'script-src': ['self', ...cdnEntry],
+  // jsdelivr/@scalar: the /api-docs page loads the @scalar/api-reference
+  // bundle from jsdelivr; it also dynamically imports further chunks, so
+  // the host needs to be in connect-src too. Scoped to the @scalar org
+  // path (trailing slash = prefix match) to cover versioned chunks while
+  // excluding the rest of the CDN.
+  'script-src': ['self', ...cdnEntry, 'https://cdn.jsdelivr.net/npm/@scalar/'],
   'style-src': ['self', appHtmlStyleHash, ...cdnEntry],
   // Svelte's `style:` directive (and any hand-written `style="..."`
   // attribute) compiles to an inline style attribute, which CSP gates
@@ -210,12 +215,16 @@ const cspReportOnlyDirectives = {
   // here is the standard compromise for Svelte/React apps.
   'style-src-attr': ['unsafe-inline'],
   'img-src': ['self', 'https:', 'data:'],
-  'font-src': ['self', ...cdnEntry],
+  // fonts.scalar.com: the @scalar/api-reference widget on /api-docs loads
+  // its own Inter webfonts (incl. inter-greek.woff2) from there, even
+  // though we override --scalar-font. Allow it so the fetch isn't reported.
+  'font-src': ['self', ...cdnEntry, 'https://fonts.scalar.com'],
   'connect-src': [
     'self',
     ...cdnEntry,
     ...(sentryOrigin ? [sentryOrigin] : []),
     'https://us.i.posthog.com',
+    'https://cdn.jsdelivr.net/npm/@scalar/',
   ],
   'frame-ancestors': ['none'],
   'frame-src': ['none'],


### PR DESCRIPTION
## Summary

The `/api-docs` page renders the `@scalar/api-reference` widget, which loads its bundle from jsdelivr and its Inter webfonts from `fonts.scalar.com`. These origins weren't in the CSP, so they showed up as report-only violations in Sentry (blocked fonts + blocked jsdelivr script).

- Add `https://cdn.jsdelivr.net/npm/@scalar/` to `script-src` and `connect-src` (scoped to the `@scalar` org path; trailing slash = prefix match to cover the entry bundle plus its dynamically-imported, versioned chunks while excluding the rest of the CDN).
- Add `https://fonts.scalar.com` to `font-src`.

Clears the Sentry CSP-violation noise and keeps the API docs page working once CSP moves from report-only to enforced.

## Test plan

- [ ] Load `/api-docs` in production build; confirm the Scalar reference renders.
- [ ] Verify no new CSP violation reports for `cdn.jsdelivr.net` or `fonts.scalar.com` in Sentry.