### PR TITLE
chore: tighten and extend approve-bash hook

### DIFF
--- a/.claude/hooks/approve-bash.sh
+++ b/.claude/hooks/approve-bash.sh
@@ -46,6 +46,7 @@ ALLOWED_PREFIXES=(
   "grep"
   "ls"
   "make"
+  "mv"
   "npm view"
   "npx eslint"
   "npx prettier"
@@ -62,12 +63,49 @@ ALLOWED_PREFIXES=(
   "wc"
 )
 
+# Normalize a leading `git -C <path>` to plain `git` so it obeys the same per-subcommand
+# allowlist below (a bare `git -C` prefix would auto-approve ANY subcommand, e.g.
+# `git -C /repo reset --hard`). A quoted path with spaces won't normalize and falls through.
+MATCH_COMMAND=$(printf '%s' "$COMMAND" | sed -E 's#^git -C [^ ]+ #git #')
+
 for prefix in "${ALLOWED_PREFIXES[@]}"; do
-  if [[ "$COMMAND" == "$prefix"* ]]; then
+  if [[ "$MATCH_COMMAND" == "$prefix"* ]]; then
     echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
     exit 0
   fi
 done
+
+# Auto-approve scratch-file writes: a simple cat/echo/printf whose redirect targets
+# are ALL under /tmp (covers heredoc scaffolding like `cat > /tmp/pr-body.md <<'EOF'`).
+# Only line 1 (the command itself) is inspected; the heredoc body is data, not commands,
+# and must never be pattern-matched for safety. Any chaining/substitution on the command
+# line, or a redirect pointing anywhere but /tmp, falls through to a normal prompt.
+FIRST_LINE=$(printf '%s\n' "$COMMAND" | head -n1)
+case "$(printf '%s' "$FIRST_LINE" | awk '{print $1}')" in
+  cat|echo|printf)
+    case "$FIRST_LINE" in
+      *'&&'*|*'||'*|*';'*|*'|'*|*'$('*|*'`'*) ;;  # chained/substituted — not simple
+      *)
+        TARGETS=$(printf '%s' "$FIRST_LINE" | grep -oE '>>?[[:space:]]*[^[:space:]<>|&;()]+' | sed -E 's/^>>?[[:space:]]*//')
+        if [ -n "$TARGETS" ]; then
+          ALL_TMP=1
+          while IFS= read -r target; do
+            case "$target" in
+              /tmp/*|/private/tmp/*) ;;
+              *) ALL_TMP=0; break ;;
+            esac
+          done <<EOF
+$TARGETS
+EOF
+          if [ "$ALL_TMP" -eq 1 ]; then
+            echo '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
+            exit 0
+          fi
+        fi
+        ;;
+    esac
+    ;;
+esac
 
 # Not matched — fall through to normal permission handling
 exit 0


### PR DESCRIPTION
## Summary

Tighten and extend the `approve-bash.sh` PreToolUse hook so common scratch-file scaffolding stops prompting, while closing a `git -C` blast-radius hole.

- **Auto-approve `/tmp` scratch writes**: a simple `cat`/`echo`/`printf` whose redirect targets are all under `/tmp` (or `/private/tmp`) is auto-approved — covers heredoc scaffolding like `cat > /tmp/pr-body.md <<'EOF'`. Only the command line (line 1) is inspected; the heredoc body is treated as data and never pattern-matched. Any chaining/substitution on the command line, or a redirect pointing anywhere but `/tmp`, falls through to a normal prompt.
- **Tighten `git -C`**: a bare `git -C` prefix auto-approved *any* subcommand (e.g. `git -C /repo reset --hard`). Replaced it by normalizing a leading `git -C <path>` to plain `git` so it obeys the same per-subcommand allowlist as ordinary `git`.
- **Add `mv`** to the allowed prefixes.

## Test plan

- [x] `cat > /tmp/x.txt <<'EOF' … EOF` (body containing backticks/pipes) — auto-approved, no prompt
- [x] `git -C <path> status` — auto-approved (normalizes to enumerated `git status`)
- [x] `git -C <path> reset --hard` / `clean -fdx` — still prompts (not enumerated)
- [x] writes/heredocs targeting non-`/tmp` paths — still prompt
- [x] chained commands after a `/tmp` write (`… && …`, `… ; …`) — still prompt
- [x] existing prefix allows (`git status`, `pnpm vitest`, …) — unchanged
