### PR TITLE
feat(search): SSR the /search page; delete the orphaned /all/ endpoints

### DIFF
--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from typing import Any
 
 from django.db.models import F, Prefetch, Q, QuerySet
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
@@ -14,7 +13,6 @@ from ninja.decorators import decorate_view
 from ninja.pagination import paginate
 from ninja.responses import Status
 from ninja.security import django_auth
-from pydantic import TypeAdapter
 
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -42,12 +40,9 @@ from apps.provenance.schemas import (
     ChangeSetInputSchema,
 )
 
-from ..cache import get_cached_response, models_all_key, set_cached_response
 from ..models import (
     Cabinet,
     CorporateEntity,
-    CorporateEntityAlias,
-    CorporateEntityLocation,
     Credit,
     CreditRole,
     DisplaySubtype,
@@ -56,7 +51,6 @@ from ..models import (
     GameplayFeature,
     MachineModel,
     MachineModelGameplayFeature,
-    ModelAbbreviation,
     Person,
     RewardType,
     System,
@@ -117,23 +111,6 @@ from .soft_delete import (
 # ---------------------------------------------------------------------------
 # Schemas
 # ---------------------------------------------------------------------------
-
-
-class ModelGridItemSchema(Schema):
-    name: str
-    slug: str
-    year: int | None = None
-    manufacturer_name: str | None = None
-    technology_generation_name: str | None = None
-    thumbnail_url: str | None = None
-    abbreviations: list[str] = []
-    search_text: str | None = None
-    title_slug: str | None = None
-
-
-_ALL_ADAPTER: TypeAdapter[list[ModelGridItemSchema]] = TypeAdapter(
-    list[ModelGridItemSchema]
-)
 
 
 class ModelListItemSchema(Schema):
@@ -698,171 +675,6 @@ def list_recent_models(request: HttpRequest) -> list[ModelRecentSchema]:
         if len(results) == 3:
             break
     return results
-
-
-@models_router.get("/all/", response=list[ModelGridItemSchema])
-@decorate_view(cache_control(no_cache=True))
-def list_all_models(
-    request: HttpRequest,
-) -> HttpResponse | list[dict[str, Any]]:
-    """Return every model (including variants) for client-side search/grid.
-
-    Performance-critical: serializes ~7k models with search_text built from
-    M2M relations.  Uses ``values_list`` to avoid ORM object hydration and
-    bulk through-table queries for M2M data.  See ``list_all_titles`` for
-    the full explanation of this pattern.
-    """
-    response = get_cached_response(models_all_key())
-    if response is not None:
-        return response
-
-    min_rank = get_minimum_display_rank()
-
-    rows = list(
-        MachineModel.objects.active()
-        .annotate(
-            mfr_id=F("corporate_entity__manufacturer__id"),
-            mfr_name=F("corporate_entity__manufacturer__name"),
-            tech_gen_name=F("technology_generation__name"),
-            display_type_name=F("display_type__name"),
-            display_subtype_name=F("display_subtype__name"),
-            title_slug=F("title__slug"),
-            system_name=F("system__name"),
-            cabinet_name=F("cabinet__name"),
-            game_format_name=F("game_format__name"),
-        )
-        .values_list(
-            "id",
-            "name",
-            "slug",
-            "year",
-            "extra_data",
-            "mfr_id",
-            "mfr_name",
-            "tech_gen_name",
-            "display_type_name",
-            "display_subtype_name",
-            "title_slug",
-            "system_name",
-            "cabinet_name",
-            "game_format_name",
-            named=True,
-        )
-        .order_by("name")
-    )
-    model_ids = {r.id for r in rows}
-    media_by_model = fetch_model_media_map(model_ids)
-
-    # --- Bulk M2M queries for search_text ---
-    model_themes: dict[int, list[str]] = defaultdict(list)
-    for mid, name in MachineModel.themes.through.objects.filter(
-        machinemodel_id__in=model_ids
-    ).values_list("machinemodel_id", "theme__name"):
-        model_themes[mid].append(name)
-
-    model_tags: dict[int, list[str]] = defaultdict(list)
-    for mid, name in MachineModel.tags.through.objects.filter(
-        machinemodel_id__in=model_ids
-    ).values_list("machinemodel_id", "tag__name"):
-        model_tags[mid].append(name)
-
-    model_gf: dict[int, list[str]] = defaultdict(list)
-    for mid, name in MachineModel.gameplay_features.through.objects.filter(
-        machinemodel_id__in=model_ids
-    ).values_list("machinemodel_id", "gameplayfeature__name"):
-        model_gf[mid].append(name)
-
-    model_credits: dict[int, list[str]] = defaultdict(list)
-    for mid, name in Credit.objects.filter(model_id__in=model_ids).values_list(
-        "model_id", "person__name"
-    ):
-        model_credits[mid].append(name)
-
-    model_abbrevs: dict[int, list[str]] = defaultdict(list)
-    for mid, value in ModelAbbreviation.objects.filter(
-        machine_model_id__in=model_ids
-    ).values_list("machine_model_id", "value"):
-        model_abbrevs[mid].append(value)
-
-    # --- Bulk manufacturer search text (entity names, aliases, locations) ---
-    # Build manufacturer_id → search parts map
-    mfr_search_parts: dict[int, list[str]] = defaultdict(list)
-
-    # Entity names
-    for mfr_id, ename in CorporateEntity.objects.active().values_list(
-        "manufacturer_id", "name"
-    ):
-        if mfr_id:
-            mfr_search_parts[mfr_id].append(ename)
-
-    # Entity aliases
-    for mfr_id, aval in CorporateEntityAlias.objects.filter(
-        corporate_entity__manufacturer__isnull=False
-    ).values_list("corporate_entity__manufacturer_id", "value"):
-        mfr_search_parts[mfr_id].append(aval)
-
-    # Location names (walk hierarchy via pre-fetched chain)
-    for mfr_id, loc_name, p1, p2, p3, p4 in (
-        CorporateEntityLocation.objects.filter(
-            corporate_entity__manufacturer__isnull=False
-        )
-        .select_related("location__parent__parent__parent__parent")
-        .values_list(
-            "corporate_entity__manufacturer_id",
-            "location__name",
-            "location__parent__name",
-            "location__parent__parent__name",
-            "location__parent__parent__parent__name",
-            "location__parent__parent__parent__parent__name",
-        )
-    ):
-        for n in (loc_name, p1, p2, p3, p4):
-            if n:
-                mfr_search_parts[mfr_id].append(n)
-
-    # --- Assembly ---
-    result: list[dict[str, Any]] = []
-    for r in rows:
-        mid = r.id
-        thumbnail_url, _ = extract_image_urls(
-            r.extra_data or {}, media_by_model.get(mid), min_rank=min_rank
-        )
-
-        # Build search_text from bulk maps
-        parts: list[str] = []
-        if r.mfr_name:
-            parts.append(r.mfr_name)
-            parts.extend(mfr_search_parts.get(r.mfr_id, []))
-        for name in (
-            r.system_name,
-            r.tech_gen_name,
-            r.display_type_name,
-            r.display_subtype_name,
-            r.cabinet_name,
-            r.game_format_name,
-        ):
-            if name:
-                parts.append(name)
-        parts.extend(model_themes.get(mid, []))
-        parts.extend(model_tags.get(mid, []))
-        parts.extend(model_gf.get(mid, []))
-        parts.extend(model_credits.get(mid, []))
-        parts.extend(model_abbrevs.get(mid, []))
-
-        result.append(
-            {
-                "name": r.name,
-                "slug": r.slug,
-                "year": r.year,
-                "manufacturer_name": r.mfr_name,
-                "technology_generation_name": r.tech_gen_name,
-                "thumbnail_url": thumbnail_url,
-                "abbreviations": model_abbrevs.get(mid, []),
-                "search_text": " | ".join(parts) if parts else None,
-                "title_slug": r.title_slug,
-            }
-        )
-    return set_cached_response(models_all_key(), _ALL_ADAPTER, result)
 
 
 @models_router.get("/edit-options/", response=ModelEditOptionsSchema)

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -398,6 +398,44 @@ def list_manufacturers(
 
 
 # ---------------------------------------------------------------------------
+# Global search — the Manufacturers section of GET /api/pages/search
+# ---------------------------------------------------------------------------
+
+
+class ManufacturerSearchSectionSchema(Schema):
+    """The Manufacturers section of the global ``/search`` page: up to 10 cards plus
+    a ``has_more`` flag (the section caps at 10; the frontend links to
+    ``/manufacturers?q=`` for the rest). ``items`` reuses the listing card so a section
+    row matches the ``/manufacturers`` grid exactly."""
+
+    items: list[ManufacturerCardSchema]
+    has_more: bool
+
+
+def manufacturer_search_section(
+    q: str, *, min_rank: int
+) -> ManufacturerSearchSectionSchema:
+    """Top ≤10 manufacturer cards matching ``q``, composing the **ordered** listing
+    queryset + card serializer so results match ``/manufacturers?q=`` exactly. Slices
+    ``[:11]`` to detect ">10" without a second ``count()``."""
+    rows = list(ordered(MfrFilters(q=q))[:11])
+    items = rows[:10]
+    thumbnails = _page_thumbnails([m.pk for m in items], min_rank=min_rank)
+    return ManufacturerSearchSectionSchema(
+        items=[
+            ManufacturerCardSchema(
+                name=m.name,
+                slug=m.slug,
+                model_count=cast(HasModelCount, m).model_count,
+                thumbnail_url=thumbnails.get(m.pk),
+            )
+            for m in items
+        ],
+        has_more=len(rows) > 10,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Listing page — facet options (GET /api/pages/manufacturers)
 # ---------------------------------------------------------------------------
 

--- a/backend/apps/catalog/api/page_endpoints.py
+++ b/backend/apps/catalog/api/page_endpoints.py
@@ -15,7 +15,7 @@ Auto-discovered via the ``routers`` list convention in config/api.py.
 from __future__ import annotations
 
 from django.http import HttpRequest, HttpResponse
-from ninja import Query, Router
+from ninja import Query, Router, Schema
 
 from apps.catalog.models import (
     Cabinet,
@@ -38,6 +38,7 @@ from apps.catalog.models import (
     Theme,
     Title,
 )
+from apps.core.licensing import get_minimum_display_rank
 
 from .corporate_entities import CorporateEntityDetailSchema
 from .corporate_entities import _detail_qs as _corp_entity_detail_qs
@@ -60,11 +61,19 @@ from .manufacturers import (
     ManufacturerDetailSchema,
     ManufacturerFacetsPageSchema,
     ManufacturerFilterQuerySchema,
+    ManufacturerSearchSectionSchema,
     _manufacturer_qs,
     _serialize_manufacturer_detail,
     manufacturer_facets_response,
+    manufacturer_search_section,
 )
-from .people import PersonDetailSchema, _person_qs, _serialize_person_detail
+from .people import (
+    PersonDetailSchema,
+    PersonSearchSectionSchema,
+    _person_qs,
+    _serialize_person_detail,
+    person_search_section,
+)
 from .series import SeriesDetailSchema, _serialize_series_detail, _series_detail_qs
 from .systems import SystemDetailSchema, _serialize_system_detail, _system_detail_qs
 from .taxonomy import (
@@ -89,12 +98,59 @@ from .titles import (
     TitleDetailSchema,
     TitleFacetsPageSchema,
     TitleFilterQuerySchema,
+    TitleSearchSectionSchema,
     _serialize_title_detail,
     title_facets_response,
+    title_search_section,
 )
 from .titles import _detail_qs as _title_detail_qs
 
 pages_router = Router(tags=["private"])
+
+# Minimum trimmed ``q`` length the global search acts on. Below this the endpoint
+# returns empty sections without touching the DB, and the SvelteKit page shows a
+# "type at least N characters" hint instead of calling the endpoint.
+_MIN_SEARCH_CHARS = 3
+
+
+class SearchResultsSchema(Schema):
+    """Global ``/search`` payload: three stacked entity sections in fixed render
+    order (Titles → Manufacturers → People). The frontend renders them in this
+    declaration order; there is no Models section (models only roll up into titles
+    elsewhere, and search doesn't surface them)."""
+
+    titles: TitleSearchSectionSchema
+    manufacturers: ManufacturerSearchSectionSchema
+    people: PersonSearchSectionSchema
+
+
+def _empty_search_results() -> SearchResultsSchema:
+    """All three sections empty — the ``q`` too short / no-work response."""
+    return SearchResultsSchema(
+        titles=TitleSearchSectionSchema(items=[], has_more=False),
+        manufacturers=ManufacturerSearchSectionSchema(items=[], has_more=False),
+        people=PersonSearchSectionSchema(items=[], has_more=False),
+    )
+
+
+@pages_router.get("/search", response=SearchResultsSchema)
+def search_page(request: HttpRequest, q: str = "") -> SearchResultsSchema:
+    """Global search across Titles, Manufacturers and People for the ``/search`` SSR
+    page. Each section composes that entity's ordered listing queryset + card
+    serializer (so a section's top rows match its ``/…?q=`` listing) and caps at 10
+    with a ``has_more`` flag. Trimmed ``q`` shorter than ``_MIN_SEARCH_CHARS`` returns
+    empty sections without querying. Uncached — free-text ``q`` has a poor cache hit
+    rate, and each query is narrow + ``[:11]`` + index-friendly."""
+    q = q.strip()
+    if len(q) < _MIN_SEARCH_CHARS:
+        return _empty_search_results()
+    # One Constance lookup shared by the title + manufacturer thumbnail resolvers.
+    min_rank = get_minimum_display_rank()
+    return SearchResultsSchema(
+        titles=title_search_section(q, min_rank=min_rank),
+        manufacturers=manufacturer_search_section(q, min_rank=min_rank),
+        people=person_search_section(q),
+    )
 
 
 @pages_router.get("/titles", response=TitleFacetsPageSchema)

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -4,18 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import cast
 
 from django.db import models
 from django.db.models import Count, F, Prefetch, Q, QuerySet
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
-from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
-from ninja.decorators import decorate_view
 from ninja.responses import Status
 from ninja.security import django_auth
-from pydantic import TypeAdapter
 
 from apps.catalog.naming import normalize_catalog_name
 from apps.core.authz.markers import requires
@@ -39,7 +36,6 @@ from apps.provenance.rate_limits import (
 )
 from apps.provenance.schemas import ChangeSetInputSchema
 
-from ..cache import get_cached_response, people_all_key, set_cached_response
 from ..models import Credit, MachineModel, Person
 from ._typing import HasCreditCount
 from .edit_claims import ClaimSpec, execute_claims, plan_scalar_field_claims
@@ -83,9 +79,6 @@ class PersonCardSchema(Schema):
     aliases: list[str] = []
     credit_count: int = 0
     thumbnail_url: str | None = None
-
-
-_ALL_ADAPTER: TypeAdapter[list[PersonCardSchema]] = TypeAdapter(list[PersonCardSchema])
 
 
 class PersonTitleSchema(RelatedTitleSchema):
@@ -214,12 +207,11 @@ def _person_qs() -> QuerySet[Person]:
 def _people_thumbnails(person_pks: Sequence[int]) -> dict[int, str | None]:
     """Newest-credited-model image per person, batched over *person_pks*.
 
-    The single thumbnail source for both the cached ``/all/`` list and the paginated
-    ``GET /`` (the latter via the core's ``ThumbnailProvider`` over one page's pks), so
-    the two presentations can't drift. Picks the newest credited model carrying
-    ``extra_data`` per person, then extracts its display image at the current min rank.
-    Mirrors the original ``list_all_people`` batch — no active-status filter on the
-    credit's model, by design, matching the prior ``/all/`` behavior.
+    The single thumbnail source for the paginated ``GET /`` list (via the core's
+    ``ThumbnailProvider`` over one page's pks) and the global search section, so the two
+    presentations can't drift. Picks the newest credited model carrying ``extra_data``
+    per person, then extracts its display image at the current min rank. No
+    active-status filter on the credit's model, by design.
     """
     if not person_pks:
         return {}
@@ -258,9 +250,9 @@ def _people_thumbnails(person_pks: Sequence[int]) -> dict[int, str | None]:
 
 
 def _person_list_qs() -> QuerySet[Person]:
-    """Active people annotated with total credit count, most-credited first — the
-    ``/all/`` presentation the page renders today (``list_people`` ordered by name).
-    The paginated core appends a ``pk`` tiebreak for stable offset pages."""
+    """Active people annotated with total credit count, most-credited first — the base
+    queryset shared by the paginated ``GET /`` list and the search section. Callers
+    append a ``pk`` tiebreak for a stable total order before slicing."""
     return (
         Person.objects.active()
         .annotate(credit_count=Count("credits"))
@@ -339,37 +331,6 @@ def person_search_section(q: str) -> PersonSearchSectionSchema:
         items=[_serialize_person_row(p, thumbnails.get(p.pk)) for p in items],
         has_more=len(rows) > 10,
     )
-
-
-@people_router.get("/all/", response=list[PersonCardSchema])
-@decorate_view(cache_control(no_cache=True))
-def list_all_people(
-    request: HttpRequest,
-) -> HttpResponse | list[dict[str, Any]]:
-    """Return every person with credit count and thumbnail.
-
-    Uses a bulk query to find the newest credited model per person for
-    thumbnails, instead of prefetching all credits and iterating in Python.
-    See ``list_all_titles`` for the full explanation of this pattern.
-    """
-    response = get_cached_response(people_all_key())
-    if response is not None:
-        return response
-
-    people = list(_person_list_qs())
-    thumbnails = _people_thumbnails([p.pk for p in people])
-
-    result: list[dict[str, Any]] = [
-        {
-            "name": p.name,
-            "slug": p.slug,
-            "aliases": [a.value for a in p.aliases.all()],
-            "credit_count": cast(HasCreditCount, p).credit_count,
-            "thumbnail_url": thumbnails.get(p.pk),
-        }
-        for p in people
-    ]
-    return set_cached_response(people_all_key(), _ALL_ADAPTER, result)
 
 
 @people_router.patch(

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -50,7 +50,7 @@ from .entity_create import (
     validate_name,
     validate_slug_format,
 )
-from .entity_list import paginated_list_response
+from .entity_list import _apply_list_q, paginated_list_response
 from .images import (
     extract_image_urls,
     fetch_model_media_map,
@@ -310,6 +310,35 @@ def list_people(request: HttpRequest, q: str = "", page: int = 1) -> PersonListS
         thumbnail_provider=_people_thumbnails,
     )
     return PersonListSchema(items=result.items, count=result.total)
+
+
+class PersonSearchSectionSchema(Schema):
+    """The People section of the global ``/search`` page: up to 10 cards plus a
+    ``has_more`` flag (the section caps at 10; the frontend links to ``/people?q=``
+    for the rest). ``items`` reuses the listing card so a section row matches the
+    ``/people`` grid exactly."""
+
+    items: list[PersonCardSchema]
+    has_more: bool
+
+
+def person_search_section(q: str) -> PersonSearchSectionSchema:
+    """Top ≤10 person cards matching ``q``, composing the listing queryset + card
+    serializer so results match ``/people?q=`` exactly. Re-applies the explicit
+    ``("-credit_count", "name", "pk")`` total order (``_person_list_qs`` omits the
+    ``pk`` tiebreak, so the slice would be nondeterministic on credit-count ties).
+    Slices ``[:11]`` to detect ">10" without a second ``count()``."""
+    # Splat a tuple (not literal args) so django-stubs doesn't field-check
+    # ``credit_count`` — it's a real annotation from ``_person_list_qs`` that the stub
+    # can't see across the ``_apply_list_q`` boundary (same shape ``list_people`` uses).
+    ordering = ("-credit_count", "name", "pk")
+    rows = list(_apply_list_q(_person_list_qs(), q).order_by(*ordering)[:11])
+    items = rows[:10]
+    thumbnails = _people_thumbnails([p.pk for p in items])
+    return PersonSearchSectionSchema(
+        items=[_serialize_person_row(p, thumbnails.get(p.pk)) for p in items],
+        has_more=len(rows) > 10,
+    )
 
 
 @people_router.get("/all/", response=list[PersonCardSchema])

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -221,7 +221,7 @@ def list_all_series(request: HttpRequest) -> HttpResponse | list[dict[str, Any]]
     editor option-pickers need, which the paginated ``GET /`` can't serve them.
 
     Cached (audience-keyed, busted on any catalog mutation) because it does full-set
-    thumbnail batching + per-row rich text, structurally like ``/api/people/all/``.
+    thumbnail batching + per-row rich text, structurally like ``/api/titles/all/``.
     Emits plain dicts (not Schema instances) so ``set_cached_response`` can serialize
     them; the paginated ``GET /`` uses the Schema-returning ``_serialize_series_row``.
     """

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -870,6 +870,35 @@ def list_titles(
     )
 
 
+# ---------------------------------------------------------------------------
+# Global search — the Titles section of GET /api/pages/search
+# ---------------------------------------------------------------------------
+
+
+class TitleSearchSectionSchema(Schema):
+    """The Titles section of the global ``/search`` page: up to 10 cards plus a
+    ``has_more`` flag (the section caps at 10; the frontend links to ``/titles?q=``
+    for the rest). ``items`` reuses the listing card so a section row matches the
+    ``/titles`` grid exactly."""
+
+    items: list[TitleCardSchema]
+    has_more: bool
+
+
+def title_search_section(q: str, *, min_rank: int) -> TitleSearchSectionSchema:
+    """Top ≤10 title cards matching ``q``, composing the **ordered** listing
+    queryset + card serializer so results match ``/titles?q=`` exactly. Slices
+    ``[:11]`` to detect ">10" without a second ``count()``."""
+    rows = list(
+        ordered_titles(TitleFilters(q=q)).prefetch_related(_card_models_prefetch())[:11]
+    )
+    items = rows[:10]
+    return TitleSearchSectionSchema(
+        items=[_serialize_card(t, min_rank=min_rank) for t in items],
+        has_more=len(rows) > 10,
+    )
+
+
 @titles_router.get("/all/", response=list[TitleListItemSchema])
 @decorate_view(cache_control(no_cache=True))
 def list_all_titles(request: HttpRequest) -> HttpResponse:

--- a/backend/apps/catalog/cache.py
+++ b/backend/apps/catalog/cache.py
@@ -30,9 +30,7 @@ from apps.core.licensing import current_audience
 # unchanged payloads, which rebuild on first read. (Per-bump history: git blame.)
 _CACHE_VERSION = "v4"
 
-_MODELS_ALL_BASE = f"catalog:models:all:{_CACHE_VERSION}"
 _MANUFACTURERS_ALL_BASE = f"catalog:manufacturers:all:{_CACHE_VERSION}"
-_PEOPLE_ALL_BASE = f"catalog:people:all:{_CACHE_VERSION}"
 _SERIES_ALL_BASE = f"catalog:series:all:{_CACHE_VERSION}"
 _TITLES_ALL_BASE = f"catalog:titles:all:{_CACHE_VERSION}"
 # No-filter facet option lists for the /titles page (GET /api/pages/titles). Static
@@ -43,9 +41,7 @@ _MANUFACTURERS_FACETS_BASE = f"catalog:manufacturers:facets:{_CACHE_VERSION}"
 _LOCATIONS_TREE_BASE = f"catalog:locations:tree:{_CACHE_VERSION}"
 
 _BASES: tuple[str, ...] = (
-    _MODELS_ALL_BASE,
     _MANUFACTURERS_ALL_BASE,
-    _PEOPLE_ALL_BASE,
     _SERIES_ALL_BASE,
     _TITLES_ALL_BASE,
     _TITLES_FACETS_BASE,
@@ -56,16 +52,8 @@ _BASES: tuple[str, ...] = (
 _AUDIENCES: tuple[str, ...] = ("default", "kiosk")
 
 
-def models_all_key() -> str:
-    return f"{_MODELS_ALL_BASE}:{current_audience()}"
-
-
 def manufacturers_all_key() -> str:
     return f"{_MANUFACTURERS_ALL_BASE}:{current_audience()}"
-
-
-def people_all_key() -> str:
-    return f"{_PEOPLE_ALL_BASE}:{current_audience()}"
 
 
 def series_all_key() -> str:

--- a/backend/apps/catalog/tests/test_api_cache.py
+++ b/backend/apps/catalog/tests/test_api_cache.py
@@ -2,7 +2,11 @@ import pytest
 from constance.signals import config_updated
 from django.core.cache import cache
 
-from apps.catalog.cache import _MODELS_ALL_BASE, models_all_key, titles_all_key
+from apps.catalog.cache import (
+    _TITLES_ALL_BASE,
+    manufacturers_all_key,
+    titles_all_key,
+)
 from apps.catalog.models import (
     Cabinet,
     CorporateEntity,
@@ -28,7 +32,6 @@ from apps.catalog.models import (
     Title,
 )
 from apps.catalog.signals import _cache_invalidating_models
-from apps.catalog.tests.conftest import make_machine_model
 
 
 class TestAllEndpointCache:
@@ -37,30 +40,6 @@ class TestAllEndpointCache:
         cache.clear()
         yield
         cache.clear()
-
-    def test_models_all_caches_on_second_request(self, client, machine_model):
-        resp1 = client.get("/api/models/all/")
-        assert resp1.status_code == 200
-        assert cache.get(models_all_key()) is not None
-
-        resp2 = client.get("/api/models/all/")
-        assert resp2.json() == resp1.json()
-
-    def test_model_save_invalidates_cache(self, client, machine_model):
-        client.get("/api/models/all/")
-        assert cache.get(models_all_key()) is not None
-
-        machine_model.name = "Medieval Madness LE"
-        machine_model.save()
-        assert cache.get(models_all_key()) is None
-
-    def test_new_model_appears_after_invalidation(self, client, machine_model):
-        resp1 = client.get("/api/models/all/")
-        count_before = len(resp1.json())
-
-        make_machine_model(name="Godzilla", slug="godzilla", year=2021)
-        resp2 = client.get("/api/models/all/")
-        assert len(resp2.json()) == count_before + 1
 
     def test_titles_all_caches_on_second_request(self, client, machine_model):
         resp1 = client.get("/api/titles/all/")
@@ -139,10 +118,10 @@ class TestPolicyChangeInvalidation:
         # Populate both audience slots — default via a vanilla request, kiosk
         # via a request carrying the mode=kiosk cookie. The policy-change
         # signal must clear both.
-        client.get("/api/models/all/")
-        client.get("/api/models/all/", HTTP_COOKIE="mode=kiosk")
-        assert cache.get(f"{_MODELS_ALL_BASE}:default") is not None
-        assert cache.get(f"{_MODELS_ALL_BASE}:kiosk") is not None
+        client.get("/api/titles/all/")
+        client.get("/api/titles/all/", HTTP_COOKIE="mode=kiosk")
+        assert cache.get(f"{_TITLES_ALL_BASE}:default") is not None
+        assert cache.get(f"{_TITLES_ALL_BASE}:kiosk") is not None
 
         config_updated.send(
             sender=None,
@@ -150,12 +129,12 @@ class TestPolicyChangeInvalidation:
             old_value="licensed-only",
             new_value="show-all",
         )
-        assert cache.get(f"{_MODELS_ALL_BASE}:default") is None
-        assert cache.get(f"{_MODELS_ALL_BASE}:kiosk") is None
+        assert cache.get(f"{_TITLES_ALL_BASE}:default") is None
+        assert cache.get(f"{_TITLES_ALL_BASE}:kiosk") is None
 
     def test_unrelated_key_change_does_not_invalidate(self, client, machine_model):
-        client.get("/api/models/all/")
-        assert cache.get(models_all_key()) is not None
+        client.get("/api/titles/all/")
+        assert cache.get(titles_all_key()) is not None
 
         config_updated.send(
             sender=None,
@@ -163,7 +142,7 @@ class TestPolicyChangeInvalidation:
             old_value="a",
             new_value="b",
         )
-        assert cache.get(models_all_key()) is not None
+        assert cache.get(titles_all_key()) is not None
 
 
 class TestKioskAudienceCacheIsolation:
@@ -171,7 +150,7 @@ class TestKioskAudienceCacheIsolation:
 
     The middleware reads ``mode=kiosk`` from request cookies and flips a
     contextvar that ``current_audience()`` reads, which is what
-    ``models_all_key()`` / ``titles_all_key()`` / etc. fold into the
+    ``titles_all_key()`` / ``manufacturers_all_key()`` / etc. fold into the
     cache key.
     """
 
@@ -182,39 +161,39 @@ class TestKioskAudienceCacheIsolation:
         cache.clear()
 
     def test_kiosk_request_populates_kiosk_slot_only(self, client, machine_model):
-        client.get("/api/models/all/", HTTP_COOKIE="mode=kiosk")
-        assert cache.get(f"{_MODELS_ALL_BASE}:kiosk") is not None
-        assert cache.get(f"{_MODELS_ALL_BASE}:default") is None
+        client.get("/api/titles/all/", HTTP_COOKIE="mode=kiosk")
+        assert cache.get(f"{_TITLES_ALL_BASE}:kiosk") is not None
+        assert cache.get(f"{_TITLES_ALL_BASE}:default") is None
 
     def test_default_request_populates_default_slot_only(self, client, machine_model):
-        client.get("/api/models/all/")
-        assert cache.get(f"{_MODELS_ALL_BASE}:default") is not None
-        assert cache.get(f"{_MODELS_ALL_BASE}:kiosk") is None
+        client.get("/api/titles/all/")
+        assert cache.get(f"{_TITLES_ALL_BASE}:default") is not None
+        assert cache.get(f"{_TITLES_ALL_BASE}:kiosk") is None
 
     def test_invalidate_all_clears_both_audience_slots(self, client, machine_model):
         from apps.catalog.cache import invalidate_all
 
-        client.get("/api/models/all/")
-        client.get("/api/models/all/", HTTP_COOKIE="mode=kiosk")
-        assert cache.get(f"{_MODELS_ALL_BASE}:default") is not None
-        assert cache.get(f"{_MODELS_ALL_BASE}:kiosk") is not None
+        client.get("/api/titles/all/")
+        client.get("/api/titles/all/", HTTP_COOKIE="mode=kiosk")
+        assert cache.get(f"{_TITLES_ALL_BASE}:default") is not None
+        assert cache.get(f"{_TITLES_ALL_BASE}:kiosk") is not None
 
         invalidate_all()
 
-        assert cache.get(f"{_MODELS_ALL_BASE}:default") is None
-        assert cache.get(f"{_MODELS_ALL_BASE}:kiosk") is None
+        assert cache.get(f"{_TITLES_ALL_BASE}:default") is None
+        assert cache.get(f"{_TITLES_ALL_BASE}:kiosk") is None
 
     def test_kiosk_payload_not_served_to_default_request(self, client, machine_model):
         # Warm only the kiosk slot.
-        client.get("/api/models/all/", HTTP_COOKIE="mode=kiosk")
-        assert cache.get(f"{_MODELS_ALL_BASE}:kiosk") is not None
-        assert cache.get(f"{_MODELS_ALL_BASE}:default") is None
+        client.get("/api/titles/all/", HTTP_COOKIE="mode=kiosk")
+        assert cache.get(f"{_TITLES_ALL_BASE}:kiosk") is not None
+        assert cache.get(f"{_TITLES_ALL_BASE}:default") is None
 
         # A subsequent default-audience request must not reuse the kiosk
         # slot — it populates its own slot fresh.
-        resp = client.get("/api/models/all/")
+        resp = client.get("/api/titles/all/")
         assert resp.status_code == 200
-        assert cache.get(f"{_MODELS_ALL_BASE}:default") is not None
+        assert cache.get(f"{_TITLES_ALL_BASE}:default") is not None
 
 
 class TestConditionalGet:
@@ -227,7 +206,7 @@ class TestConditionalGet:
         yield
         cache.clear()
 
-    @pytest.mark.parametrize("path", ["/api/models/all/", "/api/titles/all/"])
+    @pytest.mark.parametrize("path", ["/api/titles/all/", "/api/manufacturers/all/"])
     def test_304_on_matching_etag(self, client, machine_model, path):
         resp = client.get(path)
         assert resp.status_code == 200
@@ -237,7 +216,7 @@ class TestConditionalGet:
         resp2 = client.get(path, headers={"If-None-Match": etag})
         assert resp2.status_code == 304
 
-    @pytest.mark.parametrize("path", ["/api/models/all/", "/api/titles/all/"])
+    @pytest.mark.parametrize("path", ["/api/titles/all/", "/api/manufacturers/all/"])
     def test_200_on_stale_etag(self, client, machine_model, path):
         client.get(path)  # populate cache
 
@@ -248,8 +227,8 @@ class TestConditionalGet:
     @pytest.mark.parametrize(
         ("path", "cache_key"),
         [
-            ("/api/models/all/", models_all_key()),
             ("/api/titles/all/", titles_all_key()),
+            ("/api/manufacturers/all/", manufacturers_all_key()),
         ],
     )
     def test_cache_stores_bytes_and_etag(self, client, machine_model, path, cache_key):

--- a/backend/apps/catalog/tests/test_api_models.py
+++ b/backend/apps/catalog/tests/test_api_models.py
@@ -84,17 +84,6 @@ class TestModelsAPI:
         assert data["count"] == 1
         assert data["items"][0]["name"] == "Medieval Madness"
 
-    def test_all_models_includes_variants(self, client, machine_model):
-        make_machine_model(
-            name="Medieval Madness (LE)",
-            slug="medieval-madness-le",
-            variant_of=machine_model,
-        )
-        resp = client.get("/api/models/all/")
-        names = [m["name"] for m in resp.json()]
-        assert "Medieval Madness" in names
-        assert "Medieval Madness (LE)" in names
-
     def test_list_models_thumbnail(self, client, db):
         make_machine_model(
             name="With Image",

--- a/backend/apps/catalog/tests/test_api_people.py
+++ b/backend/apps/catalog/tests/test_api_people.py
@@ -7,7 +7,7 @@ from apps.catalog.models import (
     PersonAlias,
     Title,
 )
-from apps.catalog.tests.conftest import SAMPLE_IMAGES, make_machine_model
+from apps.catalog.tests.conftest import make_machine_model
 
 
 class TestPeopleAPI:
@@ -65,62 +65,14 @@ class TestPeopleAPI:
 
 
 @pytest.mark.django_db
-class TestPeopleListParityWithAll:
-    """The paginated ``GET /`` must serve the same card data the page rendered via
-    ``/all/`` (its source today) — same people, credit_counts, aliases and thumbnails,
-    differing only by pagination. Asserted as set-equality + monotonic ``-credit_count``,
-    not positional: ``/all/`` carries no ``pk`` tiebreak, so tied counts are unordered
-    and a positional diff would be flaky."""
-
-    def _card_keys(self, cards):
-        return {
-            (c["slug"], c["credit_count"], tuple(c["aliases"]), c["thumbnail_url"])
-            for c in cards
-        }
-
-    def test_paginated_matches_all_card_data(self, client, credit_roles):
-        role = CreditRole.objects.get(slug="design")
-        title = Title.objects.create(name="Funhouse", slug="funhouse")
-        m_img = make_machine_model(
-            name="Funhouse",
-            slug="funhouse",
-            title=title,
-            extra_data={"opdb.images": SAMPLE_IMAGES},
-        )
-        m_plain = make_machine_model(name="Taxi", slug="taxi", title=title)
-
-        top = Person.objects.create(name="Top", slug="top", status="active")
-        mid_a = Person.objects.create(name="Mid A", slug="mid-a", status="active")
-        mid_b = Person.objects.create(name="Mid B", slug="mid-b", status="active")
-        Person.objects.create(name="Zero", slug="zero", status="active")
-        PersonAlias.objects.create(person=mid_a, value="Alias A")
-
-        # top: 2 credits (newest model carries an image → thumbnail);
-        # mid_a / mid_b: 1 credit each (a tie); zero: none.
-        Credit.objects.create(model=m_img, person=top, role=role)
-        Credit.objects.create(model=m_plain, person=top, role=role)
-        Credit.objects.create(model=m_img, person=mid_a, role=role)
-        Credit.objects.create(model=m_plain, person=mid_b, role=role)
-
-        all_cards = client.get("/api/people/all/").json()
-        paginated = client.get("/api/people/").json()
-        items = paginated["items"]
-
-        assert paginated["count"] == 4
-        # Same card data, regardless of order or pagination.
-        assert self._card_keys(items) == self._card_keys(all_cards)
-        # Monotonic non-increasing by credit_count (the popularity sort).
-        counts = [c["credit_count"] for c in items]
-        assert counts == sorted(counts, reverse=True)
-        assert items[0]["slug"] == "top"
-        # The thumbnail provider actually ran (top + mid_a credited on the imaged model).
-        assert any(c["thumbnail_url"] for c in items)
+class TestPeopleListAliasFold:
+    """The paginated ``GET /`` list and the search section both pair a
+    ``Count("credits")`` GROUP-BY sort key with alias matching, so the alias fold must
+    stay an ``Exists`` subquery (not a join) — a join would multiply the grouped rows and
+    inflate ``credit_count``."""
 
     def test_q_alias_match_preserves_credit_count(self, client, credit_roles):
-        """People uniquely combine a ``Count("credits")`` GROUP-BY sort key with alias
-        matching. The alias fold must stay an ``Exists`` subquery, not a join — a join
-        would multiply the grouped rows and inflate ``credit_count``. Match by alias on a
-        person with multiple credits and assert the count is exact."""
+        """Match by alias on a person with multiple credits; the count stays exact."""
         role = CreditRole.objects.get(slug="design")
         title = Title.objects.create(name="Funhouse", slug="funhouse")
         m1 = make_machine_model(name="A", slug="a", title=title)

--- a/backend/apps/catalog/tests/test_api_search.py
+++ b/backend/apps/catalog/tests/test_api_search.py
@@ -1,0 +1,186 @@
+"""Tests for the global search page endpoint ``GET /api/pages/search``.
+
+The endpoint stacks three entity sections (Titles → Manufacturers → People), each
+reusing its listing-page ``q`` + card serializer, capped at 10 with a ``has_more``
+flag. These tests pin: the ``<3``-char no-work guard, per-section matching + card
+shape, the 10-cap, the diacritic dev/prod split, fixed section order, that a section
+preserves its listing sort, the all-empty case, and a constant-query N+1 guard.
+"""
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from apps.catalog.models import Credit, CreditRole, Manufacturer, Person, Title
+from apps.catalog.tests.conftest import SAMPLE_IMAGES, make_machine_model
+from apps.provenance.models import Claim, Source
+
+CARD_KEYS = {
+    "titles": {"name", "slug", "year", "model_count", "manufacturer", "thumbnail_url"},
+    "manufacturers": {"name", "slug", "model_count", "thumbnail_url"},
+    "people": {"name", "slug", "aliases", "credit_count", "thumbnail_url"},
+}
+
+
+def _make_manufacturer(name: str, slug: str, source: Source) -> Manufacturer:
+    mfr = Manufacturer.objects.create(name=name, slug=slug)
+    Claim.objects.assert_claim(mfr, "name", name, source=source)
+    return mfr
+
+
+def _make_person(name: str, slug: str, source: Source) -> Person:
+    p = Person.objects.create(name=name, slug=slug)
+    Claim.objects.assert_claim(p, "name", name, source=source)
+    return p
+
+
+@pytest.fixture
+def nova_in_each_section(_bootstrap_source):
+    """One matching row per section for the term ``nova``."""
+    Title.objects.create(name="Nova Madness", slug="nova-madness")
+    _make_manufacturer("Nova Games", "nova-games", _bootstrap_source)
+    _make_person("Nova Lawlor", "nova-lawlor", _bootstrap_source)
+
+
+def test_short_q_returns_empty_sections_and_does_no_db_work(
+    client, db, django_assert_num_queries
+):
+    """Trimmed ``q`` shorter than 3 chars → all sections empty, no queries run."""
+    with django_assert_num_queries(0):
+        resp = client.get("/api/pages/search?q=no")
+    assert resp.status_code == 200
+    data = resp.json()
+    for section in ("titles", "manufacturers", "people"):
+        assert data[section] == {"items": [], "has_more": False}
+
+
+def test_whitespace_q_is_trimmed_below_threshold(client, db):
+    """A two-char term padded with spaces is still below the 3-char floor."""
+    resp = client.get("/api/pages/search?q=%20%20ab%20%20")
+    data = resp.json()
+    assert all(not data[s]["items"] for s in ("titles", "manufacturers", "people"))
+
+
+def test_basic_q_matches_each_section_with_card_shape(client, nova_in_each_section):
+    resp = client.get("/api/pages/search?q=nova")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["titles"]["items"][0]["name"] == "Nova Madness"
+    assert data["manufacturers"]["items"][0]["name"] == "Nova Games"
+    assert data["people"]["items"][0]["name"] == "Nova Lawlor"
+    for section, keys in CARD_KEYS.items():
+        assert set(data[section]["items"][0]) == keys
+        assert data[section]["has_more"] is False
+
+
+def test_section_caps_at_ten_and_sets_has_more(client, db, _bootstrap_source):
+    """11 matches → 10 cards + ``has_more``; the other sections stay empty."""
+    for i in range(11):
+        _make_manufacturer(f"Capco {i:02d}", f"capco-{i:02d}", _bootstrap_source)
+    data = client.get("/api/pages/search?q=capco").json()
+    assert len(data["manufacturers"]["items"]) == 10
+    assert data["manufacturers"]["has_more"] is True
+    assert data["titles"] == {"items": [], "has_more": False}
+    assert data["people"] == {"items": [], "has_more": False}
+
+
+def test_exactly_ten_matches_does_not_set_has_more(client, db, _bootstrap_source):
+    for i in range(10):
+        _make_manufacturer(f"Tenco {i:02d}", f"tenco-{i:02d}", _bootstrap_source)
+    data = client.get("/api/pages/search?q=tenco").json()
+    assert len(data["manufacturers"]["items"]) == 10
+    assert data["manufacturers"]["has_more"] is False
+
+
+def test_q_diacritic_is_backend_specific(client, db):
+    """Folds diacritics on Postgres only (prod), plain ``icontains`` on SQLite (dev/CI)
+    — the same documented gap the listing endpoints carry. Exact spelling matches on
+    both backends."""
+    Title.objects.create(name="Pokémon Pinball", slug="pokemon-pinball-search")
+    folded = client.get("/api/pages/search?q=pokemon").json()["titles"]
+    exact = client.get("/api/pages/search?q=Pok%C3%A9mon").json()["titles"]
+    assert len(exact["items"]) == 1
+    expected = 1 if connection.vendor == "postgresql" else 0
+    assert len(folded["items"]) == expected
+
+
+def test_section_order_is_titles_manufacturers_people(client, nova_in_each_section):
+    """The wire payload renders sections in fixed declaration order."""
+    data = client.get("/api/pages/search?q=nova").json()
+    assert list(data.keys()) == ["titles", "manufacturers", "people"]
+
+
+def test_no_match_returns_all_empty_sections(client, nova_in_each_section):
+    data = client.get("/api/pages/search?q=zzzznomatch").json()
+    for section in ("titles", "manufacturers", "people"):
+        assert data[section] == {"items": [], "has_more": False}
+
+
+def test_people_section_preserves_listing_order(
+    client, db, _bootstrap_source, credit_roles, williams_entity
+):
+    """A section's rows are a prefix of its listing — so the People section must keep
+    the ``-credit_count, name, pk`` order. This guards the explicit ``order_by`` the
+    search builder re-applies (``_person_list_qs`` drops the ``pk`` tiebreak); the
+    chosen names sort the opposite way alphabetically, so a result ordered by name
+    instead of credit count would fail.
+    """
+    mm = make_machine_model(
+        name="Order Game", slug="order-game", corporate_entity=williams_entity
+    )
+    design = CreditRole.objects.get(slug="design")
+    art = CreditRole.objects.get(slug="art")
+
+    # Names sort the OPPOSITE way to credit count, so a by-name regression fails.
+    two = _make_person("Order Zzz", "order-zzz", _bootstrap_source)  # 2 credits
+    one = _make_person("Order Mmm", "order-mmm", _bootstrap_source)  # 1 credit
+    _make_person("Order Aaa", "order-aaa", _bootstrap_source)  # 0 credits
+    Credit.objects.create(model=mm, person=two, role=design)
+    Credit.objects.create(model=mm, person=two, role=art)
+    Credit.objects.create(model=mm, person=one, role=design)
+
+    names = [
+        p["name"]
+        for p in client.get("/api/pages/search?q=order").json()["people"]["items"]
+    ]
+    assert names == ["Order Zzz", "Order Mmm", "Order Aaa"]
+
+
+def test_query_count_is_constant_across_result_size(
+    client, db, _bootstrap_source, credit_roles, williams_entity
+):
+    """N+1 guard: each section batches its rows, related cards and thumbnails, so the
+    query count must not grow with the number of matching rows. Rows carry real models,
+    manufacturers, credits and media so the card serializers exercise their
+    select_related / prefetch / thumbnail paths — a dropped prefetch would surface here
+    as a per-row query.
+    """
+    design = CreditRole.objects.get(slug="design")
+
+    def add_matching_row(i: int) -> None:
+        model = make_machine_model(
+            name=f"Scale Title {i}",
+            slug=f"scale-title-{i}",
+            corporate_entity=williams_entity,
+            year=1990 + i,
+            extra_data={"opdb.images": SAMPLE_IMAGES},
+        )
+        _make_manufacturer(f"Scale Mfr {i}", f"scale-mfr-{i}", _bootstrap_source)
+        person = _make_person(
+            f"Scale Person {i}", f"scale-person-{i}", _bootstrap_source
+        )
+        Credit.objects.create(model=model, person=person, role=design)
+
+    def query_count() -> int:
+        with CaptureQueriesContext(connection) as ctx:
+            client.get("/api/pages/search?q=scale")
+        return len(ctx)
+
+    add_matching_row(1)
+    small = query_count()
+
+    for i in range(2, 9):
+        add_matching_row(i)
+    large = query_count()
+
+    assert small == large

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -18,3 +18,11 @@ export { NARROW_BREAKPOINT, WIDE_BREAKPOINT } from './breakpoints.js';
 
 /** Build a browser tab title like "Manufacturers — Flipcommons Pinball Encyclopedia". */
 export const pageTitle = (name: string) => `${name} — ${SITE_TITLE}`;
+
+/**
+ * Minimum trimmed query length the global `/search` page acts on. Below this the
+ * page shows a "type at least N characters" hint and skips the request. Mirrors
+ * the backend's own floor (`_MIN_SEARCH_CHARS`), which stays the source of truth
+ * and returns empty sections below it regardless.
+ */
+export const MIN_SEARCH_QUERY_LENGTH = 3;

--- a/frontend/src/routes/search/+page.server.ts
+++ b/frontend/src/routes/search/+page.server.ts
@@ -1,0 +1,29 @@
+import { error } from '@sveltejs/kit';
+import { createServerClient } from '$lib/api/server';
+import { MIN_SEARCH_QUERY_LENGTH } from '$lib/constants';
+import type { PageServerLoad } from './$types';
+
+/**
+ * SSR load for /search. With a long-enough `q` the one search endpoint is
+ * **awaited** so the result cards land in the server HTML (fast first paint, no
+ * client blob loads). Below the threshold we return `results: null` and skip the
+ * call — the page renders the "type at least N characters" hint. A backend
+ * failure surfaces as an error page rather than a misleading empty result set.
+ */
+export const load: PageServerLoad = async ({ fetch, url, request }) => {
+  const client = createServerClient(fetch, url, request);
+  const q = (url.searchParams.get('q') ?? '').trim();
+
+  if (q.length < MIN_SEARCH_QUERY_LENGTH) {
+    return { q, results: null };
+  }
+
+  const { data, response } = await client.GET('/api/pages/search', {
+    params: { query: { q } },
+  });
+  if (!data) {
+    throw error(response.status || 500, 'Search failed');
+  }
+
+  return { q, results: data };
+};

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -1,58 +1,88 @@
 <script lang="ts">
-  import { afterNavigate, replaceState } from '$app/navigation';
-  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { navigating } from '$app/state';
+  import { resolve } from '$app/paths';
   import SearchBox from '$lib/components/ui/SearchBox.svelte';
   import SearchResults from './_components/SearchResults.svelte';
-  import { SITE_TITLE } from '$lib/constants';
-  import { resolve } from '$app/paths';
+  import { MIN_SEARCH_QUERY_LENGTH, pageTitle } from '$lib/constants';
 
-  let searchQuery = $state('');
-  let lastSyncedQ = '';
+  let { data } = $props();
 
-  // Sync URL → state. Uses window.location directly because page.url
-  // may still reflect the prerendered URL (no query params) during hydration.
-  function syncFromUrl() {
-    const urlQ = new URLSearchParams(window.location.search).get('q') ?? '';
-    searchQuery = urlQ;
-    lastSyncedQ = urlQ.trim();
-  }
+  // Writable `$derived`: re-adopts `data.q` whenever the load re-runs (a debounce
+  // landing, back/forward), but stays locally writable so it can bind the input.
+  let queryInput = $derived(data.q);
 
-  // onMount guarantees we read the real browser URL after hydration.
-  onMount(syncFromUrl);
-
-  // afterNavigate handles back/forward navigation (does NOT fire on replaceState).
-  afterNavigate(syncFromUrl);
-
-  // State → URL: update query string as user types.
+  // Debounce typing → one `goto ?q=` per pause, which re-runs the SSR load.
+  // `replaceState` so typing a multi-character query leaves a single history
+  // entry, not one per keystroke-pause. Skipped when the input already matches
+  // the committed `q` (seed / popstate / our own goto's landing, each of which
+  // resets `queryInput` via the `$derived` above) so there's no echo loop.
+  let timer: ReturnType<typeof setTimeout> | undefined;
   $effect(() => {
-    const q = searchQuery.trim();
-    if (q !== lastSyncedQ) {
-      lastSyncedQ = q;
-      const search = q ? `?q=${encodeURIComponent(q)}` : '';
-      replaceState(`${resolve('/search')}${search}`, {});
-    }
+    const next = queryInput.trim();
+    if (next === data.q) return;
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      const search = next ? `?q=${encodeURIComponent(next)}` : '';
+      void goto(`${resolve('/search')}${search}`, {
+        keepFocus: true,
+        replaceState: true,
+        noScroll: true,
+      });
+    }, 250);
+    return () => clearTimeout(timer);
   });
+
+  // A real (≥ MIN) query whose SSR load is in flight. Keyed off `queryInput` (the
+  // live input), so it's true the moment the debounced `goto` starts — covering the
+  // FIRST query (no prior results to dim yet → a "Searching…" line) as well as
+  // query-to-query edits (dim the results already on screen). Sub-threshold navs —
+  // typing 1–2 chars, or clearing back toward the hint — don't count, since those
+  // skip the backend.
+  let searching = $derived(
+    navigating.to?.route.id === '/search' && queryInput.trim().length >= MIN_SEARCH_QUERY_LENGTH,
+  );
 </script>
 
 <svelte:head>
-  <title>Search — {SITE_TITLE}</title>
-  <link rel="preload" as="fetch" href="/api/titles/all/" crossorigin="anonymous" />
-  <link rel="preload" as="fetch" href="/api/manufacturers/all/" crossorigin="anonymous" />
-  <link rel="preload" as="fetch" href="/api/models/all/" crossorigin="anonymous" />
-  <link rel="preload" as="fetch" href="/api/people/all/" crossorigin="anonymous" />
+  <title>{pageTitle('Search')}</title>
 </svelte:head>
 
 <div class="search-page">
   <SearchBox
-    bind:value={searchQuery}
+    bind:value={queryInput}
     placeholder="Search titles, manufacturers, people..."
     autofocus
   />
-  <SearchResults query={searchQuery} />
+
+  {#if !searching && data.q.length > 0 && data.q.length < MIN_SEARCH_QUERY_LENGTH}
+    <p class="hint">Type at least {MIN_SEARCH_QUERY_LENGTH} characters to search</p>
+  {:else if data.results}
+    <div class="results" class:pending={searching}>
+      <SearchResults results={data.results} q={data.q} />
+    </div>
+  {:else if searching}
+    <p class="hint">Searching…</p>
+  {/if}
 </div>
 
 <style>
   .search-page {
     padding: var(--size-5) 0;
+  }
+
+  .hint {
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-1);
+    margin-top: var(--size-2);
+  }
+
+  .results {
+    transition: opacity 0.15s var(--ease-2);
+  }
+
+  .results.pending {
+    opacity: 0.55;
   }
 </style>

--- a/frontend/src/routes/search/+page.ts
+++ b/frontend/src/routes/search/+page.ts
@@ -1,1 +1,0 @@
-export const prerender = true;

--- a/frontend/src/routes/search/_components/SearchResults.svelte
+++ b/frontend/src/routes/search/_components/SearchResults.svelte
@@ -1,129 +1,45 @@
 <script lang="ts">
-  import { SvelteSet } from 'svelte/reactivity';
-  import client from '$lib/api/client';
-  import { createAsyncLoader } from '$lib/async-loader.svelte';
+  import { resolve } from '$app/paths';
   import CardGrid from '$lib/components/collections/grid/CardGrid.svelte';
   import ManufacturerCard from '$lib/components/collections/cards/ManufacturerCard.svelte';
   import PersonCard from '$lib/components/collections/cards/PersonCard.svelte';
   import TitleCard from '$lib/components/collections/cards/TitleCard.svelte';
-  import { normalizeText } from '$lib/utils';
+  import type { SearchResultsSchema } from '$lib/api/schema';
 
-  const MIN_QUERY_LENGTH = 2;
-  const PREVIEW_SIZE = 5;
+  let { results, q }: { results: SearchResultsSchema; q: string } = $props();
 
-  let { query }: { query: string } = $props();
+  // A section caps at 10; when `has_more`, link to that entity's listing page,
+  // which already does the same server-side `q` search with pagination. So a
+  // capped section is a doorway to the full result set, not a dead end.
+  const titlesHref = $derived(`${resolve('/titles')}?q=${encodeURIComponent(q)}`);
+  const manufacturersHref = $derived(`${resolve('/manufacturers')}?q=${encodeURIComponent(q)}`);
+  const peopleHref = $derived(`${resolve('/people')}?q=${encodeURIComponent(q)}`);
 
-  let expanded: Record<string, boolean> = $state({});
-
-  const titles = createAsyncLoader(async () => {
-    const { data } = await client.GET('/api/titles/all/');
-    return data ?? [];
-  }, []);
-
-  const manufacturers = createAsyncLoader(async () => {
-    const { data } = await client.GET('/api/manufacturers/all/');
-    return data ?? [];
-  }, []);
-
-  const models = createAsyncLoader(async () => {
-    const { data } = await client.GET('/api/models/all/');
-    return data ?? [];
-  }, []);
-
-  const people = createAsyncLoader(async () => {
-    const { data } = await client.GET('/api/people/all/');
-    return data ?? [];
-  }, []);
-
-  // Reset expanded when query changes
-  $effect(() => {
-    void query;
-    expanded = {};
-  });
-
-  let normalizedQuery = $derived(normalizeText(query.trim()));
-  let isSearching = $derived(normalizedQuery.length >= MIN_QUERY_LENGTH);
-
-  function textMatches(q: string, ...fields: (string | number | null | undefined)[]): boolean {
-    return fields.some((f) => f != null && normalizeText(String(f)).includes(q));
-  }
-
-  let matchedModels = $derived.by(() => {
-    if (!isSearching) return [];
-    return models.data.filter(
-      (m) =>
-        textMatches(normalizedQuery, m.name, ...(m.abbreviations ?? [])) ||
-        (m.search_text && normalizeText(m.search_text).includes(normalizedQuery)),
-    );
-  });
-
-  // Title slugs from matched models for roll-up
-  let rollupTitleSlugs = $derived.by(() => {
-    const slugs = new SvelteSet<string>();
-    for (const m of matchedModels) {
-      if (m.title_slug) slugs.add(m.title_slug);
-    }
-    return slugs;
-  });
-
-  let matchedTitles = $derived.by(() => {
-    if (!isSearching) return [];
-    return titles.data.filter(
-      (t) =>
-        textMatches(normalizedQuery, t.name, ...(t.abbreviations ?? [])) ||
-        rollupTitleSlugs.has(t.slug),
-    );
-  });
-
-  let matchedManufacturers = $derived.by(() => {
-    if (!isSearching) return [];
-    return manufacturers.data.filter(
-      (m) =>
-        textMatches(normalizedQuery, m.name) ||
-        (m.search_text && normalizeText(m.search_text).includes(normalizedQuery)),
-    );
-  });
-
-  let matchedPeople = $derived.by(() => {
-    if (!isSearching) return [];
-    return people.data.filter((p) => textMatches(normalizedQuery, p.name));
-  });
-
-  let totalResults = $derived(
-    matchedTitles.length + matchedManufacturers.length + matchedPeople.length,
+  const shownCount = $derived(
+    results.titles.items.length + results.manufacturers.items.length + results.people.items.length,
   );
+  const empty = $derived(shownCount === 0);
 
-  let anyLoading = $derived(
-    titles.loading || models.loading || manufacturers.loading || people.loading,
+  // Concise summary for assistive tech. One persistent live region whose text
+  // swaps on each load announces just this line once the debounce settles —
+  // unlike wrapping the card grid, which would re-read every card per keystroke.
+  const statusText = $derived(
+    empty ? `No results for "${q}"` : `Showing ${shownCount} result${shownCount === 1 ? '' : 's'}`,
   );
-
-  function toggleGroup(group: string) {
-    expanded[group] = !expanded[group];
-  }
 </script>
 
-{#if query.trim().length > 0 && query.trim().length < MIN_QUERY_LENGTH}
-  <p class="hint">Type at least {MIN_QUERY_LENGTH} characters to search</p>
-{/if}
+<p class="visually-hidden" aria-live="polite">{statusText}</p>
 
-{#if isSearching}
-  <div class="results-summary">
-    {#if anyLoading}
-      <p class="count">Searching...</p>
-    {:else}
-      <p class="count">
-        {totalResults.toLocaleString()} result{totalResults === 1 ? '' : 's'}
-      </p>
-    {/if}
-  </div>
-
-  {#if matchedTitles.length > 0}
-    {@const showAll = expanded['titles']}
-    {@const items = showAll ? matchedTitles : matchedTitles.slice(0, PREVIEW_SIZE)}
+{#if empty}
+  <!-- aria-hidden: the visually-hidden live region above already announces this
+       to assistive tech, so don't read it a second time in the reading order. -->
+  <p class="no-results" aria-hidden="true">No results for "{q}"</p>
+{:else}
+  {#if results.titles.items.length > 0}
     <section class="result-group">
-      <h2>Titles <span class="group-count">{matchedTitles.length}</span></h2>
+      <h2>Titles</h2>
       <CardGrid>
-        {#each items as title (title.slug)}
+        {#each results.titles.items as title (title.slug)}
           <TitleCard
             slug={title.slug}
             name={title.name}
@@ -133,23 +49,17 @@
           />
         {/each}
       </CardGrid>
-      {#if matchedTitles.length > PREVIEW_SIZE}
-        <button class="see-all" onclick={() => toggleGroup('titles')}>
-          {showAll ? 'Show less' : `See all ${matchedTitles.length.toLocaleString()} titles`}
-        </button>
+      {#if results.titles.has_more}
+        <a class="see-all" href={titlesHref}>See all Titles matching "{q}" →</a>
       {/if}
     </section>
   {/if}
 
-  {#if matchedManufacturers.length > 0}
-    {@const showAll = expanded['manufacturers']}
-    {@const items = showAll ? matchedManufacturers : matchedManufacturers.slice(0, PREVIEW_SIZE)}
+  {#if results.manufacturers.items.length > 0}
     <section class="result-group">
-      <h2>
-        Manufacturers <span class="group-count">{matchedManufacturers.length}</span>
-      </h2>
+      <h2>Manufacturers</h2>
       <CardGrid>
-        {#each items as mfr (mfr.slug)}
+        {#each results.manufacturers.items as mfr (mfr.slug)}
           <ManufacturerCard
             slug={mfr.slug}
             name={mfr.name}
@@ -158,23 +68,17 @@
           />
         {/each}
       </CardGrid>
-      {#if matchedManufacturers.length > PREVIEW_SIZE}
-        <button class="see-all" onclick={() => toggleGroup('manufacturers')}>
-          {showAll
-            ? 'Show less'
-            : `See all ${matchedManufacturers.length.toLocaleString()} manufacturers`}
-        </button>
+      {#if results.manufacturers.has_more}
+        <a class="see-all" href={manufacturersHref}>See all Manufacturers matching "{q}" →</a>
       {/if}
     </section>
   {/if}
 
-  {#if matchedPeople.length > 0}
-    {@const showAll = expanded['people']}
-    {@const items = showAll ? matchedPeople : matchedPeople.slice(0, PREVIEW_SIZE)}
+  {#if results.people.items.length > 0}
     <section class="result-group">
-      <h2>People <span class="group-count">{matchedPeople.length}</span></h2>
+      <h2>People</h2>
       <CardGrid>
-        {#each items as person (person.slug)}
+        {#each results.people.items as person (person.slug)}
           <PersonCard
             slug={person.slug}
             name={person.name}
@@ -183,37 +87,14 @@
           />
         {/each}
       </CardGrid>
-      {#if matchedPeople.length > PREVIEW_SIZE}
-        <button class="see-all" onclick={() => toggleGroup('people')}>
-          {showAll ? 'Show less' : `See all ${matchedPeople.length.toLocaleString()} people`}
-        </button>
+      {#if results.people.has_more}
+        <a class="see-all" href={peopleHref}>See all People matching "{q}" →</a>
       {/if}
     </section>
-  {/if}
-
-  {#if !anyLoading && totalResults === 0}
-    <p class="no-results">No results found for "{query.trim()}"</p>
   {/if}
 {/if}
 
 <style>
-  .hint {
-    text-align: center;
-    color: var(--color-text-muted);
-    font-size: var(--font-size-1);
-    margin-top: var(--size-2);
-  }
-
-  .results-summary {
-    text-align: center;
-    margin-bottom: var(--size-4);
-  }
-
-  .count {
-    color: var(--color-text-muted);
-    font-size: var(--font-size-1);
-  }
-
   .result-group {
     margin-bottom: var(--size-6);
   }
@@ -223,35 +104,13 @@
     font-weight: 600;
     color: var(--color-text);
     margin-bottom: var(--size-3);
-    display: flex;
-    align-items: baseline;
-    gap: var(--size-2);
-  }
-
-  .group-count {
-    font-size: var(--font-size-1);
-    font-weight: 400;
-    color: var(--color-text-muted);
   }
 
   .see-all {
-    display: block;
-    margin: var(--size-3) auto 0;
-    padding: var(--size-2) var(--size-4);
-    background: none;
-    border: 1px solid var(--color-border-soft);
-    border-radius: var(--radius-2);
+    display: inline-block;
+    margin-top: var(--size-3);
     color: var(--color-link);
     font-size: var(--font-size-1);
-    cursor: pointer;
-    transition:
-      background-color 0.15s ease,
-      border-color 0.15s ease;
-  }
-
-  .see-all:hover {
-    background-color: var(--color-surface);
-    border-color: var(--color-link);
   }
 
   .no-results {

--- a/frontend/src/routes/search/search-page.dom.test.ts
+++ b/frontend/src/routes/search/search-page.dom.test.ts
@@ -1,0 +1,166 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SearchResultsSchema } from '$lib/api/schema';
+
+const { goto, navigating } = vi.hoisted(() => ({
+  goto: vi.fn(),
+  // Mutable so a test can simulate an in-flight navigation to /search. Read at
+  // render time; reset before each test.
+  navigating: { to: null as { route: { id: string | null } } | null },
+}));
+vi.mock('$app/navigation', () => ({ goto }));
+// `navigating` drives the pending affordance; `page` is read by card/meta helpers.
+vi.mock('$app/state', () => ({
+  navigating,
+  page: { url: new URL('http://localhost/search') },
+}));
+
+import Page from './+page.svelte';
+
+beforeEach(() => {
+  navigating.to = null;
+});
+
+function section<T>(items: T[], hasMore = false) {
+  return { items, has_more: hasMore };
+}
+
+function results(overrides: Partial<SearchResultsSchema> = {}): SearchResultsSchema {
+  return {
+    titles: section([
+      {
+        name: 'Medieval Madness',
+        slug: 'medieval-madness',
+        year: 1997,
+        model_count: 2,
+        manufacturer: { public_id: 'williams', name: 'Williams' },
+        thumbnail_url: null,
+      },
+    ]),
+    manufacturers: section([
+      { name: 'Medieval Co', slug: 'medieval-co', model_count: 4, thumbnail_url: null },
+    ]),
+    people: section([
+      {
+        name: 'Medi Designer',
+        slug: 'medi-designer',
+        aliases: [],
+        credit_count: 7,
+        thumbnail_url: null,
+      },
+    ]),
+    ...overrides,
+  };
+}
+
+describe('/search page', () => {
+  it('shows the "type at least 3 characters" hint below the threshold, no results', () => {
+    render(Page, { props: { data: { q: 'me', results: null } } });
+    expect(screen.getByText(/type at least 3 characters/i)).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+  });
+
+  it('renders the three sections in order: Titles, Manufacturers, People', () => {
+    render(Page, { props: { data: { q: 'medieval', results: results() } } });
+    const headings = screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent);
+    expect(headings).toEqual(['Titles', 'Manufacturers', 'People']);
+    expect(screen.getByText('Medieval Madness')).toBeInTheDocument();
+    expect(screen.getByText('Medieval Co')).toBeInTheDocument();
+    expect(screen.getByText('Medi Designer')).toBeInTheDocument();
+  });
+
+  it('hides empty sections', () => {
+    render(Page, {
+      props: {
+        data: {
+          q: 'medieval',
+          results: results({ manufacturers: section([]), people: section([]) }),
+        },
+      },
+    });
+    const headings = screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent);
+    expect(headings).toEqual(['Titles']);
+  });
+
+  it('renders a "See all" listing link when a section has_more', () => {
+    render(Page, {
+      props: {
+        data: {
+          q: 'medieval',
+          results: results({
+            titles: section(results().titles.items, true),
+          }),
+        },
+      },
+    });
+    const link = screen.getByRole('link', { name: /see all titles matching "medieval"/i });
+    expect(link).toHaveAttribute('href', '/titles?q=medieval');
+  });
+
+  it('omits the "See all" link when a section is within the cap', () => {
+    render(Page, { props: { data: { q: 'medieval', results: results() } } });
+    expect(screen.queryByRole('link', { name: /see all/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a single "No results" line when every section is empty', () => {
+    render(Page, {
+      props: {
+        data: {
+          q: 'zzz',
+          results: results({
+            titles: section([]),
+            manufacturers: section([]),
+            people: section([]),
+          }),
+        },
+      },
+    });
+    // The visible message (the status line carries the same text for AT).
+    expect(
+      screen.getByText('No results for "zzz"', { selector: '.no-results' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
+  });
+
+  it('debounces typing into one ?q= navigation', async () => {
+    const user = userEvent.setup();
+    render(Page, { props: { data: { q: '', results: null } } });
+
+    await user.type(screen.getByRole('searchbox'), 'medieval');
+
+    await waitFor(() => expect(goto).toHaveBeenCalledTimes(1));
+    expect(goto.mock.calls[0][0]).toBe('/search?q=medieval');
+    expect(goto.mock.calls[0][1]).toMatchObject({ replaceState: true, keepFocus: true });
+  });
+
+  it('seeds the search box from the committed q', () => {
+    render(Page, { props: { data: { q: 'medieval', results: results() } } });
+    expect(screen.getByRole('searchbox')).toHaveValue('medieval');
+  });
+
+  it('shows a "Searching…" affordance for the first query, before any results exist', () => {
+    // An in-flight load to /search with a >=3-char query and no results yet — the
+    // first-query case the result-dim alone can't cover (nothing on screen to dim).
+    navigating.to = { route: { id: '/search' } };
+    render(Page, { props: { data: { q: 'medieval', results: null } } });
+    expect(screen.getByText(/^searching/i)).toBeInTheDocument();
+    expect(screen.queryByText(/type at least/i)).not.toBeInTheDocument();
+  });
+
+  it('does not show "Searching…" for a sub-threshold in-flight nav', () => {
+    // Clearing back toward the hint navigates too, but skips the backend — no
+    // "Searching…", just the hint.
+    navigating.to = { route: { id: '/search' } };
+    render(Page, { props: { data: { q: 'me', results: null } } });
+    expect(screen.queryByText(/^searching/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/type at least 3 characters/i)).toBeInTheDocument();
+  });
+
+  it('announces the visible result count to assistive tech', () => {
+    render(Page, { props: { data: { q: 'medieval', results: results() } } });
+    const live = screen.getByText(/showing 3 results/i);
+    // The polite live region wraps the announcement.
+    expect(live.closest('[aria-live="polite"]')).not.toBeNull();
+  });
+});

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -275,9 +275,11 @@ const config = {
     // into a <meta http-equiv> tag — and the CSP spec disallows the
     // Report-Only variant in meta. So routes with `export const
     // prerender = true` (currently /systems, /series, /reward-types,
-    // /gameplay-features, /people, /search, /api-docs, /(legal)/terms,
+    // /gameplay-features, /people, /api-docs, /(legal)/terms,
     // /(legal)/privacy, /(legal)/licensing) will produce zero reports
-    // regardless of violations. Before flipping to enforce, build with
+    // regardless of violations. (/search was here but is now SSR, so it
+    // gets report-only CSP coverage like the other SSR routes.) Before
+    // flipping to enforce, build with
     // the report-only directives moved to `directives` and smoke-test
     // those prerendered routes locally. The week-of-clean-reports gate
     // applies to SSR'd routes only.


### PR DESCRIPTION
## Summary

Move the global `/search` page from CSR-over-`/all/`-blobs to a single SSR page backed by one new `GET /api/pages/search` endpoint, then delete the two `/all/` blob endpoints that change orphans.

**Commit 1 — Search SSR.** `/api/pages/search` composes each entity's existing ordered listing queryset + card serializer into three stacked sections (Titles → Manufacturers → People), each capped at 10 with a `has_more` flag, so a section's rows match its `/…?q=` listing exactly. Below 3 chars it returns empty sections without querying. The frontend route SSRs the one endpoint, debounces typing into a `goto`, dims/announces a pending state (covering the cold first query), and links capped sections to the listing pages. Drops the four `/all/` fetches, in-memory filtering, preload hints and the `prerender` flag; updates the CSP KNOWN-GAP note (`/search` now gets report-only coverage).

**Commit 2 — delete orphans.** With the last frontend callers gone, removes `GET /api/models/all/` and `GET /api/people/all/` and the code they orphaned — including the entire model `search_text` blob builder (the −190 in `machine_models.py`) — plus their `cache.py` bases/keys. Repoints the generic cache-behavior tests onto the surviving titles/manufacturers `/all/`.

### Accepted tradeoffs (server-side search vs the old in-memory blob)
- **Discovery breadth narrows:** a theme/feature match no longer surfaces the parent Title (designers stay findable in People). Most user-visible change.
- **Punctuation no longer folded** (e.g. "acdc" ↛ "AC/DC") — deferred, same as the listing pages.
- **Per-section cap of 10** — recovered via "See all … →" links to the entity's listing page (same `q`, with pagination).
- **Typing latency:** instant → a 250ms-debounced uncached server round-trip per query.

### Kept (still consumed)
`titles/all/` (kiosk), `manufacturers/all/` (system-editor dropdown), `PersonCardSchema`, the shared people list helpers, `fetch_model_media_map`, and `cache.py` core + surviving bases.

## Test plan

- [ ] `make codegen && cd backend && uv run pytest apps/catalog/tests/test_api_search.py` — endpoint: `<3`-char no-work guard, per-section card shape, 10-cap/`has_more`, section order == listing order, diacritic dev/prod split, constant-query N+1 guard
- [ ] `cd frontend && pnpm test src/routes/search` — hint, section render/order, "See all" link hrefs, hidden empty sections, all-empty "No results", debounce→one `?q=`, first-query "Searching…" affordance
- [ ] `make dev`, visit `/search`: type `<3` chars (hint) → a real query (SSR sections, ≤10 each, "See all" where applicable) → back/forward restores the query → clear returns to empty; devtools Network shows **no `/all/`**
- [ ] Diacritic test against Docker Postgres (`fc-pg`) to exercise the `UNACCENT` branch SQLite skips
- [ ] Smoke the surviving `/all/` consumers: kiosk display-config picker, system-editor manufacturer dropdown
- [ ] `make quality` + full backend suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)