### PR TITLE
docs(api): document the public catalog API

### DIFF
--- a/backend/apps/catalog/api/constants.py
+++ b/backend/apps/catalog/api/constants.py
@@ -1,1 +1,29 @@
+from typing import Annotated
+
+from ninja.params.functions import Query as QueryParam
+
 DEFAULT_PAGE_SIZE = 50
+
+# ---------------------------------------------------------------------------
+# Reusable documented query params for the public list endpoints.
+#
+# ``ninja.Query`` is the generic ``Annotated[T, ...]`` alias used for the
+# schema-as-query form (``Query[FooFilterSchema]``); calling it as ``Query(...)``
+# trips mypy. ``ninja.params.functions.Query`` is the underlying param function
+# (returns ``Any``), so it's the mypy-clean way to attach a ``description`` to a
+# bare handler argument via ``Annotated``. These aliases bake in the wording so
+# the per-endpoint docs can't drift.
+# ---------------------------------------------------------------------------
+
+_Q_NAME_DESC = "Free-text search by name. Accent- and case-insensitive substring match."
+_Q_NAME_ALIAS_DESC = (
+    "Free-text search by name or alias. Accent- and case-insensitive substring match."
+)
+_PAGE_DESC = "Page number, 1-based."
+
+# ``q`` for entities matched by name only.
+NameQuery = Annotated[str, QueryParam("", description=_Q_NAME_DESC)]
+# ``q`` for entities that also match on their aliases.
+NameAliasQuery = Annotated[str, QueryParam("", description=_Q_NAME_ALIAS_DESC)]
+# Standard 1-based ``page`` param.
+PageParam = Annotated[int, QueryParam(1, description=_PAGE_DESC)]

--- a/backend/apps/catalog/api/corporate_entities.py
+++ b/backend/apps/catalog/api/corporate_entities.py
@@ -25,6 +25,7 @@ from ..models import (
     Manufacturer,
 )
 from ._typing import HasModelCount
+from .constants import NameAliasQuery, PageParam
 from .edit_claims import (
     execute_claims,
     plan_alias_claims,
@@ -64,8 +65,8 @@ class CorporateEntityListItemSchema(Schema):
 
 
 class CorporateEntityListSchema(Schema):
-    """``{items, count}`` page of corporate entities — the wire shape
-    ``createPaginatedLoader`` expects (it derives has_more from items.length < count)."""
+    """A page of corporate entities: ``items`` holds this page's rows; ``count`` is
+    the total number of matching corporate entities across all pages."""
 
     items: list[CorporateEntityListItemSchema]
     count: int
@@ -177,10 +178,10 @@ def _serialize_corporate_entity_row(
 
 @corporate_entities_router.get("/", response=CorporateEntityListSchema)
 def list_corporate_entities(
-    request: HttpRequest, q: str = "", page: int = 1
+    request: HttpRequest, q: NameAliasQuery = "", page: PageParam = 1
 ) -> CorporateEntityListSchema:
-    """One page of corporate entities, by manufacturer then founding year, filtered
-    server-side by ``q`` (name or alias)."""
+    """Corporate entities, paginated. Search with ``q``. Ordered by manufacturer,
+    then founding year."""
     result = paginated_list_response(
         _corporate_entity_list_qs(),
         q=q,

--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -20,6 +20,7 @@ from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 
 from ..models import Franchise, MachineModel, Title
 from ._typing import HasTitleCount
+from .constants import NameQuery, PageParam
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
 from .entity_list import paginated_list_response
@@ -40,8 +41,8 @@ class FranchiseListItemSchema(Schema):
 
 
 class FranchiseListSchema(Schema):
-    """``{items, count}`` page of franchises — the wire shape ``createPaginatedLoader``
-    expects (it derives has_more from items.length < count)."""
+    """A page of franchises: ``items`` holds this page's rows; ``count`` is the total
+    number of matching franchises across all pages."""
 
     items: list[FranchiseListItemSchema]
     count: int
@@ -81,10 +82,10 @@ def _serialize_franchise_row(
 
 @franchises_router.get("/", response=FranchiseListSchema)
 def list_franchises(
-    request: HttpRequest, q: str = "", page: int = 1
+    request: HttpRequest, q: NameQuery = "", page: PageParam = 1
 ) -> FranchiseListSchema:
-    """One page of franchises (cards in page 1's SSR HTML, infinite scroll for 2…N),
-    ordered most-titled first, filtered server-side by ``q``."""
+    """Franchises, paginated. Search with ``q``. Ordered by title count, then
+    alphabetically."""
     result = paginated_list_response(
         _franchise_list_qs(),
         q=q,

--- a/backend/apps/catalog/api/gameplay_features.py
+++ b/backend/apps/catalog/api/gameplay_features.py
@@ -18,7 +18,7 @@ from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 
 from ..models import GameplayFeature
 from ._counts import bulk_title_counts_via_models
-from .constants import DEFAULT_PAGE_SIZE
+from .constants import DEFAULT_PAGE_SIZE, NameAliasQuery, PageParam
 from .edit_claims import (
     execute_claims,
     plan_alias_claims,
@@ -50,8 +50,8 @@ class GameplayFeatureListItemSchema(Schema):
 
 
 class GameplayFeatureListSchema(Schema):
-    """``{items, count}`` page of gameplay features — the wire shape
-    ``createPaginatedLoader`` expects (it derives has_more from items.length < count)."""
+    """A page of gameplay features: ``items`` holds this page's rows; ``count`` is the
+    total number of matching gameplay features across all pages."""
 
     items: list[GameplayFeatureListItemSchema]
     count: int
@@ -146,15 +146,17 @@ def _active_gameplay_features() -> list[GameplayFeature]:
 
 @gameplay_features_router.get("/", response=GameplayFeatureListSchema)
 def list_gameplay_features(
-    request: HttpRequest, q: str = "", page: int = 1
+    request: HttpRequest, q: NameAliasQuery = "", page: PageParam = 1
 ) -> GameplayFeatureListSchema:
-    """One page of gameplay features, most-titled first, filtered server-side by ``q``
-    (name or alias). The ``-title_count`` sort is the hierarchical ``children_map``
-    rollup, not a SQL column, so this handler does its own compute-sort-slice over the
-    full active set rather than going through ``paginated_list_response``'s SQL slice.
-    The rollup is computed over **all** active features (a matched feature's count
-    reflects its whole descendant set, not just descendants matching ``q``); ``q``
-    selects which rows show."""
+    """Gameplay features, paginated. Search with ``q``. Ordered by title count, then
+    alphabetically.
+
+    Title counts roll up the feature hierarchy: a feature's count reflects its whole
+    descendant set, not just itself. ``q`` selects which rows show, but does not
+    narrow the counts."""
+    # The ``-title_count`` sort is the hierarchical ``children_map`` rollup, not a
+    # SQL column, so this handler does its own compute-sort-slice over the full
+    # active set rather than going through ``paginated_list_response``'s SQL slice.
     active = _active_gameplay_features()
     counts = _gameplay_feature_rollup(active)
 

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -1,18 +1,17 @@
 """Models (machine models) router — list, detail, and claim-patch endpoints."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from django.db.models import F, Prefetch, Q, QuerySet
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from django.views.decorators.cache import cache_control
-from ninja import Router, Schema
+from ninja import Query, Router, Schema
 from ninja.decorators import decorate_view
 from ninja.pagination import paginate
 from ninja.responses import Status
 from ninja.security import django_auth
+from pydantic import Field
 
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -581,40 +580,84 @@ class ModelListPagination(NamedPageNumberPagination):
     response_name = "ModelListSchema"
 
 
+class ModelFilterQuerySchema(Schema):
+    """Every /models filter dimension as query params. All filters combine with AND."""
+
+    manufacturer: str = Field(
+        "", description="Manufacturer slug (see `GET /api/manufacturers/`)."
+    )
+    type: str = Field(
+        "",
+        description="Technology-generation slug (see `GET /api/technology-generations/`).",
+    )
+    subgeneration: str = Field(
+        "",
+        description=(
+            "Technology-subgeneration slug. Matches the model's own subgeneration "
+            "or its system's."
+        ),
+    )
+    display: str = Field(
+        "", description="Display-type slug (see `GET /api/display-types/`)."
+    )
+    display_subtype: str = Field("", description="Display-subtype slug.")
+    feature: str = Field(
+        "",
+        description=(
+            "Gameplay-feature slug (see `GET /api/gameplay-features/`). Also matches "
+            "its sub-features."
+        ),
+    )
+    reward_type: str = Field(
+        "", description="Reward-type slug (see `GET /api/reward-types/`)."
+    )
+    game_format: str = Field(
+        "", description="Game-format slug (see `GET /api/game-formats/`)."
+    )
+    cabinet: str = Field("", description="Cabinet slug (see `GET /api/cabinets/`).")
+    tag: str = Field("", description="Tag slug (see `GET /api/tags/`).")
+    year_min: int | None = Field(None, description="Earliest release year, inclusive.")
+    year_max: int | None = Field(None, description="Latest release year, inclusive.")
+    person: str = Field(
+        "",
+        description=(
+            "Person slug (see `GET /api/people/`). Matches models this person is "
+            "credited on."
+        ),
+    )
+    ordering: str = Field(
+        "-year",
+        description=(
+            "Sort order: `name`, `-name`, `year` or `-year`. Defaults to `-year` "
+            "(newest first)."
+        ),
+    )
+
+
 @models_router.get("/", response=list[ModelListItemSchema])
 @paginate(ModelListPagination, page_size=DEFAULT_PAGE_SIZE)
 def list_models(
-    request: HttpRequest,
-    manufacturer: str = "",
-    type: str = "",
-    subgeneration: str = "",
-    display: str = "",
-    display_subtype: str = "",
-    feature: str = "",
-    reward_type: str = "",
-    game_format: str = "",
-    cabinet: str = "",
-    tag: str = "",
-    year_min: int | None = None,
-    year_max: int | None = None,
-    person: str = "",
-    ordering: str = "-year",
+    request: HttpRequest, filters: Query[ModelFilterQuerySchema]
 ) -> list[ModelListItemSchema]:
+    """Machine models, paginated. Narrow with the filters. Ordered by the ``ordering``
+    param (newest first by default).
+
+    All filters combine with AND."""
     qs = _build_model_list_qs(
-        manufacturer=manufacturer,
-        type=type,
-        subgeneration=subgeneration,
-        display=display,
-        display_subtype=display_subtype,
-        feature=feature,
-        reward_type=reward_type,
-        game_format=game_format,
-        cabinet=cabinet,
-        tag=tag,
-        year_min=year_min,
-        year_max=year_max,
-        person=person,
-        ordering=ordering,
+        manufacturer=filters.manufacturer,
+        type=filters.type,
+        subgeneration=filters.subgeneration,
+        display=filters.display,
+        display_subtype=filters.display_subtype,
+        feature=filters.feature,
+        reward_type=filters.reward_type,
+        game_format=filters.game_format,
+        cabinet=filters.cabinet,
+        tag=filters.tag,
+        year_min=filters.year_min,
+        year_max=filters.year_max,
+        person=filters.person,
+        ordering=filters.ordering,
     )
     min_rank = get_minimum_display_rank()
     return [_serialize_model_list(pm, min_rank=min_rank) for pm in qs]
@@ -628,7 +671,9 @@ class ModelRecentSchema(Schema):
     thumbnail_url: str | None = None
 
 
-@models_router.get("/recent/", response=list[ModelRecentSchema])
+# Website-only (homepage widget), not external catalog data — kept out of the
+# public API docs via tags=["private"].
+@models_router.get("/recent/", response=list[ModelRecentSchema], tags=["private"])
 @decorate_view(cache_control(no_cache=True))
 def list_recent_models(request: HttpRequest) -> list[ModelRecentSchema]:
     """Return the 3 newest non-variant models, one per title."""
@@ -673,7 +718,9 @@ def list_recent_models(request: HttpRequest) -> list[ModelRecentSchema]:
     return results
 
 
-@models_router.get("/edit-options/", response=ModelEditOptionsSchema)
+# Serves the in-app edit form, not external consumers — kept out of the public
+# API docs via tags=["private"].
+@models_router.get("/edit-options/", response=ModelEditOptionsSchema, tags=["private"])
 @decorate_view(cache_control(no_cache=True))
 def get_model_edit_options(request: HttpRequest) -> ModelEditOptionsSchema:
     """Return all dropdown options for the MachineModel edit form."""

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from typing import cast
+from typing import Annotated, cast
 
 from django.db.models import F, Prefetch, QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404
 from ninja import Query, Router, Schema
+from ninja.params.functions import Query as QueryParam
 from ninja.security import django_auth
-from pydantic import TypeAdapter
+from pydantic import Field, TypeAdapter
 
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -72,10 +73,11 @@ from .schemas import (
 
 
 class ManufacturerCardSchema(Schema):
-    """Slim card for the /manufacturers grid and every infinite-scroll page — only
-    what ``ManufacturerCard`` renders. No facet arrays (those live on the page
-    endpoint's ``filter_options``), so the list path skips the bulk facet queries."""
+    """A manufacturer in list results: name, slug, model count and a thumbnail."""
 
+    # Slim by design — only the fields list rows render. Facet arrays live on the
+    # page endpoint's ``filter_options``, so the list path skips the bulk facet
+    # queries.
     name: str
     slug: str
     model_count: int = 0
@@ -83,8 +85,8 @@ class ManufacturerCardSchema(Schema):
 
 
 class ManufacturerListPageSchema(Schema):
-    """``{items, count}`` page of cards — the wire shape ``createPaginatedLoader``
-    expects (it derives has_more from items.length < count)."""
+    """A page of manufacturers: ``items`` holds this page's rows; ``count`` is the
+    total number of matching manufacturers across all pages."""
 
     items: list[ManufacturerCardSchema]
     count: int
@@ -95,12 +97,39 @@ class ManufacturerFilterQuerySchema(Schema):
     end (URL ⇄ this schema ⇄ ``MfrFilters``). All facets are single-value (no
     titles-style repeated multi-value params)."""
 
-    q: str = ""
-    location: str | None = None
-    person: str | None = None
-    tech_gen: str | None = None
-    year_min: int | None = None
-    year_max: int | None = None
+    q: str = Field(
+        "",
+        description=(
+            "Free-text search. Accent- and case-insensitive substring match against "
+            "the manufacturer's name and aliases, plus the names and aliases of its "
+            "corporate entities and their locations."
+        ),
+    )
+    location: str | None = Field(
+        None,
+        description=(
+            "Location path. Also matches manufacturers located anywhere beneath it."
+        ),
+    )
+    person: str | None = Field(
+        None,
+        description=(
+            "Person slug (see `GET /api/people/`). Matches manufacturers whose "
+            "machines this person is credited on."
+        ),
+    )
+    tech_gen: str | None = Field(
+        None,
+        description=(
+            "Technology-generation slug (see `GET /api/technology-generations/`)."
+        ),
+    )
+    year_min: int | None = Field(
+        None, description="Earliest machine production year, inclusive."
+    )
+    year_max: int | None = Field(
+        None, description="Latest machine production year, inclusive."
+    )
 
     def to_filters(self) -> MfrFilters:
         return MfrFilters(
@@ -340,11 +369,16 @@ def _page_thumbnails(
 
 @manufacturers_router.get("/", response=ManufacturerListPageSchema)
 def list_manufacturers(
-    request: HttpRequest, filters: Query[ManufacturerFilterQuerySchema], page: int = 1
+    request: HttpRequest,
+    filters: Query[ManufacturerFilterQuerySchema],
+    page: Annotated[int, QueryParam(1, description="Page number, 1-based.")] = 1,
 ) -> ManufacturerListPageSchema:
-    """One page of manufacturer cards for the SSR grid (page 1) and infinite scroll
-    (2…N). Slices at SQL via ``ordered`` + LIMIT/OFFSET — only the requested page is
-    serialized (never ``list(qs)`` over the whole catalog)."""
+    """Manufacturers, paginated. Narrow with the filters and the search (``q``).
+    Ordered by model count, then alphabetically.
+
+    All filters combine with AND."""
+    # Sliced at SQL via ``ordered`` + LIMIT/OFFSET so only the requested page is
+    # serialized — never ``list(qs)`` over the whole catalog.
     f = filters.to_filters()
     rows = ordered(f)
     count = rows.count()

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -38,6 +38,7 @@ from apps.provenance.schemas import ChangeSetInputSchema
 
 from ..models import Credit, MachineModel, Person
 from ._typing import HasCreditCount
+from .constants import NameAliasQuery, PageParam
 from .edit_claims import ClaimSpec, execute_claims, plan_scalar_field_claims
 from .entity_create import (
     assert_name_available,
@@ -281,17 +282,19 @@ people_router = Router(tags=["people"])
 
 
 class PersonListSchema(Schema):
-    """``{items, count}`` page of people cards — the wire shape
-    ``createPaginatedLoader`` expects (it derives has_more from items.length < count)."""
+    """A page of people: ``items`` holds this page's rows; ``count`` is the total
+    number of matching people across all pages."""
 
     items: list[PersonCardSchema]
     count: int
 
 
 @people_router.get("/", response=PersonListSchema)
-def list_people(request: HttpRequest, q: str = "", page: int = 1) -> PersonListSchema:
-    """One page of people cards (thumbnail + credit count), most-credited first,
-    filtered server-side by ``q`` (name or alias)."""
+def list_people(
+    request: HttpRequest, q: NameAliasQuery = "", page: PageParam = 1
+) -> PersonListSchema:
+    """People, paginated. Search with ``q``. Ordered by credit count, then
+    alphabetically."""
     result = paginated_list_response(
         _person_list_qs(),
         q=q,

--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -362,20 +362,18 @@ class CreditSchema(Schema):
 
 
 class CorporateEntityLocationAncestorRef(Schema):
-    """Narrowed ancestor row in :class:`CorporateEntityLocationSchema.ancestors`
-    — omits ``location_type`` because ancestors render as a breadcrumb, not as
-    links. ``public_id`` is the location's ``location_path``.
-    """
+    """An ancestor in a location's breadcrumb. ``public_id`` is the location's
+    full path."""
 
+    # Slimmer than ``CorporateEntityLocationSchema`` — ancestors render as a
+    # breadcrumb, so ``location_type`` is omitted.
     display_name: str
     public_id: str
 
 
 class CorporateEntityLocationSchema(Schema):
-    """A corporate entity's location plus its ancestor chain. ``public_id`` is
-    the location's ``location_path``; ancestors use the narrower
-    :class:`CorporateEntityLocationAncestorRef`.
-    """
+    """A corporate entity's location plus its ancestor chain. ``public_id`` is the
+    location's full path."""
 
     public_id: str
     location_type: str

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -22,6 +22,7 @@ from apps.provenance.schemas import RichTextSchema
 
 from ..models import Credit, MachineModel, Series, Title
 from ._typing import HasTitleCount
+from .constants import NameQuery, PageParam
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import register_entity_create, register_entity_delete_restore
 from .entity_list import paginated_list_response
@@ -52,8 +53,8 @@ class SeriesListItemSchema(Schema):
 
 
 class SeriesListSchema(Schema):
-    """``{items, count}`` page of series — the wire shape ``createPaginatedLoader``
-    expects (it derives has_more from items.length < count)."""
+    """A page of series: ``items`` holds this page's rows; ``count`` is the total
+    number of matching series across all pages."""
 
     items: list[SeriesListItemSchema]
     count: int
@@ -188,9 +189,11 @@ def _serialize_series_row(
 
 
 @series_router.get("/", response=SeriesListSchema)
-def list_series(request: HttpRequest, q: str = "", page: int = 1) -> SeriesListSchema:
-    """One page of series (title count + thumbnail), most-titled first, filtered
-    server-side by ``q``."""
+def list_series(
+    request: HttpRequest, q: NameQuery = "", page: PageParam = 1
+) -> SeriesListSchema:
+    """Series, paginated. Search with ``q``. Ordered by title count, then
+    alphabetically."""
     result = paginated_list_response(
         _series_list_qs(),
         q=q,

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast
+from typing import Annotated, cast
 
 from django.db import models
 from django.db.models import Count, F, Max, Prefetch, Q, QuerySet
@@ -12,6 +12,7 @@ from django.shortcuts import get_object_or_404
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
 from ninja.decorators import decorate_view
+from ninja.params.functions import Query as QueryParam
 from ninja.responses import Status
 from ninja.security import django_auth
 
@@ -30,6 +31,7 @@ from apps.provenance.rate_limits import (
 
 from ..models import MachineModel, Manufacturer, System
 from ._typing import HasModelCount
+from .constants import NameQuery, PageParam
 from .edit_claims import (
     ClaimSpec,
     StructuredValidationError,
@@ -68,8 +70,8 @@ class SystemListItemSchema(Schema):
 
 
 class SystemListSchema(Schema):
-    """``{items, count}`` page of systems — the wire shape ``createPaginatedLoader``
-    expects (it derives has_more from items.length < count)."""
+    """A page of systems: ``items`` holds this page's rows; ``count`` is the total
+    number of matching systems across all pages."""
 
     items: list[SystemListItemSchema]
     count: int
@@ -228,11 +230,22 @@ def _serialize_system_row(
 
 @systems_router.get("/", response=SystemListSchema)
 def list_systems(
-    request: HttpRequest, q: str = "", manufacturer: str | None = None, page: int = 1
+    request: HttpRequest,
+    q: NameQuery = "",
+    manufacturer: Annotated[
+        str | None,
+        QueryParam(
+            None,
+            description=(
+                "Manufacturer slug (see `GET /api/manufacturers/`). Narrows to "
+                "systems from this manufacturer."
+            ),
+        ),
+    ] = None,
+    page: PageParam = 1,
 ) -> SystemListSchema:
-    """One page of systems, alphabetical, filtered server-side by ``q`` and (optionally)
-    a ``manufacturer`` slug — the server-side replacement for the page's old client
-    manufacturer ``<select>``."""
+    """Systems, paginated. Filter by manufacturer or search with ``q``. Ordered
+    alphabetically."""
     qs = _system_list_qs()
     if manufacturer:
         qs = qs.filter(manufacturer__slug=manufacturer)
@@ -249,8 +262,9 @@ def list_systems(
 @systems_router.get("/all/", response=list[SystemListItemSchema])
 @decorate_view(cache_control(no_cache=True))
 def list_all_systems(request: HttpRequest) -> list[SystemListItemSchema]:
-    """Every system with machine count (no pagination) — reuses the paginated handler's
-    queryset and row serializer so the two presentations can't drift."""
+    """Every system with its machine count, alphabetical and unpaginated."""
+    # Reuses the paginated handler's queryset and row serializer so the two
+    # presentations can't drift.
     return [_serialize_system_row(s) for s in _system_list_qs()]
 
 

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import Any, TypeVar, cast
+from typing import Annotated, Any, TypeVar, cast
 
 from django.db.models import Count, F, Prefetch, Q, QuerySet
 from django.http import HttpRequest
@@ -11,6 +11,7 @@ from django.shortcuts import get_object_or_404
 from django.views.decorators.cache import cache_control
 from ninja import Router, Schema
 from ninja.decorators import decorate_view
+from ninja.params.functions import Path as PathParam
 from ninja.security import django_auth
 
 from apps.core.authz.markers import requires
@@ -38,6 +39,7 @@ from ..models import (
 )
 from ._counts import bulk_title_counts_via_models
 from ._typing import HasTitleCount
+from .constants import NameAliasQuery, NameQuery, PageParam
 from .edit_claims import execute_claims, plan_scalar_field_claims
 from .entity_crud import (
     register_entity_create,
@@ -300,6 +302,7 @@ technology_generations_router = Router(tags=["technology-generations"])
 def list_technology_generations(
     request: HttpRequest,
 ) -> list[TechnologyGenerationListItemSchema]:
+    """Every technology generation with its subgenerations, in curated order."""
     gens = list(TechnologyGeneration.objects.active())
     subgens = list(TechnologySubgeneration.objects.active())
 
@@ -394,6 +397,7 @@ display_types_router = Router(tags=["display-types"])
 @display_types_router.get("/", response=list[DisplayTypeListItemSchema])
 @decorate_view(cache_control(no_cache=True))
 def list_display_types(request: HttpRequest) -> list[DisplayTypeListItemSchema]:
+    """Every display type with its subtypes, in curated order."""
     types = list(DisplayType.objects.active())
     subtypes = list(DisplaySubtype.objects.active())
 
@@ -502,8 +506,8 @@ cabinets_router = Router(tags=["cabinets"])
 
 
 class CabinetListSchema(Schema):
-    """``{items, count}`` page of cabinets — the wire shape ``createPaginatedLoader``
-    expects (it derives has_more from items.length < count)."""
+    """A page of cabinets: ``items`` holds this page's rows; ``count`` is the total
+    number of matching cabinets across all pages."""
 
     items: list[TaxonomyWithTitleCountSchema]
     count: int
@@ -519,9 +523,10 @@ def _cabinet_list_qs() -> QuerySet[Cabinet]:
 
 @cabinets_router.get("/", response=CabinetListSchema)
 def list_cabinets(
-    request: HttpRequest, q: str = "", page: int = 1
+    request: HttpRequest, q: NameQuery = "", page: PageParam = 1
 ) -> CabinetListSchema:
-    """One page of cabinets, most-titled first, filtered server-side by ``q``."""
+    """Cabinet styles, paginated. Search with ``q``. Ordered by title count, then
+    alphabetically."""
     result = paginated_list_response(
         _cabinet_list_qs(),
         q=q,
@@ -558,8 +563,8 @@ game_formats_router = Router(tags=["game-formats"])
 
 
 class GameFormatListSchema(Schema):
-    """``{items, count}`` page of game formats — the wire shape
-    ``createPaginatedLoader`` expects (it derives has_more from items.length < count)."""
+    """A page of game formats: ``items`` holds this page's rows; ``count`` is the
+    total number of matching game formats across all pages."""
 
     items: list[TaxonomyWithTitleCountSchema]
     count: int
@@ -577,9 +582,9 @@ def _game_format_list_qs() -> QuerySet[GameFormat]:
 
 @game_formats_router.get("/", response=GameFormatListSchema)
 def list_game_formats(
-    request: HttpRequest, q: str = "", page: int = 1
+    request: HttpRequest, q: NameQuery = "", page: PageParam = 1
 ) -> GameFormatListSchema:
-    """One page of game formats in editorial ``display_order``, filtered by ``q``."""
+    """Game formats, paginated. Search with ``q``. In curated order."""
     result = paginated_list_response(
         _game_format_list_qs(),
         q=q,
@@ -649,8 +654,8 @@ def _serialize_reward_type_detail(rt: RewardType) -> RewardTypeDetailSchema:
 
 
 class RewardTypeListSchema(Schema):
-    """``{items, count}`` page of reward types — the wire shape
-    ``createPaginatedLoader`` expects (it derives has_more from items.length < count)."""
+    """A page of reward types: ``items`` holds this page's rows; ``count`` is the
+    total number of matching reward types across all pages."""
 
     items: list[TaxonomyWithTitleCountSchema]
     count: int
@@ -669,9 +674,10 @@ def _reward_type_list_qs() -> QuerySet[RewardType]:
 
 @reward_types_router.get("/", response=RewardTypeListSchema)
 def list_reward_types(
-    request: HttpRequest, q: str = "", page: int = 1
+    request: HttpRequest, q: NameAliasQuery = "", page: PageParam = 1
 ) -> RewardTypeListSchema:
-    """One page of reward types, most-titled first, filtered by ``q`` (name or alias)."""
+    """Reward types, paginated. Search with ``q``. Ordered by title count, then
+    alphabetically."""
     result = paginated_list_response(
         _reward_type_list_qs(),
         q=q,
@@ -718,8 +724,8 @@ tags_router = Router(tags=["tags"])
 
 
 class TagListSchema(Schema):
-    """``{items, count}`` page of tags — the wire shape ``createPaginatedLoader``
-    expects (it derives has_more from items.length < count)."""
+    """A page of tags: ``items`` holds this page's rows; ``count`` is the total
+    number of matching tags across all pages."""
 
     items: list[TaxonomyWithTitleCountSchema]
     count: int
@@ -734,8 +740,11 @@ def _tag_list_qs() -> QuerySet[Tag]:
 
 
 @tags_router.get("/", response=TagListSchema)
-def list_tags(request: HttpRequest, q: str = "", page: int = 1) -> TagListSchema:
-    """One page of tags, most-titled first, filtered server-side by ``q``."""
+def list_tags(
+    request: HttpRequest, q: NameQuery = "", page: PageParam = 1
+) -> TagListSchema:
+    """Tags, paginated. Search with ``q``. Ordered by title count, then
+    alphabetically."""
     result = paginated_list_response(
         _tag_list_qs(),
         q=q,
@@ -884,11 +893,11 @@ def _serialize_credit_role_detail_no_people(cr: CreditRole) -> CreditRoleDetailS
 
 
 class CreditRoleListSchema(Schema):
-    """``{items, count}`` page of credit roles — the wire shape
-    ``createPaginatedLoader`` expects. The no-per-row-count variant: rows carry no
-    ``title_count`` badge (they're ``TaxonomySchema``), but the page still carries the
-    pagination ``count`` the loader needs for has_more."""
+    """A page of credit roles: ``items`` holds this page's rows; ``count`` is the
+    total number of matching credit roles across all pages."""
 
+    # No-per-row-count variant: rows are plain ``TaxonomySchema`` (no
+    # ``title_count``), but the page still carries the pagination ``count``.
     items: list[TaxonomySchema]
     count: int
 
@@ -904,9 +913,9 @@ def _serialize_credit_role_row(
 
 @credit_roles_router.get("/", response=CreditRoleListSchema)
 def list_credit_roles(
-    request: HttpRequest, q: str = "", page: int = 1
+    request: HttpRequest, q: NameQuery = "", page: PageParam = 1
 ) -> CreditRoleListSchema:
-    """One page of credit roles, alphabetical, filtered server-side by ``q``."""
+    """Credit roles, paginated. Search with ``q``. Ordered alphabetically."""
     result = paginated_list_response(
         CreditRole.objects.active(),
         q=q,
@@ -989,7 +998,13 @@ register_entity_delete_restore(
 # the first matching pattern, so the more-specific routes have to come first.
 @credit_roles_router.get("/{path:public_id}", response=CreditRoleDetailSchema)
 @decorate_view(cache_control(no_cache=True))
-def get_credit_role(request: HttpRequest, public_id: str) -> CreditRoleDetailSchema:
+def get_credit_role(
+    request: HttpRequest,
+    public_id: Annotated[
+        str, PathParam(description="Credit-role slug (see `GET /api/credit-roles/`).")
+    ],
+) -> CreditRoleDetailSchema:
+    """A single credit role by its slug."""
     return _serialize_credit_role_detail(
         get_object_or_404(
             _credit_role_detail_qs(), **{CreditRole.public_id_field: public_id}

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -17,7 +17,7 @@ from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, rate_limited
 
 from ..models import MachineModel, Theme
 from ._counts import bulk_title_counts_via_models
-from .constants import DEFAULT_PAGE_SIZE
+from .constants import DEFAULT_PAGE_SIZE, NameAliasQuery, PageParam
 from .edit_claims import (
     execute_claims,
     plan_alias_claims,
@@ -51,8 +51,8 @@ class ThemeListItemSchema(Schema):
 
 
 class ThemeListSchema(Schema):
-    """``{items, count}`` page of themes — the wire shape ``createPaginatedLoader``
-    expects (it derives has_more from items.length < count)."""
+    """A page of themes: ``items`` holds this page's rows; ``count`` is the total
+    number of matching themes across all pages."""
 
     items: list[ThemeListItemSchema]
     count: int
@@ -156,13 +156,18 @@ def _theme_rollup(themes: list[Theme]) -> dict[int, int]:
 
 
 @themes_router.get("/", response=ThemeListSchema)
-def list_themes(request: HttpRequest, q: str = "", page: int = 1) -> ThemeListSchema:
-    """One page of themes, most-titled first, filtered server-side by ``q`` (name or
-    alias). The ``-title_count`` sort is the hierarchical ``children_map`` rollup, not a
-    SQL column, so this handler does its own compute-sort-slice over the full active set
-    rather than going through ``paginated_list_response``'s SQL slice. The rollup is
-    computed over **all** active themes (a matched theme's count reflects its whole
-    descendant set, not just descendants matching ``q``); ``q`` selects which rows show."""
+def list_themes(
+    request: HttpRequest, q: NameAliasQuery = "", page: PageParam = 1
+) -> ThemeListSchema:
+    """Themes, paginated. Search with ``q``. Ordered by title count, then
+    alphabetically.
+
+    Title counts roll up the theme hierarchy: a theme's count reflects its whole
+    descendant set, not just itself. ``q`` selects which rows show, but does not
+    narrow the counts."""
+    # The ``-title_count`` sort is the hierarchical ``children_map`` rollup, not a
+    # SQL column, so this handler does its own compute-sort-slice over the full
+    # active set rather than going through ``paginated_list_response``'s SQL slice.
     active = _active_themes()
     counts = _theme_rollup(active)
 

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Annotated, Any
 
 from django.db.models import (
     Prefetch,
@@ -15,9 +15,10 @@ from django.db.models import (
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404
 from ninja import Query, Router, Schema
+from ninja.params.functions import Query as QueryParam
 from ninja.responses import Status
 from ninja.security import django_auth
-from pydantic import TypeAdapter
+from pydantic import Field, TypeAdapter
 
 from apps.catalog.naming import MAX_CATALOG_NAME_LENGTH, normalize_catalog_name
 from apps.core.authz.markers import requires
@@ -126,12 +127,11 @@ from .soft_delete import (
 
 
 class TitleCardSchema(Schema):
-    """Slim card for the /titles grid and every infinite-scroll page.
+    """A pinball title in list results: identity plus a thumbnail and model count."""
 
-    Only what `TitleCard` renders — no facet arrays (those live on the page
-    endpoint's `filter_options`, not on every row). Keeping the list path lean is
-    most of the payload win and lets it skip the bulk through-table queries."""
-
+    # Slim by design — only the fields list rows render. Facet arrays live on the
+    # page endpoint's ``filter_options``, not on every row, so the list path skips
+    # the bulk through-table queries.
     name: str
     slug: str
     year: int | None = None
@@ -141,8 +141,8 @@ class TitleCardSchema(Schema):
 
 
 class TitleListPageSchema(Schema):
-    """`{items, count}` page of cards — the wire shape `createPaginatedLoader`
-    expects (it derives has_more from items.length < count)."""
+    """A page of titles: ``items`` holds this page's rows; ``count`` is the total
+    number of matching titles across all pages."""
 
     items: list[TitleCardSchema]
     count: int
@@ -153,20 +153,74 @@ class TitleFilterQuerySchema(Schema):
     (URL ⇄ this schema ⇄ `TitleFilters`). Multi-value params are **repeated**
     (`theme=a&theme=b`), read natively as `list[str]`."""
 
-    q: str = ""
-    manufacturer: str | None = None
-    person: str | None = None
-    tech_gen: str | None = None
-    display_type: str | None = None
-    system: str | None = None
-    franchise: str | None = None
-    series: str | None = None
-    player_count: int | None = None
-    year_min: int | None = None
-    year_max: int | None = None
-    theme: list[str] = []
-    feature: list[str] = []
-    reward_type: list[str] = []
+    q: str = Field(
+        "",
+        description=(
+            "Free-text search. Accent- and case-insensitive substring match "
+            "against the title's name, abbreviations and primary manufacturer."
+        ),
+    )
+    manufacturer: str | None = Field(
+        None,
+        description=(
+            "Manufacturer slug (see `GET /api/manufacturers/`). Matches the "
+            "title's primary manufacturer."
+        ),
+    )
+    person: str | None = Field(
+        None,
+        description=(
+            "Person slug (see `GET /api/people/`). Matches titles this person "
+            "is credited on."
+        ),
+    )
+    tech_gen: str | None = Field(
+        None,
+        description="Technology-generation slug (see `GET /api/technology-generations/`).",
+    )
+    display_type: str | None = Field(
+        None,
+        description="Display-type slug (see `GET /api/display-types/`).",
+    )
+    system: str | None = Field(
+        None,
+        description="System slug (see `GET /api/systems/`).",
+    )
+    franchise: str | None = Field(
+        None,
+        description="Franchise slug (see `GET /api/franchises/`).",
+    )
+    series: str | None = Field(
+        None,
+        description="Series slug (see `GET /api/series/`).",
+    )
+    player_count: int | None = Field(
+        None,
+        description="Number of players a machine supports. `6` matches 6 or more.",
+    )
+    year_min: int | None = Field(None, description="Earliest release year, inclusive.")
+    year_max: int | None = Field(None, description="Latest release year, inclusive.")
+    theme: list[str] = Field(
+        [],
+        description=(
+            "Theme slug (see `GET /api/themes/`). Repeat to require several "
+            "(`theme=a&theme=b`); a parent theme also matches its sub-themes."
+        ),
+    )
+    feature: list[str] = Field(
+        [],
+        description=(
+            "Gameplay-feature slug (see `GET /api/gameplay-features/`). Repeatable; "
+            "a parent feature also matches its sub-features."
+        ),
+    )
+    reward_type: list[str] = Field(
+        [],
+        description=(
+            "Reward-type slug (see `GET /api/reward-types/`). Repeatable; all "
+            "supplied slugs must match."
+        ),
+    )
 
     def to_filters(self) -> TitleFilters:
         return TitleFilters(
@@ -788,11 +842,14 @@ titles_router = Router(tags=["titles"])
 def list_titles(
     request: HttpRequest,
     filters: Query[TitleFilterQuerySchema],
-    page: int = 1,
+    page: Annotated[int, QueryParam(1, description="Page number, 1-based.")] = 1,
 ) -> TitleListPageSchema:
-    """One page of title cards for the SSR grid (page 1) and infinite scroll
-    (2…N). Slices at SQL via ``ordered_titles`` + LIMIT/OFFSET — only the requested
-    page is serialized (never ``list(qs)`` over the whole catalog)."""
+    """Pinball titles, paginated. Narrow with the filters and the search (``q``).
+    Ordered by release year (newest first), then alphabetically.
+
+    All filters combine with AND."""
+    # Sliced at SQL via ``ordered_titles`` + LIMIT/OFFSET so only the requested
+    # page is serialized — never ``list(qs)`` over the whole catalog.
     f = filters.to_filters()
     rows = ordered_titles(f).prefetch_related(_card_models_prefetch())
     count = rows.count()

--- a/backend/apps/core/pagination.py
+++ b/backend/apps/core/pagination.py
@@ -40,8 +40,12 @@ class NamedPaginatedResponseSchema(Schema):
 
 class NamedPageNumberPagination(PageNumberPagination):
     class PaginationParamsSchema(Schema):
-        page: int = Field(1, ge=1)
-        page_size: int | None = Field(None, ge=1)
+        page: int = Field(1, ge=1, description="Page number, 1-based.")
+        page_size: int | None = Field(
+            None,
+            ge=1,
+            description="Items per page. Defaults to the server's page size.",
+        )
 
     Input = PaginationParamsSchema  # type: ignore[assignment]
     Output = NamedPaginatedResponseSchema  # type: ignore[assignment]

--- a/frontend/src/routes/api-docs/+page.svelte
+++ b/frontend/src/routes/api-docs/+page.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
+  import { page } from '$app/state';
   import { pageTitle } from '$lib/constants';
 
   let scalarLoaded = $state(false);
   let scalarError = $state('');
+
+  // page.url.origin resolves to SITE_ORIGIN at prerender time (see
+  // svelte.config.js prerender.origin), the same source the canonical
+  // href and OG tags use, so this stays correct without hardcoding.
+  let typesCommand = $derived(
+    `npx openapi-typescript ${page.url.origin}/api/openapi.json -o schema.d.ts`,
+  );
 
   const scalarCustomCss = `
 		.scalar-api-reference {
@@ -102,8 +110,7 @@
   <div class="resource-card">
     <h3>TypeScript Types</h3>
     <p>Generate fully-typed API bindings in one command:</p>
-    <pre><code>npx openapi-typescript https://flipdb.org/api/openapi.json -o schema.d.ts</code
-      ></pre>
+    <pre><code>{typesCommand}</code></pre>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary

Flesh out the OpenAPI surface so the published catalog API reads as real external documentation rather than internal notes.

- Add descriptions to every public list/filter query param (titles, models, manufacturers, systems and the taxonomy endpoints), cross-referencing the endpoints that supply each slug.
- Rewrite schema and endpoint docstrings to describe the wire shape and behavior for an outside consumer instead of frontend-internal concerns (`createPaginatedLoader`, SSR/infinite-scroll, queryset internals moved to code comments).
- Mark website-only routes (recent models, model edit-options) as `tags=["private"]` so they stay out of the public docs.
- Centralize the reusable `q`/`page` param descriptions in `api/constants.py` so the wording can't drift across endpoints.
- Derive the TypeScript-types command on the api-docs page from `page.url.origin` instead of hardcoding the host.

## Test plan

- [ ] `make codegen` regenerates types cleanly
- [ ] Visit `/api-docs` — Scalar reference renders param descriptions; private routes are absent
- [ ] Confirm the TypeScript-types command shows the correct origin