### PR TITLE
docs(api): add OpenAPI field descriptions to catalog schemas

### DIFF
--- a/backend/apps/catalog/api/corporate_entities.py
+++ b/backend/apps/catalog/api/corporate_entities.py
@@ -9,6 +9,7 @@ from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Router, Schema
 from ninja.security import django_auth
+from pydantic import Field
 
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -55,13 +56,23 @@ from .schemas import (
 
 
 class CorporateEntityListItemSchema(Schema):
-    name: str
-    slug: str
-    manufacturer: EntityRef
-    year_start: int | None = None
-    year_end: int | None = None
-    model_count: int = 0
-    locations: list[CorporateEntityLocationSchema] = []
+    """A corporate entity in list results."""
+
+    name: str = Field(description="The corporate entity's display name.")
+    slug: str = Field(description="The corporate entity's URL slug.")
+    manufacturer: EntityRef = Field(
+        description="The manufacturer this corporate entity belongs to."
+    )
+    year_start: int | None = Field(
+        None, description="First year of operation, if known."
+    )
+    year_end: int | None = Field(None, description="Last year of operation, if known.")
+    model_count: int = Field(
+        0, description="Number of machine models from this corporate entity."
+    )
+    locations: list[CorporateEntityLocationSchema] = Field(
+        [], description="Locations associated with this corporate entity."
+    )
 
 
 class CorporateEntityListSchema(Schema):

--- a/backend/apps/catalog/api/franchises.py
+++ b/backend/apps/catalog/api/franchises.py
@@ -9,6 +9,7 @@ from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Router, Schema
 from ninja.security import django_auth
+from pydantic import Field
 
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -35,9 +36,11 @@ from .schemas import CatalogDetailSchema, ClaimPatchSchema, TitleRef
 
 
 class FranchiseListItemSchema(Schema):
-    name: str
-    slug: str
-    title_count: int = 0
+    """A franchise in list results."""
+
+    name: str = Field(description="The franchise's display name.")
+    slug: str = Field(description="The franchise's URL slug.")
+    title_count: int = Field(0, description="Number of titles in this franchise.")
 
 
 class FranchiseListSchema(Schema):

--- a/backend/apps/catalog/api/gameplay_features.py
+++ b/backend/apps/catalog/api/gameplay_features.py
@@ -7,6 +7,7 @@ from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Router, Schema
 from ninja.security import django_auth
+from pydantic import Field
 
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -42,11 +43,20 @@ from .schemas import (
 
 
 class GameplayFeatureListItemSchema(Schema):
-    name: str
-    slug: str
-    aliases: list[str] = []
-    title_count: int = 0
-    parent_slugs: list[str] = []
+    """A gameplay feature in list results."""
+
+    name: str = Field(description="The feature's display name.")
+    slug: str = Field(description="The feature's URL slug.")
+    aliases: list[str] = Field(
+        [], description="Alternative names this feature is also known by."
+    )
+    title_count: int = Field(
+        0,
+        description="Number of titles with this feature, including its sub-features.",
+    )
+    parent_slugs: list[str] = Field(
+        [], description="Slugs of this feature's parent features in the hierarchy."
+    )
 
 
 class GameplayFeatureListSchema(Schema):

--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -109,15 +109,17 @@ from .soft_delete import (
 
 
 class ModelListItemSchema(Schema):
-    name: str
-    slug: str
-    manufacturer: EntityRef | None = None
-    year: int | None = None
-    technology_generation: EntityRef | None = None
-    display_type: EntityRef | None = None
-    ipdb_id: int | None = None
-    themes: list[EntityRef] = []
-    thumbnail_url: str | None = None
+    """A machine model in list results."""
+
+    name: str = Field(description="The model's display name.")
+    slug: str = Field(description="The model's URL slug.")
+    manufacturer: EntityRef | None = Field(
+        None, description="The model's manufacturer."
+    )
+    year: int | None = Field(None, description="Release year, if known.")
+    thumbnail_url: str | None = Field(
+        None, description="URL of a thumbnail image, if available."
+    )
 
 
 class ModelVariantSchema(Schema):
@@ -204,12 +206,9 @@ def _build_model_list_qs(
         MachineModel.objects.active()
         .select_related(
             "corporate_entity__manufacturer",
-            "technology_generation",
-            "display_type",
             "title",
         )
         .prefetch_related(
-            "themes",
             Prefetch(
                 "entity_media",
                 queryset=EntityMedia.objects.filter(
@@ -277,27 +276,11 @@ def _serialize_model_list(
         if pm.corporate_entity and pm.corporate_entity.manufacturer
         else None
     )
-    # Note: technology_subgeneration not included in list view
     return ModelListItemSchema(
         name=pm.name,
         slug=pm.slug,
         manufacturer=EntityRef(name=mfr.name, public_id=mfr.public_id) if mfr else None,
         year=pm.year,
-        technology_generation=(
-            EntityRef(
-                name=pm.technology_generation.name,
-                public_id=pm.technology_generation.public_id,
-            )
-            if pm.technology_generation
-            else None
-        ),
-        display_type=(
-            EntityRef(name=pm.display_type.name, public_id=pm.display_type.public_id)
-            if pm.display_type
-            else None
-        ),
-        ipdb_id=pm.ipdb_id,
-        themes=[EntityRef(name=t.name, public_id=t.public_id) for t in pm.themes.all()],
         thumbnail_url=thumbnail_url,
     )
 

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -78,10 +78,14 @@ class ManufacturerCardSchema(Schema):
     # Slim by design — only the fields list rows render. Facet arrays live on the
     # page endpoint's ``filter_options``, so the list path skips the bulk facet
     # queries.
-    name: str
-    slug: str
-    model_count: int = 0
-    thumbnail_url: str | None = None
+    name: str = Field(description="The manufacturer's display name.")
+    slug: str = Field(description="The manufacturer's URL slug.")
+    model_count: int = Field(
+        0, description="Number of machine models from this manufacturer."
+    )
+    thumbnail_url: str | None = Field(
+        None, description="URL of a thumbnail image, if available."
+    )
 
 
 class ManufacturerListPageSchema(Schema):

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -13,6 +13,7 @@ from django.shortcuts import get_object_or_404
 from ninja import Router, Schema
 from ninja.responses import Status
 from ninja.security import django_auth
+from pydantic import Field
 
 from apps.catalog.naming import normalize_catalog_name
 from apps.core.authz.markers import requires
@@ -75,11 +76,19 @@ from .soft_delete import (
 
 
 class PersonCardSchema(Schema):
-    name: str
-    slug: str
-    aliases: list[str] = []
-    credit_count: int = 0
-    thumbnail_url: str | None = None
+    """A person in list results."""
+
+    name: str = Field(description="The person's display name.")
+    slug: str = Field(description="The person's URL slug.")
+    aliases: list[str] = Field(
+        [], description="Alternative names this person is also known by."
+    )
+    credit_count: int = Field(
+        0, description="Number of catalog credits attributed to this person."
+    )
+    thumbnail_url: str | None = Field(
+        None, description="URL of a thumbnail image, if available."
+    )
 
 
 class PersonTitleSchema(RelatedTitleSchema):

--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -60,7 +60,7 @@ class DescribedDetailSchema(Schema):
     """An entity's rich-text description."""
 
     description: RichTextSchema = Field(
-        default_factory=RichTextSchema,
+        default=RichTextSchema(),
         description="The entity's description as rich text.",
     )
 

--- a/backend/apps/catalog/api/schemas.py
+++ b/backend/apps/catalog/api/schemas.py
@@ -3,88 +3,94 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any
 
 from ninja import Schema
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 from apps.provenance.schemas import ChangeSetInputSchema, RichTextSchema
 
 
 class EntityRef(Schema):
-    """A reference to a named entity by its public id."""
+    """A reference to an entity."""
 
-    name: str
-    public_id: str
+    name: str = Field(description="The entity's human-readable display name.")
+    public_id: str = Field(
+        description="The entity's public identifier, usually its slug."
+    )
 
 
 class FacetOptionSchema(Schema):
-    """One selectable facet value with its live N-1 count — the entity-agnostic wire
-    form of the shared ``_facet_helpers.FacetOption`` leaf (``EntityRef`` + ``count``).
+    """One selectable facet value with its live result count."""
 
-    Shared by every faceted listing page (titles, manufacturers) so there is exactly
-    one OpenAPI component: two identically-named-but-separate classes would silently
-    collide into ``FacetOptionSchema`` + ``FacetOptionSchema2`` the moment one gained a
-    field, and the frontend's named import would bind non-deterministically.
-
-    ``public_id`` (not ``slug``) is the option entity's URL identity — a slug for most
-    facets, a ``location_path`` for location."""
-
-    public_id: str
-    name: str
-    count: int
+    # Shared by every faceted listing page (titles, manufacturers) so there is
+    # exactly one OpenAPI component: two identically-named-but-separate classes
+    # would collide into ``FacetOptionSchema`` + ``FacetOptionSchema2`` the moment
+    # one gained a field, and the frontend's named import would bind
+    # non-deterministically.
+    public_id: str = Field(
+        description="The facet value's identifier (the entity's slug)."
+    )
+    name: str = Field(description="The facet value's display name.")
+    count: int = Field(description="Number of matching results with this value.")
 
 
 class YearBoundsSchema(Schema):
-    """Inclusive min/max for a year-range facet — the wire form of
-    ``_facet_helpers.Bounds[int]``. Shared by the faceted listing pages (see
-    :class:`FacetOptionSchema` on why these live here rather than per-entity)."""
+    """Inclusive min/max for a year-range facet."""
 
-    min: int | None = None
-    max: int | None = None
+    # Lives here (not per-entity) for the same single-component reason as
+    # ``FacetOptionSchema``.
+    min: Annotated[int | None, Field(description="Earliest year, inclusive.")] = None
+    max: Annotated[int | None, Field(description="Latest year, inclusive.")] = None
 
 
 class LinkableDetailSchema(Schema):
-    """Wire twin of ``LinkableModel``: a top-level entity's display name and
-    uniform URL identity. ``public_id`` is ``LinkableModel.public_id`` —
-    ``slug`` for most entities, ``location_path`` for Location. Required (no
-    default) so every serializer is forced to source it.
-    """
+    """A top-level entity's display name and URL identity."""
 
-    name: str
-    public_id: str
+    name: str = Field(description="The entity's human-readable display name.")
+    # ``public_id`` is the model's ``LinkableModel.public_id`` — a slug for most
+    # entities, a ``location_path`` for Location. Required (no default) so every
+    # serializer sources it.
+    public_id: str = Field(
+        description="The entity's public identifier, usually its slug."
+    )
 
 
 class DescribedDetailSchema(Schema):
-    """Wire twin of ``DescribedModel``: the rich-text description."""
+    """An entity's rich-text description."""
 
-    description: RichTextSchema = RichTextSchema()
+    description: RichTextSchema = Field(
+        default_factory=RichTextSchema,
+        description="The entity's description as rich text.",
+    )
 
 
 class LastModifiedDetailSchema(Schema):
-    """Wire twin of ``LastUpdatedModel``: the freshness timestamp the sitemap
-    emits as ``<lastmod>`` and JSON-LD emits as ``dateModified``. Sourced from
-    ``LastUpdatedModel.last_modified`` (the ``_last_modified`` annotation), NOT
-    raw ``updated_at`` — so a ``Title`` reflects edits to its child Models.
-    Required (no default) so every serializer is forced to source it.
-    """
+    """An entity's last-modified timestamp."""
 
-    last_modified: datetime
+    # Sourced from ``LastUpdatedModel.last_modified`` (the ``_last_modified``
+    # annotation), NOT raw ``updated_at`` — so a ``Title`` reflects edits to its
+    # child Models. Drives the sitemap ``<lastmod>`` and JSON-LD ``dateModified``.
+    # Required (no default) so every serializer sources it.
+    last_modified: datetime = Field(
+        description=(
+            "When the entity was last modified. For entities with children, "
+            "reflects the most recent change to any child."
+        )
+    )
 
 
 class CatalogDetailSchema(
     LinkableDetailSchema, LastModifiedDetailSchema, DescribedDetailSchema
 ):
-    """Wire twin of ``CatalogModel`` (linkable + freshness + describable) and
-    backend counterpart of the frontend's ``EntityBaseFacts`` (name + URL
-    identity + last-modified + description; identity is exposed as
-    ``public_id``). Top-level catalog detail responses inherit this single
-    base and do not relist the mixins. ``last_modified`` rides its own
-    concern base (``LastModifiedDetailSchema``), composed here rather than
-    folded into ``LinkableDetailSchema`` — linkability ("has a canonical URL")
-    and freshness ("when did this last change") are orthogonal, mirroring the
-    ``LinkableModel`` / ``LastUpdatedModel`` split on the model side.
-    """
+    """Base for catalog detail responses: name, URL identity, last-modified and
+    description."""
+
+    # Backend counterpart of the frontend's ``EntityBaseFacts``. Composes three
+    # orthogonal concern mixins — linkability ("has a canonical URL"), freshness
+    # ("when did this last change") and describability — mirroring the
+    # ``LinkableModel`` / ``LastUpdatedModel`` / ``DescribedModel`` split on the
+    # model side. Top-level catalog detail responses inherit this single base.
 
 
 class EntityCreateInputSchema(ChangeSetInputSchema):
@@ -367,15 +373,19 @@ class CorporateEntityLocationAncestorRef(Schema):
 
     # Slimmer than ``CorporateEntityLocationSchema`` — ancestors render as a
     # breadcrumb, so ``location_type`` is omitted.
-    display_name: str
-    public_id: str
+    display_name: str = Field(description="The ancestor location's display name.")
+    public_id: str = Field(description="The ancestor location's full path.")
 
 
 class CorporateEntityLocationSchema(Schema):
     """A corporate entity's location plus its ancestor chain. ``public_id`` is the
     location's full path."""
 
-    public_id: str
-    location_type: str
-    display_name: str
-    ancestors: list[CorporateEntityLocationAncestorRef] = []
+    public_id: str = Field(description="The location's full path.")
+    location_type: str = Field(
+        description="The kind of location (e.g. country, region, city)."
+    )
+    display_name: str = Field(description="The location's display name.")
+    ancestors: list[CorporateEntityLocationAncestorRef] = Field(
+        [], description="The location's ancestor chain, as a breadcrumb."
+    )

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -51,7 +51,7 @@ class SeriesListItemSchema(Schema):
     name: str = Field(description="The series' display name.")
     slug: str = Field(description="The series' URL slug.")
     description: RichTextSchema = Field(
-        default_factory=RichTextSchema,
+        default=RichTextSchema(),
         description="The series' description as rich text.",
     )
     title_count: int = Field(0, description="Number of titles in this series.")

--- a/backend/apps/catalog/api/series.py
+++ b/backend/apps/catalog/api/series.py
@@ -10,6 +10,7 @@ from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Router, Schema
 from ninja.security import django_auth
+from pydantic import Field
 
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -45,11 +46,18 @@ from .schemas import (
 
 
 class SeriesListItemSchema(Schema):
-    name: str
-    slug: str
-    description: RichTextSchema = RichTextSchema()
-    title_count: int = 0
-    thumbnail_url: str | None = None
+    """A series in list results."""
+
+    name: str = Field(description="The series' display name.")
+    slug: str = Field(description="The series' URL slug.")
+    description: RichTextSchema = Field(
+        default_factory=RichTextSchema,
+        description="The series' description as rich text.",
+    )
+    title_count: int = Field(0, description="Number of titles in this series.")
+    thumbnail_url: str | None = Field(
+        None, description="URL of a thumbnail image, if available."
+    )
 
 
 class SeriesListSchema(Schema):

--- a/backend/apps/catalog/api/systems.py
+++ b/backend/apps/catalog/api/systems.py
@@ -15,6 +15,7 @@ from ninja.decorators import decorate_view
 from ninja.params.functions import Query as QueryParam
 from ninja.responses import Status
 from ninja.security import django_auth
+from pydantic import Field
 
 from apps.catalog.naming import normalize_catalog_name
 from apps.core.authz.markers import requires
@@ -63,10 +64,12 @@ from .schemas import (
 
 
 class SystemListItemSchema(Schema):
-    name: str
-    slug: str
-    manufacturer: EntityRef
-    model_count: int = 0
+    """A system in list results."""
+
+    name: str = Field(description="The system's display name.")
+    slug: str = Field(description="The system's URL slug.")
+    manufacturer: EntityRef = Field(description="The manufacturer of this system.")
+    model_count: int = Field(0, description="Number of machine models on this system.")
 
 
 class SystemListSchema(Schema):

--- a/backend/apps/catalog/api/taxonomy.py
+++ b/backend/apps/catalog/api/taxonomy.py
@@ -13,6 +13,7 @@ from ninja import Router, Schema
 from ninja.decorators import decorate_view
 from ninja.params.functions import Path as PathParam
 from ninja.security import django_auth
+from pydantic import Field
 
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -63,21 +64,35 @@ from .schemas import (
 
 
 class TaxonomySchema(CatalogDetailSchema):
-    slug: str
-    display_order: int
-    aliases: list[str] = []
+    """A catalog taxonomy entity (cabinet style, tag, reward type, …)."""
+
+    slug: str = Field(description="The entity's URL slug.")
+    display_order: int = Field(
+        description="Editorial sort weight; lower values sort first."
+    )
+    aliases: list[str] = Field(
+        [], description="Alternative names this entity is also known by."
+    )
 
 
 class TaxonomyWithTitleCountSchema(TaxonomySchema):
-    title_count: int = 0
+    """A taxonomy entity plus the number of titles associated with it."""
+
+    title_count: int = Field(
+        0, description="Number of titles associated with this entity."
+    )
 
 
 class DisplayTypeListItemSchema(TaxonomyWithTitleCountSchema):
-    subtypes: list[TaxonomyWithTitleCountSchema] = []
+    subtypes: list[TaxonomyWithTitleCountSchema] = Field(
+        [], description="This display type's subtypes."
+    )
 
 
 class TechnologyGenerationListItemSchema(TaxonomyWithTitleCountSchema):
-    subgenerations: list[TaxonomyWithTitleCountSchema] = []
+    subgenerations: list[TaxonomyWithTitleCountSchema] = Field(
+        [], description="This technology generation's subgenerations."
+    )
 
 
 # The two single-parent subtaxonomies expose their parent as a ref so the
@@ -779,7 +794,11 @@ def patch_tag(
 
 
 class CreditRoleDetailSchema(TaxonomySchema):
-    people: list[PersonCardSchema] = []
+    """A credit role plus the people credited in it."""
+
+    people: list[PersonCardSchema] = Field(
+        [], description="People credited in this role."
+    )
 
 
 credit_roles_router = Router(tags=["credit-roles"])

--- a/backend/apps/catalog/api/themes.py
+++ b/backend/apps/catalog/api/themes.py
@@ -7,6 +7,7 @@ from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Router, Schema
 from ninja.security import django_auth
+from pydantic import Field
 
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -43,11 +44,19 @@ from .schemas import (
 
 
 class ThemeListItemSchema(Schema):
-    name: str
-    slug: str
-    aliases: list[str] = []
-    title_count: int = 0
-    parent_slugs: list[str] = []
+    """A theme in list results."""
+
+    name: str = Field(description="The theme's display name.")
+    slug: str = Field(description="The theme's URL slug.")
+    aliases: list[str] = Field(
+        [], description="Alternative names this theme is also known by."
+    )
+    title_count: int = Field(
+        0, description="Number of titles with this theme, including its sub-themes."
+    )
+    parent_slugs: list[str] = Field(
+        [], description="Slugs of this theme's parent themes in the hierarchy."
+    )
 
 
 class ThemeListSchema(Schema):

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -132,12 +132,20 @@ class TitleCardSchema(Schema):
     # Slim by design — only the fields list rows render. Facet arrays live on the
     # page endpoint's ``filter_options``, not on every row, so the list path skips
     # the bulk through-table queries.
-    name: str
-    slug: str
-    year: int | None = None
-    model_count: int = 0
-    manufacturer: EntityRef | None = None
-    thumbnail_url: str | None = None
+    name: str = Field(description="The title's display name.")
+    slug: str = Field(description="The title's URL slug.")
+    year: int | None = Field(
+        None, description="Release year of the title's earliest model, if known."
+    )
+    model_count: int = Field(
+        0, description="Number of machine models under this title."
+    )
+    manufacturer: EntityRef | None = Field(
+        None, description="The title's primary manufacturer."
+    )
+    thumbnail_url: str | None = Field(
+        None, description="URL of a thumbnail image, if available."
+    )
 
 
 class TitleListPageSchema(Schema):

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -239,14 +239,38 @@ class ChangeSetInputSchema(Schema):
 class AttributionSchema(Schema):
     """License and source attribution for rendered content."""
 
-    license_slug: str | None = None
-    license_name: str | None = None
-    license_url: str | None = None
-    permissiveness_rank: int | None = None
-    requires_attribution: bool = False
-    source_name: str | None = None
-    source_url: str | None = None
-    attribution_text: str | None = None
+    license_slug: Annotated[
+        str | None, Field(description="Identifier of the content's license, if any.")
+    ] = None
+    license_name: Annotated[
+        str | None, Field(description="Short display name of the license.")
+    ] = None
+    license_url: Annotated[
+        str | None, Field(description="URL of the license text.")
+    ] = None
+    permissiveness_rank: Annotated[
+        int | None,
+        Field(
+            description="Relative permissiveness of the license; higher is more permissive."
+        ),
+    ] = None
+    requires_attribution: Annotated[
+        bool,
+        Field(
+            description="Whether the license requires attribution when this content is reused."
+        ),
+    ] = False
+    source_name: Annotated[
+        str | None,
+        Field(description="Name of the source this content was derived from."),
+    ] = None
+    source_url: Annotated[str | None, Field(description="URL of that source.")] = None
+    attribution_text: Annotated[
+        str | None,
+        Field(
+            description="Ready-to-use attribution string for this content, when provided."
+        ),
+    ] = None
 
 
 class ReviewLinkSchema(Schema):
@@ -259,31 +283,72 @@ class ReviewLinkSchema(Schema):
 class CitationLinkSchema(Schema):
     """A link attached to a citation source."""
 
-    url: str
-    label: str
+    url: str = Field(description="The link's URL.")
+    label: str = Field(description="Human-readable link text.")
 
 
 class InlineCitationSchema(Schema):
     """Metadata for an inline citation in rendered markdown."""
 
-    id: int
-    index: int
-    source_name: str
-    source_type: str
-    author: str
-    year: int | None = None
-    locator: str
-    links: list[CitationLinkSchema] = []
+    id: int = Field(
+        description="The citation instance's identifier (matches ``data-cite-id`` in the rendered HTML)."
+    )
+    index: int = Field(
+        description="The citation's sequential number in the text, shown as ``[1]``, ``[2]``, …"
+    )
+    source_name: str = Field(description="Name of the cited source.")
+    source_type: str = Field(
+        description="Kind of source: one of ``database``, ``wiki``, ``book``, ``editorial`` or ``other``."
+    )
+    author: str = Field(description="Author of the cited source, if recorded.")
+    year: Annotated[
+        int | None, Field(description="Publication year of the source, if known.")
+    ] = None
+    locator: str = Field(
+        description="Specific location within the source, such as a page or section."
+    )
+    links: Annotated[
+        list[CitationLinkSchema],
+        Field(description="External links for the cited source."),
+    ] = []
 
 
 class RichTextSchema(Schema):
     """A text field bundled with rendered HTML plus provenance metadata."""
 
-    text: str = ""
-    html: str = ""
-    plain: str = ""
-    citations: list[InlineCitationSchema] = []
-    attribution: AttributionSchema | None = None
+    text: Annotated[
+        str,
+        Field(
+            description=(
+                "The source text in authoring format — Markdown with "
+                "``[[type:slug]]`` tokens for entity links. Mainly for edit forms; "
+                "prefer ``html`` or ``plain`` for display."
+            )
+        ),
+    ] = ""
+    html: Annotated[str, Field(description="Display-ready rendered HTML.")] = ""
+    plain: Annotated[
+        str,
+        Field(
+            description=(
+                "Plain-text projection with markup and link tokens stripped — for "
+                "previews, meta descriptions and machine-readable use."
+            )
+        ),
+    ] = ""
+    citations: Annotated[
+        list[InlineCitationSchema],
+        Field(description="Inline citations referenced in the rendered content."),
+    ] = []
+    attribution: Annotated[
+        AttributionSchema | None,
+        Field(
+            description=(
+                "License and source attribution for this content, when it derives "
+                "from an attributed source."
+            )
+        ),
+    ] = None
 
 
 class CitationSourceSchema(Schema):


### PR DESCRIPTION
## Summary
- Annotate the public catalog and provenance API schemas with pydantic `Field` descriptions so the generated OpenAPI docs explain each field.
- Trim verbose backend-implementation docstrings on the shared schema bases (`schemas.py`) down to user-facing one-liners, moving the internal rationale into code comments.
- Slim `ModelListItemSchema` to just the fields the list view renders (drops `technology_generation`, `display_type`, `ipdb_id`, `themes`), and drop the now-unused `select_related`/`prefetch_related` joins.

## Test plan
- Pre-commit hooks pass (ruff, mypy, backend tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)