### PR TITLE
docs(api): field descriptions for core, provenance and citation schemas

### DIFF
--- a/backend/apps/citation/schemas.py
+++ b/backend/apps/citation/schemas.py
@@ -1,4 +1,29 @@
-"""API schemas for the citation app."""
+"""API schemas for the citation app — the "Sources" UI for cited evidence.
+
+A :class:`~apps.citation.models.CitationSource` is a work or evidence object
+that can be cited: a book, magazine or web page. Sources form a one-level
+hierarchy through a self FK — a *root* source (e.g. the IPDB website, or a
+magazine title) groups *child* sources (e.g. one IPDB machine page, or a
+single issue/article). ``source_type`` is one of ``book`` / ``magazine`` /
+``web``.
+
+Two derived notions recur across these schemas:
+
+- **abstract** — a source that is a container rather than a directly-citable
+  work: any source that has children, or a root ``web`` / ``magazine`` source.
+  The UI offers such a source's children for citation instead of the source
+  itself.
+- **skip_locator** — a web *child* needs no locator (page/section/fragment)
+  because its URL already pins the exact evidence; every other source needs a
+  locator when cited.
+
+Sources are NOT claims-controlled: unlike catalog entities they are edited
+directly through admin / the Sources UI. Citation *search* additionally
+recognizes a pasted URL or ISBN as belonging to a known root source (see
+:class:`CitationRecognitionSchema`), and the *extract* endpoint fetches
+metadata for a pasted URL/ISBN from an external API to prefill a create form
+(see :class:`CitationExtractResultSchema`).
+"""
 
 from __future__ import annotations
 
@@ -19,6 +44,9 @@ from .models import (
     CITATION_SOURCE_PUBLISHER_MAX_LENGTH,
 )
 
+# String fields that are non-nullable CharFields on the model: an update that
+# sends ``null`` for one of these is coerced to ``""`` (see
+# ``CitationSourceUpdateSchema.coerce_null_to_empty``).
 NONNULLABLE_STR_FIELDS = (
     "name",
     "source_type",
@@ -28,6 +56,9 @@ NONNULLABLE_STR_FIELDS = (
     "description",
 )
 
+# Length-bounded string aliases, one per model CharField, so input schemas
+# reject over-long values at the API boundary with the same limits the DB
+# enforces.
 NameStr = Annotated[str, Field(max_length=CITATION_SOURCE_NAME_MAX_LENGTH)]
 AuthorStr = Annotated[str, Field(max_length=CITATION_SOURCE_AUTHOR_MAX_LENGTH)]
 PublisherStr = Annotated[str, Field(max_length=CITATION_SOURCE_PUBLISHER_MAX_LENGTH)]
@@ -42,65 +73,141 @@ LinkLabelStr = Annotated[str, Field(max_length=CITATION_SOURCE_LINK_LABEL_MAX_LE
 
 
 class CitationSourceSearchSchema(Schema):
-    id: int
-    name: str
-    source_type: str
-    author: str
-    publisher: str
-    year: int | None = None
-    isbn: str | None = None
-    parent_id: int | None = None
-    has_children: bool = False
-    is_abstract: bool = False
-    skip_locator: bool = False
-    identifier_key: str = ""
+    """One source row in citation typeahead search results."""
+
+    id: int = Field(description="The source's identifier.")
+    name: str = Field(description="The source's display name.")
+    source_type: str = Field(description='Kind of source: "book", "magazine" or "web".')
+    author: str = Field(description="Author or creator, or an empty string.")
+    publisher: str = Field(description="Publisher, or an empty string.")
+    year: int | None = Field(None, description="Publication year, if known.")
+    isbn: str | None = Field(None, description="ISBN, if known.")
+    parent_id: int | None = Field(
+        None,
+        description="Identifier of the root source this is a child of, or null if it is itself a root.",
+    )
+    has_children: bool = Field(
+        False,
+        description="Whether other sources are grouped under this one as children.",
+    )
+    is_abstract: bool = Field(
+        False,
+        description=(
+            "Whether this source is a container rather than a directly-citable "
+            "work (it has children, or is a root web/magazine source); the UI "
+            "cites its children instead."
+        ),
+    )
+    skip_locator: bool = Field(
+        False,
+        description="Whether citing this source needs no locator — true for a web child, whose URL is the locator.",
+    )
+    identifier_key: str = Field(
+        "",
+        description=(
+            "For a root web source, the identifier scheme its children use "
+            '("ipdb" or "opdb"); an empty string otherwise.'
+        ),
+    )
 
 
 class CitationSourceMatchSchema(Schema):
-    id: int
-    name: str
-    skip_locator: bool = False
+    """A minimal reference to an existing source the user can re-cite.
+
+    Returned when search recognition or metadata extraction finds a source
+    that already exists, so the UI can offer it instead of creating a duplicate.
+    """
+
+    id: int = Field(description="The matched source's identifier.")
+    name: str = Field(description="The matched source's display name.")
+    skip_locator: bool = Field(
+        False,
+        description="Whether citing the matched source needs no locator (true for a web child).",
+    )
 
 
 class CitationSourceParentSchema(Schema):
-    id: int
-    name: str
+    """A minimal reference to a source's root/parent."""
+
+    id: int = Field(description="The parent source's identifier.")
+    name: str = Field(description="The parent source's display name.")
 
 
 class CitationRecognitionSchema(Schema):
-    """A URL or ISBN typed into citation search was recognized as belonging
-    to a known parent source. ``child`` is set when a record with the
-    extracted ``identifier`` already exists; otherwise the UI has enough to
-    prefill a create form.
-    """
+    """Recognition of a URL or ISBN typed into search as a known root source."""
 
-    parent: CitationSourceParentSchema
-    child: CitationSourceMatchSchema | None = None
-    identifier: str | None = None
+    # Built by walking the registered extractors: an extractor matches the input
+    # by URL pattern (or ISBN) to a known ``parent`` root source and, when
+    # present, the extracted ``identifier``; ``child`` is filled when a source
+    # with that identifier already exists. A bare domain match yields ``parent``
+    # only (no ``identifier``, no ``child``).
+    parent: CitationSourceParentSchema = Field(
+        description="The known root source the input belongs to."
+    )
+    child: CitationSourceMatchSchema | None = Field(
+        None,
+        description=(
+            "The existing child source for the input, when one already exists; "
+            "null when the input is new (the UI prefills a create form)."
+        ),
+    )
+    identifier: str | None = Field(
+        None,
+        description=(
+            "The structured identifier extracted from the input (e.g. an IPDB "
+            "machine id), or null when only the source's domain matched."
+        ),
+    )
 
 
 class CitationSourceSearchResponseSchema(Schema):
-    results: list[CitationSourceSearchSchema]
-    recognition: CitationRecognitionSchema | None = None
+    """Response body for the citation search typeahead."""
+
+    results: list[CitationSourceSearchSchema] = Field(
+        description="Matching source rows."
+    )
+    recognition: CitationRecognitionSchema | None = Field(
+        None,
+        description="Set when the query was recognized as a known URL or ISBN; null for plain-text queries.",
+    )
 
 
 class CitationSourceCreateSchema(Schema):
-    name: NameStr
-    source_type: str
-    author: AuthorStr = ""
-    publisher: PublisherStr = ""
-    year: int | None = None
-    month: int | None = None
-    day: int | None = None
-    date_note: DateNoteStr = ""
-    isbn: IsbnStr | None = None
-    description: DescriptionStr = ""
-    parent_id: int | None = None
-    identifier: IdentifierStr = ""
+    """Input to create a new citation source."""
+
+    name: NameStr = Field(description="The source's display name.")
+    source_type: str = Field(description='Kind of source: "book", "magazine" or "web".')
+    author: AuthorStr = Field("", description="Author or creator.")
+    publisher: PublisherStr = Field("", description="Publisher.")
+    year: int | None = Field(None, description="Publication year.")
+    month: int | None = Field(None, description="Publication month; requires year.")
+    day: int | None = Field(None, description="Publication day; requires month.")
+    date_note: DateNoteStr = Field(
+        "",
+        description="Free-text note about the date (e.g. a season or approximate date).",
+    )
+    isbn: IsbnStr | None = Field(
+        None,
+        description="ISBN; must be unique across sources. Empty input is stored as null.",
+    )
+    description: DescriptionStr = Field("", description="Free-text description.")
+    parent_id: int | None = Field(
+        None,
+        description="Identifier of the root source to nest this under, or null to create a root.",
+    )
+    identifier: IdentifierStr = Field(
+        "",
+        description="Structured identifier for this child within its parent's scheme (e.g. an IPDB machine id).",
+    )
     # Optional: atomically create a CitationSourceLink alongside the source.
-    url: LinkUrlStr | None = None
-    link_label: LinkLabelStr = ""
-    link_type: str = "homepage"
+    url: LinkUrlStr | None = Field(
+        None, description="If set, a URL to attach to the new source as a link."
+    )
+    link_label: LinkLabelStr = Field("", description="Label for the attached link.")
+    link_type: str = Field(
+        "homepage",
+        description='Type of the attached link: "homepage", "catalog", "publisher", "reference" or "archive".',
+    )
 
     @field_validator("isbn", mode="before")
     @classmethod
@@ -110,16 +217,31 @@ class CitationSourceCreateSchema(Schema):
 
 
 class CitationSourceUpdateSchema(Schema):
-    name: NameStr | None = None
-    source_type: str | None = None
-    author: AuthorStr | None = None
-    publisher: PublisherStr | None = None
-    year: int | None = None
-    month: int | None = None
-    day: int | None = None
-    date_note: DateNoteStr | None = None
-    isbn: IsbnStr | None = None
-    description: DescriptionStr | None = None
+    """Input to update a citation source; a partial update.
+
+    Omitted fields are left unchanged (the endpoint applies only the keys the
+    client sends). Sending ``null`` for a non-nullable string field clears it to
+    an empty string; sending ``null`` (or empty) for ``isbn`` clears it to null.
+    """
+
+    name: NameStr | None = Field(None, description="New display name.")
+    source_type: str | None = Field(
+        None, description='New source type: "book", "magazine" or "web".'
+    )
+    author: AuthorStr | None = Field(None, description="New author or creator.")
+    publisher: PublisherStr | None = Field(None, description="New publisher.")
+    year: int | None = Field(None, description="New publication year.")
+    month: int | None = Field(None, description="New publication month; requires year.")
+    day: int | None = Field(None, description="New publication day; requires month.")
+    date_note: DateNoteStr | None = Field(
+        None, description="New free-text note about the date."
+    )
+    isbn: IsbnStr | None = Field(
+        None, description="New ISBN; must be unique across sources."
+    )
+    description: DescriptionStr | None = Field(
+        None, description="New free-text description."
+    )
 
     @field_validator(*NONNULLABLE_STR_FIELDS, mode="before")
     @classmethod
@@ -135,53 +257,94 @@ class CitationSourceUpdateSchema(Schema):
 
 
 class CitationSourceChildSchema(Schema):
-    id: int
-    name: str
-    source_type: str
-    year: int | None = None
-    isbn: str | None = None
-    skip_locator: bool = False
-    urls: list[str] = []
+    """A child source as nested under its parent in the detail view."""
+
+    id: int = Field(description="The child source's identifier.")
+    name: str = Field(description="The child source's display name.")
+    source_type: str = Field(description='Kind of source: "book", "magazine" or "web".')
+    year: int | None = Field(None, description="Publication year, if known.")
+    isbn: str | None = Field(None, description="ISBN, if known.")
+    skip_locator: bool = Field(
+        False,
+        description="Whether citing this child needs no locator — true for a web child, whose URL is the locator.",
+    )
+    urls: list[str] = Field(
+        [],
+        description="URLs of every link attached to this child, regardless of link type.",
+    )
 
 
 class CitationSourceLinkSchema(Schema):
-    id: int
-    link_type: str
-    url: str
-    label: str
+    """A link attached to a citation source."""
+
+    id: int = Field(description="The link's identifier.")
+    link_type: str = Field(
+        description='Kind of link: "homepage", "catalog", "publisher", "reference" or "archive".'
+    )
+    url: str = Field(description="The link's URL.")
+    label: str = Field(description="Human-readable label, or an empty string.")
 
 
 class CitationSourceDetailSchema(Schema):
-    id: int
-    name: str
-    source_type: str
-    author: str
-    publisher: str
-    year: int | None = None
-    month: int | None = None
-    day: int | None = None
-    date_note: str
-    isbn: str | None = None
-    description: str
-    identifier_key: str = ""
-    skip_locator: bool = False
-    parent: CitationSourceParentSchema | None = None
-    links: list[CitationSourceLinkSchema] = []
-    children: list[CitationSourceChildSchema] = []
-    created_at: str
-    updated_at: str
+    """Full detail for a single citation source, with its links and children."""
+
+    id: int = Field(description="The source's identifier.")
+    name: str = Field(description="The source's display name.")
+    source_type: str = Field(description='Kind of source: "book", "magazine" or "web".')
+    author: str = Field(description="Author or creator, or an empty string.")
+    publisher: str = Field(description="Publisher, or an empty string.")
+    year: int | None = Field(None, description="Publication year, if known.")
+    month: int | None = Field(None, description="Publication month, if known.")
+    day: int | None = Field(None, description="Publication day, if known.")
+    date_note: str = Field(
+        description="Free-text note about the date, or an empty string."
+    )
+    isbn: str | None = Field(None, description="ISBN, if known.")
+    description: str = Field(description="Free-text description, or an empty string.")
+    identifier_key: str = Field(
+        "",
+        description='For a root web source, the identifier scheme its children use ("ipdb" or "opdb"); an empty string otherwise.',
+    )
+    skip_locator: bool = Field(
+        False,
+        description="Whether citing this source needs no locator (true for a web child).",
+    )
+    parent: CitationSourceParentSchema | None = Field(
+        None, description="The root source this is a child of, or null if it is a root."
+    )
+    links: list[CitationSourceLinkSchema] = Field(
+        [], description="Links where a reader can inspect this source."
+    )
+    children: list[CitationSourceChildSchema] = Field(
+        [], description="Sources grouped under this one as children."
+    )
+    created_at: str = Field(
+        description="When the source was created, as an ISO 8601 timestamp."
+    )
+    updated_at: str = Field(
+        description="When the source was last updated, as an ISO 8601 timestamp."
+    )
 
 
 class CitationSourceLinkCreateSchema(Schema):
-    link_type: str
-    url: LinkUrlStr
-    label: LinkLabelStr = ""
+    """Input to attach a new link to a citation source."""
+
+    link_type: str = Field(
+        description='Kind of link: "homepage", "catalog", "publisher", "reference" or "archive".'
+    )
+    url: LinkUrlStr = Field(description="The link's URL; must be unique on the source.")
+    label: LinkLabelStr = Field("", description="Human-readable label for the link.")
 
 
 class CitationSourceLinkUpdateSchema(Schema):
-    link_type: str | None = None
-    url: LinkUrlStr | None = None
-    label: LinkLabelStr | None = None
+    """Input to update a link; a partial update (omitted fields unchanged)."""
+
+    link_type: str | None = Field(
+        None,
+        description='New link type: "homepage", "catalog", "publisher", "reference" or "archive".',
+    )
+    url: LinkUrlStr | None = Field(None, description="New URL for the link.")
+    label: LinkLabelStr | None = Field(None, description="New label for the link.")
 
     @field_validator("label", mode="before")
     @classmethod
@@ -190,27 +353,71 @@ class CitationSourceLinkUpdateSchema(Schema):
 
 
 class CitationExtractInputSchema(Schema):
-    input: str
+    """Input to the metadata-extraction endpoint."""
+
+    input: str = Field(
+        description=(
+            "A pasted URL (with an http(s):// scheme) or an ISBN-10/ISBN-13. The "
+            "endpoint classifies it automatically; an ISBN takes priority."
+        )
+    )
 
 
 class CitationExtractDraftSchema(Schema):
-    name: str
-    source_type: str
-    author: str
-    publisher: str
-    year: int | None = None
-    isbn: str | None = None
-    url: str | None = None
+    """Metadata scraped from an external lookup, to prefill the create form."""
+
+    name: str = Field(description="The extracted title.")
+    source_type: str = Field(
+        description='Inferred source type: "book" for an ISBN, "web" for a URL.'
+    )
+    author: str = Field(description="Extracted author, or an empty string.")
+    publisher: str = Field(
+        description="Extracted publisher or site name, or an empty string."
+    )
+    year: int | None = Field(None, description="Extracted publication year, if found.")
+    isbn: str | None = Field(
+        None, description="The ISBN, for a book draft; null for a web draft."
+    )
+    url: str | None = Field(
+        None, description="The URL, for a web draft; null for a book draft."
+    )
 
 
 class CitationExtractResultSchema(Schema):
     """Result of looking up a pasted URL/ISBN via an external API.
-    ``match`` points at an existing source if one was found; ``draft`` is a
-    prefill for the create form; ``error`` is a user-facing failure reason.
+
+    Exactly one of ``match``, ``draft`` or ``error`` is the meaningful outcome:
+    ``match`` when a source already exists (re-cite it), ``draft`` when metadata
+    was fetched for a new source (prefill the create form), ``error`` when the
+    lookup failed.
     """
 
-    draft: CitationExtractDraftSchema | None = None
-    match: CitationSourceMatchSchema | None = None
-    error: str | None = None
-    confidence: str = ""
-    source_api: str = ""
+    draft: CitationExtractDraftSchema | None = Field(
+        None,
+        description="Prefill metadata for the create form, when extraction succeeded.",
+    )
+    match: CitationSourceMatchSchema | None = Field(
+        None,
+        description="An existing source with the same ISBN or identifier, when one was found.",
+    )
+    error: str | None = Field(
+        None,
+        description=(
+            "Failure reason, when the lookup failed: one of ``not_found``, "
+            "``timeout``, ``api_error``, ``parse_error`` or ``blocked``."
+        ),
+    )
+    confidence: str = Field(
+        "",
+        description=(
+            'How reliable the draft is: "high" for an ISBN lookup, "low" for URL '
+            "meta-tag scraping; empty when there is no draft."
+        ),
+    )
+    source_api: str = Field(
+        "",
+        description=(
+            'Which external source produced the draft: "openlibrary" for an ISBN, '
+            '"og_meta" for URL Open Graph tags; empty when there is no draft.'
+        ),
+    )

--- a/backend/apps/core/schemas.py
+++ b/backend/apps/core/schemas.py
@@ -4,117 +4,136 @@ from __future__ import annotations
 
 from typing import Literal
 
-from ninja import Schema
+from ninja import Field, Schema
 
 
 class ErrorDetailSchema(Schema):
-    """Plain 422 / 404 / 409 / 403 error body: just a ``detail`` string.
+    """Plain 422 / 404 / 409 / 403 error body: just a ``detail`` string."""
 
-    The shared shape used for non-structured failures across endpoints.
-    Structured 422s (with ``field_errors`` / ``form_errors``) come from
-    :class:`apps.catalog.api.edit_claims.StructuredValidationError` and have
-    their own wire format; this schema covers the simpler "detail only" case.
-    """
-
-    detail: str
+    # The shared shape for non-structured failures. Structured 422s (with
+    # ``field_errors`` / ``form_errors``) come from
+    # ``apps.catalog.api.edit_claims.StructuredValidationError`` and have their
+    # own wire format; this schema covers the simpler "detail only" case.
+    detail: str = Field(description="A human-readable error message.")
 
 
 class StructuredErrorBodySchema(Schema):
-    """Shared base for structured-error body schemas.
+    """Shared base for structured-error body schemas."""
 
-    Concrete variants override ``kind`` with a ``Literal`` so each emits a
-    discriminated TypeScript type via codegen. Inheritance-only — not used
-    as a router ``response=`` directly.
-    """
-
-    kind: str
-    message: str
+    # Concrete variants override ``kind`` with a ``Literal`` so each emits a
+    # discriminated TypeScript type via codegen. Inheritance-only — not used as a
+    # router ``response=`` directly.
+    kind: str = Field(description="Discriminator identifying the kind of error.")
+    message: str = Field(description="A human-readable summary of the error.")
 
 
 class ValidationErrorBodySchema(StructuredErrorBodySchema):
-    kind: Literal["validation_error"]
-    field_errors: dict[str, str]
-    form_errors: list[str]
+    """Structured 422 error body for validation failures."""
+
+    kind: Literal["validation_error"] = Field(
+        description='Discriminator; always "validation_error".'
+    )
+    field_errors: dict[str, str] = Field(
+        description="Error messages keyed by the input field they apply to."
+    )
+    form_errors: list[str] = Field(
+        description="Form-level errors not tied to any single field."
+    )
 
 
 class ValidationErrorSchema(Schema):
     """Structured 422 body produced by ``StructuredValidationError`` and by
     Ninja's malformed-body handler (see ``config/api.py``)."""
 
-    detail: ValidationErrorBodySchema
+    detail: ValidationErrorBodySchema = Field(description="The validation error body.")
 
 
 class RateLimitErrorBodySchema(StructuredErrorBodySchema):
-    kind: Literal["rate_limit"]
-    bucket: str
-    retry_after: int
+    """Structured 429 error body for rate-limit failures."""
+
+    kind: Literal["rate_limit"] = Field(
+        description='Discriminator; always "rate_limit".'
+    )
+    bucket: str = Field(
+        description="The rate-limit bucket that was exceeded (e.g. create, edit, delete)."
+    )
+    retry_after: int = Field(description="Seconds to wait before retrying the request.")
 
 
 class RateLimitErrorSchema(Schema):
     """Structured 429 body produced by ``RateLimitExceededError``."""
 
-    detail: RateLimitErrorBodySchema
+    detail: RateLimitErrorBodySchema = Field(description="The rate-limit error body.")
 
 
 class EntityLinkSchema(Schema):
-    """A reference to a catalog entity of unknown type.
+    """A reference to a catalog entity of unknown type."""
 
-    Carries everything needed to render a link to the entity: a pre-built
-    ``href`` (the consumer can't construct it without knowing the model),
-    the display ``name``, and a human-readable ``type_label``.
-    """
-
-    href: str
-    name: str
-    type_label: str
+    # Carries everything needed to render a link without knowing the model: a
+    # pre-built ``href`` the consumer can't construct itself, plus display text.
+    href: str = Field(description="Ready-to-use URL path to the entity's page.")
+    name: str = Field(description="The entity's display name.")
+    type_label: str = Field(
+        description='Human-readable entity type, e.g. "Title" or "Machine Model".'
+    )
 
 
 class LinkTypeSchema(Schema):
-    """One *kind* of wikilink target (title, model, person, …) — populates
-    the type selector in the wikilink picker. Targets within a chosen type
-    are returned as :class:`LinkTargetSchema`.
-    """
+    """One kind of wikilink target (title, model, person, …) — populates the
+    type selector in the wikilink picker."""
 
-    name: str
-    label: str
-    description: str
-    flow: str
+    # Targets within a chosen type are returned as ``LinkTargetSchema``.
+    name: str = Field(
+        description='Identifier for this link type (e.g. "title", "person").'
+    )
+    label: str = Field(description="Human-readable name shown in the type picker.")
+    description: str = Field(
+        description="Explanation of what this type targets, shown in the picker."
+    )
+    flow: str = Field(
+        description=(
+            'How targets are chosen for this type: "standard" uses the shared '
+            'autocomplete search; "custom" uses a type-specific frontend flow '
+            "(e.g. citations)."
+        )
+    )
 
 
 class LinkTargetSchema(Schema):
-    """One autocomplete result within a chosen :class:`LinkTypeSchema`.
-    ``ref`` is the wikilink string the editor inserts.
-    """
+    """One autocomplete result within a chosen :class:`LinkTypeSchema`."""
 
-    ref: str
-    label: str
+    ref: str = Field(
+        description="The wikilink reference the editor inserts for this target."
+    )
+    label: str = Field(description="Display text for the result.")
 
 
 class LinkTargetListSchema(Schema):
     """Response body for ``/link-types/targets/``."""
 
-    results: list[LinkTargetSchema]
+    results: list[LinkTargetSchema] = Field(description="The matching link targets.")
 
 
 class EntityAutocompleteResultSchema(Schema):
-    """One autocomplete result from ``/entity-autocomplete/``.
+    """One autocomplete result from ``/entity-autocomplete/``."""
 
-    ``value`` is the identity string the consumer **saves** — a ``public_id``
-    (slug) for catalog entities, a ``username`` for ``user`` later. ``label`` is
-    the display text; ``sublabel`` is an optional second line disambiguating
-    same-labeled rows (e.g. a title's "manufacturer · year").
-
-    Distinct from :class:`LinkTargetSchema` despite the similar shape: ``value``
-    is an FK to persist, whereas ``ref`` there is a wikilink token to insert.
-    Same-ish wire shape, different semantics — kept separate per ApiDesign.md.
-    """
-
-    value: str
-    label: str
-    sublabel: str | None = None
+    # Distinct from ``LinkTargetSchema`` despite the similar shape: ``value`` is
+    # an FK identity to persist, whereas ``LinkTargetSchema.ref`` is a wikilink
+    # token to insert. Same-ish wire shape, different semantics — kept separate
+    # per ApiDesign.md.
+    value: str = Field(
+        description="The identity string to save for this entity — its public id (a slug for most entities, a location path for Location)."
+    )
+    label: str = Field(description="Display text for the result.")
+    sublabel: str | None = Field(
+        None,
+        description="Optional second line disambiguating same-labeled results (e.g. a title's manufacturer and year).",
+    )
 
 
 class EntityAutocompleteListSchema(Schema):
     """Response body for ``/entity-autocomplete/``."""
 
-    results: list[EntityAutocompleteResultSchema]
+    results: list[EntityAutocompleteResultSchema] = Field(
+        description="The matching autocomplete results."
+    )

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -28,131 +28,161 @@ from .models import (
 ClaimDisplayIdentityState = Literal["resolved", "deleted", "missing"]
 """Discriminant for :class:`ClaimDisplayIdentityPartSchema`.
 
-See that schema for what each value implies about the surrounding fields.
+See that schema's ``state`` field for what each value implies.
 """
 
 
 class ClaimDisplayIdentityPartSchema(Schema):
-    """One identity slot of a relationship claim's user-facing rendering.
+    """One identity slot of a relationship claim's user-facing rendering."""
 
-    ``key`` names the identity ``ValueKeySpec`` (e.g. ``"person"``,
-    ``"alias_value"``).
-
-    ``state`` (see :data:`ClaimDisplayIdentityState`) discriminates three cases that
-    frontends typically want to render differently:
-
-    - ``"resolved"``: the backend produced a real label; ``label`` is the
-      non-empty user-facing string.
-    - ``"deleted"``: the claim references an FK target row that no longer
-      exists in the catalog (e.g. a Person was removed after the claim
-      was made). Legitimate runtime condition; ``label`` is null.
-    - ``"missing"``: the claim dict didn't carry this identity key at
-      all — an invariant violation that validation should have prevented.
-      Backend logs loudly when this happens; ``label`` is null.
-
-    No default on ``state``: every construction must pick one. Defaulting
-    to ``"resolved"`` would let ``ClaimDisplayIdentityPartSchema(key=..., label=None)``
-    construct silently with an incoherent ``(resolved, null)`` pair.
-    """
-
-    key: str
-    label: str | None
-    state: ClaimDisplayIdentityState
+    key: str = Field(
+        description='Names the identity this slot fills (e.g. "person", "alias_value").'
+    )
+    label: str | None = Field(
+        description=(
+            "The user-facing label for the referenced entity, or null when no "
+            "label could be produced (see ``state``)."
+        )
+    )
+    state: ClaimDisplayIdentityState = Field(
+        description=(
+            'Whether a label could be produced. "resolved": a real label is '
+            'present. "deleted": the referenced catalog row no longer exists, so '
+            '``label`` is null. "missing": the claim did not carry this identity '
+            "key, so ``label`` is null."
+        )
+    )
+    # No default on ``state``: every construction must pick one. Defaulting to
+    # ``"resolved"`` would let ``ClaimDisplayIdentityPartSchema(key=..., label=None)``
+    # construct silently with an incoherent ``(resolved, null)`` pair. The
+    # ``"missing"`` case is an invariant violation validation should have
+    # prevented; the backend logs loudly when it happens.
 
 
 class ClaimDisplayQualifierPartSchema(Schema):
-    """One qualifier on a relationship claim's user-facing rendering.
+    """One qualifier on a relationship claim's user-facing rendering."""
 
-    ``key`` names a non-identity ``ValueKeySpec`` (e.g. ``"count"``,
-    ``"category"``, ``"is_primary"``); ``value`` is the raw scalar so the
-    frontend can apply per-key rendering rules (``count > 1``, ``is_primary
-    === true``, etc.).
-
-    Union ordering is **most specific first**: ``bool`` before ``int``
-    because ``bool`` is an ``int`` subclass and Pydantic v2's default union
-    resolution would otherwise coerce ``True`` into ``1``, silently breaking
-    frontend ``v === true`` checks.
-    """
-
-    key: str
-    value: bool | int | str | None = None
+    key: str = Field(
+        description='Names the non-identity qualifier (e.g. "count", "category", "is_primary").'
+    )
+    value: bool | int | str | None = Field(
+        None,
+        description="The qualifier's raw scalar value, for per-key frontend rendering.",
+    )
+    # Union ordering is most specific first: ``bool`` before ``int`` because
+    # ``bool`` is an ``int`` subclass and Pydantic v2's default union resolution
+    # would otherwise coerce ``True`` into ``1``, silently breaking frontend
+    # ``v === true`` checks.
 
 
 class ClaimDisplayValueSchema(Schema):
-    """Structured user-facing rendering of a relationship-claim value.
+    """Structured user-facing rendering of a relationship-claim value."""
 
-    ``identity`` and ``qualifiers`` are lists (not dicts) so declaration
-    order is part of the wire format, not an implicit dict-insertion-order
-    contract. Direct-field scalar claims and non-relationship namespaces
-    have no ``ClaimDisplayValueSchema`` — the frontend falls back to the raw
-    ``old_value`` / ``new_value`` in that case.
-    """
-
-    identity: list[ClaimDisplayIdentityPartSchema]
-    qualifiers: list[ClaimDisplayQualifierPartSchema]
+    identity: list[ClaimDisplayIdentityPartSchema] = Field(
+        description="The claim's identity slots, in display order."
+    )
+    qualifiers: list[ClaimDisplayQualifierPartSchema] = Field(
+        description="The claim's qualifiers, in display order."
+    )
+    # Lists (not dicts) so declaration order is part of the wire format, not an
+    # implicit dict-insertion-order contract. Direct-field scalar claims and
+    # non-relationship namespaces have no ``ClaimDisplayValueSchema`` — the
+    # frontend falls back to the raw ``old_value`` / ``new_value`` there.
 
 
 class ClaimValueSchema(Schema):
-    """A claim value paired with its structured user-facing rendering.
+    """A claim value paired with its structured user-facing rendering."""
 
-    ``raw`` is the JSONField payload (scalar/dict/list/null). ``display`` is
-    the structured rendering for relationship claims (see
-    :class:`ClaimDisplayValueSchema`) or ``None`` when there's no
-    structured rendering — direct-field scalars, unknown namespaces,
-    non-dict values. Clients fall back to ``raw`` when ``display`` is null.
-    """
-
-    raw: object
-    display: ClaimDisplayValueSchema | None = None
+    raw: object = Field(
+        description=(
+            "The claim's raw JSON payload — a scalar, dict, list or null "
+            "depending on the claim kind."
+        )
+    )
+    display: ClaimDisplayValueSchema | None = Field(
+        None,
+        description=(
+            "Structured rendering for relationship claims, or null when there is "
+            "none (direct-field scalars, unknown namespaces, non-dict values); "
+            "clients fall back to ``raw``."
+        ),
+    )
 
 
 class FieldChangeSchema(Schema):
-    """A single field change within a ChangeSet (old -> new).
+    """A single field change within a ChangeSet (old → new)."""
 
-    ``old_value`` / ``new_value`` are :class:`ClaimValueSchema` — each
-    bundles the raw JSON payload with its structured display rendering.
-
-    ``old_value`` is null in two cases that this wire format does not
-    distinguish: (1) no prior claim exists in the chain, or (2) a prior
-    claim exists but its value is JSON null.
-    """
-
-    field_name: str
-    claim_key: str
-    old_value: ClaimValueSchema | None = None
-    new_value: ClaimValueSchema
-    claim_id: int | None = None
-    claim_user_id: int | None = None
-    is_active: bool | None = None
-    is_winning: bool | None = None
-    is_retracted: bool | None = None
+    field_name: str = Field(description="The entity field that changed.")
+    claim_key: str = Field(
+        description=(
+            "Identity of the claim within the field — equal to ``field_name`` for "
+            "scalar fields, or a composite key identifying one element of a "
+            "relationship."
+        )
+    )
+    # ``old_value`` is null in two cases this wire format does not distinguish:
+    # (1) no prior claim exists in the chain, or (2) a prior claim exists but its
+    # value is JSON null.
+    old_value: ClaimValueSchema | None = Field(
+        None,
+        description="The previous value, or null when there was no prior value.",
+    )
+    new_value: ClaimValueSchema = Field(
+        description="The new value asserted by this change."
+    )
+    claim_id: int | None = Field(
+        None, description="Identifier of the underlying claim, when available."
+    )
+    claim_user_id: int | None = Field(
+        None,
+        description="Identifier of the user who authored the claim, or null when it was authored by an ingest source.",
+    )
+    is_active: bool | None = Field(
+        None,
+        description="Whether the claim is currently active (not superseded or retracted).",
+    )
+    is_winning: bool | None = Field(
+        None,
+        description="Whether the claim currently wins resolution for its field; null when not computed for this response.",
+    )
+    is_retracted: bool | None = Field(
+        None, description="Whether the claim has been retracted."
+    )
 
 
 class RetractionSchema(Schema):
     """A claim that was retracted (not superseded) within a ChangeSet.
 
-    Distinct from :class:`FieldChangeSchema`: a retraction removes a prior
-    claim without replacing it, so there is no ``new_value``.
+    A retraction removes a prior claim without replacing it, so it has no
+    ``new_value`` — unlike :class:`FieldChangeSchema`.
     """
 
-    claim_id: int
-    field_name: str
-    claim_key: str
-    old_value: ClaimValueSchema
+    claim_id: int = Field(description="Identifier of the retracted claim.")
+    field_name: str = Field(
+        description="The entity field the retracted claim applied to."
+    )
+    claim_key: str = Field(
+        description="Identity of the retracted claim within the field."
+    )
+    old_value: ClaimValueSchema = Field(description="The value that was removed.")
 
 
 class ClaimUserAuthorSchema(Schema):
     """A Claim/ChangeSet authored by a user."""
 
-    kind: Literal["user"] = "user"
-    username: str
+    kind: Annotated[
+        Literal["user"], Field(description='Discriminator; always "user".')
+    ] = "user"
+    username: str = Field(description="The authoring user's username.")
 
 
 class ClaimSourceAuthorSchema(Schema):
     """A Claim/ChangeSet attributed to an ingest source."""
 
-    kind: Literal["source"] = "source"
-    name: str
+    kind: Annotated[
+        Literal["source"], Field(description='Discriminator; always "source".')
+    ] = "source"
+    name: str = Field(description="The ingest source's name.")
 
 
 ClaimAuthorSchema = Annotated[
@@ -168,46 +198,54 @@ an ingest source. Mirrors the DB-level XOR CHECK constraints
 class ClaimAttributionSchema(Schema):
     """Who asserted a Claim and when."""
 
-    author: ClaimAuthorSchema
-    created_at: str
+    author: ClaimAuthorSchema = Field(
+        description="The user or ingest source that made the assertion."
+    )
+    created_at: str = Field(
+        description="When the assertion was made, as an ISO 8601 timestamp."
+    )
 
 
 class ChangeSetBaseSchema(Schema):
     """Common fields for any read-side ChangeSet representation."""
 
-    id: int
-    attribution: ClaimAttributionSchema
-    note: str
+    id: int = Field(description="The ChangeSet's identifier.")
+    attribution: ClaimAttributionSchema = Field(
+        description="Who created the ChangeSet and when."
+    )
+    note: str = Field(
+        description="The author's note explaining the edit, or an empty string."
+    )
 
 
 class ChangeSetSchema(ChangeSetBaseSchema):
-    """A grouped edit session with per-field diffs.
+    """A grouped edit session with per-field diffs."""
 
-    ``capabilities`` is the wire contract for every ChangeSet row variant
-    in the codebase — see also ``ChangeSetSummarySchema``,
-    ``ChangeSetDetailSchema``, ``CitedChangeSetSchema``, and
-    ``UserChangeSetSchema``. The contract:
-
-    Each entry answers "is the caller authorized to *attempt* this
-    activity on this row" — it is **not** a guarantee the action will
-    succeed. ``capabilities['changeset.undo'] is True`` only means the
-    policy lets this caller call the undo endpoint with this changeset;
-    the endpoint additionally enforces operational invariants
-    (``action == DELETE``, claims not superseded) that aren't expressible
-    as pure-attribute policy predicates and so don't reflect on the wire.
-
-    A future per-row Undo UI MUST AND the embedded verdict with operational
-    eligibility before rendering an affordance, or design a separate
-    operational-eligibility wire field at that time.
-    """
-
-    changes: list[FieldChangeSchema]
-    retractions: list[RetractionSchema] = []
-    capabilities: dict[Activity, bool] = Field(default_factory=dict)
+    changes: list[FieldChangeSchema] = Field(
+        description="The field changes in this ChangeSet, one per modified field."
+    )
+    retractions: list[RetractionSchema] = Field(
+        [], description="Claims removed without replacement in this ChangeSet."
+    )
+    capabilities: dict[Activity, bool] = Field(
+        default_factory=dict,
+        description=(
+            "Per-activity authorization for the calling user: whether policy "
+            "permits attempting each action (e.g. ``changeset.undo``) on this row."
+        ),
+    )
+    # Each capability answers only "is the caller authorized to *attempt* this
+    # activity" — not a guarantee it will succeed. ``capabilities['changeset.undo']
+    # is True`` only means policy lets this caller call the undo endpoint; the
+    # endpoint additionally enforces operational invariants (``action == DELETE``,
+    # claims not superseded) that aren't expressible as pure-attribute policy
+    # predicates and so don't reflect on the wire. A future per-row Undo UI MUST
+    # AND the embedded verdict with operational eligibility before rendering an
+    # affordance, or design a separate operational-eligibility wire field then.
 
     # Declared on each concrete row variant (not on the base) — the
-    # ``authz.E101–E106`` system check reads these from ``__dict__``,
-    # so inherited declarations don't trigger the structural check.
+    # ``authz.E101–E106`` system check reads these from ``__dict__``, so
+    # inherited declarations don't trigger the structural check.
     policy_activities: ClassVar[tuple[Activity, ...]] = (Activity.CHANGESET_UNDO,)
     policy_target_model: ClassVar[type[Model]] = ChangeSet
 
@@ -215,25 +253,46 @@ class ChangeSetSchema(ChangeSetBaseSchema):
 class ClaimSchema(Schema):
     """A single per-field claim as surfaced to the Sources UI."""
 
-    attribution: ClaimAttributionSchema
-    field_name: str
-    value: ClaimValueSchema
-    citation: str
-    is_winner: bool
-    changeset_note: str | None = None
+    attribution: ClaimAttributionSchema = Field(
+        description="Who asserted the claim and when."
+    )
+    field_name: str = Field(description="The entity field the claim applies to.")
+    value: ClaimValueSchema = Field(description="The claim's asserted value.")
+    citation: str = Field(
+        description="The citation backing the claim, or an empty string when none."
+    )
+    is_winner: bool = Field(
+        description="Whether this claim currently wins resolution for its field."
+    )
+    changeset_note: str | None = Field(
+        None, description="The note from the ChangeSet that grouped this claim, if any."
+    )
 
 
 class CitationReferenceInputSchema(Schema):
     """Reference an existing CitationInstance to clone onto a user edit."""
 
-    citation_instance_id: int
+    citation_instance_id: int = Field(
+        description="Identifier of the existing citation instance to reuse."
+    )
 
 
 class ChangeSetInputSchema(Schema):
     """Base shape for any user-attributed mutation that produces a ChangeSet."""
 
-    note: Annotated[str, Field(max_length=CHANGESET_NOTE_MAX_LENGTH)] = ""
-    citation: CitationReferenceInputSchema | None = None
+    note: Annotated[
+        str,
+        Field(
+            max_length=CHANGESET_NOTE_MAX_LENGTH,
+            description="Optional note explaining the edit.",
+        ),
+    ] = ""
+    citation: Annotated[
+        CitationReferenceInputSchema | None,
+        Field(
+            description="An existing citation instance to attach to the edit, if any."
+        ),
+    ] = None
 
 
 class AttributionSchema(Schema):
@@ -276,8 +335,8 @@ class AttributionSchema(Schema):
 class ReviewLinkSchema(Schema):
     """A link out to an external page relevant to a needs-review item."""
 
-    label: str
-    url: str
+    label: str = Field(description="Human-readable link text.")
+    url: str = Field(description="The link's URL.")
 
 
 class CitationLinkSchema(Schema):
@@ -352,63 +411,93 @@ class RichTextSchema(Schema):
 
 
 class CitationSourceSchema(Schema):
-    """A reusable citation source (a book, website, person, etc.).
+    """A reusable citation source — a database, wiki, book, editorial team, etc."""
 
-    The source itself — not an individual reference *to* it. Distinct from
-    :class:`CitationInstanceSchema`, which is one use of a source on a
-    specific claim.
-    """
-
-    name: str
-    slug: str
-    source_type: str
-    priority: int
-    url: str
-    description: str
+    # The source itself — not an individual reference *to* it. Distinct from
+    # :class:`CitationInstanceSchema`, which is one use of a source on a claim.
+    name: str = Field(description="The source's display name.")
+    slug: str = Field(description="The source's URL slug.")
+    source_type: str = Field(
+        description="Kind of source: one of ``database``, ``wiki``, ``book``, ``editorial`` or ``other``."
+    )
+    priority: int = Field(
+        description="Resolution weight; when claims conflict, the higher-priority source wins."
+    )
+    url: str = Field(
+        description="URL where the source can be found, or an empty string."
+    )
+    description: str = Field(
+        description="Free-text description of the source, or an empty string."
+    )
 
 
 class ReviewClaimSchema(Schema):
-    """A flagged claim as surfaced in the global review queue.
+    """A flagged claim as surfaced in the global review queue."""
 
-    Self-contains subject context (``subject_*``, ``title_slug``,
-    ``review_links``) because the review UI displays claims *outside* any
-    entity page. Distinct from :class:`ClaimSchema`, which assumes the
-    entity context is already known (Sources page) and instead carries
-    priority/citation metadata (``citation``, ``is_winner``).
-    """
-
-    id: int
-    source_name: str
-    field_name: str
-    value: ClaimValueSchema
-    needs_review_notes: str
-    created_at: str
-    # Context about the subject (the entity this claim targets).
+    # Self-contains subject context (``subject_*``, ``title_slug``,
+    # ``review_links``) because the review UI displays claims *outside* any
+    # entity page. Distinct from :class:`ClaimSchema`, which assumes the entity
+    # context is already known (Sources page).
+    id: int = Field(description="The claim's identifier.")
+    source_name: str = Field(
+        description="Name of the source or user that authored the claim."
+    )
+    field_name: str = Field(description="The entity field the claim applies to.")
+    value: ClaimValueSchema = Field(description="The claim's asserted value.")
+    needs_review_notes: str = Field(
+        description="Explanation of why the claim needs review."
+    )
+    created_at: str = Field(
+        description="When the claim was created, as an ISO 8601 timestamp."
+    )
     # Canonical hyphenated CatalogModel.entity_type, e.g. "manufacturer".
-    subject_type: str
-    subject_name: str
-    subject_slug: str | None = None
-    # Title that this claim created (for group claims).
-    title_slug: str | None = None
-    review_links: list[ReviewLinkSchema] = []
+    subject_type: str = Field(
+        description='Entity type of the claim\'s subject (e.g. "manufacturer").'
+    )
+    subject_name: str = Field(description="Display name of the subject entity.")
+    subject_slug: str | None = Field(
+        None,
+        description="URL slug of the subject entity, or null if it no longer exists.",
+    )
+    title_slug: str | None = Field(
+        None,
+        description="For group claims that created a Title, the Title's slug; null otherwise.",
+    )
+    review_links: list[ReviewLinkSchema] = Field(
+        [], description="External links relevant to reviewing the claim."
+    )
 
 
 class RevertNoteSchema(Schema):
-    """Input for reverting a single claim to a prior value. ``note`` is required."""
+    """Input for reverting a single claim to a prior value."""
 
-    note: Annotated[str, Field(max_length=CHANGESET_NOTE_MAX_LENGTH)]
+    note: Annotated[
+        str,
+        Field(
+            max_length=CHANGESET_NOTE_MAX_LENGTH,
+            description="Required note explaining the revert.",
+        ),
+    ]
 
 
 class UndoChangeSetSchema(Schema):
     """Input for undoing an entire ChangeSet (a create/edit/delete grouping)."""
 
-    note: Annotated[str, Field(max_length=CHANGESET_NOTE_MAX_LENGTH)] = ""
+    note: Annotated[
+        str,
+        Field(
+            max_length=CHANGESET_NOTE_MAX_LENGTH,
+            description="Optional note explaining the undo.",
+        ),
+    ] = ""
 
 
 class UndoResultSchema(Schema):
     """Result of an undo: the id of the new compensating ChangeSet."""
 
-    changeset_id: int
+    changeset_id: int = Field(
+        description="Identifier of the compensating ChangeSet created by the undo."
+    )
 
 
 class CitationInstanceSchema(Schema):
@@ -419,33 +508,54 @@ class CitationInstanceSchema(Schema):
     page number, URL fragment, or other locator.
     """
 
-    id: int
-    citation_source_id: int
-    citation_source_name: str
-    claim_id: int | None = None
-    locator: str
-    created_at: str
+    id: int = Field(description="The citation instance's identifier.")
+    citation_source_id: int = Field(description="Identifier of the cited source.")
+    citation_source_name: str = Field(description="Display name of the cited source.")
+    claim_id: int | None = Field(
+        None,
+        description="Identifier of the claim this instance cites, or null when unattached.",
+    )
+    locator: str = Field(
+        description="Specific location within the source, such as a page or section, or an empty string."
+    )
+    created_at: str = Field(
+        description="When the instance was created, as an ISO 8601 timestamp."
+    )
 
 
 class CitationInstanceBatchSchema(Schema):
     """A CitationInstance flattened with its source fields for batch rendering.
 
-    Used where the UI needs source metadata (name, type, author, year)
-    alongside the instance without a separate source lookup — typically
-    when rendering many citations at once.
+    Carries source metadata (name, type, author, year) alongside the
+    instance so callers rendering many citations at once avoid a separate
+    source lookup.
     """
 
-    id: int
-    source_name: str
-    source_type: str
-    author: str
-    year: int | None = None
-    locator: str
-    links: list[CitationLinkSchema] = []
+    id: int = Field(description="The citation instance's identifier.")
+    source_name: str = Field(description="Name of the cited source.")
+    source_type: str = Field(
+        description="Kind of source: one of ``database``, ``wiki``, ``book``, ``editorial`` or ``other``."
+    )
+    author: str = Field(description="Author of the cited source, or an empty string.")
+    year: int | None = Field(
+        None, description="Publication year of the source, if known."
+    )
+    locator: str = Field(
+        description="Specific location within the source, or an empty string."
+    )
+    links: list[CitationLinkSchema] = Field(
+        [], description="External links for the cited source."
+    )
 
 
 class CitationInstanceCreateSchema(Schema):
     """Input for creating a new CitationInstance against an existing source."""
 
-    citation_source_id: int
-    locator: Annotated[str, Field(max_length=CITATION_INSTANCE_LOCATOR_MAX_LENGTH)] = ""
+    citation_source_id: int = Field(description="Identifier of the source to cite.")
+    locator: Annotated[
+        str,
+        Field(
+            max_length=CITATION_INSTANCE_LOCATOR_MAX_LENGTH,
+            description="Specific location within the source, such as a page or section.",
+        ),
+    ] = ""


### PR DESCRIPTION
## Summary
Adds OpenAPI `Field(description=...)` to the schemas in three apps so the generated docs (and the typed frontend client) explain each field:

- **`apps/core/schemas.py`** — error bodies (validation, rate-limit), entity-link and wikilink/autocomplete schemas.
- **`apps/provenance/schemas.py`** — changeset diffs, claim values/display rendering, attribution, review-queue and citation-instance schemas.
- **`apps/citation/schemas.py`** — citation source/link/search/recognition/extract schemas, plus a module-level domain primer (root/child hierarchy, abstract sources, locator skipping).

Per-field documentation that used to live in class docstrings is pulled into `Field` descriptions; internal implementation notes (computed-field derivations, extractor-walk mechanics, discriminator/union ordering, partial-update coercion) stay as `#` comments so they don't leak into the public docs. Fields that previously had no documentation got researched descriptions verified against the models and serializers, including exact enum values (`source_type`, `identifier_key`, `link_type`, extract `confidence`/`source_api`/`error`).

Defaulted fields (the author discriminator `kind`, the optional `citation`) use the `Annotated[T, Field(...)] = default` form so the default stays visible to the mypy pydantic plugin. No wire-shape or type changes — descriptions only.

## Test plan
- `make codegen` regenerates cleanly; `svelte-check` passes (0 errors).
- Backend: provenance + citation suites pass (583 tests); full-repo `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)