### PR TITLE
feat(api): rate-limit the public API

### DIFF
--- a/backend/apps/catalog/api/export.py
+++ b/backend/apps/catalog/api/export.py
@@ -24,6 +24,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Any, NamedTuple
 
+from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Count, Max, Min, Q, QuerySet, Subquery
@@ -36,6 +37,8 @@ from apps.catalog.models import CatalogModel
 from apps.core.entity_types import all_linkable_models, get_linkable_model
 from apps.core.licensing import get_minimum_display_rank
 from apps.core.models import active_status_q
+from apps.core.rate_limits import RateLimitSpec, check_and_record_ip
+from apps.core.schemas import RateLimitErrorSchema
 from apps.media.models import MediaSupportedModel
 from apps.provenance.helpers import active_claims as _active_claims
 from apps.provenance.helpers import claims_prefetch
@@ -66,6 +69,31 @@ _BASE_HANDLED = frozenset({"name", "slug", "description", "status"})
 # Per-entity System-internal / API-suppressed claim fields kept OUT of the dump.
 _MODERATION = frozenset({"needs_review", "needs_review_notes"})  # internal review notes
 _RATINGS = frozenset({"ipdb_rating", "pinside_rating"})  # already cut from the API
+
+
+# Per-IP rate limit for the public export, via the project's sanctioned IP limiter
+# (X-Real-IP, trust-flag-gated, fail-closed; structured 429 + Retry-After). One
+# shared bucket across all export endpoints, so the limit is a per-IP full-sync
+# budget (rationale + numbers: settings.EXPORT_RATELIMIT_IP). Built per-request
+# from settings (like the signup limiters) so the cap is tunable at runtime
+# without a deploy — see apps.accounts.api.signup._spec for the same pattern.
+def _export_rate_limit_spec() -> RateLimitSpec:
+    limit, window = settings.EXPORT_RATELIMIT_IP
+    return RateLimitSpec(bucket="export", limit=limit, window_seconds=window)
+
+
+def export_rate_limit_summary() -> str:
+    """Human-readable budget for the public API description, e.g. "roughly 6
+    full exports per hour".
+
+    Derived from the configured spec and the endpoint count (one request per
+    entity = one full dump), so the published description tracks
+    ``EXPORT_RATELIMIT_IP`` instead of carrying a hand-typed number that drifts.
+    """
+    limit, window = settings.EXPORT_RATELIMIT_IP
+    requests_per_full_export = len(EXPORT_ENTITY_TYPES)
+    full_exports_per_hour = round(limit / requests_per_full_export * 3600 / window)
+    return f"roughly {full_exports_per_hour} full exports per hour"
 
 
 # ---------------------------------------------------------------------------
@@ -685,7 +713,7 @@ def _register(spec: ExportSpec) -> None:
     cache_base = model.entity_type
 
     def _view(request: HttpRequest) -> HttpResponse:
-        _ = request
+        check_and_record_ip(request, _export_rate_limit_spec())
         key = export_key(cache_base)
         cached = get_cached_response(key)
         if cached is not None:
@@ -712,7 +740,9 @@ def _register(spec: ExportSpec) -> None:
     _view.__name__ = f"export_{entity_type_plural.replace('-', '_')}"
     export_router.get(
         f"/{entity_type_plural}/",
-        response=list[schema],  # type: ignore[valid-type]
+        # 429 documented so the public OpenAPI advertises the per-IP limit and
+        # its Retry-After body (the export API is the sole documented surface).
+        response={200: list[schema], 429: RateLimitErrorSchema},  # type: ignore[valid-type]
         summary=label_plural,
         description=f"Bulk export all {label_plural}.",
     )(_view)

--- a/backend/apps/catalog/tests/test_api_export.py
+++ b/backend/apps/catalog/tests/test_api_export.py
@@ -247,3 +247,40 @@ class TestExportCompleteness:
             for row in resp.json():
                 leaked = HIDDEN & row.keys()
                 assert not leaked, f"{spec.model.__name__} leaked {leaked}"
+
+
+class TestExportRateLimit:
+    @staticmethod
+    def _limit_one(settings):
+        # Squeeze the per-IP budget to 1 so the second request trips it (rather
+        # than issuing 120). Overriding the setting exercises the real per-request
+        # spec path; counters reset per test via the locmem-cache fixture.
+        settings.EXPORT_RATELIMIT_IP = (1, 3600)
+
+    def test_export_is_rate_limited_with_structured_429(
+        self, client, machine_model, settings
+    ):
+        self._limit_one(settings)
+        assert client.get("/api/export/models/").status_code == 200
+        resp = client.get("/api/export/models/")
+        assert resp.status_code == 429
+        # Same wire shape as the rest of the app: Retry-After + structured body.
+        assert resp["Retry-After"]
+        assert resp.json()["detail"]["kind"] == "rate_limit"
+
+    def test_spoofed_xff_cannot_rotate_the_bucket(
+        self, client, machine_model, settings
+    ):
+        # The limit keys on the sanctioned IP (REMOTE_ADDR in tests, X-Real-IP via
+        # Caddy in prod), never X-Forwarded-For — so rotating XFF can't dodge it.
+        self._limit_one(settings)
+        first = client.get("/api/export/models/", HTTP_X_FORWARDED_FOR="1.1.1.1")
+        second = client.get("/api/export/models/", HTTP_X_FORWARDED_FOR="9.9.9.9")
+        assert first.status_code == 200
+        assert second.status_code == 429  # different XFF, same bucket
+
+    def test_internal_api_is_not_rate_limited(self, client, machine_model):
+        # The limiter lives in the export views only; internal routes are unmetered.
+        # No squeeze needed — internal routes never read EXPORT_RATELIMIT_IP.
+        assert client.get("/api/models/").status_code == 200
+        assert client.get("/api/models/").status_code == 200

--- a/backend/apps/core/schemas.py
+++ b/backend/apps/core/schemas.py
@@ -55,7 +55,7 @@ class RateLimitErrorBodySchema(StructuredErrorBodySchema):
         description='Discriminator; always "rate_limit".'
     )
     bucket: str = Field(
-        description="The rate-limit bucket that was exceeded (e.g. create, edit, delete)."
+        description="The rate-limit bucket that was exceeded (create, edit, delete, export etc)."
     )
     retry_after: int = Field(description="Seconds to wait before retrying the request.")
 

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -12,7 +12,7 @@ from apps.catalog.api.edit_claims import (
     FieldConstraintSchema,
     StructuredValidationError,
 )
-from apps.catalog.api.export import export_router
+from apps.catalog.api.export import export_rate_limit_summary, export_router
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
 from apps.core.exceptions import StructuredApiError
@@ -33,15 +33,20 @@ api = NinjaAPI(
 # Public API: the bulk export — the sole documented, externally-consumed surface.
 # A SEPARATE NinjaAPI so its OpenAPI document *is* exactly the export (no tag
 # filtering, and internal endpoints cannot leak into it). Mounted at /api/export/
-# (config/urls.py). Read-only GET, so it needs none of the internal API's
-# structured-error / rate-limit / exception handlers below.
+# (config/urls.py). Abuse is capped per-IP by the export views (the project's
+# sanctioned IP limiter, settings.EXPORT_RATELIMIT_IP), which raises
+# StructuredApiError — so export_api registers the shared structured-error handler
+# below.
 export_api = NinjaAPI(
     title="Flipcommons Export API",
     version="1.0.0",
     description=(
-        "Bulk export records from Flipcommons. Please be gentle on the system: "
-        "save the exported data and do the rest of your operations locally on "
-        "your exported copy."
+        "Bulk export records from Flipcommons.\n\n"
+        "Please be gentle on the system: save the exported data and do the rest "
+        "of your operations locally on your exported copy. Requests are "
+        # Limit derived from the live config so the published number never goes stale.
+        f"rate-limited to {export_rate_limit_summary()} per IP; a 429 with a "
+        "Retry-After header means you've exceeded it."
     ),
     urls_namespace="export",
 )
@@ -146,7 +151,13 @@ def _structured_error_response(exc: StructuredApiError) -> JsonResponse:
     return response
 
 
+# Registered on both APIs: the internal API for its full structured-error
+# taxonomy, and the export API whose only structured error is the rate-limit 429
+# (RateLimitExceededError → {kind, retry_after} + Retry-After). Same wire shape on
+# both. The decorator returns the function unchanged, so stacking just adds a
+# second registration.
 @api.exception_handler(StructuredApiError)
+@export_api.exception_handler(StructuredApiError)
 def _handle_structured_api_error(
     request: HttpRequest, exc: StructuredApiError
 ) -> JsonResponse:

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -259,6 +259,13 @@ SIGNUP_SUBMIT_RATELIMIT_SESSION = (10, 60)
 SIGNUP_SUBMIT_RATELIMIT_IP = (30, 60)
 SIGNUP_CANCEL_RATELIMIT_IP = (20, 60)
 
+# Public bulk-export API (GET /api/export/<entity>/). One shared per-IP bucket
+# across all 20 export endpoints, so the limit is a per-IP full-sync budget: a
+# full dump is ~20 requests, so 120/hour ≈ 6 full dumps/hour. Generous for batch
+# consumers (who should save the export and work locally) while capping the
+# real-time polling the export exists to discourage. (limit, window_seconds).
+EXPORT_RATELIMIT_IP = (120, 3600)
+
 # ── WorkOS AuthKit ────────────────────────────────────────────────
 WORKOS_API_KEY = os.environ.get("WORKOS_API_KEY", "").strip()
 WORKOS_CLIENT_ID = os.environ.get("WORKOS_CLIENT_ID", "").strip()


### PR DESCRIPTION
## Summary

Rate-limit the public bulk-export API per IP with the project's sanctioned IP limiter (X-Real-IP, fail-closed; structured 429 + Retry-After). One shared per-IP bucket across all export endpoints, so the limit is a per-IP full-sync budget (~6 full dumps/hour) — generous for batch consumers who save and work locally, but it caps the real-time polling the export exists to discourage.

- Spec built per-request from `settings.EXPORT_RATELIMIT_IP`, matching the signup limiter pattern, so the cap is tunable without a deploy.
- The 429 is documented in the export OpenAPI (the sole public surface): each route declares `RateLimitErrorSchema`, and the API description states the limit — derived from live config so the number never goes stale.
- Structured-error handler now registered on the export API too (stacked decorator, no clone).
- `RateLimitErrorBodySchema` bucket docs mention the new `export` bucket.

## Test plan

- [x] `TestExportRateLimit`: structured 429 + Retry-After on the second request, spoofed X-Forwarded-For can't rotate the bucket, internal API stays unmetered
- [x] `make test` (backend suite green via pre-commit)
- [ ] Hit `/api/export/models/` past the limit in a deployed env and confirm the 429 body + `Retry-After`
- [x] Confirm `/api-docs` renders the limit in the API overview and the 429 on each endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)