### PR TITLE
feat(api): add manufacturer to model export API

### DIFF
--- a/backend/apps/catalog/api/export.py
+++ b/backend/apps/catalog/api/export.py
@@ -582,6 +582,19 @@ def _build_registry() -> dict[type[CatalogModel], ExportSpec]:
                     "credits", "credits", "credits__person", "credits__role"
                 ),
             },
+            derived={
+                # corporate_entity is the granular incarnation; this is the
+                # consolidated brand slug (the manufacturer name on the cabinet),
+                # so consumers can key models on the brand without a second hop
+                # through /export/corporate-entities/.
+                "manufacturer": DerivedField(
+                    str | None,
+                    "_export_mfr",
+                    "Consolidated manufacturer slug for this model's "
+                    "corporate entity (the brand on the cabinet).",
+                ),
+            },
+            annotate=_annotate_machine_model,
         ),
         ExportSpec(
             model=Title,
@@ -671,6 +684,15 @@ def _build_registry() -> dict[type[CatalogModel], ExportSpec]:
                 relations={**spec.relations, "aliases": _rel("aliases", "strings")},
             )
     return by_model
+
+
+def _annotate_machine_model(qs: QuerySet[Any]) -> QuerySet[Any]:
+    # corporate_entity -> manufacturer -> slug is a plain to-one chain, so a
+    # direct F reference suffices (null when the model has no corporate entity).
+    annotated: QuerySet[Any] = qs.annotate(
+        _export_mfr=models.F("corporate_entity__manufacturer__slug")
+    )
+    return annotated
 
 
 def _annotate_title(qs: QuerySet[Any]) -> QuerySet[Any]:

--- a/backend/apps/catalog/cache.py
+++ b/backend/apps/catalog/cache.py
@@ -28,7 +28,7 @@ from apps.core.licensing import current_audience
 # until the next write; versioning the keys orphans the stale entries instead.
 # The version is shared across all bases, so a bump also harmlessly orphans
 # unchanged payloads, which rebuild on first read. (Per-bump history: git blame.)
-_CACHE_VERSION = "v5"
+_CACHE_VERSION = "v6"
 
 # No-filter facet option lists for the /titles page (GET /api/pages/titles). Static
 # between catalog edits, so cached and cleared by invalidate_all().

--- a/backend/apps/catalog/tests/test_api_export.py
+++ b/backend/apps/catalog/tests/test_api_export.py
@@ -58,6 +58,14 @@ class TestExportShape:
         assert isinstance(row["themes"], list)
         assert isinstance(row["tags"], list)
 
+    def test_consolidated_manufacturer_slug_on_row(self, client, machine_model):
+        # The model links to the granular corporate entity, but the row also
+        # carries the consolidated brand slug so consumers can key on it without
+        # a second hop through /export/corporate-entities/.
+        row = _row(client, "models", machine_model.slug)
+        assert row["corporate_entity"] == "williams-electronics"
+        assert row["manufacturer"] == "williams"
+
     def test_hidden_fields_never_exported(self, client, machine_model):
         row = _row(client, "models", machine_model.slug)
         for hidden in HIDDEN:
@@ -147,6 +155,8 @@ class TestExportDriftGuard:
             "cabinet",
             "game_format",
             "production_status",
+            # derived: consolidated brand slug (corporate_entity -> manufacturer)
+            "manufacturer",
             # media
             "thumbnail_url",
             "hero_image_url",


### PR DESCRIPTION
## What

Adds a `manufacturer` field to every `/api/export/models/` row, carrying the **consolidated brand slug** (e.g. `bally`) alongside the existing `corporate_entity` (e.g. `bally-midway-manufacturing-company`).

## Why

The model export previously exposed only `corporate_entity` — the granular corporate incarnation. Consumers who key models on the brand (notably the Flip museum's data pipeline) had to second-hop through `/api/export/corporate-entities/` to resolve `corporate_entity → manufacturer`. This closes that join friction by putting the brand slug directly on the row.

## How

- New `manufacturer` `DerivedField` on the `MachineModel` export spec, fed by `_annotate_machine_model`, which annotates `corporate_entity__manufacturer__slug` via a plain `F()` reference. It's a to-one join (`corporate_entity` is already `select_related`), so no extra query — the `django_assert_max_num_queries` budget is unchanged.
- Cache version bump **v5 → v6**: the export JSON shape changed, and deploy-surviving `FileBasedCache` entries (`timeout=None`) are only evicted by `invalidate_all()` on data mutation, never on deploy. Without the bump, stale rows could serve without `manufacturer` until the next catalog edit.

## Scope

Fully contained to the export query: `_annotate_machine_model`/`_export_mfr` are referenced only in `export.py`, and `spec.annotate` is consumed only by the export view's queryset. **No impact on listing/detail pages** (they resolve manufacturer through their own `select_related` chains) and **no migration** (derived annotation, not a column).

## Tests

- Added a value assertion: a model row carries both `corporate_entity` and the consolidated `manufacturer` slug.
- Updated the export drift-guard field set to include `manufacturer`.
- Full export + cache suite green (58 passed); pre-commit (ruff, mypy, backend tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)