### PR TITLE
feat(patches): support aliases & abbreviations in data patches

### DIFF
--- a/backend/apps/catalog/api/edit_claims.py
+++ b/backend/apps/catalog/api/edit_claims.py
@@ -18,7 +18,11 @@ from django.db import models as db_models
 from ninja import Schema
 
 from apps.accounts.models import User
-from apps.catalog.claims import build_relationship_claim
+from apps.catalog.claims import (
+    build_relationship_claim,
+    normalize_abbreviation_value,
+    normalize_alias_identity,
+)
 from apps.catalog.models import (
     CorporateEntity,
     CreditRole,
@@ -41,7 +45,7 @@ from apps.provenance.models import (
     get_claim_fields,
 )
 from apps.provenance.schemas import CitationReferenceInputSchema
-from apps.provenance.validation import validate_claim_value
+from apps.provenance.validation import get_relationship_schema, validate_claim_value
 
 from ..resolve import resolve_after_mutation
 from ._typing import CreditKey, CreditPkKey
@@ -369,11 +373,13 @@ def plan_alias_claims(
     """
     # Normalise: strip, deduplicate by lowercase key, drop blanks.
     # Last-write-wins for display case when duplicates differ only in case.
+    # The strip/lower fold is shared with the data-patch adapter via
+    # ``normalize_alias_identity`` so the two paths produce identical bytes.
     desired: dict[str, str] = {}  # lowercase → display string
     for raw in desired_aliases:
-        val = raw.strip()
-        if val:
-            desired[val.lower()] = val
+        ident = normalize_alias_identity(raw)
+        if ident.value:
+            desired[ident.value] = ident.display
 
     current: dict[str, str] = {}  # lowercase → stored display string
     for a in entity.aliases.all():
@@ -741,16 +747,37 @@ def build_credit_claim_specs(
     return specs
 
 
+def _abbreviation_max_length() -> int:
+    """The abbreviation length bound, read from the registered schema.
+
+    Model-derived (populated from the through-model ``CharField`` at
+    registration), so the editor and the data-patch adapter enforce the same
+    limit from one source instead of a hardcoded constant.
+    """
+    schema = get_relationship_schema("abbreviation")
+    assert schema is not None, "abbreviation schema must be registered"
+    (spec,) = [s for s in schema.value_keys if s.identity is not None]
+    assert spec.max_length is not None, "abbreviation identity must declare max_length"
+    return spec.max_length
+
+
 def _normalize_abbreviations(values: list[str]) -> list[str]:
-    """Strip, deduplicate, drop blanks, enforce max length."""
+    """Strip, deduplicate, drop blanks, enforce max length.
+
+    The strip fold is shared with the data-patch adapter via
+    ``normalize_abbreviation_value`` and the length bound comes from the
+    registered schema (``_abbreviation_max_length``), so both write paths
+    normalize and bound identically.
+    """
+    max_length = _abbreviation_max_length()
     normalized: list[str] = []
     seen: set[str] = set()
     for raw_value in values:
-        value = raw_value.strip()
+        value = normalize_abbreviation_value(raw_value)
         if not value:
             continue
-        if len(value) > 50:
-            raise_form_error("Abbreviations must be 50 characters or fewer.")
+        if len(value) > max_length:
+            raise_form_error(f"Abbreviations must be {max_length} characters or fewer.")
         if value in seen:
             continue
         seen.add(value)

--- a/backend/apps/catalog/claims.py
+++ b/backend/apps/catalog/claims.py
@@ -11,6 +11,7 @@ ingest commands and the resolution layer use.
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+from typing import NamedTuple
 
 from django.contrib.contenttypes.models import ContentType
 
@@ -52,12 +53,14 @@ def register_catalog_relationship_schemas() -> None:
         GameplayFeature,
         Location,
         MachineModel,
+        ModelAbbreviation,
         Person,
         RewardType,
         Series,
         Tag,
         Theme,
         Title,
+        TitleAbbreviation,
     )
     from apps.media.models import MediaAsset
 
@@ -147,7 +150,17 @@ def register_catalog_relationship_schemas() -> None:
         valid_subjects={MachineModel},
     )
 
-    # Abbreviation (literal) on Title + MachineModel.
+    # Abbreviation (literal) on Title + MachineModel. The stored value lives on
+    # two separate through-models; read the bound from both and require they
+    # agree so a future divergence fails registration instead of silently
+    # picking one. Drives the data-patch over-length guard (see ValueKeySpec).
+    model_abbr_len = ModelAbbreviation._meta.get_field("value").max_length
+    title_abbr_len = TitleAbbreviation._meta.get_field("value").max_length
+    assert model_abbr_len is not None, "ModelAbbreviation.value must declare max_length"
+    assert model_abbr_len == title_abbr_len, (
+        "ModelAbbreviation.value and TitleAbbreviation.value must declare the "
+        f"same max_length (got {model_abbr_len!r} / {title_abbr_len!r})"
+    )
     register_relationship_schema(
         namespace="abbreviation",
         value_keys=(
@@ -156,6 +169,7 @@ def register_catalog_relationship_schemas() -> None:
                 scalar_type=str,
                 required=True,
                 identity="value",
+                max_length=model_abbr_len,
             ),
         ),
         valid_subjects={Title, MachineModel},
@@ -206,6 +220,10 @@ def register_catalog_relationship_schemas() -> None:
 
     # Alias namespaces — one schema per AliasModel subclass.
     for alias_type in discover_alias_types():
+        alias_value_len = alias_type.alias_model._meta.get_field("value").max_length
+        assert alias_value_len is not None, (
+            f"{alias_type.alias_model.__name__}.value must declare a max_length"
+        )
         register_relationship_schema(
             namespace=alias_type.claim_field,
             value_keys=(
@@ -215,6 +233,7 @@ def register_catalog_relationship_schemas() -> None:
                     required=True,
                     identity="alias",
                     display_key="alias_display",
+                    max_length=alias_value_len,
                 ),
                 ValueKeySpec(
                     name="alias_display",
@@ -287,6 +306,32 @@ def get_all_namespace_keys() -> dict[str, list[str]]:
     return result
 
 
+class AliasIdentity(NamedTuple):
+    """The canonical fold of one raw alias string.
+
+    ``value`` is the lowercased identity (drives the claim_key); ``display``
+    is the original-case rendering stored in ``alias_display``. Both the
+    in-app editor (``plan_alias_claims``) and the data-patch adapter build
+    alias claims through this one fold so their bytes are identical by
+    construction — a patch alias and an editor alias supersede/dedup against
+    each other only if the (value, display) pair matches exactly.
+    """
+
+    value: str
+    display: str
+
+
+def normalize_alias_identity(raw: str) -> AliasIdentity:
+    """Canonical alias fold: strip, lowercase for identity, keep original case."""
+    s = raw.strip()
+    return AliasIdentity(value=s.lower(), display=s)
+
+
+def normalize_abbreviation_value(raw: str) -> str:
+    """Canonical abbreviation fold: strip only — abbreviations are case-sensitive."""
+    return raw.strip()
+
+
 def build_relationship_claim(
     field_name: str,
     identity: Mapping[str, IdentityPart],
@@ -297,24 +342,40 @@ def build_relationship_claim(
     ``identity`` contains the identity fields for this relationship, e.g.,
     ``{"person": 42, "role": 5}`` or ``{"alias_value": "foo"}``. Keys are
     value-dict names (``alias_value``), not identity labels (``alias``) —
-    the mapping is resolved via ``ValueKeySpec.identity``.
+    the mapping is resolved via ``ValueKeySpec.identity``. The mapping may
+    also carry non-identity keys (e.g. ``alias_display``) for an assert.
 
     The claim_key is derived from identity using the registered schema for
-    *field_name*. The value dict includes all identity fields plus ``exists``.
+    *field_name*.
+
+    Tombstone invariant: when ``exists=False`` the value carries **only** the
+    schema-identity keys plus ``exists`` — any non-identity payload in
+    *identity* is dropped. No resolver reads a non-identity key off an absent
+    member (they short-circuit on ``exists=False`` first), so dropping it keeps
+    tombstone bytes canonical and lets every write path supersede/dedup
+    byte-identically. This is a no-op for callers that already pass
+    identity-only dicts on removal (all of them, today).
     """
     schema = get_relationship_schema(field_name)
     if schema is None:
         raise ValueError(f"Unknown relationship namespace: {field_name!r}")
 
     identity_parts: dict[str, IdentityPart] = {}
+    identity_key_names: list[str] = []
     for spec in schema.value_keys:
         if spec.identity is None:
             continue
         if spec.name not in identity:
             raise ValueError(f"Missing required key {spec.name!r} for {field_name!r}")
         identity_parts[spec.identity] = identity[spec.name]
+        identity_key_names.append(spec.name)
     claim_key = make_claim_key(field_name, **identity_parts)
-    value: JsonBody = {**identity, "exists": exists}
+    value: JsonBody
+    if exists:
+        value = {**identity, "exists": True}
+    else:
+        value = {name: identity[name] for name in identity_key_names}
+        value["exists"] = False
     return claim_key, value
 
 
@@ -349,8 +410,13 @@ def build_media_attachment_claim(
         {"media_asset": asset_pk},
         exists=exists,
     )
-    value["category"] = category
-    value["is_primary"] = is_primary
+    # Non-identity payload only on an assert. A detach tombstone carries the
+    # identity (media_asset) + exists only — honoring build_relationship_claim's
+    # tombstone invariant; the resolver skips an exists=False claim before it
+    # would read category/is_primary anyway.
+    if exists:
+        value["category"] = category
+        value["is_primary"] = is_primary
     return claim_key, value
 
 
@@ -371,6 +437,7 @@ def make_authoritative_scope(
 # because this module instantiates them; downstream code should import from
 # whichever module they already use.
 __all__ = [
+    "AliasIdentity",
     "RelationshipClaim",
     "RelationshipSchema",
     "ValueKeySpec",
@@ -379,5 +446,7 @@ __all__ = [
     "get_all_namespace_keys",
     "get_relationship_namespaces",
     "make_authoritative_scope",
+    "normalize_alias_identity",
+    "normalize_abbreviation_value",
     "register_catalog_relationship_schemas",
 ]

--- a/backend/apps/catalog/ingestion/patches.py
+++ b/backend/apps/catalog/ingestion/patches.py
@@ -27,7 +27,12 @@ from django.core.exceptions import ValidationError
 from django.db import models
 
 from apps.catalog.api.soft_delete import plan_soft_delete
-from apps.catalog.claims import build_relationship_claim, get_relationship_namespaces
+from apps.catalog.claims import (
+    build_relationship_claim,
+    get_relationship_namespaces,
+    normalize_abbreviation_value,
+    normalize_alias_identity,
+)
 from apps.catalog.ingestion.apply import (
     CitationRef,
     IngestPlan,
@@ -48,7 +53,7 @@ from apps.citation.seed_data.types import SeedLink, SeedSource
 from apps.citation.seeding import ensure_root_source, validate_root_source
 from apps.core.entity_types import get_linkable_model
 from apps.core.types import EntityKey, JsonBody
-from apps.provenance.models import Claim, Source, get_claim_fields
+from apps.provenance.models import Claim, IdentityPart, Source, get_claim_fields
 from apps.provenance.models.changeset import CHANGESET_NOTE_MAX_LENGTH
 from apps.provenance.validation import get_relationship_schema
 
@@ -199,10 +204,10 @@ def fingerprint(data: JsonBody) -> str:
 # ---------------------------------------------------------------------------
 
 
-# A ``remove:`` directive's shape: relationship namespace → member public_ids
-# to drop. (Both keys and members are bare ``str`` — namespace and public_id
-# are uniformly untyped strings across the catalog; this alias names the
-# structure without pretending to enforce them.)
+# A ``remove:`` directive's shape: relationship namespace → member values to
+# drop. (Both keys and members are bare ``str`` — a member is an FK public_id
+# (tag, location) or a bare string (alias, abbreviation); the catalog keeps both
+# uniformly untyped, so this alias names the structure without enforcing them.)
 type RelationshipMembers = dict[str, list[str]]
 
 # The composite key identifying one claim — a scalar/FK field name or a
@@ -262,9 +267,10 @@ class EditEntry(_PatchEntry):
     # Scalar/FK field names whose claim from this source to deactivate.
     retract: list[str]
     # The relationship analogue of ``retract``, by a *different* mechanism: a map
-    # of relationship namespace → member public_ids to drop by superseding each
-    # with an ``exists=false`` tombstone (the claim stays active, resolving to
-    # "absent") — exactly how the in-app editor drops a member.
+    # of relationship namespace → members to drop by superseding each with an
+    # ``exists=false`` tombstone (the claim stays active, resolving to "absent")
+    # — exactly how the in-app editor drops a member. A member is an FK public_id
+    # or a bare string (alias, abbreviation).
     remove: RelationshipMembers
     fields: JsonBody
 
@@ -381,7 +387,7 @@ def _parse_remove(raw_fields: JsonBody, ref: str) -> RelationshipMembers:
     ):
         raise PatchError(
             f"{ref}: 'remove' must be a mapping of relationship namespace to a "
-            f"list of member public_ids (e.g. {{location: [germany]}})"
+            f"list of member values (e.g. {{location: [germany]}})"
         )
     return cast(RelationshipMembers, raw)
 
@@ -1114,11 +1120,30 @@ def _emit_direct(
     )
 
 
-class _RelationshipMemberSpec(NamedTuple):
-    """The single-FK shape of a relationship namespace, for member resolution."""
+class _FkMemberSpec(NamedTuple):
+    """Member is a public_id resolving to an FK on another entity (tag, theme, location)."""
 
     value_key: str  # the value-dict key carrying the member FK (``spec.name``)
     target_model: type[models.Model]  # what a member public_id resolves to
+
+
+class _StringMemberSpec(NamedTuple):
+    """Member is a bare string (alias, abbreviation)."""
+
+    value_key: str  # the value-dict key carrying the member string (``spec.name``)
+    max_length: int  # the target CharField bound; over-length members are rejected
+    # ``display_key`` is the either/or *within* string members: a sibling
+    # value-key name (alias ⇒ case-fold via ``.lower()`` and carry display) or
+    # ``None`` (abbreviation ⇒ stored verbatim). It is also the proxy for "this
+    # identity case-folds" — a future string identity needing a different fold
+    # must extend ``_member_identity``, not ride the ``.lower()`` default.
+    display_key: str | None
+
+
+# Closed discriminated union: an FK member never has a display key, a string
+# member never has a target model — modelled so the illegal combinations are
+# unrepresentable rather than guarded by nullable sentinels.
+type _RelationshipMemberSpec = _FkMemberSpec | _StringMemberSpec
 
 
 def _relationship_member_spec(
@@ -1126,12 +1151,17 @@ def _relationship_member_spec(
     namespace: str,
     entry: PatchEntry,
 ) -> _RelationshipMemberSpec:
-    """Validate *namespace* as a single-FK relationship on *model_class*.
+    """Classify *namespace* as a single-identity relationship on *model_class*.
 
     Shared by the assert (``_emit_relationship``) and remove (``_add_removals``)
-    paths so both reject the same unsupported shapes with the same messages: an
-    unknown namespace, one not valid on the subject model, or a non-single-FK
-    relationship (multi-key relationships are unsupported in v1).
+    paths so both reject the same unsupported shapes with the same messages.
+    Rejects an unknown namespace, one not valid on the subject model, a
+    genuinely multi-key relationship (e.g. credit — still unsupported), and a
+    single-identity relationship whose identity is neither an FK nor a string.
+
+    Classification keys off declared schema properties (``fk_target``,
+    ``scalar_type``, ``max_length``), never a model name or ``isinstance`` —
+    so every FK-identity and string-identity relationship lights up uniformly.
     """
     schema = get_relationship_schema(namespace)
     if schema is None:
@@ -1142,37 +1172,87 @@ def _relationship_member_spec(
             f"{model_class.__name__}"
         )
     identity_specs = [s for s in schema.value_keys if s.identity is not None]
-    if len(identity_specs) != 1 or identity_specs[0].fk_target is None:
+    if len(identity_specs) != 1:
         raise PatchError(
-            f"{entry.ref}: relationship {namespace!r} is not a single-FK "
-            f"relationship (unsupported in v1)"
+            f"{entry.ref}: relationship {namespace!r} is not a single-key "
+            f"relationship (multi-key relationships are unsupported)"
         )
     spec = identity_specs[0]
-    assert spec.fk_target is not None  # guarded above
-    return _RelationshipMemberSpec(
-        value_key=spec.name, target_model=spec.fk_target.model
+    if spec.fk_target is not None:
+        return _FkMemberSpec(value_key=spec.name, target_model=spec.fk_target.model)
+    if spec.scalar_type is str:
+        if spec.max_length is None:
+            raise PatchError(
+                f"{entry.ref}: string relationship {namespace!r} has no declared "
+                f"length bound (unsupported)"
+            )
+        return _StringMemberSpec(
+            value_key=spec.name,
+            max_length=spec.max_length,
+            display_key=spec.display_key,
+        )
+    raise PatchError(
+        f"{entry.ref}: relationship {namespace!r} has a non-FK, non-string "
+        f"identity ({spec.scalar_type.__name__}) — unsupported"
     )
 
 
-def _resolve_member_pk(
+def _member_identity(
     member: object,
     namespace: str,
     rel_spec: _RelationshipMemberSpec,
     entry: PatchEntry,
-) -> int:
-    """Resolve one relationship member public_id to its target PK, or raise."""
-    if not isinstance(member, str):
-        raise PatchError(
-            f"{entry.ref}: relationship {namespace!r} member {member!r} "
-            f"must be a public_id string"
-        )
-    member_pk = _lookup_pk(rel_spec.target_model, member)
-    if member_pk is None:
-        raise PatchError(
-            f"{entry.ref}: relationship {namespace!r} member {member!r} "
-            f"does not resolve to a {rel_spec.target_model.__name__}"
-        )
-    return member_pk
+) -> dict[str, IdentityPart]:
+    """Build the value-dict identity for one relationship member, or raise.
+
+    Returns the **same** dict for assert and remove — the removal caller passes
+    it to ``build_relationship_claim(..., exists=False)``, which strips any
+    non-identity key (e.g. ``alias_display``) to produce the canonical
+    tombstone — so this stays the one authoritative identity builder.
+
+    ``member`` is untyped parsed YAML, so each branch re-checks it is a ``str``
+    at this boundary (a parse-edge guard, not a model-type branch).
+    """
+    match rel_spec:
+        case _FkMemberSpec(value_key, target_model):
+            if not isinstance(member, str):
+                raise PatchError(
+                    f"{entry.ref}: relationship {namespace!r} member {member!r} "
+                    f"must be a public_id string"
+                )
+            member_pk = _lookup_pk(target_model, member)
+            if member_pk is None:
+                raise PatchError(
+                    f"{entry.ref}: relationship {namespace!r} member {member!r} "
+                    f"does not resolve to a {target_model.__name__}"
+                )
+            return {value_key: member_pk}
+        case _StringMemberSpec(value_key, max_length, display_key):
+            if not isinstance(member, str):
+                raise PatchError(
+                    f"{entry.ref}: relationship {namespace!r} member {member!r} "
+                    f"must be a string"
+                )
+            stripped = member.strip()
+            # Reject empty-after-strip loudly: the editor silently drops blanks,
+            # so a "   " member here must error rather than become value="".
+            if not stripped:
+                raise PatchError(
+                    f"{entry.ref}: relationship {namespace!r} has a blank member "
+                    f"({member!r})"
+                )
+            if len(stripped) > max_length:
+                raise PatchError(
+                    f"{entry.ref}: relationship {namespace!r} member {member!r} "
+                    f"exceeds the {max_length}-character limit"
+                )
+            # display_key present ⇒ alias (case-fold + carry display);
+            # absent ⇒ abbreviation (verbatim). Shared fold keeps the algorithm
+            # in one declarative place, byte-identical to the editor.
+            if display_key is not None:
+                ident = normalize_alias_identity(member)
+                return {value_key: ident.value, display_key: ident.display}
+            return {value_key: normalize_abbreviation_value(member)}
 
 
 def _emit_relationship(
@@ -1195,14 +1275,23 @@ def _emit_relationship(
     rel_spec = _relationship_member_spec(model_class, namespace, entry)
     if not isinstance(value, list):
         raise PatchError(
-            f"{entry.ref}: relationship {namespace!r} value must be a list of public_ids"
+            f"{entry.ref}: relationship {namespace!r} value must be a list of members"
         )
     emitted_keys: list[ClaimKey] = []
+    seen_keys: set[ClaimKey] = set()
     for member in value:
-        member_pk = _resolve_member_pk(member, namespace, rel_spec, entry)
-        claim_key, claim_value = build_relationship_claim(
-            namespace, {rel_spec.value_key: member_pk}
-        )
+        identity = _member_identity(member, namespace, rel_spec, entry)
+        claim_key, claim_value = build_relationship_claim(namespace, identity)
+        # Reject a post-fold duplicate within one entry (e.g. [Stern, stern] →
+        # same alias identity): emitting the same claim_key twice into one plan
+        # is an authoring error, clearer rejected than silently collapsed. Keyed
+        # on claim_key (the schema identity), not the full dict — alias_display
+        # differs between "Stern"/"stern" but the identity collides.
+        if claim_key in seen_keys:
+            raise PatchError(
+                f"{entry.ref}: duplicate member {member!r} in {namespace!r}"
+            )
+        seen_keys.add(claim_key)
         _emit_assert(
             plan,
             target,
@@ -1258,11 +1347,19 @@ def _add_removals(
                 f"namespace on {model_class.__name__} (use 'retract:' for scalar/FK)"
             )
         rel_spec = _relationship_member_spec(model_class, namespace, entry)
+        seen_keys: set[ClaimKey] = set()
         for member in members:
-            member_pk = _resolve_member_pk(member, namespace, rel_spec, entry)
+            identity = _member_identity(member, namespace, rel_spec, entry)
             claim_key, claim_value = build_relationship_claim(
-                namespace, {rel_spec.value_key: member_pk}, exists=False
+                namespace, identity, exists=False
             )
+            # Reject an intra-list duplicate member (same fold → same claim_key),
+            # mirroring the assert path's strictness.
+            if claim_key in seen_keys:
+                raise PatchError(
+                    f"{entry.ref}: duplicate member {member!r} in {namespace!r}"
+                )
+            seen_keys.add(claim_key)
             # Record the removal *intent* for the assert/remove conflict guard
             # before the no-op skip below. Asserting and removing the same member
             # is an authoring contradiction knowable from the patch text alone, so

--- a/backend/apps/catalog/tests/test_claims.py
+++ b/backend/apps/catalog/tests/test_claims.py
@@ -3,9 +3,12 @@
 import pytest
 
 from apps.catalog.claims import (
+    AliasIdentity,
     build_relationship_claim,
     get_relationship_namespaces,
     make_authoritative_scope,
+    normalize_abbreviation_value,
+    normalize_alias_identity,
 )
 from apps.catalog.models import MachineModel, Manufacturer
 from apps.catalog.tests.conftest import make_machine_model
@@ -68,6 +71,28 @@ class TestBuildRelationshipClaim:
         )
         assert val["exists"] is False
 
+    def test_tombstone_strips_non_identity_keys(self):
+        # Step 8 invariant: an exists=False claim carries only schema-identity
+        # keys + exists — alias_display (non-identity) is dropped, so every
+        # write path produces a byte-identical tombstone.
+        _, val = build_relationship_claim(
+            "manufacturer_alias",
+            {"alias_value": "stern inc", "alias_display": "Stern Inc"},
+            exists=False,
+        )
+        assert val == {"alias_value": "stern inc", "exists": False}
+
+    def test_assert_keeps_non_identity_keys(self):
+        _, val = build_relationship_claim(
+            "manufacturer_alias",
+            {"alias_value": "stern inc", "alias_display": "Stern Inc"},
+        )
+        assert val == {
+            "alias_value": "stern inc",
+            "alias_display": "Stern Inc",
+            "exists": True,
+        }
+
     def test_unknown_namespace_raises(self):
         with pytest.raises(ValueError, match="Unknown relationship namespace"):
             build_relationship_claim("bogus", {"person": 1, "role": 2})
@@ -75,6 +100,23 @@ class TestBuildRelationshipClaim:
     def test_missing_required_key_raises(self):
         with pytest.raises(ValueError, match="Missing required key"):
             build_relationship_claim("credit", {"person": 1})
+
+
+class TestCanonicalFold:
+    """The string folds shared by the editor and the data-patch adapter."""
+
+    def test_alias_strips_and_lowercases(self):
+        assert normalize_alias_identity("  Stern Pinball  ") == AliasIdentity(
+            value="stern pinball", display="Stern Pinball"
+        )
+
+    def test_alias_value_drives_identity_display_preserves_case(self):
+        ident = normalize_alias_identity("MedMad")
+        assert ident.value == "medmad"
+        assert ident.display == "MedMad"
+
+    def test_abbreviation_strips_only_no_casefold(self):
+        assert normalize_abbreviation_value("  MM  ") == "MM"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -11,10 +11,17 @@ from django.core.management.base import CommandError
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 
-from apps.catalog.claims import build_relationship_claim
+from apps.catalog.claims import (
+    build_relationship_claim,
+    normalize_abbreviation_value,
+    normalize_alias_identity,
+)
 from apps.catalog.ingestion.apply import RunReport, apply_plan
 from apps.catalog.ingestion.patches import (
+    EditEntry,
     PatchError,
+    _member_identity,
+    _relationship_member_spec,
     build_plan,
     fingerprint,
     load_patch,
@@ -24,12 +31,18 @@ from apps.catalog.models import (
     CorporateEntity,
     CorporateEntityLocation,
     Location,
+    MachineModel,
     Manufacturer,
     Tag,
 )
 from apps.catalog.resolve import resolve_all_corporate_entity_locations
 from apps.citation.models import CitationSource, CitationSourceLink
 from apps.provenance.models import ChangeSet, CitationInstance, Claim, IngestRun, Source
+from apps.provenance.validation import (
+    RelationshipSchema,
+    ValueKeySpec,
+    get_relationship_schema,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -1826,3 +1839,311 @@ def test_command_reports_citation_sources(tmp_path):
     call_command("ingest_patches", "--patches-dir", str(tmp_path), stdout=out)
     assert "citation sources: 1 created, 1 links added" in out.getvalue()
     assert CitationSource.objects.filter(name="Wikipedia").exists()
+
+
+# ── Alias & abbreviation relationship members (string identity) ────
+
+
+def _alias_values(mfr: Manufacturer) -> set[str]:
+    return set(mfr.aliases.values_list("value", flat=True))
+
+
+def _alias_claim(value_lower: str) -> Claim:
+    """The active 'manufacturer_alias' claim for the lowercased identity."""
+    claim_key, _ = build_relationship_claim(
+        "manufacturer_alias", {"alias_value": value_lower}
+    )
+    return Claim.objects.get(
+        claim_key=claim_key, field_name="manufacturer_alias", is_active=True
+    )
+
+
+def test_assert_manufacturer_alias(stern):
+    text = """
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      manufacturer_alias: [Stern Pinball]
+"""
+    report = _apply(text)
+    assert report.rejected == 0
+
+    stern.refresh_from_db()
+    assert _alias_values(stern) == {"Stern Pinball"}
+
+    claim = _alias_claim("stern pinball")
+    assert claim.value == {
+        "alias_value": "stern pinball",
+        "alias_display": "Stern Pinball",
+        "exists": True,
+    }
+    # Parity: the emitted claim_key is byte-identical to what the editor's
+    # build_relationship_claim produces from the same identity — the heart of
+    # the feature.
+    expected_key, _ = build_relationship_claim(
+        "manufacturer_alias",
+        {"alias_value": "stern pinball", "alias_display": "Stern Pinball"},
+    )
+    assert claim.claim_key == expected_key
+
+
+def test_assert_abbreviation(machine_model):
+    text = f"""
+attribution: flip-museum
+claims:
+  - model.{machine_model.slug}:
+      abbreviation: [MM]
+"""
+    report = _apply(text)
+    assert report.rejected == 0
+
+    assert set(machine_model.abbreviations.values_list("value", flat=True)) == {"MM"}
+    claim_key, _ = build_relationship_claim("abbreviation", {"value": "MM"})
+    claim = Claim.objects.get(
+        claim_key=claim_key, field_name="abbreviation", is_active=True
+    )
+    # No case-folding: abbreviations are stored verbatim.
+    assert claim.value == {"value": "MM", "exists": True}
+
+
+def test_remove_alias_tombstone_parity(stern):
+    # An earlier patch asserts two aliases; a later one removes one. The dropped
+    # member's tombstone must be lowercased and carry NO alias_display.
+    assert_text = """
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      manufacturer_alias: [Stern Pinball, Stern Inc]
+"""
+    _apply(assert_text, patch_id="0001-aliases")
+    stern.refresh_from_db()
+    assert _alias_values(stern) == {"Stern Pinball", "Stern Inc"}
+
+    remove_text = """
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      remove: { manufacturer_alias: [Stern Inc] }
+"""
+    report = _apply(remove_text, patch_id="0002-drop-alias")
+    assert report.rejected == 0
+
+    stern.refresh_from_db()
+    assert _alias_values(stern) == {"Stern Pinball"}
+
+    tombstone = _alias_claim("stern inc")
+    # Exact tombstone shape — lowercased, no alias_display (step 8 invariant).
+    assert tombstone.value == {"alias_value": "stern inc", "exists": False}
+    expected_key, _ = build_relationship_claim(
+        "manufacturer_alias", {"alias_value": "stern inc"}, exists=False
+    )
+    assert tombstone.claim_key == expected_key
+
+
+def test_remove_alias_noop_when_source_lacks_claim(stern):
+    # flip-museum never claimed this alias, so removing it warns (no-op) and
+    # writes no tombstone — re-running a patch stays safe.
+    text = """
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      remove: { manufacturer_alias: [Never Claimed] }
+"""
+    report = _apply(text, patch_id="0001-noop-alias")
+    assert report.rejected == 0
+    assert any("no-op" in w for w in report.warnings)
+    claim_key, _ = build_relationship_claim(
+        "manufacturer_alias", {"alias_value": "never claimed"}
+    )
+    assert not Claim.objects.filter(claim_key=claim_key).exists()
+
+
+def test_reassert_alias_is_unchanged(stern):
+    # Re-asserting the same alias from the same source diffs as unchanged.
+    text = """
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      manufacturer_alias: [Stern Pinball]
+"""
+    _apply(text, patch_id="0001-first")
+    first = _alias_claim("stern pinball")
+    report = _apply(text, patch_id="0002-again")
+    assert report.rejected == 0
+    second = _alias_claim("stern pinball")
+    # Same active claim row — no new claim written for an unchanged re-assert.
+    assert second.pk == first.pk
+
+
+def test_multi_key_relationship_member_rejected(machine_model):
+    # 'credit' is a registered multi-key relationship (person + role); the gate
+    # rejects at classification — before any member resolution — so no person /
+    # role fixtures are needed. Confirms we narrowed the gate, not removed it.
+    text = f"""
+attribution: flip-museum
+claims:
+  - model.{machine_model.slug}:
+      credit: [pat-lawlor]
+"""
+    with pytest.raises(PatchError, match="single-key relationship"):
+        _apply(text)
+
+
+def test_non_string_identity_rejected(monkeypatch):
+    # The gate keys on scalar_type, not just fk_target. No prod schema has a
+    # single non-FK, non-str identity, so craft one and monkeypatch the lookup —
+    # no global registry mutation (a successful register would persist).
+    crafted = RelationshipSchema(
+        namespace="fake_int_identity",
+        value_keys=(
+            ValueKeySpec(
+                name="amount",
+                scalar_type=int,
+                required=True,
+                identity="amount",
+            ),
+        ),
+        valid_subjects=frozenset({Manufacturer}),
+    )
+    monkeypatch.setattr(
+        "apps.catalog.ingestion.patches.get_relationship_schema",
+        lambda namespace: crafted if namespace == "fake_int_identity" else None,
+    )
+    entry = EditEntry(
+        entity_type="manufacturer",
+        public_id="stern",
+        expect={},
+        retract=[],
+        remove={},
+        fields={},
+    )
+    with pytest.raises(PatchError, match="non-FK, non-string identity"):
+        _relationship_member_spec(Manufacturer, "fake_int_identity", entry)
+
+
+def test_alias_over_length_rejected(stern):
+    long_alias = "x" * 201  # alias_value bound is 200
+    text = f"""
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      manufacturer_alias: ["{long_alias}"]
+"""
+    with pytest.raises(PatchError, match="exceeds the 200-character limit"):
+        _apply(text, dry_run=True)
+
+
+def test_abbreviation_over_length_rejected(machine_model):
+    long_abbr = "y" * 51  # abbreviation value bound is 50
+    text = f"""
+attribution: flip-museum
+claims:
+  - model.{machine_model.slug}:
+      abbreviation: ["{long_abbr}"]
+"""
+    with pytest.raises(PatchError, match="exceeds the 50-character limit"):
+        _apply(text, dry_run=True)
+
+
+def test_schema_carries_max_length():
+    # A future refactor that drops the registration-time population must fail
+    # loudly here, not silently re-open the over-length trap.
+    abbr = get_relationship_schema("abbreviation")
+    assert abbr is not None
+    (abbr_id,) = [s for s in abbr.value_keys if s.identity is not None]
+    assert abbr_id.max_length == 50
+
+    alias = get_relationship_schema("manufacturer_alias")
+    assert alias is not None
+    (alias_id,) = [s for s in alias.value_keys if s.identity is not None]
+    assert alias_id.max_length == 200
+
+
+def test_intra_list_duplicate_alias_rejected(stern):
+    # Stern and stern fold to the same identity → same claim_key twice.
+    text = """
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      manufacturer_alias: [Stern, stern]
+"""
+    with pytest.raises(PatchError, match="duplicate member"):
+        _apply(text)
+
+
+def test_intra_list_duplicate_abbreviation_rejected(machine_model):
+    text = f"""
+attribution: flip-museum
+claims:
+  - model.{machine_model.slug}:
+      abbreviation: [MM, MM]
+"""
+    with pytest.raises(PatchError, match="duplicate member"):
+        _apply(text)
+
+
+def test_intra_list_duplicate_in_remove_rejected(stern):
+    # The remove path dedups by the same fold → claim_key as the assert path.
+    text = """
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      remove: { manufacturer_alias: [Stern Inc, stern inc] }
+"""
+    with pytest.raises(PatchError, match="duplicate member"):
+        _apply(text)
+
+
+def test_blank_alias_member_rejected(stern):
+    text = """
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      manufacturer_alias: ["   "]
+"""
+    with pytest.raises(PatchError, match="blank member"):
+        _apply(text)
+
+
+def test_blank_abbreviation_member_rejected(machine_model):
+    text = f"""
+attribution: flip-museum
+claims:
+  - model.{machine_model.slug}:
+      abbreviation: ["   "]
+"""
+    with pytest.raises(PatchError, match="blank member"):
+        _apply(text)
+
+
+def test_member_identity_shares_canonical_fold():
+    # The patch path and the shared fold helpers produce identical bytes — the
+    # structural guard that editor and patch consume one fold. Pure registry +
+    # fold; no DB rows needed.
+    entry = EditEntry(
+        entity_type="manufacturer",
+        public_id="stern",
+        expect={},
+        retract=[],
+        remove={},
+        fields={},
+    )
+    alias_spec = _relationship_member_spec(Manufacturer, "manufacturer_alias", entry)
+    ident = _member_identity("Stern Pinball", "manufacturer_alias", alias_spec, entry)
+    folded = normalize_alias_identity("Stern Pinball")
+    assert ident == {
+        "alias_value": folded.value,
+        "alias_display": folded.display,
+    }
+
+    abbr_entry = EditEntry(
+        entity_type="model",
+        public_id="medieval-madness",
+        expect={},
+        retract=[],
+        remove={},
+        fields={},
+    )
+    abbr_spec = _relationship_member_spec(MachineModel, "abbreviation", abbr_entry)
+    abbr_ident = _member_identity("MedMad", "abbreviation", abbr_spec, abbr_entry)
+    assert abbr_ident == {"value": normalize_abbreviation_value("MedMad")}

--- a/backend/apps/media/tests/test_detach.py
+++ b/backend/apps/media/tests/test_detach.py
@@ -121,6 +121,33 @@ class TestDetachEndpoint:
         assert not MediaAsset.objects.filter(pk=asset.pk).exists()
         assert not MediaRendition.objects.filter(asset_id=asset.pk).exists()
 
+    def test_detach_tombstone_is_identity_only(
+        self, auth_client, machine_model, asset, renditions, attached
+    ):
+        """The detach tombstone carries identity (media_asset) + exists only.
+
+        Step 8 regression: build_media_attachment_claim drops the inert
+        category/is_primary on exists=False, so the stored tombstone bytes are
+        canonical. Asserted here because the endpoint deletes the asset but
+        leaves the exists=false claim active.
+        """
+        claim_key, _ = build_media_attachment_claim(
+            machine_model, asset.pk, exists=False
+        )
+        resp = auth_client.post(
+            "/api/media/detach/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 204
+
+        tombstone = Claim.objects.get(claim_key=claim_key, is_active=True)
+        assert tombstone.value == {"media_asset": asset.pk, "exists": False}
+
     def test_detach_deletes_storage_files(
         self,
         auth_client,

--- a/backend/apps/media/tests/test_media_claims.py
+++ b/backend/apps/media/tests/test_media_claims.py
@@ -110,10 +110,14 @@ class TestBuildMediaAttachmentClaim:
             )
 
     def test_retraction(self, machine_model, asset):
+        # Tombstone invariant (build_relationship_claim step 8): an exists=False
+        # detach claim carries identity (media_asset) + exists only — the inert
+        # category/is_primary are dropped. The resolver skips an exists=False
+        # claim before it would read them, so this is resolver-inert.
         _claim_key, value = build_media_attachment_claim(
             machine_model, asset.pk, exists=False
         )
-        assert value["exists"] is False
+        assert value == {"media_asset": asset.pk, "exists": False}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -65,6 +65,14 @@ class ValueKeySpec:
     ``display_key="alias_display"`` so resolvers and display engines both
     read the override from one declaration. See
     ``register_relationship_schema`` for the full set of invariants.
+
+    ``max_length`` (optional, string-identity specs only) carries the target
+    ``CharField`` length bound, derived from the model at registration. It is
+    consumed by the data-patch adapter, which must reject an over-long member
+    at plan-build time: SQLite (the patch author's local DB) silently ignores
+    ``CharField(max_length=...)``, so an over-long string would pass every
+    local check and only fail as an ``IntegrityError`` on Postgres in prod.
+    ``None`` for FK and non-length-bounded keys.
     """
 
     name: str
@@ -74,6 +82,7 @@ class ValueKeySpec:
     identity: str | None = None
     fk_target: FkTarget | None = None
     display_key: str | None = None
+    max_length: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/docs/DataPatchAuthoring.md
+++ b/docs/DataPatchAuthoring.md
@@ -77,6 +77,22 @@ Some patches set narrative record descriptions (Manufacturer, Model, …) — pr
 
 Corporate entity locations should be a city. Not a country, not a state, not a region. Even if it's hard to find the city, find it. If you can't find a conclusive citation, don't include a citation. We'd rather have an uncited city than no city at all.
 
+## Aliases and abbreviations
+
+Aliases (`manufacturer_alias` and the other `<entity>_alias` namespaces) and `abbreviation` (Title + Model) are relationship members carrying a **bare string**, not a public_id. Author them with the literal registered namespace as the field key and a list of strings:
+
+```yaml
+claims:
+  - manufacturer.stern:
+      manufacturer_alias: [Stern Pinball, Stern Inc, Stern Electronics]
+```
+
+- **Case.** Alias values **case-fold** for identity — `Stern` and `stern` are the same alias — but the original case you write is preserved as the display form. Abbreviations are stored **verbatim** (`MM` ≠ `mm`), so write them exactly as they should render.
+- **No duplicates within one list.** Two members that fold to the same identity (`[Stern, stern]`, `[MM, MM]`) are rejected — list each distinct value once.
+- **Length.** Members are length-checked at build time against the model's column bound (alias 200, abbreviation 50); an over-long member is rejected on `--dry-run`, not silently truncated.
+- **Remove** drops a member exactly like an FK member: `remove: { manufacturer_alias: [Stern Inc] }`, attributed to the source holding the membership claim.
+- **No `note:` or `cite:` needed.** Unlike other claims, aliases and abbreviations don't require provenance — they're self-evident names, not asserted facts. Still attribute the patch to the curating source (e.g. `flip-museum`); a `note:`/`cite:` is optional, for the rare name whose origin isn't obvious.
+
 ## Validate behind a snapshot
 
 Patches are immutable once applied (per-DB fingerprint), so iterate behind a snapshot — see [DataPatches.md → Iterating on localhost](DataPatches.md#iterating-on-localhost-snapshot-first) for the snapshot/rollback loop and naming. Apply your new, uncommitted patches **from an isolated dir** so the already-applied 0001–N stay untouched:

--- a/docs/DataPatchKit.md
+++ b/docs/DataPatchKit.md
@@ -55,18 +55,20 @@ import patchkit as pk
 
 Import from the authoring dir (`gen.py` does `sys.path.insert(0, <authoring>)`).
 
-| function                                                                                            | purpose                                                                                                 |
-| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `guard(row, prefer=("ipdb_id","year","corporate_entity"))`                                          | most specific `expect:` dict from a live-values row; `{}` if none                                       |
-| `check_resolved(requested, found)`                                                                  | raise if any ref didn't resolve (typo/drift)                                                            |
-| `sentences(text)` / `sentence_with(blob, needle)`                                                   | split source free text; pull the sentence containing a needle                                           |
-| `clean_ipdb_quote(text, limit=240)`                                                                 | normalize a quote's typography, strip the IPD header and `…: "<passage>` framing, truncate with `[...]` |
-| `source_note(source, verbatim, tail="")`                                                            | build `IPDB says "<verbatim>"` (normalizes typography, preserves non-ASCII; mark omissions `[...]`)     |
-| `entry(ref, *, create, expect, note, cite, fields, description, tags, retract, commented, comment)` | one correctly-escaped `claims:` block                                                                   |
-| `write_patch(path, *, attribution, description, entries)`                                           | a complete patch file                                                                                   |
-| `yamlq` / `clean_text`                                                                              | the escaper / the typography normalizer, if you need them directly                                      |
+| function                                                                                                                   | purpose                                                                                                 |
+| -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `guard(row, prefer=("ipdb_id","year","corporate_entity"))`                                                                 | most specific `expect:` dict from a live-values row; `{}` if none                                       |
+| `check_resolved(requested, found)`                                                                                         | raise if any ref didn't resolve (typo/drift)                                                            |
+| `sentences(text)` / `sentence_with(blob, needle)`                                                                          | split source free text; pull the sentence containing a needle                                           |
+| `clean_ipdb_quote(text, limit=240)`                                                                                        | normalize a quote's typography, strip the IPD header and `…: "<passage>` framing, truncate with `[...]` |
+| `source_note(source, verbatim, tail="")`                                                                                   | build `IPDB says "<verbatim>"` (normalizes typography, preserves non-ASCII; mark omissions `[...]`)     |
+| `entry(ref, *, create, expect, note, cite, fields, description, tags, relationships, remove, retract, commented, comment)` | one correctly-escaped `claims:` block                                                                   |
+| `write_patch(path, *, attribution, description, entries)`                                                                  | a complete patch file                                                                                   |
+| `yamlq` / `clean_text`                                                                                                     | the escaper / the typography normalizer, if you need them directly                                      |
 
 **Escaping is solved — use it.** Notes go through `yamlq` (single-quoted YAML: literal except `'`, which doubles). This carries both the double quotes in `... says "x"` and apostrophes, with no backslashes. Do **not** `json.dumps` notes.
+
+**Relationship members.** `entry(...)` also takes `relationships={namespace: [members]}` (the general emitter; `tags=` is the `tag` shorthand) and `remove={namespace: [members]}`. Members are escaped, so string members for aliases / abbreviations are safe — e.g. `relationships={"manufacturer_alias": ["Stern Pinball", "Stern, Inc"]}` or `remove={"abbreviation": ["MedievalMadness"]}`. Alias values case-fold for identity; abbreviations are verbatim (see [DataPatchAuthoring.md → Aliases and abbreviations](DataPatchAuthoring.md#aliases-and-abbreviations)).
 
 Minimal generator:
 

--- a/docs/DataPatches.md
+++ b/docs/DataPatches.md
@@ -90,6 +90,19 @@ claims:
       note: 'flip-museum says "headquartered in Berlin".'
 ```
 
+Set string-valued relationship members — aliases and abbreviations. The field key is the **literal registered namespace** (`manufacturer_alias`, `abbreviation`); members are bare strings, not public_ids. Alias values case-fold for identity (original case preserved for display); abbreviations are stored verbatim. `remove:` drops a member the same way it drops an FK member:
+
+```yaml
+attribution: flip-museum
+claims:
+  - manufacturer.stern:
+      manufacturer_alias: [Stern Pinball, Stern Inc, Stern Electronics] # known trade names
+      note: "flip-museum: trade names across the company history."
+  - model.medieval-madness:
+      abbreviation: [MM, MedMad] # shared Title/MachineModel namespace
+      remove: { abbreviation: [MedievalMadness] } # drop a bad earlier abbreviation
+```
+
 Delete, after reassigning the firm's one machine to another corporate entity. The reassignment must land in an **earlier** patch: the delete's referrer check reads live DB state, so a same-patch reassignment isn't yet visible and the delete would still see the machine as a blocker.
 
 ```yaml
@@ -113,7 +126,7 @@ claims:
 
 **Entity reference** is `type.public_id` — the canonical `entity_type` (`model`, `manufacturer`, `corporate-entity`, …) and the public id (slug for most, `location_path` for Location), split on the first `.`.
 
-**Field keys** are classified by introspection: **scalar** (`year`) — value used as-is; **FK** (`manufacturer`, `production_status`) — value is the target's public_id; **relationship** (`tag`, `theme`) — key is the namespace, value a list of member public_ids. The lifecycle field **`status` is not directly assertable** — a raw `status: deleted` would skip the delete planner's blocker check and cascade, so it's rejected; soft-delete via `delete: true` instead.
+**Field keys** are classified by introspection: **scalar** (`year`) — value used as-is; **FK** (`manufacturer`, `production_status`) — value is the target's public_id; **relationship** (`tag`, `theme`, `manufacturer_alias`, `abbreviation`) — key is the namespace, value a list of members (FK public_ids, or bare strings for aliases/abbreviations). The lifecycle field **`status` is not directly assertable** — a raw `status: deleted` would skip the delete planner's blocker check and cascade, so it's rejected; soft-delete via `delete: true` instead.
 
 **Reserved keys** (directives, not claim fields):
 
@@ -121,7 +134,7 @@ claims:
 - `delete: true` — soft-delete an existing entity: writes a `status=deleted` claim (no row removal), exactly like an in-app delete. Reuses the app's soft-delete planner, so it obeys the same record-lifecycle rules — it **refuses** when an active PROTECT referrer would be left dangling, and **cascades** `status=deleted` to owned lifecycle children (a warning lists them). A delete entry takes only `expect:`/`note:`/`cite:` — no field assertions (reassign references in a separate, earlier patch first; see below), no `create`, no `retract`. `note`/`cite` ride the `status=deleted` claim. Idempotent: re-deleting an already-deleted entity diffs as unchanged. Takes effect only if the `status=deleted` claim wins resolution, so attribute it to a source that outranks any existing `status` claim.
 - `expect:` — drift guard: a map of currently-resolved values the target must already have, checked before any write (mismatch → error). Covers scalar + FK. Stops a hand-authored id from writing to a drifted or same-named row.
 - `retract:` — scalar/FK field names whose claim (from this patch's source) to deactivate, on an existing entity. A no-op with a warning if already gone, so re-runs are safe. Not valid with `create`, nor alongside asserting the same field. Retracting the sole claim of a non-nullable FK doesn't clear it (NOT NULL forbids it) — the last value freezes in place, provenance-orphaned; to _change_ a required FK, assert the new value instead. Because it is scoped to this patch's source, attributing the retract to a source that never claimed the field silently does nothing — confirm which source holds the active claim first.
-- `remove:` — a map of **relationship** namespace → member public*ids to drop from an existing entity (the relationship counterpart of `retract:`, which is scalar/FK only). It is **not** a retraction: it supersedes this source's `exists=true` membership claim with an `exists=false` tombstone — the same write the in-app editor makes to drop a member — so the claim stays active and provenance (`note:`/`cite:`) rides it. Because the resolver unions `exists=true` across sources, attribute it to the source holding the active membership claim; a member this source doesn't currently claim present is a no-op with a warning (so re-runs are safe), not an error — but because a no-op emits no tombstone, an entry whose \_only* effect is a no-op removal can't anchor a `note:`/`cite:` and is rejected (the provenance would silently vanish). Not valid with `create`/`delete`, nor removing a member the same entry also asserts present. Relationship `remove:` is the only relationship retraction path — plain `retract:` rejects a relationship namespace.
+- `remove:` — a map of **relationship** namespace → member values (FK public_ids, or bare strings for aliases/abbreviations) to drop from an existing entity (the relationship counterpart of `retract:`, which is scalar/FK only). It is **not** a retraction: it supersedes this source's `exists=true` membership claim with an `exists=false` tombstone — the same write the in-app editor makes to drop a member — so the claim stays active and provenance (`note:`/`cite:`) rides it. Because the resolver unions `exists=true` across sources, attribute it to the source holding the active membership claim; a member this source doesn't currently claim present is a no-op with a warning (so re-runs are safe), not an error — but because a no-op emits no tombstone, an entry whose \_only\* effect is a no-op removal can't anchor a `note:`/`cite:` and is rejected (the provenance would silently vanish). Not valid with `create`/`delete`, nor removing a member the same entry also asserts present. Relationship `remove:` is the only relationship retraction path — plain `retract:` rejects a relationship namespace.
 - `note:` — a per-entity free-text reason (≤1000 chars) → the entity's ChangeSet note, shown on its edit-history page. (`description:` explains the whole patch; `note:` explains one entry.) All of an entity's claims in a patch collapse into one changeset, so the note is per-entity. The per-entity `note:` is the user-facing one; the whole-patch `description:` (→ `IngestRun.note`) is, as of this writing, surfaced only in Django admin — so put anything readers should see in `note:`, not `description:`.
 - `cite:` — external evidence, in one of these forms, attached to each of the entry's authored claims and shown beside the field on the edit-history page:
   - **`scheme:identifier`** (`ipdb:4443`, `opdb:GRhX5`) — a known scheme. Get-or-creates the source under that scheme's seeded root.
@@ -231,7 +244,7 @@ On localhost, snapshot the DB before applying (see [Iterating on localhost](#ite
 
 ## Undoing a patch
 
-No automatic revert — source-attributed claims aren't user-revertible. Undo a patch with a **compensating patch** (a later claim supersedes the earlier one).
+There's no automatic revert; source-attributed claims aren't user-revertible. Undo a patch with a **compensating patch** (a later claim supersedes the earlier one).
 
 On localhost, the simplest undo is restoring a pre-apply snapshot (see [Iterating on localhost](#iterating-on-localhost-snapshot-first)) — the compensating-patch rule is for seeded/shared databases whose history can't be rewound.
 
@@ -241,6 +254,6 @@ We've been building the patch system on an as-needed basis. These haven't been n
 
 - **No same-patch reassign-then-delete** — a `delete:`'s referrer check reads live DB state, so a reference reassigned earlier in the _same_ patch isn't yet visible; reassign in an earlier numbered patch, then delete.
 - `expect:` covers scalar + FK only, not relationships. (`retract:` is scalar/FK; relationship members are dropped with `remove:`.)
-- Relationship `remove:` covers **single-FK** relationships (`tag`, `location`, `theme`). Multi-key relationships (e.g. credits) aren't yet removable via patch.
-- **Only single-FK relationships are writable** — `tag`, `location`, `theme`, and the like, whose member is an FK to another entity. **Alias relationships are not patch-writable**: `manufacturer_alias`, `corporate_entity_alias` and the other alias namespaces carry a bare string value rather than an FK, so asserting one is rejected (`not a single-FK relationship`). Add aliases through the in-app editor or Django admin for now.
+- Relationship `remove:` covers **single-identity** relationships — single-FK members (`tag`, `location`, `theme`) and single string members (aliases, `abbreviation`). Multi-key relationships (e.g. credits) aren't yet removable via patch.
+- **Single-identity relationships are writable** — both single-FK members (`tag`, `location`, `theme`, …, whose member is an FK to another entity) and single **string** members (`manufacturer_alias` and the other alias namespaces, `abbreviation`), whose member is a bare string. Alias values **case-fold** for identity (the original case is preserved for display); abbreviations are stored verbatim. **Multi-key** relationships (e.g. credits, person + role) remain unsupported.
 - **No same-patch FK target creation.** An FK value (on a `create` _or_ an edit) is resolved by a live DB lookup against entities already committed, so its target must exist in the seed or an **earlier** numbered patch — a target created earlier in the _same_ patch isn't yet visible. This is the same rule as a location's `parent` and a relationship member: create the target (manufacturer, title, tag, parent location, …) in an earlier patch, then reference it.


### PR DESCRIPTION
## What

Data patches can now set **alias** and **abbreviation** relationship members (e.g. `manufacturer_alias: [Stern Pinball, Stern Inc]`, `abbreviation: [MM, MedMad]`), with `remove:` working through the same path. Previously these namespaces were rejected (`not a single-FK relationship`) because their members carry a bare string rather than an FK public_id — leaving the in-app editor or Django admin as the only way to set them, with no reproducible, prod-replayable correction path.

No new YAML grammar — `field: [members]` already parses; the namespaces already classify as relationships.

## How

- **Model-driven gate.** The patch adapter's member-resolution path becomes a closed discriminated union (`_FkMemberSpec | _StringMemberSpec`). Classification keys off declared schema properties (`fk_target`, `scalar_type`, `max_length`) — never a model name or `isinstance` — so every alias type and `abbreviation` lights up uniformly. Multi-key (credit) and non-FK/non-string identities are still rejected.
- **Parity by construction.** The strip/lowercase fold the in-app editor uses is extracted into shared helpers (`normalize_alias_identity`, `normalize_abbreviation_value`) that both the editor and the patch adapter call, so a patch alias and an editor alias supersede/dedup **byte-identically**. The editor also now reads the abbreviation length bound from the registered schema instead of a hardcoded `50`.
- **Tombstone invariant.** `build_relationship_claim` drops non-identity keys on `exists=False` (and `build_media_attachment_claim` guards its `category`/`is_primary` appends), so removal tombstones are canonical for every write path with no per-caller flag. No resolver reads a non-identity key off an absent member, so this is behavior-preserving — media detach tombstones shed their inert `category`/`is_primary` (resolver-inert; claim_key unchanged).
- **Over-length guard at build time.** Members are checked against a model-derived `ValueKeySpec.max_length` (alias 200, abbreviation 50). SQLite (the author's local DB) silently ignores `CharField(max_length=...)`, so an over-long member would pass every local check and only fail as an `IntegrityError` on Postgres in prod — now rejected at `--dry-run`.
- Intra-list duplicate (post-fold) and blank members are rejected.

## Tests

`make lint`, full `mypy` (466 files), and the targeted suites all green. New coverage in `test_patches.py` (assert/remove/parity/dedup/blank/over-length/multi-key/non-string/schema-bound), `test_claims.py` (tombstone invariant + fold helpers), `test_media_claims.py` + `test_detach.py` (media tombstone shape). The editor regression matrix (`test_edit_claims.py`, `test_api_claims_*`) pins the fold extraction as behavior-preserving.

## Companion PR (separate repo)

The patchkit relationship emitter (`relationships=`/`remove=` kwargs on `entry()`) and the `patch.schema.json` `remove:` description tweak live in **pindata** and ride in a separate PR there — they're not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)