### PR TITLE
feat(patches): same-patch entity references

### DIFF
--- a/backend/apps/catalog/ingestion/apply.py
+++ b/backend/apps/catalog/ingestion/apply.py
@@ -523,23 +523,22 @@ def _planned_public_ids(
     return result
 
 
-def _fk_value_is_planned(
+def _fk_target_is_planned(
+    subject_model: type[models.Model],
     pca: PlannedClaimAssert,
     planned: dict[type[ClaimControlledModel], set[str]],
 ) -> bool:
-    """True if *pca* is an FK claim whose value names a same-plan-created entity.
+    """True if *pca* is an FK claim on *subject_model* naming a same-plan create.
 
-    *planned* is the precomputed ``_planned_public_ids`` map. Used only by the
-    dry-run path to skip DB existence validation for FK targets that don't
-    exist yet because they're created in this same plan.
+    The shared core: given the subject model the claim lives on, decide whether
+    the claim's value points at an entity this plan will create. Callers supply
+    the subject from whatever they have — ``content_type_id`` for an
+    existing-entity claim, the create handle for a planned-entity claim.
     """
-    if pca.content_type_id is None or not isinstance(pca.value, str):
-        return False
-    model_class = ContentType.objects.get_for_id(pca.content_type_id).model_class()
-    if model_class is None:
+    if not isinstance(pca.value, str):
         return False
     try:
-        django_field = model_class._meta.get_field(pca.field_name)
+        django_field = subject_model._meta.get_field(pca.field_name)
     except FieldDoesNotExist:
         return False
     if not isinstance(django_field, models.ForeignKey):
@@ -550,6 +549,25 @@ def _fk_value_is_planned(
     ):
         return False
     return pca.value.strip() in planned.get(target_model, set())
+
+
+def _fk_value_is_planned(
+    pca: PlannedClaimAssert,
+    planned: dict[type[ClaimControlledModel], set[str]],
+) -> bool:
+    """True if *pca* is an existing-entity FK claim naming a same-plan create.
+
+    Subject model derived from ``content_type_id`` (the claim targets an existing
+    row). *planned* is the precomputed ``_planned_public_ids`` map. Used only by
+    the dry-run path to skip DB existence validation for FK targets that don't
+    exist yet because they're created in this same plan.
+    """
+    if pca.content_type_id is None:
+        return False
+    model_class = ContentType.objects.get_for_id(pca.content_type_id).model_class()
+    if model_class is None:
+        return False
+    return _fk_target_is_planned(model_class, pca, planned)
 
 
 def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
@@ -595,7 +613,27 @@ def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
 
     # Claims targeting planned entities: validate only (all are new by
     # definition).  Build sentinel claims without mutating the plan.
-    planned_assertions = [p for p in concrete if p.handle is not None]
+    handle_to_model: dict[str, type[ClaimControlledModel]] = {
+        e.handle: e.model_class for e in plan.entities
+    }
+    # A create whose FK points at *another* same-plan create carries a concrete,
+    # handle-targeted provenance claim whose value names the planned target. Its
+    # DB existence check would spuriously fail (target only planned), so carve it
+    # out exactly like the existing-entity case above. The live path is immune —
+    # creates run first in the same transaction, so the target exists by then.
+    fk_on_create_planned = [
+        p
+        for p in concrete
+        if p.handle is not None
+        and p.handle in handle_to_model
+        and _fk_target_is_planned(handle_to_model[p.handle], p, planned)
+    ]
+    report.asserted += len(fk_on_create_planned)
+    fk_on_create_ids = {id(p) for p in fk_on_create_planned}
+
+    planned_assertions = [
+        p for p in concrete if p.handle is not None and id(p) not in fk_on_create_ids
+    ]
     if planned_assertions:
         handle_to_ct: dict[str, int] = {
             e.handle: ContentType.objects.get_for_model(e.model_class).pk

--- a/backend/apps/catalog/ingestion/patches.py
+++ b/backend/apps/catalog/ingestion/patches.py
@@ -217,6 +217,14 @@ type RelationshipMembers = dict[str, list[str]]
 # ``str``-typed claim machinery (``apps.catalog.claims``, apply's ClaimIdentity).
 type ClaimKey = str
 
+# A catalog entity's public_id — the URL-identity value of its ``public_id_field``
+# (``slug`` for most entities, ``location_path`` for Location), and what an FK or
+# relationship member names its target by. A transparent alias of ``str`` like
+# ``ClaimKey``: it distinguishes a public_id from the other ``str``s in this module
+# (a handle/entry ``ref``, a relationship ``namespace``) at the points where the
+# distinction is otherwise invisible — e.g. a ``dict[str, set[str]]`` adjacency map.
+type PublicId = str
+
 
 @dataclass(frozen=True, kw_only=True)
 class _PatchEntry:
@@ -551,6 +559,56 @@ class _RemovalResult(NamedTuple):
     carrier_written: bool
 
 
+class _CreatedKey(NamedTuple):
+    """Identity of an entity created earlier in the same patch.
+
+    Keyed by the *resolved concrete model class* (never the ``entity_type``
+    label), so a later reference looks it up by the FK/relationship target's
+    ``related_model`` — the same class ``_lookup_pk`` queries — with no
+    ``"corporate-entity"`` vs ``corporate_entity`` or base-vs-concrete drift.
+
+    Typed ``type[models.Model]`` (not ``type[CatalogModel]``) because lookups key
+    by an FK target's ``related_model``, which Django only types as ``Model``; at
+    runtime every catalog FK target *is* a ``CatalogModel``. The key is pure
+    identity, so the wider annotation costs nothing.
+    """
+
+    model_class: type[models.Model]
+    public_id: PublicId
+
+
+class _MemberEmitResult(NamedTuple):
+    """Outcome of ``_emit_relationship`` for one entry's namespace.
+
+    ``clash_keys`` are the *concrete* claim_keys the assert/remove clash guard
+    and ``asserted_members`` consume; a deferred (same-patch-created) member has
+    no concrete claim_key at plan time and contributes none. ``carrier_written``
+    is whether any assertion — concrete or deferred — was emitted, so a
+    ``note:``/``cite:`` on an entry whose members are *all* same-patch creates is
+    not wrongly rejected by the provenance-carrier check.
+    """
+
+    clash_keys: list[ClaimKey]
+    carrier_written: bool
+
+
+class _HierarchyEdge(NamedTuple):
+    """A child→parent edge asserted into a self-referential hierarchy.
+
+    Self-referential relationship namespaces (``theme_parent``,
+    ``gameplay_feature_parent`` — structurally: a single FK identity whose
+    target *is* the subject model) form a DAG. Each ``exists=true`` member is a
+    child→parent edge, identified by public_id so same-patch creates (no PK yet)
+    and existing rows share one namespace. Collected for the plan-wide acyclicity
+    guard that the API enforces but the patch path otherwise bypasses.
+    """
+
+    namespace: str
+    child: PublicId
+    parent: PublicId
+    ref: str  # the entry-ref/handle that asserted the edge, for the error message
+
+
 class _RawCite(NamedTuple):
     """A ``cite:`` value split into its primary and durable-snapshot parts.
 
@@ -711,6 +769,17 @@ def build_plan(doc: PatchDoc, *, source: Source, patch_id: str) -> IngestPlan:
     # mint a duplicate handle and blow up as a ValueError deep in the apply layer
     # (which the command doesn't catch); reject it cleanly in _process_entry.
     created_refs: set[str] = set()
+    # Registry of same-patch creates → handle, keyed by concrete model class +
+    # public_id, so a *later* entry can reference an entity an *earlier* entry
+    # creates (backward references). A miss falls through to the seed/earlier-
+    # patch DB lookup; only neither-found errors. (Kept separate from
+    # ``created_refs``: that dedups by the entry-ref label; this resolves by
+    # concrete class + public_id — different keys, different jobs.)
+    created: dict[_CreatedKey, str] = {}
+    # child→parent edges asserted into self-referential hierarchies, for the
+    # plan-wide acyclicity guard (the patch path's equivalent of the API's
+    # plan_parent_claims self-link/cycle check).
+    hierarchy_added: dict[type[CatalogModel], list[_HierarchyEdge]] = defaultdict(list)
 
     results = [
         _process_entry(
@@ -720,11 +789,14 @@ def build_plan(doc: PatchDoc, *, source: Source, patch_id: str) -> IngestPlan:
             rel_namespaces=rel_namespaces,
             rel_fields_by_model=rel_fields_by_model,
             created_refs=created_refs,
+            created=created,
+            hierarchy_added=hierarchy_added,
         )
         for entry in doc.claims
     ]
     plan.records_matched = sum(r.matched for r in results)
     _validate_plan_wide(results)
+    _validate_hierarchy_acyclic(hierarchy_added)
 
     # Relationship resolution: delegate to the canonical post-mutation
     # dispatch (model-driven; no hand-maintained namespace→resolver map). The
@@ -748,6 +820,8 @@ def _process_entry(
     rel_namespaces: frozenset[str],
     rel_fields_by_model: dict[type[CatalogModel], set[str]],
     created_refs: set[str],
+    created: dict[_CreatedKey, str],
+    hierarchy_added: dict[type[CatalogModel], list[_HierarchyEdge]],
 ) -> _EntryResult:
     """Resolve, validate and emit one claim entry; return its cross-entry contribution.
 
@@ -799,7 +873,15 @@ def _process_entry(
         if entry.ref in created_refs:
             raise PatchError(f"{entry.ref}: duplicate create entry in this patch")
         created_refs.add(entry.ref)
-        _add_create(plan, model_class, entry, entry.ref, note=note)
+        _add_create(plan, model_class, entry, entry.ref, created=created, note=note)
+        # Register after _add_create, so a create's own *FK fields* (resolved
+        # inside _add_create against earlier creates) can't point at itself. NB
+        # this entry's *relationship* fields are emitted below, after this line,
+        # so a same-entry self-referential member (theme_parent/
+        # gameplay_feature_parent) IS resolvable here — self-link and cycle
+        # safety for those is enforced separately by the plan-wide hierarchy
+        # guard, not by registration timing.
+        created[_CreatedKey(model_class, entry.public_id)] = entry.ref
         target = _Target(handle=entry.ref)
     else:
         if existing is None:
@@ -835,21 +917,25 @@ def _process_entry(
             if target.object_id is not None:
                 asserted_fields.add(key)
         elif key in rel_namespaces:
-            emitted_keys = _emit_relationship(
+            emit = _emit_relationship(
                 plan,
                 model_class,
                 key,
                 value,
                 target,
                 entry,
+                created=created,
+                hierarchy_added=hierarchy_added,
                 note=note,
                 citation_ref=citation_ref,
             )
             rel_fields_by_model[model_class].add(key)
-            if emitted_keys:
+            if emit.carrier_written:
                 carrier_written = True
             if target.object_id is not None:
-                asserted_members.update(emitted_keys)
+                # Only concrete claim_keys feed the clash guard; a deferred
+                # (same-patch) member has none yet — see _MemberEmitResult.
+                asserted_members.update(emit.clash_keys)
         else:
             raise PatchError(f"{entry.ref}: unknown field {key!r}")
 
@@ -936,6 +1022,80 @@ def _check_provenance_carrier(
             f"retract a currently-claimed field, create, or remove a "
             f"currently-present member (a no-op carries nothing)"
         )
+
+
+def _existing_parent_edges(
+    model_class: type[CatalogModel],
+) -> dict[PublicId, set[PublicId]]:
+    """Current resolved child→parent public_id edges for a hierarchy model.
+
+    ``parents`` is a runtime-generated self-M2M descriptor django-stubs can't
+    see; the two ignores are confined to this boundary helper (same rationale as
+    ``resolve._get_parents_through``). Only called for models that actually have
+    the hierarchy ``parents`` M2M (those with a self-referential FK relationship).
+    """
+    edges: dict[PublicId, set[PublicId]] = {}
+    queryset = model_class._default_manager.prefetch_related("parents")  # type: ignore[misc]
+    for inst in queryset:
+        parents: models.Manager[CatalogModel] = inst.parents  # type: ignore[attr-defined]
+        edges[inst.public_id] = {p.public_id for p in parents.all()}
+    return edges
+
+
+def _reaches_via_parents(
+    parent_map: dict[PublicId, set[PublicId]], start: PublicId, target: PublicId
+) -> bool:
+    """Walking parent edges up from *start*, is *target* reachable?
+
+    ``start == target`` reaches trivially (used for the self-link case). Tolerant
+    of pre-existing cycles in the graph via the ``seen`` guard.
+    """
+    stack = [start]
+    seen: set[str] = set()
+    while stack:
+        node = stack.pop()
+        if node == target:
+            return True
+        if node in seen:
+            continue
+        seen.add(node)
+        stack.extend(parent_map.get(node, ()))
+    return False
+
+
+def _validate_hierarchy_acyclic(
+    hierarchy_added: dict[type[CatalogModel], list[_HierarchyEdge]],
+) -> None:
+    """Reject self-parent links and cycles in self-referential hierarchies.
+
+    The patch path otherwise bypasses the API's ``plan_parent_claims`` guard, so
+    a patch could assert ``gameplay_feature_parent: [self]`` or two mutually-
+    referencing parents and silently corrupt the DAG (the resolver materializes
+    whatever wins, with no self/cycle check).
+
+    Conservative by design: the post-patch parent graph is the current resolved
+    edges *plus* this patch's added edges, ignoring removals — so it never misses
+    a cycle (a removal can only break one, and a removal that's a no-op for this
+    source leaves the edge in place via another). A patch that both removes and
+    re-adds around an edge may be over-rejected; split it across patches.
+    """
+    for model_class, edges in hierarchy_added.items():
+        # Post-patch graph: current resolved edges + this patch's added edges.
+        parent_map = _existing_parent_edges(model_class)
+        for edge in edges:
+            if edge.child == edge.parent:
+                raise PatchError(
+                    f"{edge.ref}: a {model_class.entity_type} cannot be its own "
+                    f"parent ({edge.namespace})"
+                )
+            parent_map.setdefault(edge.child, set()).add(edge.parent)
+        for edge in edges:
+            # Adding child→parent closes a cycle iff parent already reaches child.
+            if _reaches_via_parents(parent_map, edge.parent, edge.child):
+                raise PatchError(
+                    f"{edge.ref}: {edge.namespace} would create a cycle "
+                    f"({edge.child} → {edge.parent} → … → {edge.child})"
+                )
 
 
 def _validate_plan_wide(results: list[_EntryResult]) -> None:
@@ -1263,23 +1423,72 @@ def _emit_relationship(
     target: _Target,
     entry: PatchEntry,
     *,
+    created: dict[_CreatedKey, str],
+    hierarchy_added: dict[type[CatalogModel], list[_HierarchyEdge]],
     note: str = "",
     citation_ref: CitationRef | None = None,
-) -> list[ClaimKey]:
-    """Emit ``exists=true`` member assertions; return their claim_keys.
+) -> _MemberEmitResult:
+    """Emit ``exists=true`` member assertions; return their clash keys + carrier flag.
 
-    The caller records the returned claim_keys against the target entity so the
-    plan-wide assert/remove conflict guard can detect a member that is both
-    asserted present and removed.
+    A member that resolves against the DB is emitted concretely (its ``claim_key``
+    is recorded for the plan-wide assert/remove conflict guard). An FK member that
+    instead names a *same-patch* create is emitted **deferred**
+    (``relationship_namespace`` + ``identity_refs``), resolved post-creation in
+    ``_patch_handles`` — it has no concrete claim_key yet, so it stays out of the
+    clash list (the remove path can't reference a same-patch create at all, so
+    there is nothing to clash with). Either way a carrier is written.
     """
     rel_spec = _relationship_member_spec(model_class, namespace, entry)
     if not isinstance(value, list):
         raise PatchError(
             f"{entry.ref}: relationship {namespace!r} value must be a list of members"
         )
-    emitted_keys: list[ClaimKey] = []
+    clash_keys: list[ClaimKey] = []
     seen_keys: set[ClaimKey] = set()
+    # Deferred members lack a concrete claim_key, so dedup them on the target
+    # handle (the namespace is fixed for this call) to keep the same "duplicate
+    # member" strictness as the concrete path's seen_keys.
+    seen_deferred: set[str] = set()
+    carrier_written = False
+    # A relationship whose FK identity targets its own subject model is a
+    # self-referential hierarchy (theme_parent/gameplay_feature_parent); record
+    # each asserted edge for the plan-wide acyclicity guard, whether the parent
+    # is an existing row or a same-patch create.
+    is_self_hierarchy = (
+        isinstance(rel_spec, _FkMemberSpec) and rel_spec.target_model is model_class
+    )
     for member in value:
+        if is_self_hierarchy and isinstance(member, str):
+            hierarchy_added[model_class].append(
+                _HierarchyEdge(
+                    namespace=namespace,
+                    child=entry.public_id,
+                    parent=member,
+                    ref=entry.ref,
+                )
+            )
+        if isinstance(rel_spec, _FkMemberSpec) and isinstance(member, str):
+            handle = created.get(_CreatedKey(rel_spec.target_model, member))
+            if handle is not None:
+                if handle in seen_deferred:
+                    raise PatchError(
+                        f"{entry.ref}: duplicate member {member!r} in {namespace!r}"
+                    )
+                seen_deferred.add(handle)
+                plan.assertions.append(
+                    PlannedClaimAssert(
+                        field_name=namespace,
+                        relationship_namespace=namespace,
+                        identity_refs={rel_spec.value_key: handle},
+                        note=note,
+                        citation_ref=citation_ref,
+                        content_type_id=target.content_type_id,
+                        object_id=target.object_id,
+                        handle=target.handle,
+                    )
+                )
+                carrier_written = True
+                continue
         identity = _member_identity(member, namespace, rel_spec, entry)
         claim_key, claim_value = build_relationship_claim(namespace, identity)
         # Reject a post-fold duplicate within one entry (e.g. [Stern, stern] →
@@ -1301,8 +1510,9 @@ def _emit_relationship(
             note=note,
             citation_ref=citation_ref,
         )
-        emitted_keys.append(claim_key)
-    return emitted_keys
+        clash_keys.append(claim_key)
+        carrier_written = True
+    return _MemberEmitResult(clash_keys=clash_keys, carrier_written=carrier_written)
 
 
 def _add_removals(
@@ -1420,6 +1630,7 @@ def _add_create(
     entry: CreateEntry,
     handle: str,
     *,
+    created: dict[_CreatedKey, str],
     note: str = "",
 ) -> None:
     """Emit a ``PlannedEntityCreate`` plus its required identity/status claims.
@@ -1485,6 +1696,11 @@ def _add_create(
         pid_field: entry.public_id,
         LIFECYCLE_STATUS_FIELD: "active",
     }
+    # FK columns whose target is created earlier in this same patch: deferred to
+    # the target handle's PK by the apply layer (resolved after the bulk-create).
+    # The field loop still emits the concrete provenance claim, which
+    # _validate_entity_claim_consistency pairs with this handle_ref.
+    handle_refs: dict[str, str] = {}
 
     for key, value in entry.fields.items():
         if key not in claim_fields:
@@ -1496,12 +1712,16 @@ def _add_create(
             if not isinstance(value, str):
                 raise PatchError(f"{entry.ref}: FK {key!r} value must be a public_id")
             target_pk = _lookup_pk(target_model, value)
-            if target_pk is None:
-                raise PatchError(
-                    f"{entry.ref}: FK {key!r} target {value!r} does not exist "
-                    f"(creating an FK target in the same patch is unsupported)"
-                )
-            kwargs[django_field.attname] = target_pk
+            if target_pk is not None:
+                kwargs[django_field.attname] = target_pk
+            else:
+                ref_handle = created.get(_CreatedKey(target_model, value))
+                if ref_handle is None:
+                    raise PatchError(
+                        f"{entry.ref}: FK {key!r} target {value!r} is not in the "
+                        f"seed, an earlier patch, or this patch"
+                    )
+                handle_refs[django_field.attname] = ref_handle
         else:
             kwargs[key] = value
 
@@ -1517,7 +1737,12 @@ def _add_create(
             )
 
     plan.entities.append(
-        PlannedEntityCreate(model_class=model_class, kwargs=kwargs, handle=handle)
+        PlannedEntityCreate(
+            model_class=model_class,
+            kwargs=kwargs,
+            handle=handle,
+            handle_refs=handle_refs,
+        )
     )
     # The public-id claim is adapter-owned only when the public id *is* a claim
     # field (slug, absent from entry.fields) — emit it here. For a derived public

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -30,10 +30,12 @@ from apps.catalog.ingestion.patches import (
 from apps.catalog.models import (
     CorporateEntity,
     CorporateEntityLocation,
+    GameplayFeature,
     Location,
     MachineModel,
     Manufacturer,
     Tag,
+    Title,
 )
 from apps.catalog.resolve import resolve_all_corporate_entity_locations
 from apps.citation.models import CitationSource, CitationSourceLink
@@ -376,10 +378,9 @@ claims:
     assert not IngestRun.objects.filter(patch_id="0002-stern").exists()
 
 
-def test_relationship_member_created_same_patch_is_rejected(machine_model):
-    # Unlike FK fields, relationship members are resolved against the DB
-    # eagerly — a member created in the same patch is not supported (it must
-    # already exist). See docs/DataPatches.md "Limits".
+def test_relationship_member_created_earlier_same_patch(machine_model):
+    # A relationship member created by an *earlier* entry in the same patch
+    # resolves via the deferred (identity_refs) path — no longer rejected.
     text = f"""
 attribution: flip-museum
 claims:
@@ -389,7 +390,318 @@ claims:
   - model.{machine_model.slug}:
       tag: [brand-new-tag]
 """
-    with pytest.raises(PatchError, match="does not resolve"):
+    report = _apply(text)
+    assert report.rejected == 0
+
+    tag = Tag.objects.get(slug="brand-new-tag")
+    machine_model.refresh_from_db()
+    assert list(machine_model.tags.values_list("slug", flat=True)) == [tag.slug]
+
+
+# ── Same-patch backward references (create-first) ──────────────────
+
+
+def test_backward_fk_on_create(_bootstrap_source):
+    # Create a manufacturer, then create a corporate-entity whose `manufacturer`
+    # FK points at it — both in one patch, the dependency declared first.
+    text = """
+attribution: flip-museum
+claims:
+  - manufacturer.western:
+      create: true
+      name: Western
+  - corporate-entity.western-inc:
+      create: true
+      name: Western Inc
+      manufacturer: western
+"""
+    report = _apply(text, patch_id="0001-western")
+    assert report.rejected == 0
+
+    mfr = Manufacturer.objects.get(slug="western")
+    ce = CorporateEntity.objects.get(slug="western-inc")
+    assert ce.manufacturer_id == mfr.pk
+    # The FK provenance claim landed on the create.
+    assert ce.claims.filter(field_name="manufacturer", is_active=True).exists()
+
+
+def test_backward_fk_on_create_dry_run(_bootstrap_source):
+    # Dry-run must not reject the FK-to-planned-target just because the target
+    # doesn't exist yet, and must write nothing (guards the apply.py P1 carve-out).
+    text = """
+attribution: flip-museum
+claims:
+  - manufacturer.western:
+      create: true
+      name: Western
+  - corporate-entity.western-inc:
+      create: true
+      name: Western Inc
+      manufacturer: western
+"""
+    report = _apply(text, patch_id="0001-western", dry_run=True)
+    assert report.rejected == 0
+    assert not Manufacturer.objects.filter(slug="western").exists()
+    assert not CorporateEntity.objects.filter(slug="western-inc").exists()
+    assert not IngestRun.objects.filter(patch_id="0001-western").exists()
+
+
+def test_backward_parent_location():
+    # Create a parent location, then a child whose `parent` FK names it.
+    _country("usa", "USA")
+    text = """
+attribution: flip-museum
+claims:
+  - location.usa/tx:
+      create: true
+      name: Texas
+      slug: tx
+      parent: usa
+      location_type: state
+  - location.usa/tx/paris:
+      create: true
+      name: Paris
+      slug: paris
+      parent: usa/tx
+      location_type: city
+"""
+    report = _apply(text, patch_id="0001-paris")
+    assert report.rejected == 0
+
+    tx = Location.objects.get(location_path="usa/tx")
+    paris = Location.objects.get(location_path="usa/tx/paris")
+    assert paris.parent_id == tx.pk
+
+
+def test_backward_parent_location_dry_run():
+    _country("usa", "USA")
+    text = """
+attribution: flip-museum
+claims:
+  - location.usa/tx:
+      create: true
+      name: Texas
+      slug: tx
+      parent: usa
+      location_type: state
+  - location.usa/tx/paris:
+      create: true
+      name: Paris
+      slug: paris
+      parent: usa/tx
+      location_type: city
+"""
+    report = _apply(text, patch_id="0001-paris", dry_run=True)
+    assert report.rejected == 0
+    assert not Location.objects.filter(location_path="usa/tx").exists()
+
+
+def test_backward_title_then_model(williams_entity):
+    # Create a Title, then a MachineModel whose `title` FK names it.
+    text = """
+attribution: flip-museum
+claims:
+  - title.foo:
+      create: true
+      name: Foo
+  - model.foo:
+      create: true
+      name: Foo
+      title: foo
+"""
+    report = _apply(text, patch_id="0001-foo")
+    assert report.rejected == 0
+
+    title = Title.objects.get(slug="foo")
+    model = MachineModel.objects.get(slug="foo")
+    assert model.title_id == title.pk
+
+
+def test_backward_member_on_existing_entity(bally_wulff):
+    # Create a Location, then assert it as a `location` relationship member on an
+    # existing corporate-entity — the deferred (identity_refs) path.
+    text = """
+attribution: flip-museum
+claims:
+  - location.germany/munich:
+      create: true
+      name: Munich
+      slug: munich
+      parent: germany
+      location_type: city
+  - corporate-entity.bally-wulff:
+      location: [germany/munich]
+"""
+    report = _apply(text, patch_id="0001-munich")
+    assert report.rejected == 0
+
+    munich = Location.objects.get(location_path="germany/munich")
+    assert "germany/munich" in _ce_location_paths(bally_wulff)
+    assert _location_claim("munich").value["location"] == munich.pk
+
+
+def test_backward_member_on_created_subject(_bootstrap_source):
+    # Both the relationship subject (a CE) and its member (a Location) are
+    # created in this same patch — the deferred member targets the subject's
+    # *handle*, not an existing row, plus a backward FK to a created manufacturer.
+    _country("germany", "Germany")
+    text = """
+attribution: flip-museum
+claims:
+  - manufacturer.acme-co:
+      create: true
+      name: Acme Co
+  - location.germany/cologne:
+      create: true
+      name: Cologne
+      slug: cologne
+      parent: germany
+      location_type: city
+  - corporate-entity.acme-inc:
+      create: true
+      name: Acme Inc
+      manufacturer: acme-co
+      location: [germany/cologne]
+"""
+    report = _apply(text, patch_id="0001-acme")
+    assert report.rejected == 0
+
+    ce = CorporateEntity.objects.get(slug="acme-inc")
+    assert ce.manufacturer.slug == "acme-co"
+    assert "germany/cologne" in _ce_location_paths(ce)
+
+
+def test_backward_member_carries_note_and_cite(bally_wulff):
+    # An entry whose relationship members are *all* same-patch creates, carrying
+    # note: and cite:. The carrier must register (no spurious rejection) and the
+    # note/citation must land on the resolved member claim.
+    text = """
+attribution: flip-museum
+claims:
+  - location.germany/munich:
+      create: true
+      name: Munich
+      slug: munich
+      parent: germany
+      location_type: city
+  - corporate-entity.bally-wulff:
+      location: [germany/munich]
+      note: 'flip-museum places it in Munich.'
+      cite: https://example.org/bally-wulff
+sources:
+  - name: Example
+    source_type: web
+    links:
+      - { url: "https://example.org/", label: Example, link_type: homepage }
+"""
+    report = _apply(text, patch_id="0001-munich-cite")
+    assert report.rejected == 0
+
+    claim = _location_claim("munich")
+    assert claim.changeset is not None
+    assert claim.changeset.note == "flip-museum places it in Munich."
+    assert CitationInstance.objects.filter(claim=claim).exists()
+
+
+def test_backward_duplicate_deferred_member_rejected(bally_wulff):
+    # [munich, munich] with a same-patch-created munich → the same "duplicate
+    # member" rejection the concrete path raises (parity for deferred members).
+    text = """
+attribution: flip-museum
+claims:
+  - location.germany/munich:
+      create: true
+      name: Munich
+      slug: munich
+      parent: germany
+      location_type: city
+  - corporate-entity.bally-wulff:
+      location: [germany/munich, germany/munich]
+"""
+    with pytest.raises(PatchError, match="duplicate member"):
+        _apply(text)
+
+
+def test_self_parent_on_create_rejected():
+    # A create that names itself as its own parent must be rejected — the patch
+    # path enforces the same self-link guard as the API's plan_parent_claims.
+    text = """
+attribution: flip-museum
+claims:
+  - gameplay-feature.multiball:
+      create: true
+      name: Multiball
+      gameplay_feature_parent: [multiball]
+"""
+    with pytest.raises(PatchError, match="cannot be its own"):
+        _apply(text)
+
+
+def test_cycle_via_edit_referencing_same_patch_create_rejected():
+    # The vector same-patch refs newly enables: create a child under an existing
+    # root, then point the root at the child — a 2-cycle through a created node.
+    GameplayFeature.objects.create(name="Root", slug="root")
+    text = """
+attribution: flip-museum
+claims:
+  - gameplay-feature.child:
+      create: true
+      name: Child
+      gameplay_feature_parent: [root]
+  - gameplay-feature.root:
+      gameplay_feature_parent: [child]
+"""
+    with pytest.raises(PatchError, match="cycle"):
+        _apply(text)
+
+
+def test_cycle_between_existing_nodes_rejected():
+    # The pre-existing hole the guard also closes: two existing features pointed
+    # at each other in one patch.
+    GameplayFeature.objects.create(name="A", slug="a")
+    GameplayFeature.objects.create(name="B", slug="b")
+    text = """
+attribution: flip-museum
+claims:
+  - gameplay-feature.a:
+      gameplay_feature_parent: [b]
+  - gameplay-feature.b:
+      gameplay_feature_parent: [a]
+"""
+    with pytest.raises(PatchError, match="cycle"):
+        _apply(text)
+
+
+def test_valid_hierarchy_in_one_patch():
+    # A genuine parent→child DAG built in one patch must NOT trip the guard.
+    text = """
+attribution: flip-museum
+claims:
+  - gameplay-feature.ramps:
+      create: true
+      name: Ramps
+  - gameplay-feature.center-ramp:
+      create: true
+      name: Center Ramp
+      gameplay_feature_parent: [ramps]
+"""
+    report = _apply(text, patch_id="0001-ramps")
+    assert report.rejected == 0
+    child = GameplayFeature.objects.get(slug="center-ramp")
+    assert list(child.parents.values_list("slug", flat=True)) == ["ramps"]
+
+
+def test_backward_unresolvable_ref_errors(_bootstrap_source):
+    # A reference in neither the DB nor this patch → PatchError, updated message.
+    text = """
+attribution: flip-museum
+claims:
+  - corporate-entity.western-inc:
+      create: true
+      name: Western Inc
+      manufacturer: does-not-exist
+"""
+    with pytest.raises(PatchError, match="not in the seed, an earlier patch"):
         _apply(text)
 
 

--- a/docs/DataPatchAuthoring.md
+++ b/docs/DataPatchAuthoring.md
@@ -29,6 +29,43 @@ uv run python manage.py shell -c "from apps.catalog.models.taxonomy import GameF
 # taxonomy examples: GameFormat -> 'game-format', ProductionStatus -> 'production-status', Tag -> 'tag'
 ```
 
+## Authoring a good patch
+
+These principles apply whether you hand-author or generate. Each is elaborated in a section below or in [DataPatches.md](DataPatches.md).
+
+### Data patch attribution
+
+**Attribute to `flipcommons-catalog` by default.** It's Flipcommons' own attribution for values we research, scrape and classify ourselves, and it owns the overwhelming majority of patches. Anything web-scraped where we apply editorial judgment is `flipcommons-catalog`; scraping a fact off IPDB or Kineticist does **not** mean attributing the patch to them. Deriving a structured value by classifying a source's free text (parsing IPDB notes into a `game_format`, say) is this same default case, not an exception: `flipcommons-catalog`, with `cite:` to the source text as evidence and `note:` quoting it — there's no source claim to supersede, because the source never had that field.
+
+Reach for a different attribution only in these cases:
+
+- **Retracting or superseding another source's seed-ingest claim** → attribute to _that_ source (`ipdb`, `opdb`, …), so you act on its own claim. This is the only time `ipdb`/`opdb` attribute a patch — never a fresh first-party assertion.
+- **Wholesale import of structured data from an external site or API** → create or reuse a source for that site and attribute to it: the site supplies the field directly, so there's no judgment of ours to own.
+- **A first-party curatorial source states the fact directly** → that source — `flip-museum` for museum-curated facts no one else claims.
+- **AI-generated record descriptions** → the per-entity-type description source `flipcommons-ai-desc-<entity-type>` (see [Record descriptions](#record-descriptions)).
+
+### One entity per entry
+
+**One entity per entry**, carrying all its fields and its single `note`/`cite`.
+
+### Guard every entry
+
+**Guard every entry with `expect:`** against a current resolved value — `year`, or another stable field like `corporate_entity` when year is null — so a typo'd or drifted public_id fails loudly instead of writing to the wrong row. When claims are keyed off an external record (IPDB/OPDB), guard on that id — `expect: { ipdb_id: 4965 }`: it's the most specific guard, it's the same record your `cite:` points at, and it's present even when `year` and `corporate_entity` are both null.
+
+### Note every entry
+
+**Explain every change with `note:`**, written as `<source> says "<verbatim quote>"`. Quote the source _verbatim_ and mark your own omissions with `[...]`. **Preserve the source's own characters**, including non-ASCII letters in foreign-language quotes (e.g. `Günter`, `gegründet`) — notes are stored as UTF-8, so don't strip or transliterate them. Only normalize stray _typography_ that's a copy-paste artifact rather than part of the quote: straighten smart quotes (`“ ”` → `"`) and spell out an ellipsis `…` as `[...]`.
+
+### Cite most entries
+
+**Cite external evidence with `cite:`** — `scheme:identifier` for IPDB/OPDB records, or a raw `http(s)://` URL for any other web page (a forum thread, an archive scan, a manufacturer's page). Reach for the scheme form whenever one exists; the URL form is the escape hatch for sources without a scheme. A URL cite needs its **website root seeded first** (a parentless web source whose homepage link shares the domain) — seed it in an earlier patch, the same vocab-first pattern, then cite pages under it (see [Citation sources](#citation-sources)). Skip the citation when the evidence is in the entity's own data and instead write it in the note such as "Its name contains the word 'prototype'". The cite can also differ from the `expect:` guard: when the evidence lives in a _different_ record's note (a cross-reference — "‹other game› is not a pinball"), guard on the model's own id but `cite:` the record that contains the statement.
+
+**Only assert what a source supports.** If you can't point to evidence, leave the field unset rather than guess: an unset value reads as "unknown", a wrong claim reads as fact.
+
+### Script large patches
+
+**Large curated patches: keep a worksheet, emit from a script.** For a patch spanning dozens of curated rows, record every search you ran (including the ones that found nothing) and the verbatim source text behind each call in a review worksheet, then generate the YAML from a script that reads live field values for the `expect:` guards. Hand-copying guards drifts from the DB; a generator keeps them true and the worksheet keeps the editorial judgment auditable. The dead-end searches matter too — proving a term is absent from the sources is what justifies relying on the signal you did find. **Don't reinvent the generator** — follow [DataPatchKit.md](DataPatchKit.md) and use the shared `patchkit` helper (escaping, `expect:` guards, source-text extraction).
+
 ## Patch description
 
 Every patch should contain a top-level description. Don't restate the details of each changeset. Don't reference other patches by number. Examples:
@@ -36,17 +73,17 @@ Every patch should contain a top-level description. Don't restate the details of
 - ❌ NO: Models for the new active makers, one per game. Each model's title (0053) and corporate entity (0051) already exist. Production status reflects each game's real state: Alice Goes to Wonderland is shipping (produced); the rest are announced (a pre-order, an intended launch, a trademark filing). Corporate inception years stay off the entities; these model years carry the makers' timeline. The Wonderland and Pawlowski home machines carry the home-use tag; the already-catalogued Ramp's Road Trip is tagged widebody.
 - ✅ YES: Models for the new active makers created in a previous patch.
 
-## Create vocabulary and FK targets in an earlier patch
+## Create new vocabulary in a patch, not the seed
 
-**Vocabulary must be created by a patch, not added to the seed.** Production is seeded **once** and never re-ingested — it only replays patches. A new taxonomy value (a `GameFormat`, `ProductionStatus`, `Tag`) added only to the pindata seed would never reach prod, and an assignment patch referencing it would fail there. So: create new vocab in an **earlier** patch (its own file, since vocab is usually `flip-museum` while assignments are source-attributed), then reference it.
+**New vocabulary must be created by a patch**, never added to the pindata seed. Production is seeded **once** and never re-ingested — it only replays patches — so a new taxonomy value (`GameFormat`, `ProductionStatus`, `Tag`) added only to the seed would never reach prod, and a patch referencing it would fail there. Create the vocab in a patch, then reference it. The same holds for any new FK target — a manufacturer, a title, a parent location.
 
-The same rule covers **any FK target** — a manufacturer, a title, a parent location — because a target is resolved by a live DB lookup and one created earlier in the _same_ patch isn't yet visible (see [DataPatches.md → Limitations](DataPatches.md#limitations)). Create the target in an earlier numbered patch, then point at it.
+Within a file, declare a target **above** the entry that references it (same-patch backward refs resolve). Only a _forward_ reference — pointing at an entry below — still needs an earlier patch (see [DataPatches.md → Limitations](DataPatches.md#limitations)).
 
-Those target-creation patches can be **scaffolding-only**: for example, creating Titles before Models, a Franchise before title-franchise links, or Locations before corporate-entity location claims. A scaffolding-only patch may omit per-entry `note:`/`cite:` when it only creates obvious target records and the patch `description:` says why the targets are needed. The later patch that makes the substantive assignment still needs normal evidence.
+Target-creating entries can be **scaffolding** — obvious records like Titles before Models or Locations before corporate-entity claims — and may omit per-entry `note:`/`cite:` when the patch `description:` says why they're needed. The substantive assignment that uses them still needs normal evidence.
 
 ## Citation sources
 
-A `cite:` to a web URL needs its **website root** seeded first — created in an earlier patch via a top-level `sources:` block (mechanics and the get-or-create policy are in [DataPatches.md → Citation sources](DataPatches.md#citation-sources)). It's another create-in-an-earlier-patch prerequisite, like vocab and FK targets.
+A `cite:` to a web URL needs its **website root** — declared via a top-level `sources:` block (mechanics and the get-or-create policy are in [DataPatches.md → Citation sources](DataPatches.md#citation-sources)). The `sources:` block is processed before claims, so a root declared in the **same** patch is citable in that patch (order-independent), or it can come from an earlier patch.
 
 Write a root's `description:` to only describe **the source itself** — what it is; do NOT include why this patch cites it:
 
@@ -55,11 +92,7 @@ Write a root's `description:` to only describe **the source itself** — what it
 
 This is because a root is reusable, so a reason-specific description goes stale the moment the next patch cites the same root for an unrelated fact. Leave per-fact reasoning to the citing entry's `note:`.
 
-## Provenance
-
-The attribution, cite-vs-guard, scaffolding-only exception, and verbatim-note rules are canonical in [DataPatches.md → Authoring a good patch](DataPatches.md#authoring-a-good-patch). Don't restate them — follow them whether you hand-author or generate.
-
-## Writing record descriptions
+## Record descriptions
 
 Some patches set narrative record descriptions (Manufacturer, Model, …) — prose, not classified values. The rules:
 
@@ -93,9 +126,23 @@ claims:
 - **Remove** drops a member exactly like an FK member: `remove: { manufacturer_alias: [Stern Inc] }`, attributed to the source holding the membership claim.
 - **No `note:` or `cite:` needed.** Aliases and abbreviations don't require `note:`/`cite:`. It fine for them to ride in a Change Set whose `note:`/`cite:` supports other things.
 
-## Validate behind a snapshot
+## Validation process
 
-Patches are immutable once applied (per-DB fingerprint), so iterate behind a snapshot — see [DataPatches.md → Iterating on localhost](DataPatches.md#iterating-on-localhost-snapshot-first) for the snapshot/rollback loop and naming. Apply your new, uncommitted patches **from an isolated dir** so the already-applied 0001–N stay untouched:
+How to validate your changes:
+
+1. [`--dry-run`](#dry-run) is the cheap first pass: it parses the patch and runs every structural check without writing.
+2. [Validate via snapshot](#validate-via-snapshot) is the real check: it commits to localhost, so you see the resolved effect in the running app and can validate cross-file dependencies, then roll back.
+3. [Hand off to user](#hand-off-to-user) only after those. Committing is the user's call.
+
+### Dry run
+
+`--dry-run` parses the patch and runs every structural check (schema, escaping, `expect:` guards, citation roots) without writing. This catches most single-file mistakes in seconds. However, what it cannot do is show the resolved result or validate a dependency that spans patch files, because it commits nothing.
+
+**`--dry-run` can't validate a reference to an entity from another patch file.** Dry-run commits nothing, so if a later patch references something an earlier patch file creates — a title before its model, a manufacturer, a parent location, a vocab value — the later patch reports "FK target does not exist" for it. When you are testing multiple patch files together where one depends on a previous, validate with the snapshot+apply above instead of dry-run.
+
+### Validate via snapshot
+
+Because a patch is immutable once applied (see [DataPatches.md → The ledger](DataPatches.md#the-ledger-applied-once-immutably)), you can't tweak it and re-run against a DB that already has it. Instead, iterate behind a DB snapshot: copy the SQLite file before applying and restore it to roll back. Name the snapshot after the patch (`db.pre-NNNN.sqlite3`) so it's clear which state it captures; the `.sqlite3` suffix keeps it under the gitignored `*.sqlite3` rule. Apply your new, uncommitted patches **from an isolated dir** so the already-applied 0001–N stay untouched:
 
 ```bash
 cd backend
@@ -106,6 +153,26 @@ uv run python manage.py ingest_patches --patches-dir /tmp/p
 cp db.pre-00NN.sqlite3 db.sqlite3                      # roll back
 ```
 
-**`--dry-run` is misleading for vocab+assignment pairs.** Dry-run doesn't commit the vocab-creating patch, so the assignment patch reports "FK target does not exist" for every new vocab value. That's an artifact, not a failure — a real apply commits the vocab patch first. Validate with the snapshot+apply above, not dry-run, when one patch creates vocab the next uses.
+#### Verify snapshot
 
-Then ship: commit + push pindata, publish to R2, and on prod `make pull-ingest && make ingest-patches`.
+After applying, spot-check that the change resolved the way you intended — pull a representative entity and confirm its winning claim carries the right source, value, `cite:` and `note:` (`citation_instances` carries the cite, `changeset.note` the note):
+
+```python
+from apps.catalog.models import MachineModel
+from apps.provenance.models import Claim
+from django.contrib.contenttypes.models import ContentType
+
+ct = ContentType.objects.get_for_model(MachineModel)
+c = Claim.objects.filter(
+    content_type=ct,
+    object_id=MachineModel.objects.get(slug="hyperball").id,
+    field_name="game_format",
+    is_active=True,
+).first()
+print(c.source.slug, c.value, [ci.citation_source.identifier for ci in c.citation_instances.all()])
+print(c.changeset.note)
+```
+
+### Hand off to user
+
+Committing and `make push` in pindata are the user's call — never do either yourself.

--- a/docs/DataPatchKit.md
+++ b/docs/DataPatchKit.md
@@ -91,32 +91,21 @@ entries = [
     )
     for r in rows
 ]
-pk.write_patch("../../0010-game-formats.yaml", attribution="ipdb", description="...", entries=entries)
+pk.write_patch("../../0010-game-formats.yaml", attribution="flipcommons-catalog", description="...", entries=entries)
 ```
 
 ## Provenance in generated patches
 
-The attribution, cite-vs-guard and verbatim-note rules are canonical in [DataPatches.md → Authoring a good patch](DataPatches.md#authoring-a-good-patch) and summarized in [DataPatchAuthoring.md → Provenance](DataPatchAuthoring.md#provenance). Two consequences specific to generated patches:
+The attribution, cite-vs-guard and verbatim-note rules are canonical in [DataPatchAuthoring.md → Authoring a good patch](DataPatchAuthoring.md#authoring-a-good-patch). Two consequences specific to generated patches:
 
-- The carry-a-value-vs-derive-structured-data split usually forces vocab and assignments into **separate files** (different attributions). The 0010/0011 `game_format` patches are the derive case: `flipcommons-catalog` + `cite: ipdb:<id>`. Because vocab must exist before the assignment references it (see [DataPatchAuthoring.md → Create vocabulary](DataPatchAuthoring.md#create-vocabulary-and-fk-targets-in-an-earlier-patch)), the vocab lands in an earlier file: `0009-game-format-vocab.yaml` → `0010-game-formats.yaml`.
+- Vocab and its assignment can share one file now — the derive case attributes both to `flipcommons-catalog` (the assignment carries `cite: ipdb:<id>`), and same-patch backward refs let the vocab entries sit above the assignments that reference them. Split vocab into an earlier file only when the two genuinely need different attributions. The historical 0009→0010/0011 `game_format` patches predate same-patch refs and split anyway (`0009-game-format-vocab.yaml` → `0010-game-formats.yaml`; see [DataPatchAuthoring.md → Create new vocabulary in a patch](DataPatchAuthoring.md#create-new-vocabulary-in-a-patch-not-the-seed)).
 - `source_note` / `clean_text` enforce the verbatim-note shape for you — use them rather than hand-formatting `<Source> says "<quote>"`.
 
 ## Validate
 
-Iterate behind a localhost snapshot — see [DataPatchAuthoring.md → Validate behind a snapshot](DataPatchAuthoring.md#validate-behind-a-snapshot) for the isolated-dir snapshot/rollback loop and the misleading-dry-run trap that bites vocab+assignment pairs.
+Iterate behind a localhost snapshot, then verify and hand off — the full loop (snapshot/rollback, the per-row spot-check, the misleading-dry-run trap on references that span patch files, and the hand-off) is in [DataPatchAuthoring.md → Validation process](DataPatchAuthoring.md#validation-process).
 
-After applying, verify the population landed — distribution looks right, and a spot-checked row carries the source, value, cite and note (`citation_instances` carries the cite, `changeset.note` the note):
-
-```python
-from apps.catalog.models import MachineModel
-from apps.provenance.models import Claim
-from django.contrib.contenttypes.models import ContentType
-ct = ContentType.objects.get_for_model(MachineModel)
-c = Claim.objects.filter(content_type=ct, object_id=MachineModel.objects.get(slug="hyperball").id,
-                         field_name="game_format", is_active=True).first()
-print(c.source.slug, c.value, [ci.citation_source.identifier for ci in c.citation_instances.all()])
-print(c.changeset.note)
-```
+Generator-specific addition: a curated patch classifies a whole **population**, so after applying confirm the population landed — the distribution across buckets looks right and the row counts match your worksheet — not just that one spot-checked entity resolved.
 
 ## Gotchas (learned the hard way)
 

--- a/docs/DataPatchReviewing.md
+++ b/docs/DataPatchReviewing.md
@@ -22,10 +22,10 @@ When you need to read deeper:
 
 ## Checklist — confirm the Authoring rules hold
 
-Check each against [DataPatchAuthoring.md](DataPatchAuthoring.md) and [DataPatches.md → Authoring a good patch](DataPatches.md#authoring-a-good-patch):
+Check each against [DataPatchAuthoring.md](DataPatchAuthoring.md):
 
 - **Attribution** — the right source owns each claim; a retraction sits with whoever made the original claim; a narrative description uses its `flipcommons-ai-desc-<entity-type>` source.
 - **Values accurate** — each asserted value matches the cited evidence.
 - **Notes verbatim** — `note:` quotes the source faithfully (omissions marked `[...]`, non-ASCII preserved).
 - **Citations support the claim** — the `cite:` record actually states the asserted fact.
-- **Descriptions** — follow [Writing record descriptions](DataPatchAuthoring.md#writing-record-descriptions): factual, supported, not a title dump, no phrasing that will date.
+- **Descriptions** — follow [Record descriptions](DataPatchAuthoring.md#record-descriptions): factual, supported, not a title dump, no phrasing that will date.

--- a/docs/DataPatches.md
+++ b/docs/DataPatches.md
@@ -6,7 +6,7 @@ A **data patch** is a small set of catalog claims authored as YAML and applied t
 
 It's the schema-migration model, but for catalog data. The seed ingest is an **immutable baseline** we never edit to fix data. Corrections and ongoing source updates are **append-only, numbered patches replayed on top of the seed in every environment**: a fresh database reaches production's state by replaying seed → `0001` → `0002` → …. Production is seeded once, then patches arrive over time.
 
-A patch is **attributed to the source making the claim** (which may be `flipcommons-catalog` when we derive structured data from another source's prose — see [Authoring a good patch](#authoring-a-good-patch)) and does one of three things to _that source's_ claims:
+A patch is **attributed to a source** — usually `flipcommons-catalog`, Flipcommons' own attribution for values we research, scrape and classify ourselves (see [DataPatchAuthoring.md → Authoring a good patch](DataPatchAuthoring.md#authoring-a-good-patch)) — and does one of three things to _that source's_ claims:
 
 - **assert / supersede** — (re-)assert a claim; the engine deactivates the source's prior claim for that `(entity, claim_key)` and writes the new one. Corrects a wrong value or carries a source's updated one.
 - **create** — make a new entity and its claims.
@@ -14,20 +14,24 @@ A patch is **attributed to the source making the claim** (which may be `flipcomm
 - **remove** — drop a relationship _member_ (a tag, a location) by superseding it with an `exists=false` tombstone. Distinct from retract: the claim stays active, resolving to "absent" — the same mechanism the in-app editor uses.
 - **delete** — soft-delete an entity (the `status=deleted` lifecycle), distinct from a claim retract.
 
-## Where data patches live
+## Patches live in pindata
 
-All data patches live in the [pindata](https://github.com/deanmoses/pindata) repo under `patches/` and ride the R2 export → `make pull-ingest` path to `data/ingest_sources/pindata/patches/`.
+Data patches live in the [pindata](https://github.com/deanmoses/pindata) repo in the `patches/` directory. They are numbered files `NNNN-slug.yaml`, like `0001-prototype-tags`.
 
-They are numbered files `NNNN-slug.yaml`, like `0001-prototype-tags`.
+From there they are exported via pindata's `make pull-ingest` to R2, under the path `data/ingest_sources/pindata/patches/`.
 
 ## File format
 
-One patch carries **one attribution** (→ one `IngestRun`).
+Each patch file carries **one attribution** (→ one `IngestRun`).
+
+### Edit
+
+Edit an existing record:
 
 ```yaml
-attribution: flip-museum # a Source slug; must already exist
+attribution: flipcommons-catalog # a Source slug; must already exist
 description:
-  > # optional; the whole-patch "why" → IngestRun.note (only viewable in Django admin and git for now)
+  > # The whole-patch "why" → IngestRun.note (only viewable in Django admin and git for now)
   Tag known unreleased prototypes.
 claims: # ordered list of single-key entries
   - model.mazatron: # entity ref: <entity_type>.<public_id>
@@ -38,39 +42,25 @@ claims: # ordered list of single-key entries
       tag: [prototype] # relationship: namespace → member public_ids
 ```
 
-Create + supersede, attributed to the source whose value it corrects. An FK target must already exist in the DB (the seed or an _earlier_ patch), so the new manufacturer is created in an earlier-numbered patch than the corporate entity that points at it — a target created earlier in the _same_ patch isn't yet resolvable (see [Limitations](#limitations)):
+### Create
+
+Create a new record:
 
 ```yaml
-# 0010-create-western.yaml — create the FK target first, on its own
 attribution: flipcommons-catalog
 claims:
   - manufacturer.western-products:
       name: Western Products
       create: true # opt-in to create a missing entity
-```
-
-```yaml
-# 0011-western-corporate-entity.yaml — now the manufacturer exists to point at
-attribution: flipcommons-catalog
-claims:
   - corporate-entity.western-products-incorporated:
-      manufacturer: western-products # FK → public_id; supersedes this source's prior claim
+      manufacturer: western-products # FK → public_id; resolves to the create above
 ```
 
-Creating a **Location** is the one create whose public id is _derived_ rather than authored: `location_path` is built from `parent` + `slug`. Write `slug` and `parent` as ordinary claims; the adapter takes the path from the entity reference, never claims it, and verifies it composes from `parent + slug` (a mismatch is an error). The `parent` must already exist (an earlier patch or the seed) — a parent created in the same patch isn't resolvable yet. Omit `parent` for a root (country).
+`create: true` opts in to making a new entity — without it an unresolved ref errors; with it on a ref that already resolves, an error (duplicate). An FK target must already exist when the entry runs — in the seed, an _earlier_ patch, or **earlier in this same patch** — so a manufacturer and the corporate entity pointing at it can land together, the manufacturer declared first (a _forward_ reference, pointing at an entry below, isn't supported yet; see [Limitations](#limitations)). Creating a **Location** is the one create whose id is _derived_: write `slug` and `parent` as ordinary claims, and the `location_path` in the ref must compose from `parent + slug` (a mismatch errors).
 
-```yaml
-attribution: flip-museum
-claims:
-  - location.usa/tx/paris: # location_path = parent + slug
-      create: true
-      name: Paris
-      slug: paris # the claim-based form input
-      parent: usa/tx # FK by location_path; must already exist
-      location_type: city
-```
+### Retract
 
-Retract, attributed to the source whose claim it removes:
+Deactivate a scalar/FK claim from this patch's source, on an existing entity:
 
 ```yaml
 attribution: ipdb
@@ -79,73 +69,112 @@ claims:
       retract: [manufacturer] # drop ipdb's manufacturer claim
 ```
 
-Remove a relationship member and refine to a more specific one — here, replacing a coarse `germany` location with `germany/berlin`. Attributed to the source holding the membership claim, so its `exists=false` supersedes its own `exists=true`:
+It is attributed to the source whose claim it drops.
+
+A no-op with a warning if the claim is already gone, so re-runs are safe. Not valid with `create:`, nor alongside asserting the same field. Retracting the sole claim of a non-nullable FK doesn't clear it (NOT NULL forbids it) — the last value freezes in place, provenance-orphaned; to _change_ a required FK, assert the new value instead. Because retract is scoped to this patch's source, attributing it to a source that never claimed the field silently does nothing — confirm which source holds the active claim first.
+
+### Remove
+
+Remove a relationship member:
 
 ```yaml
-attribution: flip-museum
+attribution: flip-museum # a museum-curated fact → flip-museum
 claims:
   - corporate-entity.bally-wulff:
       location: [germany/berlin] # assert the more-specific member (exists=true)
       remove: { location: [germany] } # supersede the coarse member (exists=false)
-      note: 'flip-museum says "headquartered in Berlin".'
+      note: "Headquartered in Berlin, not just Germany."
 ```
 
-Set string-valued relationship members — aliases and abbreviations. The field key is the **literal registered namespace** (`manufacturer_alias`, `abbreviation`); members are bare strings, not public_ids. Alias values case-fold for identity (original case preserved for display); abbreviations are stored verbatim. `remove:` drops a member the same way it drops an FK member:
+This is the relationship counterpart of `retract:` (which is scalar/FK only). Above it refines a coarse `germany` location to `germany/berlin`. It is **not** a retraction: it supersedes this source's `exists=true` membership claim with an `exists=false` tombstone — the same write the in-app editor makes to drop a member — so the claim stays active and provenance (`note:`/`cite:`) rides it. Attribute it to the source holding the active membership claim (the resolver unions `exists=true` across sources):
+
+A member this source doesn't currently claim present is a no-op with a warning (so re-runs are safe), not an error — but a no-op emits no tombstone, so an entry whose _only_ effect is a no-op removal can't anchor a `note:`/`cite:` and is rejected (the provenance would silently vanish). Not valid with `create:`/`delete:`, nor removing a member the same entry also asserts present. Relationship `remove:` is the only relationship retraction path — plain `retract:` rejects a relationship namespace.
+
+### Delete
+
+Soft-delete an entity:
 
 ```yaml
-attribution: flip-museum
+attribution: flipcommons-catalog
+claims:
+  - corporate-entity.chicago-coin-machinery-company:
+      expect: { manufacturer: chicago-coin } # guard the row you're deleting
+      delete: true
+      note: "Duplicate of chicago-coin; its sole machine was reassigned first."
+```
+
+This writes a `status=deleted` claim (no row removal), exactly like an in-app delete. It reuses the app's soft-delete planner, so it obeys the same record-lifecycle rules: it **refuses** while an active PROTECT referrer would be left dangling — reassign any such referrer in an **earlier** patch first (the referrer check reads live DB state — see [Limitations](#limitations)) — and **cascades** `status=deleted` to owned lifecycle children (a warning lists them). A delete entry takes only `expect:`/`note:`/`cite:` — no field assertions, no `create:`, no `retract:`; `note`/`cite` ride the `status=deleted` claim. Idempotent: re-deleting an already-deleted entity diffs as unchanged. It takes effect only if the `status=deleted` claim wins resolution, so attribute it to a source that outranks any existing `status` claim.
+
+### Entity references
+
+Entity references are of format `type.public_id` — the canonical `entity_type` (`model`, `manufacturer`, `corporate-entity`, …) and the public id (slug for most, `location_path` for Location), split on the first `.`.
+
+### Field keys
+
+Field keys are classified by introspection: **scalar** (`year`) — value used as-is; **FK** (`manufacturer`, `production_status`) — value is the target's `public_id`; **relationship** (`tag`, `theme`, `manufacturer_alias`, `abbreviation`) — key is the namespace, value a list of members (FK public_ids, or bare strings for aliases/abbreviations). The lifecycle field **`status` is not directly assertable** — a raw `status: deleted` would skip the delete planner's blocker check and cascade, so it's rejected; soft-delete via `delete: true` instead.
+
+Distinct from field keys are the **reserved keys** — directives, not claims: `create:`, `delete:`, `retract:` and `remove:` (each covered with its operation above), plus the cross-cutting `expect:`, `note:` and `cite:` (below).
+
+### Aliases & abbreviations
+
+Aliases and abbreviations are sets/arrays:
+
+```yaml
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       manufacturer_alias: [Stern Pinball, Stern Inc, Stern Electronics] # known trade names
-      note: "flip-museum: trade names across the company history."
   - model.medieval-madness:
       abbreviation: [MM, MedMad] # shared Title/MachineModel namespace
       remove: { abbreviation: [MedievalMadness] } # drop a bad earlier abbreviation
 ```
 
-Delete, after reassigning the firm's one machine to another corporate entity. The reassignment must land in an **earlier** patch: the delete's referrer check reads live DB state, so a same-patch reassignment isn't yet visible and the delete would still see the machine as a blocker.
+The field key is the **literal registered namespace** (`manufacturer_alias`, `abbreviation`); members are bare strings, not public_ids (alias values case-fold for identity, original case preserved for display; abbreviations are verbatim). Aliases and abbreviations need no `note:`/`cite:`. `remove:` drops a member the same way it drops an FK member.
+
+### Drift guard
+
+`expect:` is a drift guard: a map of currently-resolved values the target must already have, checked before any write (mismatch → error). Covers scalar + FK. It stops a hand-authored id from writing to a drifted or same-named row — guard every entry with it.
 
 ```yaml
-# 0007-reassign-machine.yaml — reassign first, on its own
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
-  - model.some-machine:
-      expect: { corporate_entity: chicago-coin-machinery-company }
-      corporate_entity: chicago-coin # the surviving firm
+  - model.medieval-madness:
+      expect: { ipdb_id: 4032 } # write only if this row already resolves to IPDB 4032
+      production_status: produced
 ```
+
+### Notes & citations
+
+Write a `note:` about the changeset and `cite:` citations:
 
 ```yaml
-# 0008-delete-firm.yaml — now the firm has no active referrer
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
-  - corporate-entity.chicago-coin-machinery-company:
-      expect: { manufacturer: chicago-coin } # guard the row you're deleting
-      delete: true
-      note: "flip-museum: duplicate of chicago-coin; its sole machine reassigned."
+  - model.mazatron:
+      note: 'IPDB says "exists only as a prototype machine".' # the per-entity "why"
+      cite: ipdb:4443 # scheme:identifier — dedups through the seeded IPDB root
+      production_status: unreleased
+  - model.medieval-madness:
+      note: 'Wikipedia says it "was released in 1997".'
+      cite: https://en.wikipedia.org/wiki/Medieval_Madness # raw URL — needs a seeded website root (see Citation sources)
+      year: 1997
 ```
 
-**Entity reference** is `type.public_id` — the canonical `entity_type` (`model`, `manufacturer`, `corporate-entity`, …) and the public id (slug for most, `location_path` for Location), split on the first `.`.
+`note:` is the entity's ChangeSet note, shown on its Edit History page.
 
-**Field keys** are classified by introspection: **scalar** (`year`) — value used as-is; **FK** (`manufacturer`, `production_status`) — value is the target's public_id; **relationship** (`tag`, `theme`, `manufacturer_alias`, `abbreviation`) — key is the namespace, value a list of members (FK public_ids, or bare strings for aliases/abbreviations). The lifecycle field **`status` is not directly assertable** — a raw `status: deleted` would skip the delete planner's blocker check and cascade, so it's rejected; soft-delete via `delete: true` instead.
+`cite:` is external evidence, attached to each of the entry's authored claims and shown beside the field on the edit-history page, in one of two forms:
 
-**Reserved keys** (directives, not claim fields):
-
-- `create: true` — opt-in to create. Unresolved ref without it → error; resolved ref with it → error (duplicate).
-- `delete: true` — soft-delete an existing entity: writes a `status=deleted` claim (no row removal), exactly like an in-app delete. Reuses the app's soft-delete planner, so it obeys the same record-lifecycle rules — it **refuses** when an active PROTECT referrer would be left dangling, and **cascades** `status=deleted` to owned lifecycle children (a warning lists them). A delete entry takes only `expect:`/`note:`/`cite:` — no field assertions (reassign references in a separate, earlier patch first; see below), no `create`, no `retract`. `note`/`cite` ride the `status=deleted` claim. Idempotent: re-deleting an already-deleted entity diffs as unchanged. Takes effect only if the `status=deleted` claim wins resolution, so attribute it to a source that outranks any existing `status` claim.
-- `expect:` — drift guard: a map of currently-resolved values the target must already have, checked before any write (mismatch → error). Covers scalar + FK. Stops a hand-authored id from writing to a drifted or same-named row.
-- `retract:` — scalar/FK field names whose claim (from this patch's source) to deactivate, on an existing entity. A no-op with a warning if already gone, so re-runs are safe. Not valid with `create`, nor alongside asserting the same field. Retracting the sole claim of a non-nullable FK doesn't clear it (NOT NULL forbids it) — the last value freezes in place, provenance-orphaned; to _change_ a required FK, assert the new value instead. Because it is scoped to this patch's source, attributing the retract to a source that never claimed the field silently does nothing — confirm which source holds the active claim first.
-- `remove:` — a map of **relationship** namespace → member values (FK public_ids, or bare strings for aliases/abbreviations) to drop from an existing entity (the relationship counterpart of `retract:`, which is scalar/FK only). It is **not** a retraction: it supersedes this source's `exists=true` membership claim with an `exists=false` tombstone — the same write the in-app editor makes to drop a member — so the claim stays active and provenance (`note:`/`cite:`) rides it. Because the resolver unions `exists=true` across sources, attribute it to the source holding the active membership claim; a member this source doesn't currently claim present is a no-op with a warning (so re-runs are safe), not an error — but because a no-op emits no tombstone, an entry whose \_only\* effect is a no-op removal can't anchor a `note:`/`cite:` and is rejected (the provenance would silently vanish). Not valid with `create`/`delete`, nor removing a member the same entry also asserts present. Relationship `remove:` is the only relationship retraction path — plain `retract:` rejects a relationship namespace.
-- `note:` — a per-entity free-text reason (≤1000 chars) → the entity's ChangeSet note, shown on its edit-history page. (`description:` explains the whole patch; `note:` explains one entry.) All of an entity's claims in a patch collapse into one changeset, so the note is per-entity. The per-entity `note:` is the user-facing one; the whole-patch `description:` (→ `IngestRun.note`) is, as of this writing, surfaced only in Django admin — so put anything readers should see in `note:`, not `description:`.
-- `cite:` — external evidence, in one of these forms, attached to each of the entry's authored claims and shown beside the field on the edit-history page:
-  - **`scheme:identifier`** (`ipdb:4443`, `opdb:GRhX5`) — a known scheme. Get-or-creates the source under that scheme's seeded root.
-  - **a `http(s)://` URL** (`https://en.wikipedia.org/wiki/...`) — any other web page. The URL's domain must match a **seeded website root** (a parentless web source whose homepage link shares the domain); the cite get-or-creates a `reference` child page under that root, keyed by the exact URL (re-citing reuses it). If no root matches, the patch errors — seed the website root in an earlier patch first. (A root web source is an abstract container, so a patch never mints a parentless one.) A URL matching a known scheme's record pattern (e.g. an `ipdb.org/machine.cgi?id=...` link) is **rejected** — cite it as `scheme:identifier` so it dedups through the scheme path.
+- **`scheme:identifier`** (`ipdb:4443`, `opdb:GRhX5`) — a known scheme. Get-or-creates the source under that scheme's seeded root.
+- **a `http(s)://` URL** (`https://en.wikipedia.org/wiki/...`) — any other web page. The URL's domain must match a **seeded website root** (a parentless web source whose homepage link shares the domain); the cite get-or-creates a `reference` child page under that root, keyed by the exact URL (re-citing reuses it). If no root matches, the patch errors — declare the website root in this patch's `sources:` block (processed before claims) or an earlier patch. (A root web source is an abstract container, so a patch never mints a parentless one.) A URL matching a known scheme's record pattern (e.g. an `ipdb.org/machine.cgi?id=...` link) is **rejected** — cite it as `scheme:identifier` so it dedups through the scheme path.
 
 Two rules tie note/cite to the single changeset an entry produces:
 
 - **One provenance-bearing entry per entity.** Two entries resolving to the same entity that both set `note`/`cite` is an error — combine them into one.
 - **Provenance rides only an actual write (v1).** note/cite attach to what the patch writes. An entry with nothing to attach to (retraction-only, field-less create, empty `tag: []`) is a hard error. And re-asserting a value the entity already has from the same source diffs as unchanged — no claim, no changeset — so its `note`/`cite` are **silently dropped though the patch reports success**. To record provenance, the entry must change a value or create the entity.
 
-**Strict parsing:** duplicate keys error, and values must be JSON-shaped — YAML coercion is off, so a bare `1996-01-01` stays a string and `no` stays `"no"`. A `note:` containing `"` needs YAML quoting (single-quote the value, as above).
+### Strict parsing
+
+Duplicate keys error, and values must be JSON-shaped — YAML coercion is off, so a bare `1996-01-01` stays a string and `no` stays `"no"`. A `note:` containing `"` needs YAML quoting (single-quote the value, as in the examples above).
 
 ## Citation sources
 
@@ -176,26 +205,12 @@ A `sources:` node is the seed-data source shape (`name`, `source_type`, optional
 **Identity and the get-or-create policy.** A source has no slug; identity is `isbn` if present, else `(name, source_type)`. The block is **additive get-or-create**, never an overwrite:
 
 - not found → create the source and its declared links.
-- found → leave the existing row untouched (a divergent declared field is a **warning**, not an error), and **additively backfill** any declared link the row is missing. An existing link with the same URL but a different `link_type`/`label` is left as-is and warned.
+- found → leave the existing row untouched (a divergent declared field is a **warning**, not an error), and **additively backfill** any declared link the row is missing — so a later `cite:` can nest under the root even when the row already existed without your `homepage` link. An existing link with the same URL but a different `link_type`/`label` is left as-is and warned.
 - two-plus rows match `(name, source_type)` → operate on the first, warn.
 
 This is deliberate: a user can create a source through the app, so a same-identity collision is invisible when you author the patch. A strict "differs → error" policy would let one such collision **fail the patch and dam every later patch on prod** (patches stop at the first failure). Get-or-create never wedges and never clobbers user data — at the cost that, on a collision, the patch's description/links don't win (correctable only in Django admin). Because it's additive, re-applying is a clean no-op.
 
 **What still hard-errors** (all author-controllable, and all surface at `--dry-run` on localhost before you ship): an unknown key, a nested `children`, a missing `name`/`source_type`, and any value the model rejects — a bad `source_type`, an out-of-range `year`/`month`/`day`, an invalid `identifier_key` or `link_type`, a malformed URL, or a duplicate declared link URL.
-
-**Backfill enables nesting.** A web root is only recognized by a later `cite:` URL if it has a `homepage` link on that domain. The additive backfill is what makes a found-but-linkless root usable. (Edge: if the row already has that URL typed `reference`, the `homepage` duplicate can't be added — recognition won't match, and a cite on that domain can still fail. Rare; fix the link in admin.)
-
-## Authoring a good patch
-
-- **Attribute to whoever makes the claim.** A value the source itself states → that source (`ipdb`, `opdb`); correcting it → still that source, so you supersede or retract _its_ claim. A structured value _we derive_ by classifying a source's free text (the source has no such field — e.g. parsing IPDB notes into a `game_format`) → `flipcommons-catalog`, with `cite:` to the source text as evidence; there's no source claim to supersede. Museum-curated facts no one else claims → `flip-museum`.
-- **One entity per entry**, carrying all its fields and its single `note`/`cite`.
-- **Create vocabulary, and any FK target, in an earlier patch.** A `tag:` member, an FK target, or a `title` a model points at must already exist in the DB when the entry runs — in the seed or an _earlier_ numbered patch, **not the same one**. An FK is resolved by a live DB lookup, so a target created earlier in the same patch isn't yet visible (see [Limitations](#limitations)). Put new tags/statuses/titles in an earlier patch, then reference them — e.g. one patch creates the `aftermarket` status and re-theme tags, the next assigns them; one patch creates the titles, the next creates the models.
-- **Guard every entry with `expect:`** against a current resolved value — `year`, or another stable field like `corporate_entity` when year is null — so a typo'd or drifted public_id fails loudly instead of writing to the wrong row. When claims are keyed off an external record (IPDB/OPDB), guard on that id — `expect: { ipdb_id: 4965 }`: it's the most specific guard, it's the same record your `cite:` points at, and it's present even when `year` and `corporate_entity` are both null.
-- **Explain every change with `note:`**, written as `<source> says "<verbatim quote>"`. Quote the source _verbatim_ and mark your own omissions with `[...]`. **Preserve the source's own characters**, including non-ASCII letters in foreign-language quotes (e.g. `Günter`, `gegründet`) — notes are stored as UTF-8, so don't strip or transliterate them. Only normalize stray _typography_ that's a copy-paste artifact rather than part of the quote: straighten smart quotes (`“ ”` → `"`) and spell out an ellipsis `…` as `[...]`.
-- **Cite external evidence with `cite:`** — `scheme:identifier` for IPDB/OPDB records, or a raw `http(s)://` URL for any other web page (a forum thread, an archive scan, a manufacturer's page). Reach for the scheme form whenever one exists; the URL form is the escape hatch for sources without a scheme. A URL cite needs its **website root seeded first** (a parentless web source whose homepage link shares the domain) — seed it in an earlier patch, the same vocab-first pattern, then cite pages under it. Skip the citation when the evidence is in the entity's own data and instead write it in the note such as "Its name contains the word 'prototype'". The cite can also differ from the `expect:` guard: when the evidence lives in a _different_ record's note (a cross-reference — "‹other game› is not a pinball"), guard on the model's own id but `cite:` the record that contains the statement.
-- **Only assert what a source supports.** If you can't point to evidence, leave the field unset rather than guess: an unset value reads as "unknown", a wrong claim reads as fact.
-- **Large curated patches: keep a worksheet, emit from a script.** For a patch spanning dozens of curated rows, record every search you ran (including the ones that found nothing) and the verbatim source text behind each call in a review worksheet, then generate the YAML from a script that reads live field values for the `expect:` guards. Hand-copying guards drifts from the DB; a generator keeps them true and the worksheet keeps the editorial judgment auditable. The dead-end searches matter too — proving a term is absent from the sources is what justifies relying on the signal you did find. **Don't reinvent the generator** — follow [DataPatchKit.md](DataPatchKit.md) and use the shared `patchkit` helper (escaping, `expect:` guards, source-text extraction).
-- **Dry-run, then localhost, then prod** — see below.
 
 ## Applying patches
 
@@ -217,20 +232,7 @@ uv run python manage.py ingest_patches --patches-dir DIR  # override the default
 
 Patches apply in numeric order. The command **pre-flights the whole batch** (filename format, unique numeric prefixes), then **stops at the first failure** — patches before it stay committed, the failing one and everything after are left unapplied. A missing or empty directory is a no-op. It is idempotent — the ledger skips already-applied patches.
 
-### Iterating on localhost: snapshot first
-
-Because an applied patch is immutable per-database (see [The ledger](#the-ledger-applied-once-immutably)), you can't tweak a patch and re-run it against a DB that already has it — the fingerprint guard hard-errors. To test-and-revise on localhost, snapshot the SQLite file before applying and restore it to roll back:
-
-```bash
-cd backend
-cp db.sqlite3 db.pre-0009.sqlite3          # snapshot before applying patch 0009
-uv run python manage.py ingest_patches
-# inspect the effect in the running app / Django admin
-# wrong? roll back, edit the patch, re-apply:
-cp db.pre-0009.sqlite3 db.sqlite3
-```
-
-`--dry-run` previews without writing; the snapshot loop is for when you want to apply for real, browse the resolved result, then revert. Name the snapshot after the patch you're about to apply (`db.pre-NNNN.sqlite3`) so it's clear which state it captures; the `.sqlite3` suffix keeps it under the gitignored `*.sqlite3` rule, so it won't be committed. Once the patch is right, it's safe to push to prod.
+To test-and-revise a patch on localhost before shipping, snapshot the DB first — see [DataPatchAuthoring.md → Validate via snapshot](DataPatchAuthoring.md#validate-via-snapshot).
 
 ### Full ingest also applies patches
 
@@ -240,13 +242,13 @@ cp db.pre-0009.sqlite3 db.sqlite3
 
 A patch application **is** an ingest run. Each `IngestRun` carries the `patch_id` (filename stem) and an `input_fingerprint` (sha256 of the normalized parsed content — comments, whitespace and key order ignored). The applied set is the `SUCCESS` runs with a `patch_id`, tracked **per database** (what makes "run locally, then on prod" work). On re-run: fingerprint matches → skip (a cosmetic reformat still skips); fingerprint differs → **hard error**, since an applied patch is immutable — a semantic change means you changed history, so add a new numbered patch instead. The invariant is enforced by a partial unique index on `patch_id` where `status='success'`, flipped in the same transaction as the claims.
 
-On localhost, snapshot the DB before applying (see [Iterating on localhost](#iterating-on-localhost-snapshot-first)) so you can roll back and re-apply a revised patch rather than fighting this guard.
+On localhost, snapshot the DB before applying (see [DataPatchAuthoring.md → Validate via snapshot](DataPatchAuthoring.md#validate-via-snapshot)) so you can roll back and re-apply a revised patch rather than fighting this guard.
 
 ## Undoing a patch
 
 There's no automatic revert; source-attributed claims aren't user-revertible. Undo a patch with a **compensating patch** (a later claim supersedes the earlier one).
 
-On localhost, the simplest undo is restoring a pre-apply snapshot (see [Iterating on localhost](#iterating-on-localhost-snapshot-first)) — the compensating-patch rule is for seeded/shared databases whose history can't be rewound.
+On localhost, the simplest undo is restoring a pre-apply snapshot (see [DataPatchAuthoring.md → Validate via snapshot](DataPatchAuthoring.md#validate-via-snapshot)) — the compensating-patch rule is for seeded/shared databases whose history can't be rewound.
 
 ## Limitations
 
@@ -256,4 +258,5 @@ We've been building the patch system on an as-needed basis. These haven't been n
 - `expect:` covers scalar + FK only, not relationships. (`retract:` is scalar/FK; relationship members are dropped with `remove:`.)
 - Relationship `remove:` covers **single-identity** relationships — single-FK members (`tag`, `location`, `theme`) and single string members (aliases, `abbreviation`). Multi-key relationships (e.g. credits) aren't yet removable via patch.
 - **Single-identity relationships are writable** — both single-FK members (`tag`, `location`, `theme`, …, whose member is an FK to another entity) and single **string** members (`manufacturer_alias` and the other alias namespaces, `abbreviation`), whose member is a bare string. Alias values **case-fold** for identity (the original case is preserved for display); abbreviations are stored verbatim. **Multi-key** relationships (e.g. credits, person + role) remain unsupported.
-- **No same-patch FK target creation.** An FK value (on a `create` _or_ an edit) is resolved by a live DB lookup against entities already committed, so its target must exist in the seed or an **earlier** numbered patch — a target created earlier in the _same_ patch isn't yet visible. This is the same rule as a location's `parent` and a relationship member: create the target (manufacturer, title, tag, parent location, …) in an earlier patch, then reference it.
+- **No forward same-patch references.** A reference — an FK on a `create` or edit, a location `parent`, or a relationship member (`tag`, `location`, …) — resolves against the seed, an earlier patch, or an entry **earlier in this same patch**. What it can't yet do is point _forward_ at an entry declared **below** it: declare the target (manufacturer, title, tag, parent location, …) above its reference, or in an earlier patch. (Citing a `sources:`-declared website root in the same patch always works regardless of order — the source block is processed before claims.)
+- **Parent hierarchies stay acyclic.** The self-referential parent relationships (`theme_parent`, `gameplay_feature_parent`) reject a self-link or a cycle, same as the in-app editor. The check is conservative: it weighs the patch's added edges against the current resolved graph and ignores `remove:`, so a patch that both detaches and re-attaches around the same edge may be over-rejected — split it across patches.


### PR DESCRIPTION
## Summary

Let a data patch reference an entity created by an **earlier** entry in the same patch — an FK on a `create` (manufacturer, title, location `parent`) or a relationship member (`tag`, `location`, …) — removing the patch fragmentation that forced each target into its own earlier-numbered file.

- **patches.py** — a same-patch-create registry keyed by `(concrete model, public_id)`; `_add_create` emits `handle_refs` on a planned-target FK miss; `_emit_relationship` emits a deferred (`identity_refs`) member assert and returns `_MemberEmitResult` so an all-deferred entry's `note`/`cite` isn't wrongly rejected by the provenance-carrier check.
- **apply.py** — factor the FK-to-planned core out of `_fk_value_is_planned` and apply it to handle-targeted create claims so dry-run doesn't spuriously reject them.
- **Hierarchy guard** — closes a hole the patch path always had (now easier to hit via same-patch refs): the self-referential parent relationships (`theme_parent`, `gameplay_feature_parent`) bypassed the API's `plan_parent_claims` self-link/cycle guard, and the resolver materializes whatever wins with no acyclicity check. New plan-wide `_validate_hierarchy_acyclic` rejects self-parents and cycles, weighing the patch's added edges against the current resolved graph.
- **Typing** — `type PublicId = str` (matching the existing `ClaimKey` transparent-alias convention) threaded through the registry/hierarchy helpers, so the formerly opaque `dict[str, set[str]]` reads as `dict[PublicId, set[PublicId]]`.
- **docs** — same-patch backward refs documented as supported; only forward refs need an earlier patch; parent hierarchies reject self-links/cycles.

**Scope:** backward (declare-first) references only. Forward references (pointing at an entry declared below) remain unsupported and fail cleanly — a follow-up PR adds the two-pass plan-build + topological sort for those.

## Test plan

- [x] `cd backend && uv run pytest apps/catalog/tests/test_patches.py apps/catalog/tests/test_apply.py` (166 passing)
- [x] Full catalog suite green (1914), `make mypy` and `make lint` clean
- [x] New coverage: backward FK-on-create (live + dry-run), backward parent location (live + dry-run), title→model, deferred relationship member on existing and on same-patch-created subjects, all-deferred `note`+`cite` carrier, duplicate-deferred-member rejection, unresolvable-ref message; hierarchy guard (self-parent, edit→create 2-cycle, existing-node 2-cycle, valid DAG)
- [x] End-to-end `uv run python manage.py ingest_patches --dry-run` on a real two-entity patch (exercises the P1 dry-run carve-out)
