### PR TITLE
feat(patches): inline citations in record descriptions

### DIFF
--- a/backend/apps/catalog/ingestion/apply.py
+++ b/backend/apps/catalog/ingestion/apply.py
@@ -106,6 +106,14 @@ class CitationRef:
     archive_url: str = ""
 
 
+# A patch-local citation handle: the ephemeral label wiring a ``[[cite:N]]``
+# authoring marker to its ``cites:`` source spec. A transparent alias of ``str``
+# (like the adapter's ``ClaimKey``/``PublicId``) that names the role where a bare
+# ``str`` key would otherwise be ambiguous — notably the inner key of the patch
+# adapter's field→handle→ref map. All-digits while authoring (``"1"``); rewritten
+# to a ``CitationInstance.slug`` at mint, so it never reaches storage.
+type CiteHandle = str
+
 # Per-claim provenance maps produced by ``_collect_plan_provenance`` and
 # consumed by ``_persist`` / ``_attach_plan_citations``. Named so the opaque
 # ``str`` (a ChangeSet note) and the per-claim citation mapping read clearly
@@ -172,6 +180,13 @@ class PlannedClaimAssert:
     # CitationInstance on the resulting claim at apply time.
     note: str = ""
     citation_ref: CitationRef | None = None
+    # Inline-citation footnotes referenced by ``[[cite:<numeric-handle>]]`` markers
+    # in a markdown field's value, keyed by the patch-local numeric handle. Each
+    # is a *new* citation minted at apply time (a floating ``claim=None``
+    # CitationInstance), after which the handle markers are rewritten to the
+    # minted slug. Existing-slug markers (``[[cite:<slug>]]``) carry nothing here —
+    # they self-resolve through standard conversion. Empty for non-cited fields.
+    inline_cites: dict[CiteHandle, CitationRef] = field(default_factory=dict)
     content_type_id: int | None = None
     object_id: int | None = None
     handle: str | None = None
@@ -286,6 +301,11 @@ def apply_plan(plan: IngestPlan, *, dry_run: bool = False) -> RunReport:
             report.records_created = len(plan.entities)
 
             _patch_handles(plan.assertions, handle_map)
+            # Mint new inline-citation footnotes and rewrite their handle markers
+            # to minted slugs *before* claims are built/validated, so the standard
+            # markdown conversion in _validate_fail_fast resolves them to storage
+            # form. Existing-slug markers self-resolve and aren't touched here.
+            _materialize_inline_citations(plan.assertions)
             # Per-claim provenance (note/citation) carried by the plan, collected
             # once now that handles are resolved (so every assertion carries its
             # real ct/obj). Kept out of _build_claims so that helper's signature —
@@ -585,6 +605,19 @@ def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
 
     report.asserted += len(deferred)
 
+    # New-handle inline citations can't validate in dry-run: nothing is minted,
+    # so ``convert_authoring_to_storage`` would raise ``Cite not found`` on the
+    # unminted slug. Carve the whole assertion out — count asserted, skip
+    # validate/diff — mirroring the fk-to-planned carve-outs below, across BOTH
+    # the existing-entity and planned-entity sub-paths. Whole-assertion: a
+    # description mixing new handles with existing slugs loses dry-run validation
+    # of its existing-slug portion too. Correspondence + spec parse already ran at
+    # process time, so structural errors still surfaced. (Existing-slug-only
+    # assertions carry no ``inline_cites`` and stay on the standard path; real
+    # validation of new cites is the snapshot+apply loop.)
+    new_inline_cite_ids = {id(p) for p in concrete if p.inline_cites}
+    report.asserted += len(new_inline_cite_ids)
+
     # FK claims on existing entities whose value points at an entity created
     # *in this same plan* cannot be validated in dry-run — the FK existence
     # check queries the DB, but the target is only planned (the live path
@@ -600,7 +633,11 @@ def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
 
     # Claims targeting existing entities: validate + diff.
     existing_assertions = [
-        p for p in concrete if p.handle is None and id(p) not in fk_to_planned_ids
+        p
+        for p in concrete
+        if p.handle is None
+        and id(p) not in fk_to_planned_ids
+        and id(p) not in new_inline_cite_ids
     ]
     if existing_assertions:
         claims = _build_claims(existing_assertions, plan.source)
@@ -632,7 +669,11 @@ def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
     fk_on_create_ids = {id(p) for p in fk_on_create_planned}
 
     planned_assertions = [
-        p for p in concrete if p.handle is not None and id(p) not in fk_on_create_ids
+        p
+        for p in concrete
+        if p.handle is not None
+        and id(p) not in fk_on_create_ids
+        and id(p) not in new_inline_cite_ids
     ]
     if planned_assertions:
         handle_to_ct: dict[str, int] = {
@@ -986,6 +1027,31 @@ def _collect_plan_provenance(
     return entity_notes, claim_citations
 
 
+def _resolve_cite_source_id(ref: CitationRef, cache: dict[CitationRef, int]) -> int:
+    """Resolve a ``CitationRef`` to a ``CitationSource`` pk, memoized via ``cache``.
+
+    Shared by the field-level ``cite:`` path (:func:`_attach_plan_citations`) and
+    the inline-footnote path (:func:`_materialize_inline_citations`). Uses the
+    same ``get_or_create_*`` resolvers, so source dedup, web-root matching and
+    ``{url, archive}`` backfill come free. Created sources are *uncounted* — the
+    resolvers return a bare ``CitationSource``, not created-ness — matching the
+    field-``cite:`` stance (only the ``sources:`` block bumps the counters).
+    """
+    source_id = cache.get(ref)
+    if source_id is None:
+        from apps.citation.extractors import (
+            get_or_create_external_source,
+            get_or_create_web_source,
+        )
+
+        if ref.url:
+            source_id = get_or_create_web_source(ref.url, ref.archive_url).pk
+        else:
+            source_id = get_or_create_external_source(ref.scheme, ref.identifier).pk
+        cache[ref] = source_id
+    return source_id
+
+
 def _attach_plan_citations(
     to_create: list[Claim],
     claim_citations: ClaimCitations,
@@ -999,10 +1065,6 @@ def _attach_plan_citations(
     """
     if not claim_citations:
         return
-    from apps.citation.extractors import (
-        get_or_create_external_source,
-        get_or_create_web_source,
-    )
     from apps.provenance.models import CitationInstance
 
     source_cache: dict[CitationRef, int] = {}
@@ -1013,16 +1075,57 @@ def _attach_plan_citations(
         )
         if ref is None:
             continue
-        source_id = source_cache.get(ref)
-        if source_id is None:
-            if ref.url:
-                source_id = get_or_create_web_source(ref.url, ref.archive_url).pk
-            else:
-                source_id = get_or_create_external_source(ref.scheme, ref.identifier).pk
-            source_cache[ref] = source_id
+        source_id = _resolve_cite_source_id(ref, source_cache)
         instances.append(CitationInstance(citation_source_id=source_id, claim=claim))
     if instances:
         CitationInstance.objects.mint_many(instances)
+
+
+def _materialize_inline_citations(assertions: list[PlannedClaimAssert]) -> None:
+    """Mint floating ``CitationInstance`` rows for *new* inline citations.
+
+    For each assertion carrying ``inline_cites`` (a ``{numeric-handle:
+    CitationRef}`` map populated by the patch adapter), mints one
+    ``claim=None`` ``CitationInstance`` per handle, then rewrites that handle's
+    ``[[cite:<handle>]]`` markers in the assertion value to the minted
+    ``[[cite:<slug>]]``. Existing-slug markers are left untouched.
+
+    Runs after ``_patch_handles`` (so a same-patch ``create:``'s handle-targeted
+    assertion already carries real ct/obj — created and edited entities handled
+    identically) and *before* ``_build_claims``/validation, so the standard
+    ``convert_authoring_to_storage`` then resolves every ``[[cite:slug]]`` to
+    ``[[cite:id:pk]]`` storage and ``_diff_claims`` diffs the final text — no
+    bespoke storage rewrite here. Live path only: dry-run never reaches here (it
+    carves new-cite assertions out before minting). Inside ``apply_plan``'s
+    ``transaction.atomic()``, so a failed apply rolls the mint back; ``mint_many``
+    is savepoint-wrapped for slug-collision retry.
+    """
+    cited = [pca for pca in assertions if pca.inline_cites]
+    if not cited:
+        return
+    from apps.provenance.models import CitationInstance
+
+    # Mint every new instance in one batch, tracking the (assertion, handle) each
+    # belongs to so we can read its assigned slug back after mint_many. Minting is
+    # per-assertion (i.e. per markdown field): a handle reused across two markdown
+    # fields of one entry would mint one instance per field — the design's
+    # per-field footnote semantics, not a shared one. Moot while every entity has
+    # a single markdown field; intentional if that ever changes.
+    source_cache: dict[CitationRef, int] = {}
+    instances: list[CitationInstance] = []
+    owners: list[tuple[PlannedClaimAssert, CiteHandle]] = []
+    for pca in cited:
+        for handle, ref in pca.inline_cites.items():
+            source_id = _resolve_cite_source_id(ref, source_cache)
+            instances.append(CitationInstance(citation_source_id=source_id, claim=None))
+            owners.append((pca, handle))
+    CitationInstance.objects.mint_many(instances)  # assigns each ``.slug`` in place
+
+    for (pca, handle), instance in zip(owners, instances, strict=True):
+        # Full-marker literal replace: the closing ``]]`` makes ``[[cite:1]]``
+        # unambiguous against ``[[cite:11]]``, so no regex/order hazard.
+        assert isinstance(pca.value, str)
+        pca.value = pca.value.replace(f"[[cite:{handle}]]", f"[[cite:{instance.slug}]]")
 
 
 def _persist(

--- a/backend/apps/catalog/ingestion/patches.py
+++ b/backend/apps/catalog/ingestion/patches.py
@@ -35,6 +35,7 @@ from apps.catalog.claims import (
 )
 from apps.catalog.ingestion.apply import (
     CitationRef,
+    CiteHandle,
     IngestPlan,
     PlannedClaimAssert,
     PlannedClaimRetract,
@@ -52,6 +53,7 @@ from apps.citation.models import (
 from apps.citation.seed_data.types import SeedLink, SeedSource
 from apps.citation.seeding import ensure_root_source, validate_root_source
 from apps.core.entity_types import get_linkable_model
+from apps.core.markdown import get_markdown_fields
 from apps.core.types import EntityKey, JsonBody
 from apps.provenance.models import Claim, IdentityPart, Source, get_claim_fields
 from apps.provenance.models.changeset import CHANGESET_NOTE_MAX_LENGTH
@@ -59,9 +61,22 @@ from apps.provenance.validation import get_relationship_schema
 
 PATCH_ID_RE = re.compile(r"^\d{4}-[a-z0-9-]+$")
 
+# Inline-citation marker scan. Deliberately BROADER than the wikilink registry's
+# ``cite`` authoring pattern (which carries a ``(?!id:)`` negative lookahead):
+# this captures *every* ``[[cite:...]]`` marker — including the ``[[cite:id:N]]``
+# storage form — precisely so the strict-grammar classification below can reject a
+# patch-authored raw-pk marker. Do NOT dedupe this against the registry pattern.
+_CITE_MARKER_RE = re.compile(r"\[\[cite:([^\]]+)\]\]")
+# Strict handle grammars — classification is purely lexical (no DB lookup). A real
+# slug is 8 lowercase consonants (Step 1's ``validate_citation_slug`` + length
+# CHECK), a strict subset of ``^[a-z]+$`` and provably disjoint from ``^[0-9]+$``,
+# so a numeric new-handle can never masquerade as a slug or vice-versa.
+_NUMERIC_HANDLE_RE = re.compile(r"^[0-9]+$")
+_SLUG_HANDLE_RE = re.compile(r"^[a-z]+$")
+
 # Keys in a claim entry's value mapping that are directives, not claim fields.
 RESERVED_FIELD_KEYS = frozenset(
-    {"create", "delete", "expect", "retract", "remove", "note", "cite"}
+    {"create", "delete", "expect", "retract", "remove", "note", "cite", "cites"}
 )
 
 # The claim-controlled lifecycle field (``LifecycleStatusModel.status``).
@@ -251,6 +266,14 @@ class _PatchEntry:
     note: str = ""
     cite: str = ""
     cite_archive: str = ""
+    # Inline-citation specs for *new* footnotes referenced by numeric-handle
+    # ``[[cite:1]]`` markers in this entry's markdown fields, keyed by the
+    # patch-local handle (``"1"``). Each value is a parsed CitationRef minted at
+    # apply time as a floating ``claim=None`` CitationInstance. Existing-slug
+    # markers (``[[cite:<slug>]]``) need no entry here — they self-resolve. Empty
+    # when unset; only ``CreateEntry``/``EditEntry`` ever populate it (a
+    # ``DeleteEntry`` with ``cites:`` is rejected — no markdown claim to bind to).
+    cites: dict[CiteHandle, CitationRef] = field(default_factory=dict)
 
     @property
     def ref(self) -> str:
@@ -400,6 +423,33 @@ def _parse_remove(raw_fields: JsonBody, ref: str) -> RelationshipMembers:
     return cast(RelationshipMembers, raw)
 
 
+def _parse_cites(raw_cites: object, ref: str) -> dict[CiteHandle, CitationRef]:
+    """Parse a ``cites:`` map of ``{handle: cite-spec}`` into CitationRefs.
+
+    Each value is a cite spec in the same grammar as the entry-level ``cite:``
+    (a ``scheme:identifier``/URL string or a ``{url, archive}`` mapping), parsed
+    through the shared :func:`_normalize_raw_cite` + :func:`_parse_cite_value`
+    path so it dedups and errors identically. Handle keys are always strings —
+    the strict YAML loader's ``_assert_json`` rejects a bare integer mapping key
+    before this runs, so an unquoted ``1:`` is a parse error the adapter never
+    sees. The handle *grammar* (numeric new-cite vs slug existing-cite) and
+    marker↔map correspondence are enforced later, at process time, against the
+    actual markdown markers.
+    """
+    if not isinstance(raw_cites, dict):
+        raise PatchError(f"{ref}: 'cites' must be a mapping of handle to cite spec")
+    parsed: dict[CiteHandle, CitationRef] = {}
+    for handle, raw_spec in raw_cites.items():
+        # _assert_json guarantees string keys; assert for the type-checker.
+        assert isinstance(handle, str)
+        spec_ref = f"{ref} cites[{handle!r}]"
+        cite, archive = _normalize_raw_cite(raw_spec, spec_ref)
+        if not cite:
+            raise PatchError(f"{spec_ref}: cite spec must be non-empty")
+        parsed[handle] = _parse_cite_value(cite, archive, spec_ref)
+    return parsed
+
+
 def _parse_entry(raw_entry: object, index: int) -> PatchEntry:
     """Parse + structurally validate one ``claims:`` entry into a typed kind.
 
@@ -425,8 +475,11 @@ def _parse_entry(raw_entry: object, index: int) -> PatchEntry:
     delete = _require_bool(raw_fields, "delete", ref)
     note = _require_str(raw_fields, "note", ref)
     cite, cite_archive = _normalize_raw_cite(raw_fields.get("cite", ""), ref)
+    cites = _parse_cites(raw_fields.get("cites", {}), ref)
     # Authored claim fields: everything that isn't a reserved directive key.
     fields = {k: v for k, v in raw_fields.items() if k not in RESERVED_FIELD_KEYS}
+    # ``cites`` is passed per-constructor below rather than spread here — its
+    # ``dict[str, CitationRef]`` value would widen this all-``str`` mapping.
     common = {
         "entity_type": entity_type,
         "public_id": public_id,
@@ -448,16 +501,17 @@ def _parse_entry(raw_entry: object, index: int) -> PatchEntry:
                 f"({', '.join(sorted(fields))}) — reassign references in a "
                 f"separate entry, in an earlier patch, before the delete"
             )
-        return DeleteEntry(**common, expect=_parse_expect(raw_fields, ref))
+        return DeleteEntry(**common, cites=cites, expect=_parse_expect(raw_fields, ref))
 
     if create:
         for key in ("expect", "retract", "remove"):
             if key in raw_fields:
                 raise PatchError(f"{ref}: {key!r} is meaningless on a create")
-        return CreateEntry(**common, fields=fields)
+        return CreateEntry(**common, cites=cites, fields=fields)
 
     return EditEntry(
         **common,
+        cites=cites,
         expect=_parse_expect(raw_fields, ref),
         retract=_parse_retract(raw_fields, ref),
         remove=_parse_remove(raw_fields, ref),
@@ -678,55 +732,75 @@ def _parse_provenance(entry: PatchEntry) -> tuple[str, CitationRef | None]:
         )
     if not entry.cite:
         return note, None
-    if entry.cite.startswith(("http://", "https://")):
-        return note, _parse_cite_url(entry)
-    scheme, sep, raw_id = entry.cite.partition(":")
+    return note, _parse_cite_value(entry.cite, entry.cite_archive, entry.ref)
+
+
+def _parse_cite_value(cite: str, archive: str, ref: str) -> CitationRef:
+    """Parse one non-empty cite spec into a :class:`CitationRef`.
+
+    Shared by the entry-level ``cite:`` (via :func:`_parse_provenance`) and the
+    inline ``cites:`` map (:func:`_parse_cites`). Two forms:
+
+    * a ``http(s)://`` URL — a standalone web source; an optional ``archive``
+      durable-snapshot URL rides along;
+    * ``scheme:identifier`` — the scheme must be a known extractor and the
+      identifier must normalize (``ipdb:4443``).
+
+    The empty-cite short-circuit and (for the entry path) the archive-without-URL
+    guard stay with :func:`_parse_provenance`, which allows an absent cite; here
+    ``cite`` is always non-empty.
+    """
+    if cite.startswith(("http://", "https://")):
+        return _parse_cite_url(cite, archive, ref)
+    if archive:
+        raise PatchError(
+            f"{ref}: 'cite.archive' is only valid alongside a http(s):// URL "
+            f"cite, not a scheme cite"
+        )
+    scheme, sep, raw_id = cite.partition(":")
     if not sep or not scheme or not raw_id:
         raise PatchError(
-            f"{entry.ref}: cite {entry.cite!r} must be 'scheme:identifier' (e.g. 'ipdb:4443')"
+            f"{ref}: cite {cite!r} must be 'scheme:identifier' (e.g. 'ipdb:4443')"
         )
     extractor = EXTRACTORS.get(scheme)
     if extractor is None:
         raise PatchError(
-            f"{entry.ref}: unknown cite scheme {scheme!r} "
+            f"{ref}: unknown cite scheme {scheme!r} "
             f"(known: {', '.join(sorted(EXTRACTORS))})"
         )
     normalized = extractor.normalize(raw_id)
     if normalized is None:
-        raise PatchError(f"{entry.ref}: invalid {scheme} identifier {raw_id!r}")
+        raise PatchError(f"{ref}: invalid {scheme} identifier {raw_id!r}")
     if len(normalized) > CITATION_SOURCE_IDENTIFIER_MAX_LENGTH:
         raise PatchError(
-            f"{entry.ref}: cite identifier exceeds "
+            f"{ref}: cite identifier exceeds "
             f"{CITATION_SOURCE_IDENTIFIER_MAX_LENGTH} characters"
         )
-    return note, CitationRef(scheme=scheme, identifier=normalized)
+    return CitationRef(scheme=scheme, identifier=normalized)
 
 
-def _parse_cite_url(entry: PatchEntry) -> CitationRef:
-    """Validate a ``http(s)://`` ``cite`` URL into a standalone-web CitationRef.
+def _parse_cite_url(url: str, archive_url: str, ref: str) -> CitationRef:
+    """Validate a ``http(s)://`` cite URL into a standalone-web CitationRef.
 
     Rejects a URL that matches a known scheme's record pattern (it has a
     canonical ``scheme:identifier`` form that dedups correctly), a malformed
     URL, and one too long for the link column.
     """
-    url = entry.cite
     for scheme, extractor in EXTRACTORS.items():
         identifier = extractor.extract(url)
         if identifier is not None:
             raise PatchError(
-                f"{entry.ref}: cite URL matches the {scheme} scheme — "
+                f"{ref}: cite URL matches the {scheme} scheme — "
                 f"cite it as {scheme}:{identifier} instead"
             )
     # The caller guarantees an http(s):// scheme, so a host is all that's left
     # to validate (``https://`` alone has none).
     if not urlparse(url).hostname:
-        raise PatchError(f"{entry.ref}: cite {url!r} is not a valid URL")
+        raise PatchError(f"{ref}: cite {url!r} is not a valid URL")
     if len(url) > CITATION_SOURCE_LINK_URL_MAX_LENGTH:
         raise PatchError(
-            f"{entry.ref}: cite URL exceeds {CITATION_SOURCE_LINK_URL_MAX_LENGTH} "
-            f"characters"
+            f"{ref}: cite URL exceeds {CITATION_SOURCE_LINK_URL_MAX_LENGTH} characters"
         )
-    archive_url = entry.cite_archive
     if archive_url:
         # Deliberately NOT scheme-checked: a Wayback URL embeds the original
         # page URL as a path segment, so an ipdb/opdb page would false-match.
@@ -736,12 +810,11 @@ def _parse_cite_url(entry: PatchEntry) -> CitationRef:
             or not urlparse(archive_url).hostname
         ):
             raise PatchError(
-                f"{entry.ref}: cite archive {archive_url!r} is not a valid "
-                f"http(s):// URL"
+                f"{ref}: cite archive {archive_url!r} is not a valid http(s):// URL"
             )
         if len(archive_url) > CITATION_SOURCE_LINK_URL_MAX_LENGTH:
             raise PatchError(
-                f"{entry.ref}: cite archive URL exceeds "
+                f"{ref}: cite archive URL exceeds "
                 f"{CITATION_SOURCE_LINK_URL_MAX_LENGTH} characters"
             )
     return CitationRef(url=url, archive_url=archive_url)
@@ -812,6 +885,79 @@ def build_plan(doc: PatchDoc, *, source: Source, patch_id: str) -> IngestPlan:
     return plan
 
 
+def _classify_inline_cites(
+    entry: CreateEntry | EditEntry,
+    model_class: type[CatalogModel],
+) -> dict[str, dict[CiteHandle, CitationRef]]:
+    """Validate this entry's inline ``[[cite:...]]`` markers against its ``cites:`` map.
+
+    Scans **every** markdown field of the entry (the gate — a marker with no
+    backing never survives), classifies each handle by strict grammar, enforces
+    marker↔map correspondence, and returns ``{field_name: {numeric_handle:
+    CitationRef}}`` for each markdown field carrying ≥1 *new*-cite marker (the
+    minting payload :func:`_emit_direct` attaches to its assertion). All checks
+    are DB-free; existing-slug validity is enforced downstream by
+    ``convert_authoring_to_storage`` (raises ``Cite not found`` on a bad slug).
+    """
+    markdown_fields = set(get_markdown_fields(model_class))
+    md_values = {
+        k: v
+        for k, v in entry.fields.items()
+        if k in markdown_fields and isinstance(v, str)
+    }
+    if entry.cites and not md_values:
+        raise PatchError(
+            f"{entry.ref}: 'cites:' requires a markdown-field claim to bind to — "
+            f"none of this entry's fields is a citable description field"
+        )
+
+    per_field_numeric: dict[str, set[CiteHandle]] = {}
+    all_numeric: set[CiteHandle] = set()
+    for field_name, value in md_values.items():
+        for handle in _CITE_MARKER_RE.findall(value):
+            if _NUMERIC_HANDLE_RE.match(handle):
+                per_field_numeric.setdefault(field_name, set()).add(handle)
+                all_numeric.add(handle)
+            elif _SLUG_HANDLE_RE.match(handle):
+                continue  # existing-cite slug — resolved later by conversion
+            else:
+                raise PatchError(
+                    f"{entry.ref}: malformed inline citation '[[cite:{handle}]]' in "
+                    f"{field_name!r} — a handle must be all-digits (a new citation, "
+                    f"needs a 'cites:' entry) or all-lowercase-letters (an existing "
+                    f"cite slug); this rejects a raw-pk '[[cite:id:N]]'"
+                )
+
+    # Correspondence (DB-free, loud). A slug-keyed ``cites:`` entry is its own
+    # misuse — check it before the generic "unreferenced" case so the message is
+    # specific.
+    cite_handles = set(entry.cites)
+    slug_keyed = {h for h in cite_handles if not _NUMERIC_HANDLE_RE.match(h)}
+    if slug_keyed:
+        raise PatchError(
+            f"{entry.ref}: 'cites:' key(s) {sorted(slug_keyed)} must be numeric "
+            f"handles (e.g. '1') — an existing cite is named by its slug marker, "
+            f"not declared in 'cites:'"
+        )
+    missing = all_numeric - cite_handles
+    if missing:
+        raise PatchError(
+            f"{entry.ref}: inline citation handle(s) {sorted(missing)} have no "
+            f"'cites:' entry to mint from"
+        )
+    unused = cite_handles - all_numeric
+    if unused:
+        raise PatchError(
+            f"{entry.ref}: 'cites:' entr(y/ies) {sorted(unused)} are not referenced "
+            f"by any '[[cite:N]]' marker"
+        )
+
+    return {
+        field_name: {h: entry.cites[h] for h in handles}
+        for field_name, handles in per_field_numeric.items()
+    }
+
+
 def _process_entry(
     plan: IngestPlan,
     entry: PatchEntry,
@@ -835,7 +981,12 @@ def _process_entry(
     model_class = _resolve_model_class(entry)
     ct_id = ContentType.objects.get_for_model(model_class).pk
     existing = _lookup_entity(model_class, entry.public_id)
-    has_provenance = bool(note) or citation_ref is not None
+    # Inline ``cites:`` count as provenance: each mints a per-assertion floating
+    # instance, but two entries asserting one entity's markdown field collapse to
+    # one claim (last-write-wins in _build_claims), which would orphan the
+    # discarded entry's mint. The multi-entry guard rejects that — same rule as
+    # note/cite: an entity's claims belong in a single entry.
+    has_provenance = bool(note) or citation_ref is not None or bool(entry.cites)
 
     # A delete carries no field assertions and no relationship work, so it
     # finishes here, registering every soft-deleted entity (root + cascade) with
@@ -843,6 +994,11 @@ def _process_entry(
     # status=deleted claim, so a separate entry on any of them that also carries
     # provenance is a genuine collision.
     if isinstance(entry, DeleteEntry):
+        if entry.cites:
+            raise PatchError(
+                f"{entry.ref}: 'cites:' requires a markdown-field claim to bind to — "
+                f"a delete entry takes no field assertions"
+            )
         if existing is None:
             raise PatchError(f"{entry.ref}: no such {entry.entity_type} to delete")
         _check_expect(model_class, existing, entry)
@@ -894,6 +1050,12 @@ def _process_entry(
         )
         target = _Target(content_type_id=ct_id, object_id=existing.pk)
 
+    # Inline-citation markers in the entry's markdown fields: validate grammar +
+    # marker↔``cites:`` correspondence (DB-free) and get the per-field new-cite
+    # minting payloads. Runs once over the whole entry before emitting, so a
+    # marker in any markdown field is gated even if that field is emitted later.
+    inline_cites_by_field = _classify_inline_cites(entry, model_class)
+
     # Shared field loop (create + edit). Track which scalar/FK fields and which
     # relationship members were asserted on an *existing* entity — creates target
     # a handle, so object_id is None and they contribute nothing to the guards —
@@ -912,7 +1074,15 @@ def _process_entry(
                 f"soft-delete with 'delete: true', not a direct claim"
             )
         if key in claim_fields:
-            _emit_direct(plan, key, value, target, note=note, citation_ref=citation_ref)
+            _emit_direct(
+                plan,
+                key,
+                value,
+                target,
+                note=note,
+                citation_ref=citation_ref,
+                inline_cites=inline_cites_by_field.get(key, {}),
+            )
             carrier_written = True
             if target.object_id is not None:
                 asserted_fields.add(key)
@@ -1133,7 +1303,7 @@ def _validate_plan_wide(results: list[_EntryResult]) -> None:
         if count > 1 and has_provenance[tkey]:
             raise PatchError(
                 f"{target_ref[tkey]}: multiple entries target this entity and at "
-                f"least one carries note/cite — combine them into one entry "
+                f"least one carries note/cite/cites — combine them into one entry "
                 f"(an entity's claims share a single changeset)"
             )
 
@@ -1245,6 +1415,7 @@ def _emit_assert(
     claim_key: ClaimKey = "",
     note: str = "",
     citation_ref: CitationRef | None = None,
+    inline_cites: dict[CiteHandle, CitationRef] | None = None,
 ) -> None:
     plan.assertions.append(
         PlannedClaimAssert(
@@ -1253,6 +1424,7 @@ def _emit_assert(
             claim_key=claim_key,
             note=note,
             citation_ref=citation_ref,
+            inline_cites=dict(inline_cites) if inline_cites else {},
             content_type_id=target.content_type_id,
             object_id=target.object_id,
             handle=target.handle,
@@ -1268,8 +1440,14 @@ def _emit_direct(
     *,
     note: str = "",
     citation_ref: CitationRef | None = None,
+    inline_cites: dict[CiteHandle, CitationRef] | None = None,
 ) -> None:
-    """Emit a scalar or FK claim assertion (FK value is the target public_id)."""
+    """Emit a scalar or FK claim assertion (FK value is the target public_id).
+
+    ``inline_cites`` carries any new (numeric-handle) inline citations to mint
+    for a markdown field's value; empty for non-markdown fields and for markdown
+    fields whose cites are all existing slugs.
+    """
     _emit_assert(
         plan,
         target,
@@ -1277,6 +1455,7 @@ def _emit_direct(
         value=value,
         note=note,
         citation_ref=citation_ref,
+        inline_cites=inline_cites,
     )
 
 

--- a/backend/apps/catalog/ingestion/patches.py
+++ b/backend/apps/catalog/ingestion/patches.py
@@ -68,9 +68,9 @@ PATCH_ID_RE = re.compile(r"^\d{4}-[a-z0-9-]+$")
 # patch-authored raw-pk marker. Do NOT dedupe this against the registry pattern.
 _CITE_MARKER_RE = re.compile(r"\[\[cite:([^\]]+)\]\]")
 # Strict handle grammars — classification is purely lexical (no DB lookup). A real
-# slug is 8 lowercase consonants (Step 1's ``validate_citation_slug`` + length
-# CHECK), a strict subset of ``^[a-z]+$`` and provably disjoint from ``^[0-9]+$``,
-# so a numeric new-handle can never masquerade as a slug or vice-versa.
+# CitationInstance slug is constrained to 8 lowercase consonants, a strict subset
+# of ``^[a-z]+$`` and provably disjoint from ``^[0-9]+$``, so a numeric new-handle
+# can never masquerade as a slug or vice-versa.
 _NUMERIC_HANDLE_RE = re.compile(r"^[0-9]+$")
 _SLUG_HANDLE_RE = re.compile(r"^[a-z]+$")
 

--- a/backend/apps/catalog/management/commands/dump_patch_entry.py
+++ b/backend/apps/catalog/management/commands/dump_patch_entry.py
@@ -1,0 +1,210 @@
+"""Rehydrate a catalog entity's markdown fields as a runnable data-patch entry.
+
+Emits a complete patch document (``attribution:`` + a single ``claims:`` entry)
+carrying the entity's current markdown fields in **authoring** format
+(``[[cite:<slug>]]``), so the generation pipeline or a human can reword one
+sentence and resubmit with every untouched citation intact.
+
+Re-applying the unedited dump is a no-op: existing slugs self-resolve to the
+same ``[[cite:id:<pk>]]`` storage, so the diff is empty and nothing is minted —
+*provided* the patch is attributed to the source that owns the field's winning
+claim, because ``_diff_claims`` compares only against active claims from the same
+source. The command therefore defaults ``attribution:`` to that owning source;
+``--attribution`` overrides it, which **forks** the text into a new
+source-owned claim (resolved against the original by priority) rather than
+preserving no-op semantics.
+
+A description edited interactively in-app is owned by a ``user`` (``source`` is
+null), and a source-attributed patch cannot faithfully reproduce it — so a
+user-owned winning claim is an error unless ``--attribution`` is supplied.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import yaml
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+
+from apps.catalog.models import CatalogModel
+from apps.core.entity_types import get_linkable_model
+from apps.core.markdown import convert_storage_to_authoring, get_markdown_fields
+from apps.provenance.helpers import active_claims, claims_prefetch
+from apps.provenance.models import Claim, Source
+
+
+class _LiteralStr(str):
+    """A string the dumper must render as a literal (``|``) block scalar.
+
+    Scoping the literal-block style to this wrapper keeps it off the plain
+    scalars (the ``attribution`` value, the ``type.public_id`` key) that must
+    stay unquoted.
+    """
+
+
+class _PatchDumper(yaml.SafeDumper):
+    """SafeDumper with a literal-block representer for ``_LiteralStr`` only."""
+
+
+def _represent_literal(dumper: _PatchDumper, data: _LiteralStr) -> yaml.ScalarNode:
+    # ``style='|'`` is a hint: PyYAML's scalar analysis silently falls back to
+    # double-quoted when the text has trailing whitespace on a line (markdown
+    # hard breaks), blank-only/leading-space lines or tabs. The fallback still
+    # round-trips byte-for-byte through the loader — only readability degrades.
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data), style="|")
+
+
+_PatchDumper.add_representer(_LiteralStr, _represent_literal)
+
+
+class _EmittedField(NamedTuple):
+    """One markdown field's authoring text and the source that owns it."""
+
+    field: str
+    text: str
+    source: Source | None
+
+
+class Command(BaseCommand):
+    help = (
+        "Dump a catalog entity's markdown fields as a runnable patch entry "
+        "(authoring-format text, real citation slugs in place)."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "entity_ref",
+            help="Entity reference as 'type.public_id' (e.g. model.mazatron).",
+        )
+        parser.add_argument(
+            "--attribution",
+            default=None,
+            help=(
+                "Source slug to attribute the patch to. Defaults to the source "
+                "that owns the field's winning claim. Overriding forks the text "
+                "into a new source-owned claim (not a no-op)."
+            ),
+        )
+
+    def handle(self, *args: object, **options: object) -> None:
+        entity_ref = str(options["entity_ref"])
+        attribution_opt = options["attribution"]
+        attribution = str(attribution_opt) if attribution_opt is not None else None
+
+        model_class, public_id = _resolve(entity_ref)
+        markdown_fields = get_markdown_fields(model_class)
+        if not markdown_fields:
+            raise CommandError(
+                f"{entity_ref}: {model_class.entity_type!r} has no markdown fields"
+            )
+
+        obj = (
+            model_class._default_manager.prefetch_related(
+                claims_prefetch(field_names=markdown_fields)
+            )
+            .filter(**{model_class.public_id_field: public_id})
+            .first()
+        )
+        if obj is None:
+            raise CommandError(
+                f"{entity_ref}: no such {model_class.entity_type} {public_id!r}"
+            )
+
+        emitted = _collect_fields(obj, markdown_fields)
+        if not emitted:
+            raise CommandError(f"{entity_ref}: no markdown content to dump")
+
+        attribution = attribution or _default_attribution(entity_ref, emitted)
+
+        ref = f"{model_class.entity_type}.{public_id}"
+        document = {
+            "attribution": attribution,
+            "claims": [{ref: {e.field: _LiteralStr(e.text) for e in emitted}}],
+        }
+        self.stdout.write(
+            yaml.dump(
+                document,
+                Dumper=_PatchDumper,
+                sort_keys=False,
+                allow_unicode=True,
+                default_flow_style=False,
+                width=1_000_000,  # never line-wrap plain scalars
+            ),
+            ending="",
+        )
+
+
+def _resolve(entity_ref: str) -> tuple[type[CatalogModel], str]:
+    """Resolve ``type.public_id`` to its concrete catalog model + public id."""
+    entity_type, _, public_id = entity_ref.partition(".")
+    if not entity_type or not public_id:
+        raise CommandError(
+            f"{entity_ref!r} must be 'type.public_id' (e.g. model.mazatron)"
+        )
+    try:
+        model_class = get_linkable_model(entity_type)
+    except ValueError as exc:
+        raise CommandError(f"{entity_ref}: {exc}") from exc
+    if not issubclass(model_class, CatalogModel):
+        raise CommandError(f"{entity_ref}: {entity_type!r} is not a catalog entity")
+    return model_class, public_id
+
+
+def _collect_fields(
+    obj: CatalogModel, markdown_fields: list[str]
+) -> list[_EmittedField]:
+    """Authoring text + owning source for each non-empty markdown field.
+
+    The authoring text is the materialized storage value run through
+    ``convert_storage_to_authoring`` — the exact inverse a re-apply runs, so an
+    unedited dump round-trips to byte-identical storage. Call it **directly**,
+    not via ``build_rich_text(...).text``: that round-trip inverse is the
+    contract, not the edit form's schema builder, which could grow text
+    normalization that would silently break byte-identity. Fields no claim has
+    set (empty value) are skipped.
+    """
+    active = active_claims(obj)
+    emitted: list[_EmittedField] = []
+    for field in markdown_fields:
+        stored = getattr(obj, field) or ""
+        if not stored:
+            continue
+        text = convert_storage_to_authoring(stored)
+        emitted.append(_EmittedField(field, text, _winning_source(active, field)))
+    return emitted
+
+
+def _default_attribution(entity_ref: str, emitted: list[_EmittedField]) -> str:
+    """The slug of the source owning every emitted field's winning claim.
+
+    A field with no owning source (its winning claim is user-authored, or its
+    source is disabled and so excluded from the prefetch) or fields owned by
+    differing sources have no single attribution — both demand an explicit
+    ``--attribution``.
+    """
+    sources = {e.source for e in emitted}
+    if None in sources:
+        raise CommandError(
+            f"{entity_ref}: a winning markdown claim has no owning source "
+            f"(user-authored, or its source is disabled); pass --attribution "
+            f"<slug> to fork it into a source-owned claim (not a faithful no-op)."
+        )
+    slugs = {source.slug for source in sources if source is not None}
+    if len(slugs) > 1:
+        raise CommandError(
+            f"{entity_ref}: markdown fields are owned by different sources "
+            f"({', '.join(sorted(slugs))}); pass --attribution <slug>."
+        )
+    return slugs.pop()
+
+
+def _winning_source(active: list[Claim], field: str) -> Source | None:
+    """The source of the winning (highest-priority) claim for ``field``.
+
+    ``active`` is ordered by claim_key, -priority, -created_at, so the first
+    claim for the field is the winner. Returns ``None`` when it is user-authored.
+    """
+    for claim in active:
+        if claim.field_name == field:
+            return claim.source
+    return None

--- a/backend/apps/catalog/tests/conftest.py
+++ b/backend/apps/catalog/tests/conftest.py
@@ -96,6 +96,27 @@ def source(db):
 
 
 @pytest.fixture
+def flipcommons_catalog(db):
+    """The default patch-attribution Source.
+
+    In production the pindata ingest seeds ``flipcommons-catalog`` (see
+    ``ingest_pindata``); no migration creates it. Tests that attribute patches to
+    the catalog's own default source must therefore seed it themselves. It's the
+    default attribution for hand- and AI-authored patches — see
+    docs/DataPatchAuthoring.md.
+    """
+    src, _ = Source.objects.get_or_create(
+        slug="flipcommons-catalog",
+        defaults={
+            "name": "Flipcommons Catalog",
+            "source_type": "editorial",
+            "priority": 300,
+        },
+    )
+    return src
+
+
+@pytest.fixture
 def manufacturer(db, _bootstrap_source):
     mfr = Manufacturer.objects.create(name="Williams", slug="williams")
     Claim.objects.assert_claim(mfr, "name", "Williams", source=_bootstrap_source)

--- a/backend/apps/catalog/tests/test_dump_patch_entry.py
+++ b/backend/apps/catalog/tests/test_dump_patch_entry.py
@@ -1,0 +1,203 @@
+"""Tests for the ``dump_patch_entry`` rehydration command.
+
+Storage → patch-authoring is just ``convert_storage_to_authoring``
+(``[[cite:id:N]]`` → ``[[cite:slug]]``). The command emits a complete, runnable
+patch document so the gen pipeline / a human can reword a sentence and resubmit
+with untouched citations intact. The load-bearing guarantee is byte-identity:
+re-applying the unedited dump produces the same storage and diffs as a no-op.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+import yaml
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from apps.catalog.ingestion.apply import apply_plan
+from apps.catalog.ingestion.patches import EditEntry, build_plan, load_patch
+from apps.catalog.models import MachineModel
+from apps.catalog.tests.conftest import make_machine_model
+from apps.citation.models import CitationSource
+from apps.core.markdown import convert_authoring_to_storage
+from apps.provenance.models import CitationInstance, Claim, Source
+from apps.provenance.test_factories import user_changeset
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+def _dump(entity_ref: str, *, attribution: str | None = None) -> str:
+    out = StringIO()
+    args = [entity_ref]
+    if attribution is not None:
+        args += ["--attribution", attribution]
+    call_command("dump_patch_entry", *args, stdout=out)
+    return out.getvalue()
+
+
+def _description_of(doc_text: str) -> str:
+    """Extract the description field from a dumped patch document."""
+    doc = load_patch(doc_text)
+    (entry,) = doc.claims
+    assert isinstance(entry, EditEntry)
+    value = entry.fields["description"]
+    assert isinstance(value, str)
+    return value
+
+
+def _apply(text: str, *, patch_id: str = "0001-test") -> None:
+    doc = load_patch(text)
+    source = Source.objects.get(slug=doc.attribution)
+    apply_plan(build_plan(doc, source=source, patch_id=patch_id))
+
+
+def _stored_description(slug: str) -> str:
+    claim = MachineModel.objects.get(slug=slug).claims.get(
+        field_name="description", is_active=True
+    )
+    assert isinstance(claim.value, str)
+    return claim.value
+
+
+@pytest.fixture
+def ipdb_root(db):
+    return CitationSource.objects.create(
+        name="Internet Pinball Database", source_type="web", identifier_key="ipdb"
+    )
+
+
+# ── round-trip byte-identity ───────────────────────────────────────
+
+
+def test_round_trip_byte_identity_with_adversarial_text(flipcommons_catalog):
+    """Dump → load → convert back equals the stored value, byte-for-byte.
+
+    The text is deliberately hostile to PyYAML's literal-block style — blank
+    lines, a trailing-two-spaces hard break, a leading-space line and no
+    trailing newline — so it exercises the double-quoted fallback. It also
+    carries non-ASCII characters (descriptions hold foreign-language quotes) to
+    exercise ``allow_unicode=True`` under the byte-identity assertion.
+    Byte-identity is style-independent, so correctness survives the readability
+    cliff.
+    """
+    src = CitationSource.objects.create(
+        name="IPDB", source_type="web", identifier_key="ipdb"
+    )
+    ci1 = CitationInstance.objects.create(citation_source=src, claim=None)
+    ci2 = CitationInstance.objects.create(citation_source=src, claim=None)
+
+    stored = (
+        f"Gegründet by Günter — a café prototype.[[cite:id:{ci1.pk}]]\n"
+        "\n"
+        "Hard break here  \n"
+        " leading-space line\n"
+        f"End with no trailing newline.[[cite:id:{ci2.pk}]]"
+    )
+    pm = make_machine_model(name="Adversarial", slug="adversarial", description=stored)
+    Claim.objects.assert_claim(pm, "description", stored, source=flipcommons_catalog)
+
+    dumped = _dump("model.adversarial")
+    authoring = _description_of(dumped)
+
+    # Existing slugs are in place; no cites: map needed for a re-edit.
+    assert f"[[cite:{ci1.slug}]]" in authoring
+    assert f"[[cite:{ci2.slug}]]" in authoring
+    assert convert_authoring_to_storage(authoring) == stored
+
+
+def test_dump_is_runnable_no_op(flipcommons_catalog, ipdb_root):
+    """Re-applying the unedited dump mints nothing and diffs as a no-op."""
+    make_machine_model(name="Medieval Madness", slug="medieval-madness")
+    _apply(
+        """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "Solid-state classic.[[cite:1]] Few survive.[[cite:2]]"
+      cites:
+        '1': ipdb:4443
+        '2': ipdb:9999
+"""
+    )
+    instances_before = set(CitationInstance.objects.values_list("pk", flat=True))
+    stored_before = _stored_description("medieval-madness")
+
+    dumped = _dump("model.medieval-madness")
+    _apply(dumped, patch_id="0002-reapply")
+
+    assert (
+        set(CitationInstance.objects.values_list("pk", flat=True)) == instances_before
+    )
+    assert _stored_description("medieval-madness") == stored_before
+
+
+# ── attribution ────────────────────────────────────────────────────
+
+
+def test_attribution_defaults_to_owning_source(flipcommons_catalog):
+    pm = make_machine_model(name="Attar", slug="attar", description="Just text.")
+    Claim.objects.assert_claim(
+        pm, "description", "Just text.", source=flipcommons_catalog
+    )
+
+    doc = yaml.safe_load(_dump("model.attar"))
+    assert doc["attribution"] == "flipcommons-catalog"
+
+
+def test_attribution_override(flipcommons_catalog):
+    other = Source.objects.create(
+        slug="flipcommons-ai-desc-model", name="AI Desc", source_type="editorial"
+    )
+    pm = make_machine_model(name="Override", slug="override", description="Text.")
+    Claim.objects.assert_claim(pm, "description", "Text.", source=flipcommons_catalog)
+
+    doc = yaml.safe_load(_dump("model.override", attribution=other.slug))
+    assert doc["attribution"] == "flipcommons-ai-desc-model"
+
+
+def test_user_owned_winning_claim_requires_attribution(flipcommons_catalog):
+    user = User.objects.create_user(username="editor", email="ed@example.com")
+    pm = make_machine_model(name="UserEd", slug="user-ed", description="Hand edited.")
+    Claim.objects.assert_claim(
+        pm,
+        "description",
+        "Hand edited.",
+        user=user,
+        changeset=user_changeset(user),
+    )
+
+    with pytest.raises(CommandError, match="user-authored"):
+        _dump("model.user-ed")
+
+    # …but an explicit attribution forks it into a source-owned claim.
+    doc = yaml.safe_load(_dump("model.user-ed", attribution="flipcommons-catalog"))
+    assert doc["attribution"] == "flipcommons-catalog"
+
+
+# ── errors ──────────────────────────────────────────────────────────
+
+
+def test_unknown_entity_type_errors(db):
+    with pytest.raises(CommandError):
+        _dump("nonesuch.foo")
+
+
+def test_malformed_ref_errors(db):
+    with pytest.raises(CommandError, match="type.public_id"):
+        _dump("model")
+
+
+def test_no_such_entity_errors(flipcommons_catalog):
+    with pytest.raises(CommandError, match="no such"):
+        _dump("model.ghost")
+
+
+def test_no_markdown_content_errors(flipcommons_catalog):
+    make_machine_model(name="Empty", slug="empty")
+    with pytest.raises(CommandError, match="no markdown content"):
+        _dump("model.empty")

--- a/backend/apps/catalog/tests/test_patch_inline_cites.py
+++ b/backend/apps/catalog/tests/test_patch_inline_cites.py
@@ -1,0 +1,407 @@
+"""Tests for inline-cited patch descriptions (Step 2).
+
+A patch may carry rich markdown descriptions whose facts are backed by inline
+``[[cite:<handle>]]`` footnotes. A *new* footnote uses a numeric handle declared
+in a ``cites:`` map (minted to a floating ``claim=None`` CitationInstance at apply
+time); an *existing* footnote uses the instance's durable slug and needs no
+``cites:`` entry (it self-resolves through standard conversion). Covers parse +
+correspondence guards, apply-time minting + marker rewrite, the re-edit
+round-trip, and the new-cite dry-run carve-out.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from apps.catalog.ingestion.apply import apply_plan
+from apps.catalog.ingestion.patches import PatchError, build_plan, load_patch
+from apps.catalog.models import Manufacturer
+from apps.catalog.tests.conftest import make_machine_model
+from apps.citation.models import CitationSource
+from apps.core.markdown import (
+    convert_storage_to_authoring,
+    render_all_links,
+)
+from apps.provenance.models import CitationInstance, Source
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def ipdb_root(db):
+    """The root CitationSource for the ipdb scheme (children hang under it)."""
+    return CitationSource.objects.create(
+        name="Internet Pinball Database", source_type="web", identifier_key="ipdb"
+    )
+
+
+@pytest.fixture
+def kineticist_root(db):
+    """A non-scheme root web source with a homepage link, for domain matching."""
+    root = CitationSource.objects.create(name="Kineticist", source_type="web")
+    root.links.create(link_type="homepage", url="https://kineticist.com/")
+    return root
+
+
+@pytest.fixture
+def pm(db, flipcommons_catalog):
+    return make_machine_model(
+        name="Medieval Madness", slug="medieval-madness", year=1997
+    )
+
+
+def _apply(text: str, *, patch_id: str = "0001-test", dry_run: bool = False):
+    doc = load_patch(text)
+    source = Source.objects.get(slug=doc.attribution)
+    plan = build_plan(doc, source=source, patch_id=patch_id)
+    return apply_plan(plan, dry_run=dry_run)
+
+
+def _floating():
+    """Floating (inline) CitationInstances — minted with ``claim=None``."""
+    return CitationInstance.objects.filter(claim__isnull=True)
+
+
+def _is_slug(value: str) -> bool:
+    # Step 1's slug: exactly 8 lowercase consonants (digit- and vowel-free).
+    return len(value) == 8 and value.isalpha() and value.islower()
+
+
+def _description_value(entity) -> str:
+    value = entity.claims.get(field_name="description", is_active=True).value
+    assert isinstance(value, str)
+    return value
+
+
+# ── apply: new inline citations mint + rewrite ─────────────────────
+
+
+def test_two_new_handles_mint_two_floating_instances(
+    flipcommons_catalog, ipdb_root, kineticist_root, pm
+):
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "A solid-state classic.[[cite:1]] Few survive.[[cite:2]]"
+      cites:
+        '1': ipdb:4443
+        '2': https://kineticist.com/mm
+"""
+    _apply(text)
+
+    instances = list(_floating())
+    assert len(instances) == 2
+    assert all(_is_slug(ci.slug) for ci in instances)
+    # One per source — scheme dedups through ipdb, the URL through kineticist.
+    source_ids = {ci.citation_source_id for ci in instances}
+    assert len(source_ids) == 2
+
+    stored = _description_value(pm)
+    pks = sorted(ci.pk for ci in instances)
+    for pk in pks:
+        assert f"[[cite:id:{pk}]]" in stored
+    assert "[[cite:1]]" not in stored
+    assert "[[cite:2]]" not in stored
+
+    html = render_all_links(stored)
+    assert 'data-cite-index="1"' in html
+    assert 'data-cite-index="2"' in html
+    assert "[[cite:" not in html
+
+
+def test_same_new_handle_twice_one_instance_same_pk(flipcommons_catalog, ipdb_root, pm):
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "First mention.[[cite:1]] Second mention.[[cite:1]]"
+      cites:
+        '1': ipdb:4443
+"""
+    _apply(text)
+
+    (ci,) = list(_floating())
+    stored = _description_value(pm)
+    # Both markers resolve to the single minted instance's pk.
+    assert stored.count(f"[[cite:id:{ci.pk}]]") == 2
+
+
+def test_inline_cite_on_create_entity(flipcommons_catalog, ipdb_root):
+    # A same-patch create: the description assertion targets a handle, resolved
+    # by _patch_handles before _materialize_inline_citations rewrites it.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - manufacturer.mazatron:
+      create: true
+      name: Mazatron
+      description: "Founded 1990.[[cite:1]]"
+      cites:
+        '1': ipdb:4443
+"""
+    _apply(text)
+
+    mfr = Manufacturer.objects.get(slug="mazatron")
+    (ci,) = list(_floating())
+    assert _is_slug(ci.slug)
+    assert f"[[cite:id:{ci.pk}]]" in _description_value(mfr)
+
+
+def test_url_archive_spec_backfills_archive_link(
+    flipcommons_catalog, kineticist_root, pm
+):
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "Archived fact.[[cite:1]]"
+      cites:
+        '1':
+          url: https://kineticist.com/mm
+          archive: https://web.archive.org/web/2020/https://kineticist.com/mm
+"""
+    _apply(text)
+
+    (ci,) = list(_floating())
+    urls = set(ci.citation_source.links.values_list("url", flat=True))
+    assert "https://kineticist.com/mm" in urls
+    assert "https://web.archive.org/web/2020/https://kineticist.com/mm" in urls
+
+
+def test_two_inline_cited_edits_same_entity_rejected(
+    flipcommons_catalog, ipdb_root, pm
+):
+    # Two entries editing the same entity's description, each with inline cites:
+    # _build_claims keeps only the last (last-write-wins), so minting per entry
+    # would orphan the discarded entry's floating instance. Inline cites are
+    # provenance, so this trips the multi-entry guard at build time, before any
+    # mint — combine them into one entry, like note/cite.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "First take.[[cite:1]]"
+      cites:
+        '1': ipdb:4443
+  - model.medieval-madness:
+      description: "Second take.[[cite:1]]"
+      cites:
+        '1': ipdb:5555
+"""
+    with pytest.raises(PatchError, match="combine them into one entry"):
+        _apply(text)
+    assert _floating().count() == 0  # rejected before apply — nothing minted
+
+
+def test_out_of_order_noncontiguous_handles_accepted(
+    flipcommons_catalog, ipdb_root, kineticist_root, pm
+):
+    # Handles need no ordering or contiguity: '5' and '2', markers reversed.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "Later fact.[[cite:5]] Earlier fact.[[cite:2]]"
+      cites:
+        '5': ipdb:4443
+        '2': https://kineticist.com/mm
+"""
+    _apply(text)
+    assert _floating().count() == 2
+
+
+# ── re-edit round-trip (existing slugs) ────────────────────────────
+
+
+def test_reedit_with_existing_slug_no_mint_no_churn(flipcommons_catalog, ipdb_root, pm):
+    _apply(
+        "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
+        '      description: "A fact.[[cite:1]]"\n      cites:\n        '
+        "'1': ipdb:4443\n"
+    )
+    (ci,) = list(_floating())
+    authoring = convert_storage_to_authoring(_description_value(pm))
+    assert f"[[cite:{ci.slug}]]" in authoring  # rehydrated to the durable slug
+
+    # Resubmit the rehydrated text verbatim, no cites: — byte-identical storage.
+    report = _apply(
+        f"attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
+        f'      description: "{authoring}"\n',
+        patch_id="0002-reedit",
+    )
+    assert _floating().count() == 1  # no new mint — slug reused
+    assert report.asserted == 0
+    assert report.unchanged == 1
+
+    # Reword one sentence, keep the slug marker — only the text diffs.
+    reworded = authoring.replace("A fact.", "A reworded fact.")
+    report = _apply(
+        f"attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
+        f'      description: "{reworded}"\n',
+        patch_id="0003-reword",
+    )
+    assert _floating().count() == 1  # still no new mint
+    assert report.asserted == 1
+    assert report.superseded == 1
+    assert f"[[cite:id:{ci.pk}]]" in _description_value(pm)
+
+
+def test_unknown_existing_slug_rejected_at_conversion(flipcommons_catalog, pm):
+    # A slug-grammar marker with no backing passes the lexical classifier but
+    # fails downstream in convert_authoring_to_storage ("Cite not found").
+    text = (
+        "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
+        '      description: "Bad.[[cite:zzzzzzzz]]"\n'
+    )
+    with pytest.raises(ValidationError):
+        _apply(text)
+
+
+# ── correspondence / grammar guards (PatchError, DB-free) ──────────
+
+
+def test_numeric_handle_without_cites_entry_rejected(flipcommons_catalog, pm):
+    text = (
+        "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
+        '      description: "Fact.[[cite:1]]"\n'
+    )
+    with pytest.raises(PatchError, match="no 'cites:' entry to mint from"):
+        _apply(text)
+
+
+def test_unused_cites_entry_rejected(flipcommons_catalog, ipdb_root, pm):
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "Fact.[[cite:1]]"
+      cites:
+        '1': ipdb:4443
+        '2': ipdb:5555
+"""
+    with pytest.raises(PatchError, match="not referenced"):
+        _apply(text)
+
+
+def test_slug_keyed_cites_entry_rejected(flipcommons_catalog, ipdb_root, pm):
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "Fact.[[cite:bqntvkrs]]"
+      cites:
+        bqntvkrs: ipdb:4443
+"""
+    with pytest.raises(PatchError, match="must be numeric handles"):
+        _apply(text)
+
+
+def test_cites_without_markdown_claim_rejected(flipcommons_catalog, ipdb_root, pm):
+    # year is not a markdown field — nothing for the cite to bind to.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      year: 1998
+      cites:
+        '1': ipdb:4443
+"""
+    with pytest.raises(PatchError, match="requires a markdown-field claim"):
+        _apply(text)
+
+
+def test_cites_on_delete_entry_rejected(flipcommons_catalog, ipdb_root, pm):
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      delete: true
+      cites:
+        '1': ipdb:4443
+"""
+    with pytest.raises(PatchError, match="requires a markdown-field claim"):
+        _apply(text)
+
+
+# ── raw-pk / malformed-handle guard ────────────────────────────────
+
+
+@pytest.mark.parametrize("handle", ["id:1", "1a", "Foo"])
+def test_malformed_inline_handle_rejected(flipcommons_catalog, pm, handle):
+    # The load-bearing case is [[cite:id:1]]: without the strict grammar it would
+    # classify as a slug and store verbatim, reopening the raw-pk hole.
+    text = (
+        "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
+        f'      description: "X.[[cite:{handle}]]"\n'
+    )
+    with pytest.raises(PatchError, match="malformed inline citation"):
+        _apply(text)
+
+
+def test_unquoted_integer_handle_is_parse_error(flipcommons_catalog, pm):
+    # A bare integer YAML key is rejected by the strict loader before the adapter
+    # runs (patchkit and hand-authors must quote handles).
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "Fact.[[cite:1]]"
+      cites:
+        1: ipdb:4443
+"""
+    with pytest.raises(PatchError, match="non-string mapping key"):
+        _apply(text)
+
+
+# ── dry-run carve-out ──────────────────────────────────────────────
+
+
+def test_dry_run_new_cite_edit_does_not_raise(flipcommons_catalog, ipdb_root, pm):
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "Fact.[[cite:1]]"
+      cites:
+        '1': ipdb:4443
+"""
+    report = _apply(text, dry_run=True)
+    assert not report.errors
+    assert report.asserted == 1
+    assert _floating().count() == 0  # nothing minted in dry-run
+
+
+def test_dry_run_new_cite_create_does_not_raise(flipcommons_catalog, ipdb_root):
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - manufacturer.mazatron:
+      create: true
+      name: Mazatron
+      description: "Founded 1990.[[cite:1]]"
+      cites:
+        '1': ipdb:4443
+"""
+    report = _apply(text, dry_run=True)
+    assert not report.errors
+    assert not Manufacturer.objects.filter(slug="mazatron").exists()
+
+
+def test_dry_run_existing_slug_validates_normally(flipcommons_catalog, ipdb_root, pm):
+    # Mint a real cite, then dry-run a re-edit using its slug (no cites:): the
+    # slug resolves against the DB, so it stays on the standard validate path.
+    _apply(
+        "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
+        '      description: "A fact.[[cite:1]]"\n      cites:\n        '
+        "'1': ipdb:4443\n"
+    )
+    authoring = convert_storage_to_authoring(_description_value(pm))
+    report = _apply(
+        f"attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
+        f'      description: "{authoring}"\n',
+        patch_id="0002-dry",
+        dry_run=True,
+    )
+    assert not report.errors

--- a/backend/apps/catalog/tests/test_patch_inline_cites.py
+++ b/backend/apps/catalog/tests/test_patch_inline_cites.py
@@ -1,4 +1,4 @@
-"""Tests for inline-cited patch descriptions (Step 2).
+"""Tests for inline-cited patch descriptions.
 
 A patch may carry rich markdown descriptions whose facts are backed by inline
 ``[[cite:<handle>]]`` footnotes. A *new* footnote uses a numeric handle declared
@@ -64,7 +64,7 @@ def _floating():
 
 
 def _is_slug(value: str) -> bool:
-    # Step 1's slug: exactly 8 lowercase consonants (digit- and vowel-free).
+    # CitationInstance slugs are exactly 8 lowercase consonants.
     return len(value) == 8 and value.isalpha() and value.islower()
 
 

--- a/backend/apps/catalog/tests/test_patch_provenance.py
+++ b/backend/apps/catalog/tests/test_patch_provenance.py
@@ -32,20 +32,6 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def flip_museum(db):
-    # flip-museum is seeded by a provenance data migration, so get-or-create.
-    source, _ = Source.objects.get_or_create(
-        slug="flip-museum",
-        defaults={
-            "name": "Flip Museum",
-            "source_type": "editorial",
-            "priority": 10000,
-        },
-    )
-    return source
-
-
-@pytest.fixture
 def ipdb_root(db):
     """The root CitationSource for the ipdb scheme (children hang under it)."""
     return CitationSource.objects.create(
@@ -64,7 +50,7 @@ def kineticist_root(db):
 
 
 @pytest.fixture
-def pm(db, flip_museum):
+def pm(db, flipcommons_catalog):
     return make_machine_model(
         name="Medieval Madness", slug="medieval-madness", year=1997
     )
@@ -87,7 +73,7 @@ def _apply(text: str, *, patch_id: str = "0001-test"):
 
 def test_note_and_cite_parsed_and_excluded_from_fields():
     doc = load_patch(
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.x:\n"
         "      note: tagged because the name says so\n"
@@ -109,29 +95,29 @@ def test_note_must_be_string():
 # ── build_plan validation ──────────────────────────────────────────
 
 
-def test_bad_cite_format_rejected(flip_museum, pm):
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      cite: ipdb\n      year: 1998\n"
+def test_bad_cite_format_rejected(flipcommons_catalog, pm):
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb\n      year: 1998\n"
     with pytest.raises(PatchError, match="scheme:identifier"):
         _apply(text)
 
 
-def test_unknown_cite_scheme_rejected(flip_museum, pm):
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      cite: bogus:4443\n      year: 1998\n"
+def test_unknown_cite_scheme_rejected(flipcommons_catalog, pm):
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: bogus:4443\n      year: 1998\n"
     with pytest.raises(PatchError, match="unknown cite scheme"):
         _apply(text)
 
 
-def test_invalid_cite_identifier_rejected(flip_museum, pm):
+def test_invalid_cite_identifier_rejected(flipcommons_catalog, pm):
     # ipdb ids are digits; a non-numeric id fails normalization.
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:not-a-number\n      year: 1998\n"
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:not-a-number\n      year: 1998\n"
     with pytest.raises(PatchError, match="invalid ipdb identifier"):
         _apply(text)
 
 
-def test_overlong_note_rejected(flip_museum, pm):
+def test_overlong_note_rejected(flipcommons_catalog, pm):
     long_note = "x" * 1001
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         f"      note: {long_note}\n"
@@ -141,11 +127,11 @@ def test_overlong_note_rejected(flip_museum, pm):
         _apply(text)
 
 
-def test_same_entity_provenance_conflict_rejected(flip_museum, pm):
+def test_same_entity_provenance_conflict_rejected(flipcommons_catalog, pm):
     # Two entries land on one entity and one carries a note → rejected, because
     # an entity's claims collapse into a single shared changeset.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.medieval-madness:
       note: first reason
@@ -157,42 +143,42 @@ claims:
         _apply(text)
 
 
-def test_cite_on_retraction_only_entry_rejected(flip_museum, pm):
+def test_cite_on_retraction_only_entry_rejected(flipcommons_catalog, pm):
     # A cite has nothing to attach to when the entry only retracts.
-    Claim.objects.assert_claim(pm, "year", 1998, source=flip_museum)
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      retract: [year]\n"
+    Claim.objects.assert_claim(pm, "year", 1998, source=flipcommons_catalog)
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      retract: [year]\n"
     with pytest.raises(PatchError, match="cite has no field to attach to"):
         _apply(text)
 
 
-def test_cite_on_fieldless_create_rejected(flip_museum):
-    text = "attribution: flip-museum\nclaims:\n  - manufacturer.acme:\n      create: true\n      cite: ipdb:4443\n"
+def test_cite_on_fieldless_create_rejected(flipcommons_catalog):
+    text = "attribution: flipcommons-catalog\nclaims:\n  - manufacturer.acme:\n      create: true\n      cite: ipdb:4443\n"
     with pytest.raises(PatchError, match="cite has no field to attach to"):
         _apply(text)
 
 
-def test_cite_on_empty_relationship_rejected(flip_museum, pm):
+def test_cite_on_empty_relationship_rejected(flipcommons_catalog, pm):
     # `tag: []` has a field key but emits zero claims, so the cite would attach
     # to nothing — a field *key* isn't a carrier.
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      tag: []\n"
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      tag: []\n"
     with pytest.raises(PatchError, match="cite has no field to attach to"):
         _apply(text)
 
 
-def test_note_with_no_carrier_rejected(flip_museum, pm):
+def test_note_with_no_carrier_rejected(flipcommons_catalog, pm):
     # note: alongside only an empty relationship emits no claim/changeset, so
     # the note would silently vanish.
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      note: this goes nowhere\n      tag: []\n"
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: this goes nowhere\n      tag: []\n"
     with pytest.raises(PatchError, match="note has nothing to attach to"):
         _apply(text)
 
 
-def test_duplicate_create_rejected(flip_museum):
+def test_duplicate_create_rejected(flipcommons_catalog):
     # Two creates for the same ref would mint a duplicate handle; build_plan
     # rejects it as a PatchError rather than letting it surface as a ValueError
     # deep in the apply layer (which ingest_patches doesn't catch).
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.acme:
       create: true
@@ -208,18 +194,18 @@ claims:
 # ── apply: note → ChangeSet.note ───────────────────────────────────
 
 
-def test_note_sets_changeset_note(flip_museum, pm):
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      note: corrected per the flyer\n      year: 1998\n"
+def test_note_sets_changeset_note(flipcommons_catalog, pm):
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: corrected per the flyer\n      year: 1998\n"
     _apply(text)
     cs = ChangeSet.objects.get(ingest_run__isnull=False)
     assert cs.note == "corrected per the flyer"
 
 
-def test_retract_only_entry_lands_note(flip_museum, pm):
-    # Seed a flip-museum year claim, then retract it with a note. A retraction
+def test_retract_only_entry_lands_note(flipcommons_catalog, pm):
+    # Seed a flipcommons-catalog year claim, then retract it with a note. A retraction
     # emits no assertion, so its note must still reach the changeset.
-    Claim.objects.assert_claim(pm, "year", 1998, source=flip_museum)
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      note: removing our bad year\n      retract: [year]\n"
+    Claim.objects.assert_claim(pm, "year", 1998, source=flipcommons_catalog)
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: removing our bad year\n      retract: [year]\n"
     report = _apply(text, patch_id="0002-retract")
     assert report.retracted == 1
     cs = ChangeSet.objects.get(ingest_run__patch_id="0002-retract")
@@ -230,10 +216,10 @@ def test_retract_only_entry_lands_note(flip_museum, pm):
 
 
 def test_cite_creates_source_and_attaches_to_claims(
-    flip_museum, ipdb_root, pm, prototype_tag
+    flipcommons_catalog, ipdb_root, pm, prototype_tag
 ):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.medieval-madness:
       note: only one prototype made
@@ -257,8 +243,8 @@ claims:
     assert tag_claim.citation_instances.get().citation_source_id == child.pk
 
 
-def test_cite_is_idempotent_across_applications(flip_museum, ipdb_root, pm):
-    base = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: {year}\n"
+def test_cite_is_idempotent_across_applications(flipcommons_catalog, ipdb_root, pm):
+    base = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: {year}\n"
     _apply(base.format(year=1998), patch_id="0001-a")
     _apply(base.format(year=1999), patch_id="0002-b")
     # Re-citing the same id reuses the one child source.
@@ -267,11 +253,11 @@ def test_cite_is_idempotent_across_applications(flip_museum, ipdb_root, pm):
     )
 
 
-def test_create_scaffolding_not_cited(flip_museum, ipdb_root):
+def test_create_scaffolding_not_cited(flipcommons_catalog, ipdb_root):
     # A create entry's authored field (name) is cited; the adapter-owned slug
     # and status claims are not.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.acme:
       create: true
@@ -288,36 +274,38 @@ claims:
     assert not status_claim.citation_instances.exists()
 
 
-def test_cite_on_unchanged_value_noops(flip_museum, ipdb_root, pm):
+def test_cite_on_unchanged_value_noops(flipcommons_catalog, ipdb_root, pm):
     # An already-correct, same-source value diffs as unchanged, so adding a
     # cite: writes no new claim and attaches no citation (documented v1 limit).
-    Claim.objects.assert_claim(pm, "year", 2000, source=flip_museum)
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 2000\n"
+    Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 2000\n"
     _apply(text)
-    year_claim = pm.claims.get(field_name="year", is_active=True, source=flip_museum)
+    year_claim = pm.claims.get(
+        field_name="year", is_active=True, source=flipcommons_catalog
+    )
     assert not year_claim.citation_instances.exists()
     assert not CitationInstance.objects.exists()
 
 
-def test_note_on_unchanged_value_noops(flip_museum, pm):
+def test_note_on_unchanged_value_noops(flipcommons_catalog, pm):
     # Same root cause as the cite no-op: an entry that re-asserts an
     # already-active same-source value diffs as unchanged, so no ChangeSet is
     # created and the note is silently dropped (documented v1 limit). Build
     # time can't catch this — it depends on the post-diff result.
-    Claim.objects.assert_claim(pm, "year", 2000, source=flip_museum)
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      note: confirmed correct\n      year: 2000\n"
+    Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: confirmed correct\n      year: 2000\n"
     report = _apply(text)
     assert report.asserted == 0  # nothing written
     assert not ChangeSet.objects.filter(ingest_run__isnull=False).exists()
 
 
-def test_attach_citations_is_per_claim(flip_museum, ipdb_root, pm):
+def test_attach_citations_is_per_claim(flipcommons_catalog, ipdb_root, pm):
     # Direct IngestPlan: two assertions on one entity, only one carries a
     # citation_ref. The citation must ride only that claim — never bleed onto
     # the other claim that merely shares the entity.
     ct = ContentType.objects.get_for_model(MachineModel)
     plan = IngestPlan(
-        source=flip_museum, input_fingerprint="fp", patch_id="0001-direct"
+        source=flipcommons_catalog, input_fingerprint="fp", patch_id="0001-direct"
     )
     plan.assertions.append(
         PlannedClaimAssert(
@@ -344,9 +332,9 @@ def test_attach_citations_is_per_claim(flip_museum, ipdb_root, pm):
     assert not qty_claim.citation_instances.exists()
 
 
-def test_missing_citation_root_errors(flip_museum, pm):
+def test_missing_citation_root_errors(flipcommons_catalog, pm):
     # No ipdb root seeded → a clear error, not a silent miss.
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 1998\n"
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 1998\n"
     with pytest.raises(CitationSource.DoesNotExist, match="No root CitationSource"):
         _apply(text)
 
@@ -354,13 +342,13 @@ def test_missing_citation_root_errors(flip_museum, pm):
 # ── cite: URL form → web CitationSource nested under a root ────────
 
 
-def test_url_cite_without_matching_root_errors(flip_museum, pm):
+def test_url_cite_without_matching_root_errors(flipcommons_catalog, pm):
     # A URL whose domain matches no seeded website root is rejected — a patch
     # must nest evidence under a curated root, not mint a parentless (abstract)
     # web source. The author seeds the root in an earlier patch first.
     url = "https://pinside.com/pinball/forum/topic/mm-prototype"
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         f"      cite: {url}\n"
@@ -370,14 +358,14 @@ def test_url_cite_without_matching_root_errors(flip_museum, pm):
         _apply(text)
 
 
-def test_url_cite_reuses_preexisting_source(flip_museum, pm):
+def test_url_cite_reuses_preexisting_source(flipcommons_catalog, pm):
     # A source a curator already linked to this exact URL is reused, not
     # duplicated.
     url = "https://example.com/evidence"
     existing = CitationSource.objects.create(name="Curated", source_type="web")
     existing.links.create(link_type="reference", url=url)
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         f"      cite: {url}\n"
@@ -389,12 +377,14 @@ def test_url_cite_reuses_preexisting_source(flip_museum, pm):
     assert CitationSource.objects.filter(links__url=url).distinct().count() == 1
 
 
-def test_url_cite_nests_under_domain_matched_root(flip_museum, kineticist_root, pm):
+def test_url_cite_nests_under_domain_matched_root(
+    flipcommons_catalog, kineticist_root, pm
+):
     # A URL whose domain matches a seeded root becomes a child under that root,
     # not a flat parentless orphan.
     url = "https://kineticist.com/reviews/medieval-madness"
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         f"      cite: {url}\n"
@@ -419,11 +409,13 @@ def test_url_cite_nests_under_domain_matched_root(flip_museum, kineticist_root, 
     assert year_claim.citation_instances.get().citation_source_id == child.pk
 
 
-def test_url_cite_under_root_dedups_and_separates(flip_museum, kineticist_root, pm):
+def test_url_cite_under_root_dedups_and_separates(
+    flipcommons_catalog, kineticist_root, pm
+):
     # Same URL twice → one child; a different path on the same domain → a second
     # child under the same root.
     base = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite: {url}\n"
@@ -438,13 +430,15 @@ def test_url_cite_under_root_dedups_and_separates(flip_museum, kineticist_root, 
     assert CitationSource.objects.filter(parent=kineticist_root).count() == 2
 
 
-def test_url_cite_with_archive_attaches_both_links(flip_museum, kineticist_root, pm):
+def test_url_cite_with_archive_attaches_both_links(
+    flipcommons_catalog, kineticist_root, pm
+):
     # cite: {url, archive} → the child carries BOTH a 'reference' link (the live
     # page) and an 'archive' link (the Wayback snapshot): one citation, two links.
     url = "https://kineticist.com/reviews/medieval-madness"
     archive = "https://web.archive.org/web/20240101000000/" + url
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite:\n"
@@ -462,12 +456,12 @@ def test_url_cite_with_archive_attaches_both_links(flip_museum, kineticist_root,
     assert year_claim.citation_instances.get().citation_source_id == child.pk
 
 
-def test_url_cite_archive_idempotent(flip_museum, kineticist_root, pm):
+def test_url_cite_archive_idempotent(flipcommons_catalog, kineticist_root, pm):
     # Re-applying the same {url, archive} cite never duplicates the archive link.
     url = "https://kineticist.com/x"
     archive = "https://web.archive.org/web/20240101000000/" + url
     base = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite:\n"
@@ -483,19 +477,19 @@ def test_url_cite_archive_idempotent(flip_museum, kineticist_root, pm):
     assert CitationSource.objects.filter(parent=kineticist_root).count() == 1
 
 
-def test_archive_added_to_preexisting_child(flip_museum, kineticist_root, pm):
+def test_archive_added_to_preexisting_child(flipcommons_catalog, kineticist_root, pm):
     # A first patch cites the live URL (no archive); a later patch re-cites it
     # with an archive → the archive link is added to the existing child source,
     # exercising the `existing is not None` branch + the archive backfill.
     url = "https://kineticist.com/x"
     archive = "https://web.archive.org/web/20240101000000/" + url
     _apply(
-        "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n"
+        "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
         f"      cite: {url}\n      year: 1998\n",
         patch_id="0001-a",
     )
     _apply(
-        "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n"
+        "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n"
         "      cite:\n"
         f"        url: {url}\n        archive: {archive}\n"
         "      year: 1999\n",
@@ -508,10 +502,10 @@ def test_archive_added_to_preexisting_child(flip_museum, kineticist_root, pm):
     assert CitationSource.objects.filter(parent=kineticist_root).count() == 1
 
 
-def test_cite_archive_with_scheme_cite_rejected(flip_museum, pm):
+def test_cite_archive_with_scheme_cite_rejected(flipcommons_catalog, pm):
     # An archive snapshot only makes sense for a live web page, not a scheme cite.
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite:\n"
@@ -523,9 +517,9 @@ def test_cite_archive_with_scheme_cite_rejected(flip_museum, pm):
         _apply(text)
 
 
-def test_cite_mapping_unknown_key_rejected(flip_museum, pm):
+def test_cite_mapping_unknown_key_rejected(flipcommons_catalog, pm):
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite:\n"
@@ -537,9 +531,9 @@ def test_cite_mapping_unknown_key_rejected(flip_museum, pm):
         _apply(text)
 
 
-def test_invalid_archive_url_rejected(flip_museum, kineticist_root, pm):
+def test_invalid_archive_url_rejected(flipcommons_catalog, kineticist_root, pm):
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite:\n"
@@ -551,10 +545,10 @@ def test_invalid_archive_url_rejected(flip_museum, kineticist_root, pm):
         _apply(text)
 
 
-def test_ipdb_url_cite_rejected(flip_museum, pm):
+def test_ipdb_url_cite_rejected(flipcommons_catalog, pm):
     # A known-scheme record URL must be cited via scheme:identifier so it dedups.
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite: https://www.ipdb.org/machine.cgi?id=4443\n"
@@ -564,9 +558,9 @@ def test_ipdb_url_cite_rejected(flip_museum, pm):
         _apply(text)
 
 
-def test_opdb_url_cite_rejected(flip_museum, pm):
+def test_opdb_url_cite_rejected(flipcommons_catalog, pm):
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite: https://opdb.org/machines/GRhX5\n"
@@ -576,9 +570,9 @@ def test_opdb_url_cite_rejected(flip_museum, pm):
         _apply(text)
 
 
-def test_malformed_url_cite_rejected(flip_museum, pm):
+def test_malformed_url_cite_rejected(flipcommons_catalog, pm):
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite: https://\n"
@@ -588,10 +582,10 @@ def test_malformed_url_cite_rejected(flip_museum, pm):
         _apply(text)
 
 
-def test_overlong_url_cite_rejected(flip_museum, pm):
+def test_overlong_url_cite_rejected(flipcommons_catalog, pm):
     long_url = "https://example.com/" + "x" * 2000
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         f"      cite: {long_url}\n"
@@ -601,12 +595,14 @@ def test_overlong_url_cite_rejected(flip_museum, pm):
         _apply(text)
 
 
-def test_long_url_cite_names_source_by_hostname(flip_museum, kineticist_root, pm):
+def test_long_url_cite_names_source_by_hostname(
+    flipcommons_catalog, kineticist_root, pm
+):
     # A valid URL longer than the name column falls back to the hostname for the
     # child's name (the full URL still lands on the link, which allows more).
     url = "https://kineticist.com/" + "x" * 600
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         f"      cite: {url}\n"
@@ -618,10 +614,12 @@ def test_long_url_cite_names_source_by_hostname(flip_museum, kineticist_root, pm
     assert child.links.get().url == url
 
 
-def test_url_cite_surfaced_in_edit_history(client, flip_museum, kineticist_root, pm):
+def test_url_cite_surfaced_in_edit_history(
+    client, flipcommons_catalog, kineticist_root, pm
+):
     url = "https://kineticist.com/reviews/mm"
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      note: per the forum\n"
@@ -640,14 +638,14 @@ def test_url_cite_surfaced_in_edit_history(client, flip_museum, kineticist_root,
 
 
 def test_url_cite_with_archive_surfaces_live_link_in_edit_history(
-    client, flip_museum, kineticist_root, pm
+    client, flipcommons_catalog, kineticist_root, pm
 ):
     # Compact field history shows the live page, NOT its Wayback snapshot — even
     # though "archive" sorts before "reference" in the default link ordering.
     url = "https://kineticist.com/reviews/mm"
     archive = "https://web.archive.org/web/20240101000000/" + url
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - model.medieval-madness:\n"
         "      cite:\n"
@@ -668,8 +666,8 @@ def test_url_cite_with_archive_surfaces_live_link_in_edit_history(
 # ── edit-history surfacing ─────────────────────────────────────────
 
 
-def test_edit_history_exposes_citation(client, flip_museum, ipdb_root, pm):
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      note: per ipdb\n      cite: ipdb:4443\n      year: 1998\n"
+def test_edit_history_exposes_citation(client, flipcommons_catalog, ipdb_root, pm):
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: per ipdb\n      cite: ipdb:4443\n      year: 1998\n"
     _apply(text)
 
     resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
@@ -683,10 +681,10 @@ def test_edit_history_exposes_citation(client, flip_museum, ipdb_root, pm):
     assert citation["url"] == "https://www.ipdb.org/machine.cgi?id=4443"
 
 
-def test_changeset_detail_exposes_citation(client, flip_museum, ipdb_root, pm):
+def test_changeset_detail_exposes_citation(client, flipcommons_catalog, ipdb_root, pm):
     # The changeset-detail endpoint shares build_changes with edit history, so
     # its claims prefetch must also load citation instances.
-    text = "attribution: flip-museum\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 1998\n"
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 1998\n"
     _apply(text)
     cs = ChangeSet.objects.get(ingest_run__isnull=False)
 

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -49,6 +49,13 @@ from apps.provenance.validation import (
 pytestmark = pytest.mark.django_db
 
 
+@pytest.fixture(autouse=True)
+def _seed_flipcommons_catalog(flipcommons_catalog):
+    """Patches here attribute to ``flipcommons-catalog`` by default, so seed it for
+    every test. Unlike ``flip-museum`` (migration-seeded), the catalog source is
+    created by the pindata ingest in prod, not a migration."""
+
+
 def _apply(
     text: str, *, patch_id: str = "0001-test", dry_run: bool = False
 ) -> RunReport:
@@ -106,7 +113,7 @@ def test_fingerprint_changes_with_value():
 def test_edit_scalar_and_tag(machine_model):
     Tag.objects.create(name="Prototype", slug="prototype")
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 description: tag a prototype
 claims:
   - model.{machine_model.slug}:
@@ -124,12 +131,12 @@ claims:
     # Namespace key 'tag' resolves directly (no plural→singular bridge).
     assert tag_claim.claim_key.startswith("tag")
     assert tag_claim.source is not None
-    assert tag_claim.source.slug == "flip-museum"
+    assert tag_claim.source.slug == "flipcommons-catalog"
 
 
 def test_unknown_field_rejected(machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       not_a_field: 5
@@ -140,7 +147,7 @@ claims:
 
 def test_unknown_entity_type_rejected():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - frobnicator.foo:
       year: 1
@@ -154,7 +161,7 @@ claims:
 
 def test_create_manufacturer():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 description: new brand
 claims:
   - manufacturer.acme-pinball:
@@ -168,16 +175,16 @@ claims:
     assert mfr.name == "Acme Pinball"
     # Matching claims for the create contract (slug + name + status).
     keys = set(
-        Claim.objects.filter(source__slug="flip-museum", is_active=True).values_list(
-            "field_name", flat=True
-        )
+        Claim.objects.filter(
+            source__slug="flipcommons-catalog", is_active=True
+        ).values_list("field_name", flat=True)
     )
     assert {"slug", "name", "status"} <= keys
 
 
 def test_create_when_already_exists_errors(manufacturer):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.{manufacturer.slug}:
       name: Dup
@@ -191,7 +198,7 @@ def test_create_rejects_authored_public_id_field():
     # slug comes from the entity reference; authoring it (even a mismatch that
     # would silently create the wrong entity) is rejected.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.acme:
       create: true
@@ -204,7 +211,7 @@ claims:
 
 def test_create_rejects_authored_status():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.acme:
       create: true
@@ -234,7 +241,7 @@ def test_create_location():
         parent=usa,
     )
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.usa/tx/paris:
       create: true
@@ -261,7 +268,7 @@ claims:
 
 def test_create_location_at_root():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.france:
       create: true
@@ -281,7 +288,7 @@ def test_create_location_path_mismatch_rejected():
     # usa/paris — a disagreement that would create an inconsistent row.
     _country("usa", "USA")
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.usa/tx/paris:
       create: true
@@ -296,7 +303,7 @@ claims:
 def test_create_location_requires_slug():
     _country("usa", "USA")
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.usa/paris:
       create: true
@@ -310,7 +317,7 @@ claims:
 def test_create_location_rejects_authored_location_path():
     _country("usa", "USA")
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.usa/paris:
       create: true
@@ -325,7 +332,7 @@ claims:
 
 def test_missing_reference_without_create_errors():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.does-not-exist:
       name: Nope
@@ -339,7 +346,7 @@ claims:
 
 def test_create_and_fk_reassignment(stern_entity, stern):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 description: split a firm out
 claims:
   - manufacturer.western-products:
@@ -361,7 +368,7 @@ claims:
 
 def test_dry_run_stern_shape_no_spurious_rejection(stern_entity):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.western-products:
       name: Western Products
@@ -382,7 +389,7 @@ def test_relationship_member_created_earlier_same_patch(machine_model):
     # A relationship member created by an *earlier* entry in the same patch
     # resolves via the deferred (identity_refs) path — no longer rejected.
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - tag.brand-new-tag:
       name: Brand New Tag
@@ -405,7 +412,7 @@ def test_backward_fk_on_create(_bootstrap_source):
     # Create a manufacturer, then create a corporate-entity whose `manufacturer`
     # FK points at it — both in one patch, the dependency declared first.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.western:
       create: true
@@ -429,7 +436,7 @@ def test_backward_fk_on_create_dry_run(_bootstrap_source):
     # Dry-run must not reject the FK-to-planned-target just because the target
     # doesn't exist yet, and must write nothing (guards the apply.py P1 carve-out).
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.western:
       create: true
@@ -450,7 +457,7 @@ def test_backward_parent_location():
     # Create a parent location, then a child whose `parent` FK names it.
     _country("usa", "USA")
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.usa/tx:
       create: true
@@ -476,7 +483,7 @@ claims:
 def test_backward_parent_location_dry_run():
     _country("usa", "USA")
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.usa/tx:
       create: true
@@ -499,7 +506,7 @@ claims:
 def test_backward_title_then_model(williams_entity):
     # Create a Title, then a MachineModel whose `title` FK names it.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - title.foo:
       create: true
@@ -521,7 +528,7 @@ def test_backward_member_on_existing_entity(bally_wulff):
     # Create a Location, then assert it as a `location` relationship member on an
     # existing corporate-entity — the deferred (identity_refs) path.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.germany/munich:
       create: true
@@ -546,7 +553,7 @@ def test_backward_member_on_created_subject(_bootstrap_source):
     # *handle*, not an existing row, plus a backward FK to a created manufacturer.
     _country("germany", "Germany")
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.acme-co:
       create: true
@@ -576,7 +583,7 @@ def test_backward_member_carries_note_and_cite(bally_wulff):
     # note: and cite:. The carrier must register (no spurious rejection) and the
     # note/citation must land on the resolved member claim.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.germany/munich:
       create: true
@@ -586,7 +593,7 @@ claims:
       location_type: city
   - corporate-entity.bally-wulff:
       location: [germany/munich]
-      note: 'flip-museum places it in Munich.'
+      note: 'flipcommons-catalog places it in Munich.'
       cite: https://example.org/bally-wulff
 sources:
   - name: Example
@@ -599,7 +606,7 @@ sources:
 
     claim = _location_claim("munich")
     assert claim.changeset is not None
-    assert claim.changeset.note == "flip-museum places it in Munich."
+    assert claim.changeset.note == "flipcommons-catalog places it in Munich."
     assert CitationInstance.objects.filter(claim=claim).exists()
 
 
@@ -607,7 +614,7 @@ def test_backward_duplicate_deferred_member_rejected(bally_wulff):
     # [munich, munich] with a same-patch-created munich → the same "duplicate
     # member" rejection the concrete path raises (parity for deferred members).
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - location.germany/munich:
       create: true
@@ -626,7 +633,7 @@ def test_self_parent_on_create_rejected():
     # A create that names itself as its own parent must be rejected — the patch
     # path enforces the same self-link guard as the API's plan_parent_claims.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - gameplay-feature.multiball:
       create: true
@@ -642,7 +649,7 @@ def test_cycle_via_edit_referencing_same_patch_create_rejected():
     # root, then point the root at the child — a 2-cycle through a created node.
     GameplayFeature.objects.create(name="Root", slug="root")
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - gameplay-feature.child:
       create: true
@@ -661,7 +668,7 @@ def test_cycle_between_existing_nodes_rejected():
     GameplayFeature.objects.create(name="A", slug="a")
     GameplayFeature.objects.create(name="B", slug="b")
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - gameplay-feature.a:
       gameplay_feature_parent: [b]
@@ -675,7 +682,7 @@ claims:
 def test_valid_hierarchy_in_one_patch():
     # A genuine parent→child DAG built in one patch must NOT trip the guard.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - gameplay-feature.ramps:
       create: true
@@ -694,7 +701,7 @@ claims:
 def test_backward_unresolvable_ref_errors(_bootstrap_source):
     # A reference in neither the DB nor this patch → PatchError, updated message.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.western-inc:
       create: true
@@ -710,7 +717,7 @@ claims:
 
 def test_expect_scalar_match_applies(machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       expect: {{ year: {machine_model.year} }}
@@ -723,7 +730,7 @@ claims:
 
 def test_expect_scalar_mismatch_errors_before_write(machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       expect: {{ year: 1234 }}
@@ -731,12 +738,12 @@ claims:
 """
     with pytest.raises(PatchError, match="expect year"):
         _apply(text)
-    assert not Claim.objects.filter(source__slug="flip-museum").exists()
+    assert not Claim.objects.filter(source__slug="flipcommons-catalog").exists()
 
 
 def test_expect_fk_match_and_mismatch(stern_entity):
     ok = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       expect: { manufacturer: stern }
@@ -747,7 +754,7 @@ claims:
     assert stern_entity.year_start == 1986
 
     bad = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       expect: { manufacturer: williams }
@@ -759,7 +766,7 @@ claims:
 
 def test_expect_on_create_errors():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.acme-pinball:
       name: Acme
@@ -776,19 +783,16 @@ claims:
 def test_retract_must_be_a_list():
     with pytest.raises(PatchError, match="'retract' must be a list"):
         load_patch(
-            "attribution: flip-museum\nclaims:\n  - model.a:\n      retract: name\n"
+            "attribution: flipcommons-catalog\nclaims:\n  - model.a:\n      retract: name\n"
         )
 
 
-def test_retract_fk_falls_through_to_remaining_source(stern, manufacturer):
+def test_retract_fk_falls_through_to_remaining_source(
+    stern, manufacturer, flipcommons_catalog
+):
     # Two sources claim the manufacturer FK; retracting the winning source's
     # claim makes resolution fall through to the remaining source's value.
-    catalog = Source.objects.create(
-        name="Flipcommons Catalog",
-        slug="flipcommons-catalog",
-        source_type="editorial",
-        priority=300,
-    )
+    catalog = flipcommons_catalog
     ipdb = Source.objects.create(
         name="IPDB", slug="ipdb", source_type="database", priority=100
     )
@@ -938,7 +942,7 @@ claims:
 
 def test_retract_plus_create_rejected():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.acme:
       create: true
@@ -951,7 +955,7 @@ claims:
 
 def test_retract_unknown_field_rejected(machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       retract: [not_a_field]
@@ -964,7 +968,7 @@ def test_retract_relationship_namespace_rejected(machine_model):
     # Relationship retract is deferred; a namespace key (`tag`) is rejected
     # with a relationship-specific message (distinct from an unknown field).
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       retract: [tag]
@@ -973,14 +977,9 @@ claims:
         _apply(text)
 
 
-def test_retract_one_field_assert_another_in_same_entry(stern):
+def test_retract_one_field_assert_another_in_same_entry(stern, flipcommons_catalog):
     # An entry may retract one field and assert a different one.
-    catalog = Source.objects.create(
-        name="Flipcommons Catalog",
-        slug="flipcommons-catalog",
-        source_type="editorial",
-        priority=300,
-    )
+    catalog = flipcommons_catalog
     ipdb = Source.objects.create(
         name="IPDB", slug="ipdb", source_type="database", priority=100
     )
@@ -1062,15 +1061,15 @@ claims:
 
 
 @pytest.fixture
-def bally_wulff(db):
-    """A CorporateEntity whose sole location is Germany, claimed by flip-museum.
+def bally_wulff(db, flipcommons_catalog):
+    """A CorporateEntity whose sole location is Germany, claimed by flipcommons-catalog.
 
     Mirrors the real case: a coarse pindata-derived location we refine to a more
-    specific child (Berlin). The membership claim is attributed to flip-museum so
-    a patch from the same source supersedes it; Berlin is seeded as a child of
-    Germany, ready to assert.
+    specific child (Berlin). The membership claim is attributed to
+    flipcommons-catalog so a patch from the same source supersedes it; Berlin is
+    seeded as a child of Germany, ready to assert.
     """
-    museum = Source.objects.get(slug="flip-museum")
+    catalog = flipcommons_catalog
     germany = Location.objects.create(
         location_path="germany",
         slug="germany",
@@ -1088,10 +1087,10 @@ def bally_wulff(db):
     ce = CorporateEntity.objects.create(
         name="Bally Wulff", slug="bally-wulff", manufacturer=mfr
     )
-    Claim.objects.assert_claim(ce, "name", "Bally Wulff", source=museum)
+    Claim.objects.assert_claim(ce, "name", "Bally Wulff", source=catalog)
     claim_key, value = build_relationship_claim("location", {"location": germany.pk})
     Claim.objects.assert_claim(
-        ce, "location", value, source=museum, claim_key=claim_key
+        ce, "location", value, source=catalog, claim_key=claim_key
     )
     resolve_all_corporate_entity_locations(subject_ids={ce.pk})
     return ce
@@ -1116,7 +1115,7 @@ def test_remove_member_and_assert_more_specific(bally_wulff):
     # The Germany→Berlin refinement: supersede the Germany membership with an
     # exists=false tombstone and assert Berlin. The resolved set ends as Berlin.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       location: [germany/berlin]
@@ -1141,7 +1140,7 @@ def test_remove_only_member_empties_relationship(bally_wulff):
     # A remove with no accompanying assert is a valid, provenance-bearing entry:
     # the exists=false tombstone is the carrier.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       remove: { location: [germany] }
@@ -1155,11 +1154,11 @@ claims:
 
 def test_remove_cite_and_note_ride_the_tombstone(bally_wulff):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       remove: { location: [germany] }
-      note: 'flip-museum says "headquartered in Berlin".'
+      note: 'flipcommons-catalog says "headquartered in Berlin".'
       cite: https://example.org/bally-wulff
 sources:
   - name: Example
@@ -1171,13 +1170,16 @@ sources:
     tombstone = _location_claim("germany")
     assert tombstone.value["exists"] is False
     assert tombstone.changeset is not None
-    assert tombstone.changeset.note == 'flip-museum says "headquartered in Berlin".'
+    assert (
+        tombstone.changeset.note
+        == 'flipcommons-catalog says "headquartered in Berlin".'
+    )
     assert CitationInstance.objects.filter(claim=tombstone).exists()
 
 
 def test_remove_must_be_a_mapping():
     text = (
-        "attribution: flip-museum\nclaims:\n"
+        "attribution: flipcommons-catalog\nclaims:\n"
         "  - corporate-entity.a:\n      remove: [location]\n"
     )
     with pytest.raises(PatchError, match="'remove' must be a mapping"):
@@ -1188,7 +1190,7 @@ def test_remove_scalar_field_rejected(bally_wulff):
     # A scalar/FK field isn't a relationship namespace — point the author at
     # retract: instead.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       remove: { manufacturer: [williams] }
@@ -1200,7 +1202,7 @@ claims:
 def test_remove_relationship_not_valid_on_subject(bally_wulff):
     # 'theme' is a relationship namespace, but not on CorporateEntity.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       remove: { theme: [medieval] }
@@ -1211,7 +1213,7 @@ claims:
 
 def test_remove_unknown_member_rejected(bally_wulff):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       remove: { location: [atlantis] }
@@ -1221,10 +1223,10 @@ claims:
 
 
 def test_remove_noop_when_source_lacks_claim(bally_wulff):
-    # flip-museum never claimed Berlin membership, so removing it writes no
+    # flipcommons-catalog never claimed Berlin membership, so removing it writes no
     # tombstone — a warning, not an error, so re-running a patch stays safe.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       remove: { location: [germany/berlin] }
@@ -1244,11 +1246,11 @@ def test_remove_noop_with_note_rejected(bally_wulff):
     # have nothing to attach to and would silently vanish — reject it loudly
     # instead (same rule cite: already follows).
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       remove: { location: [germany/berlin] }
-      note: 'flip-museum says "not in Berlin".'
+      note: 'flipcommons-catalog says "not in Berlin".'
 """
     with pytest.raises(PatchError, match="note has nothing to attach to"):
         _apply(text, patch_id="0001-noop-note")
@@ -1258,7 +1260,7 @@ def test_remove_and_assert_same_member_rejected(bally_wulff):
     # Asserting a member present and removing it in one patch would write the
     # same claim_key twice with opposite exists — reject the contradiction.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       location: [germany]
@@ -1271,10 +1273,10 @@ claims:
 def test_remove_and_assert_same_member_rejected_when_unclaimed(bally_wulff):
     # The contradiction is an authoring error knowable from the patch text, so it
     # must be rejected regardless of DB state — even when the source does NOT
-    # currently claim the member (so the removal is a no-op). flip-museum claims
+    # currently claim the member (so the removal is a no-op). flipcommons-catalog claims
     # germany, not germany/berlin, so the remove here is a no-op.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       location: [germany/berlin]
@@ -1286,7 +1288,7 @@ claims:
 
 def test_remove_plus_create_rejected():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.new-firm:
       name: New Firm
@@ -1299,7 +1301,7 @@ claims:
 
 def test_remove_plus_delete_rejected(bally_wulff):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.bally-wulff:
       delete: true
@@ -1318,7 +1320,7 @@ def test_delete_marks_status_deleted(stern_entity):
     # stern_entity has no active referrer, so the delete proceeds and resolves
     # status=deleted onto the entity.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       delete: true
@@ -1337,7 +1339,7 @@ def test_delete_blocked_by_active_referrer(machine_model):
     # active machine blocks the CE delete; the blocker is reported before any
     # write, naming the referrer and the relation.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.williams-electronics:
       delete: true
@@ -1345,14 +1347,14 @@ claims:
     with pytest.raises(PatchError, match="cannot delete.*still referenced"):
         _apply(text, patch_id="0001-del")
     assert not Claim.objects.filter(
-        source__slug="flip-museum", field_name="status"
+        source__slug="flipcommons-catalog", field_name="status"
     ).exists()
 
 
 def test_delete_blocked_caught_in_dry_run(machine_model):
     # The blocker check is a build-phase DB read, so --dry-run surfaces it too.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.williams-electronics:
       delete: true
@@ -1365,7 +1367,7 @@ def test_reassign_in_earlier_patch_then_delete(machine_model, stern_entity):
     # The real workflow: the referrer is reassigned away first (its own patch,
     # applied and resolved), which clears the blocker for a later delete patch.
     reassign = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       expect: {{ corporate_entity: williams-electronics }}
@@ -1376,7 +1378,7 @@ claims:
     assert machine_model.corporate_entity_id == stern_entity.pk
 
     delete = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.williams-electronics:
       delete: true
@@ -1389,7 +1391,7 @@ claims:
 
 def test_delete_is_idempotent(stern_entity):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       delete: true
@@ -1408,7 +1410,7 @@ claims:
 def test_delete_with_expect_guard(stern_entity):
     # A mismatched expect: fails loudly before the delete writes anything.
     bad = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       expect: { manufacturer: williams }
@@ -1420,7 +1422,7 @@ claims:
     assert stern_entity.status != "deleted"
 
     ok = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       expect: { manufacturer: stern }
@@ -1433,7 +1435,7 @@ claims:
 
 def test_delete_nonexistent_rejected():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.no-such-entity:
       delete: true
@@ -1444,7 +1446,7 @@ claims:
 
 def test_delete_with_create_rejected():
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.acme:
       create: true
@@ -1456,7 +1458,7 @@ claims:
 
 def test_delete_with_retract_rejected(stern_entity):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       delete: true
@@ -1470,7 +1472,7 @@ def test_delete_with_field_assertion_rejected(stern_entity):
     # A delete entry carries no field assertions — reassign references in a
     # separate entry/patch, before the delete.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       delete: true
@@ -1485,7 +1487,7 @@ def test_assert_status_field_rejected(stern_entity):
     # bypass the delete planner (no blocker check, no cascade) — reject it and
     # point the author at the directive.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       status: deleted
@@ -1500,7 +1502,7 @@ def test_assert_status_field_does_not_bypass_blocker(machine_model):
     # The back door must not let a raw status=deleted slip past the active
     # PROTECT referrer that delete: true correctly rejects.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.williams-electronics:
       status: deleted
@@ -1508,7 +1510,7 @@ claims:
     with pytest.raises(PatchError, match="'status' is lifecycle"):
         _apply(text)
     assert not Claim.objects.filter(
-        source__slug="flip-museum", field_name="status"
+        source__slug="flipcommons-catalog", field_name="status"
     ).exists()
 
 
@@ -1518,7 +1520,7 @@ def test_delete_cascade_child_same_entity_provenance_guard(machine_model):
     # child's single ChangeSet — the same-entity guard must catch it even
     # though the child was only reached via the cascade.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - title.medieval-madness-title:
       delete: true
@@ -1533,18 +1535,18 @@ claims:
 def test_delete_must_be_boolean():
     with pytest.raises(PatchError, match="'delete' must be a boolean"):
         load_patch(
-            "attribution: flip-museum\nclaims:\n"
+            "attribution: flipcommons-catalog\nclaims:\n"
             "  - corporate-entity.x:\n      delete: yes\n"
         )
 
 
 def test_delete_note_and_cite_attach_to_status_claim(stern_entity):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.stern-pinball-inc:
       delete: true
-      note: 'flip-museum says "this firm never existed".'
+      note: 'flipcommons-catalog says "this firm never existed".'
       cite: https://example.org/proof
 sources:
   - name: Example
@@ -1554,12 +1556,12 @@ sources:
 """
     _apply(text, patch_id="0001-del")
     status_claim = Claim.objects.get(
-        source__slug="flip-museum", field_name="status", is_active=True
+        source__slug="flipcommons-catalog", field_name="status", is_active=True
     )
     assert status_claim.value == "deleted"
     changeset = status_claim.changeset
     assert changeset is not None
-    assert changeset.note == 'flip-museum says "this firm never existed".'
+    assert changeset.note == 'flipcommons-catalog says "this firm never existed".'
     assert CitationInstance.objects.filter(claim=status_claim).exists()
 
 
@@ -1582,7 +1584,7 @@ sources:
 )
 def test_empty_directive_on_create_rejected(directive, match):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.acme:
       create: true
@@ -1596,7 +1598,7 @@ claims:
 @pytest.mark.parametrize("directive", ["retract: []", "remove: {}"])
 def test_empty_directive_on_delete_rejected(directive):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - corporate-entity.acme:
       delete: true
@@ -1611,7 +1613,7 @@ def test_empty_directives_on_edit_are_accepted(machine_model):
     # empty no-op directives (they resolve to no-ops), so the tightening didn't
     # over-reach — guard against a future over-correction.
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       year: 1990
@@ -1630,7 +1632,7 @@ claims:
 
 def test_reassert_same_claim_is_noop(machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       year: 1990
@@ -1647,7 +1649,7 @@ claims:
 
 def test_one_ingestrun_one_changeset(machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       year: 1990
@@ -1663,7 +1665,7 @@ claims:
 
 
 def _src() -> Source:
-    return Source.objects.get(slug="flip-museum")
+    return Source.objects.get(slug="flipcommons-catalog")
 
 
 def test_uppercase_patch_id_rejected():
@@ -1714,7 +1716,7 @@ def _write(dir_path: Path, name: str, text: str) -> None:
 
 def test_command_applies_and_skips_on_rerun(tmp_path, machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 description: tag it
 claims:
   - model.{machine_model.slug}:
@@ -1743,14 +1745,14 @@ claims:
 def test_command_immutability_semantic_change(tmp_path, machine_model):
     p = tmp_path / "0001-year.yaml"
     p.write_text(
-        f"attribution: flip-museum\nclaims:\n  - model.{machine_model.slug}:\n      year: 1990\n",
+        f"attribution: flipcommons-catalog\nclaims:\n  - model.{machine_model.slug}:\n      year: 1990\n",
         encoding="utf-8",
     )
     call_command("ingest_patches", "--patches-dir", str(tmp_path))
 
     # Semantic change to an applied patch → hard error.
     p.write_text(
-        f"attribution: flip-museum\nclaims:\n  - model.{machine_model.slug}:\n      year: 1991\n",
+        f"attribution: flipcommons-catalog\nclaims:\n  - model.{machine_model.slug}:\n      year: 1991\n",
         encoding="utf-8",
     )
     with pytest.raises(CommandError, match="immutable"):
@@ -1760,14 +1762,14 @@ def test_command_immutability_semantic_change(tmp_path, machine_model):
 def test_command_immutability_cosmetic_reformat_skips(tmp_path, machine_model):
     p = tmp_path / "0001-year.yaml"
     p.write_text(
-        f"attribution: flip-museum\nclaims:\n  - model.{machine_model.slug}:\n      year: 1990\n",
+        f"attribution: flipcommons-catalog\nclaims:\n  - model.{machine_model.slug}:\n      year: 1990\n",
         encoding="utf-8",
     )
     call_command("ingest_patches", "--patches-dir", str(tmp_path))
 
     # Cosmetic reformat (added comment + blank lines + spacing) → still skips.
     p.write_text(
-        f"# a comment\nattribution:   flip-museum\n\nclaims:\n\n  - model.{machine_model.slug}:\n      year: 1990\n",
+        f"# a comment\nattribution:   flipcommons-catalog\n\nclaims:\n\n  - model.{machine_model.slug}:\n      year: 1990\n",
         encoding="utf-8",
     )
     call_command("ingest_patches", "--patches-dir", str(tmp_path))
@@ -1780,14 +1782,16 @@ def test_command_immutability_cosmetic_reformat_skips(tmp_path, machine_model):
 
 
 def test_command_preflight_bad_filename(tmp_path):
-    _write(tmp_path, "not-numbered.yaml", "attribution: flip-museum\nclaims: []\n")
+    _write(
+        tmp_path, "not-numbered.yaml", "attribution: flipcommons-catalog\nclaims: []\n"
+    )
     with pytest.raises(CommandError, match="NNNN-slug"):
         call_command("ingest_patches", "--patches-dir", str(tmp_path))
 
 
 def test_command_preflight_duplicate_prefix(tmp_path):
-    _write(tmp_path, "0001-a.yaml", "attribution: flip-museum\nclaims: []\n")
-    _write(tmp_path, "0001-b.yaml", "attribution: flip-museum\nclaims: []\n")
+    _write(tmp_path, "0001-a.yaml", "attribution: flipcommons-catalog\nclaims: []\n")
+    _write(tmp_path, "0001-b.yaml", "attribution: flipcommons-catalog\nclaims: []\n")
     with pytest.raises(CommandError, match="Duplicate patch number"):
         call_command("ingest_patches", "--patches-dir", str(tmp_path))
 
@@ -1807,17 +1811,17 @@ def test_command_stops_at_first_failure(tmp_path, machine_model):
     _write(
         tmp_path,
         "0001-ok.yaml",
-        f"attribution: flip-museum\nclaims:\n  - model.{machine_model.slug}:\n      year: 1990\n",
+        f"attribution: flipcommons-catalog\nclaims:\n  - model.{machine_model.slug}:\n      year: 1990\n",
     )
     _write(
         tmp_path,
         "0002-bad.yaml",
-        "attribution: flip-museum\nclaims:\n  - manufacturer.nope:\n      name: Nope\n",
+        "attribution: flipcommons-catalog\nclaims:\n  - manufacturer.nope:\n      name: Nope\n",
     )
     _write(
         tmp_path,
         "0003-later.yaml",
-        f"attribution: flip-museum\nclaims:\n  - model.{machine_model.slug}:\n      year: 1992\n",
+        f"attribution: flipcommons-catalog\nclaims:\n  - model.{machine_model.slug}:\n      year: 1992\n",
     )
     with pytest.raises(CommandError):
         call_command("ingest_patches", "--patches-dir", str(tmp_path))
@@ -1836,7 +1840,7 @@ def test_command_invalid_claim_value_reported(tmp_path, stern_entity):
     _write(
         tmp_path,
         "0001-bad.yaml",
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "claims:\n"
         "  - corporate-entity.stern-pinball-inc:\n"
         "      year_start: 5000\n",
@@ -1853,7 +1857,7 @@ def test_command_invalid_claim_value_reported(tmp_path, stern_entity):
 
 
 _WIKIPEDIA = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 sources:
   - name: Wikipedia
     source_type: web
@@ -1886,17 +1890,17 @@ def test_sources_only_patch_is_valid_and_applies():
 
 def test_empty_patch_rejected():
     with pytest.raises(PatchError, match="non-empty"):
-        load_patch("attribution: flip-museum\nclaims: []\n")
+        load_patch("attribution: flipcommons-catalog\nclaims: []\n")
 
 
 def test_sources_missing_name_rejected():
     with pytest.raises(PatchError, match="'name' is required"):
-        load_patch("attribution: flip-museum\nsources:\n  - source_type: web\n")
+        load_patch("attribution: flipcommons-catalog\nsources:\n  - source_type: web\n")
 
 
 def test_sources_unknown_key_rejected():
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "sources:\n"
         "  - name: X\n"
         "    source_type: web\n"
@@ -1908,7 +1912,7 @@ def test_sources_unknown_key_rejected():
 
 def test_sources_children_rejected():
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "sources:\n"
         "  - name: X\n"
         "    source_type: web\n"
@@ -1920,7 +1924,7 @@ def test_sources_children_rejected():
 
 def test_sources_link_missing_url_rejected():
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "sources:\n"
         "  - name: X\n"
         "    source_type: web\n"
@@ -1935,7 +1939,7 @@ def test_sources_link_missing_url_rejected():
 
 
 def _bad_source(node_body: str) -> str:
-    return f"attribution: flip-museum\nsources:\n  - {node_body}\n"
+    return f"attribution: flipcommons-catalog\nsources:\n  - {node_body}\n"
 
 
 @pytest.mark.parametrize(
@@ -1962,7 +1966,7 @@ def test_sources_semantic_invalidity_rejected(node_body, match):
 
 def test_sources_duplicate_declared_link_url_rejected():
     text = (
-        "attribution: flip-museum\n"
+        "attribution: flipcommons-catalog\n"
         "sources:\n"
         "  - name: X\n"
         "    source_type: web\n"
@@ -1985,7 +1989,7 @@ def test_sources_semantic_invalidity_caught_at_dry_run():
 
 
 _MULTI_LINK = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 sources:
   - name: Wikipedia
     source_type: web
@@ -2107,7 +2111,7 @@ def test_sources_root_then_cite_nests_no_wedge(machine_model):
     # page in the same patch. The hook runs first, so the cite recognizes the
     # domain and nests under the root instead of raising.
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 sources:
   - name: Wikipedia
     source_type: web
@@ -2172,7 +2176,7 @@ def _alias_claim(value_lower: str) -> Claim:
 
 def test_assert_manufacturer_alias(stern):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       manufacturer_alias: [Stern Pinball]
@@ -2201,7 +2205,7 @@ claims:
 
 def test_assert_abbreviation(machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       abbreviation: [MM]
@@ -2222,7 +2226,7 @@ def test_remove_alias_tombstone_parity(stern):
     # An earlier patch asserts two aliases; a later one removes one. The dropped
     # member's tombstone must be lowercased and carry NO alias_display.
     assert_text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       manufacturer_alias: [Stern Pinball, Stern Inc]
@@ -2232,7 +2236,7 @@ claims:
     assert _alias_values(stern) == {"Stern Pinball", "Stern Inc"}
 
     remove_text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       remove: { manufacturer_alias: [Stern Inc] }
@@ -2253,10 +2257,10 @@ claims:
 
 
 def test_remove_alias_noop_when_source_lacks_claim(stern):
-    # flip-museum never claimed this alias, so removing it warns (no-op) and
+    # flipcommons-catalog never claimed this alias, so removing it warns (no-op) and
     # writes no tombstone — re-running a patch stays safe.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       remove: { manufacturer_alias: [Never Claimed] }
@@ -2273,7 +2277,7 @@ claims:
 def test_reassert_alias_is_unchanged(stern):
     # Re-asserting the same alias from the same source diffs as unchanged.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       manufacturer_alias: [Stern Pinball]
@@ -2292,7 +2296,7 @@ def test_multi_key_relationship_member_rejected(machine_model):
     # rejects at classification — before any member resolution — so no person /
     # role fixtures are needed. Confirms we narrowed the gate, not removed it.
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       credit: [pat-lawlor]
@@ -2336,7 +2340,7 @@ def test_non_string_identity_rejected(monkeypatch):
 def test_alias_over_length_rejected(stern):
     long_alias = "x" * 201  # alias_value bound is 200
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       manufacturer_alias: ["{long_alias}"]
@@ -2348,7 +2352,7 @@ claims:
 def test_abbreviation_over_length_rejected(machine_model):
     long_abbr = "y" * 51  # abbreviation value bound is 50
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       abbreviation: ["{long_abbr}"]
@@ -2374,7 +2378,7 @@ def test_schema_carries_max_length():
 def test_intra_list_duplicate_alias_rejected(stern):
     # Stern and stern fold to the same identity → same claim_key twice.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       manufacturer_alias: [Stern, stern]
@@ -2385,7 +2389,7 @@ claims:
 
 def test_intra_list_duplicate_abbreviation_rejected(machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       abbreviation: [MM, MM]
@@ -2397,7 +2401,7 @@ claims:
 def test_intra_list_duplicate_in_remove_rejected(stern):
     # The remove path dedups by the same fold → claim_key as the assert path.
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       remove: { manufacturer_alias: [Stern Inc, stern inc] }
@@ -2408,7 +2412,7 @@ claims:
 
 def test_blank_alias_member_rejected(stern):
     text = """
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - manufacturer.stern:
       manufacturer_alias: ["   "]
@@ -2419,7 +2423,7 @@ claims:
 
 def test_blank_abbreviation_member_rejected(machine_model):
     text = f"""
-attribution: flip-museum
+attribution: flipcommons-catalog
 claims:
   - model.{machine_model.slug}:
       abbreviation: ["   "]

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -2248,7 +2248,7 @@ claims:
     assert _alias_values(stern) == {"Stern Pinball"}
 
     tombstone = _alias_claim("stern inc")
-    # Exact tombstone shape — lowercased, no alias_display (step 8 invariant).
+    # Exact tombstone shape: lowercased, with display-only fields omitted.
     assert tombstone.value == {"alias_value": "stern inc", "exists": False}
     expected_key, _ = build_relationship_claim(
         "manufacturer_alias", {"alias_value": "stern inc"}, exists=False

--- a/docs/Citations.md
+++ b/docs/Citations.md
@@ -43,6 +43,8 @@ A `CitationInstance` is a single use of a source in a specific place, usually wi
 
 The text uses **point citations**, not text ranges. An inline marker sits at a position and means "this source supports the nearby claim", usually the preceding sentence. Ranges look more precise but demand discipline contributors won't sustain and produce misleadingly precise markup.
 
+The inline marker is a normal **public-id wikilink** keyed on the instance's durable, author-stable **`slug`**: authoring form `[[cite:<slug>]]`, storage form `[[cite:id:<pk>]]` (the same authoring↔storage split as `[[title:…]]` and the other link types). The slug is what makes an inline footnote addressable in a hand- or AI-authored data patch — see [DataPatches.md → Inline citations in descriptions](DataPatches.md#inline-citations-in-descriptions).
+
 ### CitationSourceLink
 
 A `CitationSourceLink` is a reader-facing access point — a canonical URL, an archive URL, an uploaded scan, a museum-hosted copy. Links are ways to _inspect_ a source, not separate sources. They are wholly owned by their source.

--- a/docs/DataPatchAuthoring.md
+++ b/docs/DataPatchAuthoring.md
@@ -93,6 +93,23 @@ Some patches set narrative record descriptions (Manufacturer, Model, …) — pr
 - **No speculation.** Keep it factual; tell the story, don't guess.
 - **Every statement supported.** Back each claim with the entry's `note:`, its `cite:`, or a fact already in the catalog. A statement resting on existing catalog data needs no citation; anything else does.
 - **Attribute to the description source.** Each entity type has its own description source named `flipcommons-ai-desc-<entity-type>` — `flipcommons-ai-desc-manufacturer`, `flipcommons-ai-desc-model`, … — not the generic `flipcommons-catalog`. These sources already exist (the seed ingest creates one per entity type), so just reference one — unlike a `cite:` website root, you don't create it in an earlier patch.
+- **Cite each fact inline.** A narrative description backs individual sentences with **inline `[[cite:…]]` footnotes** rather than one entry-level `cite:` — see [DataPatches.md → Inline citations in descriptions](DataPatches.md#inline-citations-in-descriptions) for the format (numeric handles plus a `cites:` map for new citations; durable slugs for existing ones). An entry-level `cite:` still works for a whole-field source, but inline footnotes are what make each statement individually verifiable. Inline `cites:` count as provenance, so all of an entity's cited fields belong in **one entry**.
+
+### Rehydrating a description for re-edit
+
+To reword one sentence of an existing cited description without re-supplying every other citation, **dump the current text back to authoring form** and edit that:
+
+```bash
+cd backend
+uv run python manage.py dump_patch_entry model.mazatron > /tmp/p/0NNN-reword.yaml
+```
+
+The command emits a complete, runnable patch document with the entity's markdown fields in authoring format (`[[cite:<slug>]]`, real durable slugs in place) — edit a sentence, drop the marker for any citation you remove, and resubmit. Existing slugs self-resolve, so an untouched citation re-applies to byte-identical storage and diffs as a no-op (no churn, no orphaned instance); only a sentence you actually change writes.
+
+Two behaviors to know:
+
+- **`attribution:` defaults to the field's _owning_ source** (the `flipcommons-ai-desc-<type>` that holds the winning description claim), because a re-apply is a faithful no-op only under that source — `_diff_claims` compares within a source. `--attribution <slug>` overrides it, which **forks** the text into a new source-owned claim rather than preserving no-op semantics. A description that was last edited **interactively in-app** is user-owned (no source) and dumps only with an explicit `--attribution`.
+- **The dump omits `expect:`**, so it carries no drift guard — it will apply even if the entity changed between dump and re-apply. Add an `expect:` yourself if that matters.
 
 ### Manufacturer descriptions
 

--- a/docs/DataPatchKit.md
+++ b/docs/DataPatchKit.md
@@ -55,20 +55,22 @@ import patchkit as pk
 
 Import from the authoring dir (`gen.py` does `sys.path.insert(0, <authoring>)`).
 
-| function                                                                                                                   | purpose                                                                                                 |
-| -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `guard(row, prefer=("ipdb_id","year","corporate_entity"))`                                                                 | most specific `expect:` dict from a live-values row; `{}` if none                                       |
-| `check_resolved(requested, found)`                                                                                         | raise if any ref didn't resolve (typo/drift)                                                            |
-| `sentences(text)` / `sentence_with(blob, needle)`                                                                          | split source free text; pull the sentence containing a needle                                           |
-| `clean_ipdb_quote(text, limit=240)`                                                                                        | normalize a quote's typography, strip the IPD header and `…: "<passage>` framing, truncate with `[...]` |
-| `source_note(source, verbatim, tail="")`                                                                                   | build `IPDB says "<verbatim>"` (normalizes typography, preserves non-ASCII; mark omissions `[...]`)     |
-| `entry(ref, *, create, expect, note, cite, fields, description, tags, relationships, remove, retract, commented, comment)` | one correctly-escaped `claims:` block                                                                   |
-| `write_patch(path, *, attribution, description, entries)`                                                                  | a complete patch file                                                                                   |
-| `yamlq` / `clean_text`                                                                                                     | the escaper / the typography normalizer, if you need them directly                                      |
+| function                                                                                                                          | purpose                                                                                                 |
+| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `guard(row, prefer=("ipdb_id","year","corporate_entity"))`                                                                        | most specific `expect:` dict from a live-values row; `{}` if none                                       |
+| `check_resolved(requested, found)`                                                                                                | raise if any ref didn't resolve (typo/drift)                                                            |
+| `sentences(text)` / `sentence_with(blob, needle)`                                                                                 | split source free text; pull the sentence containing a needle                                           |
+| `clean_ipdb_quote(text, limit=240)`                                                                                               | normalize a quote's typography, strip the IPD header and `…: "<passage>` framing, truncate with `[...]` |
+| `source_note(source, verbatim, tail="")`                                                                                          | build `IPDB says "<verbatim>"` (normalizes typography, preserves non-ASCII; mark omissions `[...]`)     |
+| `entry(ref, *, create, expect, note, cite, cites, fields, description, tags, relationships, remove, retract, commented, comment)` | one correctly-escaped `claims:` block                                                                   |
+| `write_patch(path, *, attribution, description, entries)`                                                                         | a complete patch file                                                                                   |
+| `yamlq` / `clean_text`                                                                                                            | the escaper / the typography normalizer, if you need them directly                                      |
 
 **Escaping is solved — use it.** Notes go through `yamlq` (single-quoted YAML: literal except `'`, which doubles). This carries both the double quotes in `... says "x"` and apostrophes, with no backslashes. Do **not** `json.dumps` notes.
 
 **Relationship members.** `entry(...)` also takes `relationships={namespace: [members]}` (the general emitter; `tags=` is the `tag` shorthand) and `remove={namespace: [members]}`. Members are escaped, so string members for aliases / abbreviations are safe — e.g. `relationships={"manufacturer_alias": ["Stern Pinball", "Stern, Inc"]}` or `remove={"abbreviation": ["MedievalMadness"]}`. Alias values case-fold for identity; abbreviations are verbatim (see [DataPatchAuthoring.md → Aliases and abbreviations](DataPatchAuthoring.md#aliases-and-abbreviations)).
+
+**Inline citations.** `entry(..., cites={"1": "ipdb:4443", "2": {"url": "…", "archive": "…"}})` emits a `cites:` map for the new inline footnotes a `description` references as `[[cite:1]]` / `[[cite:2]]` (see [DataPatches.md → Inline citations in descriptions](DataPatches.md#inline-citations-in-descriptions)). `entry()` runs the **within-entry marker ↔ map correspondence guard at author time** — every numeric-handle marker needs a `cites:` entry, every `cites:` key must be a numeric handle a marker references, a slug marker (`[[cite:bqntvkrs]]`, an existing citation) carries no entry — so a structural mistake raises a `ValueError` before the patch ships. It can't confirm a slug _resolves_ (that's the backend's job at apply), and the cross-entry one-entry-per-entity rule stays backend-only (`entry()` sees one entry at a time).
 
 Minimal generator:
 

--- a/docs/DataPatchReviewing.md
+++ b/docs/DataPatchReviewing.md
@@ -27,5 +27,5 @@ Check each against [DataPatchAuthoring.md](DataPatchAuthoring.md):
 - **Attribution** — the right source owns each claim; a retraction sits with whoever made the original claim; a narrative description uses its `flipcommons-ai-desc-<entity-type>` source.
 - **Values accurate** — each asserted value matches the cited evidence.
 - **Notes verbatim** — `note:` quotes the source faithfully (omissions marked `[...]`, non-ASCII preserved).
-- **Citations support the claim** — the `cite:` record actually states the asserted fact.
+- **Citations support the claim** — the `cite:` record actually states the asserted fact, and each inline `[[cite:…]]` footnote in a description has a source that supports its sentence.
 - **Descriptions** — follow [Record descriptions](DataPatchAuthoring.md#record-descriptions): factual, supported, not a title dump, no phrasing that will date.

--- a/docs/DataPatches.md
+++ b/docs/DataPatches.md
@@ -113,7 +113,7 @@ Entity references are of format `type.public_id` — the canonical `entity_type`
 
 Field keys are classified by introspection: **scalar** (`year`) — value used as-is; **FK** (`manufacturer`, `production_status`) — value is the target's `public_id`; **relationship** (`tag`, `theme`, `manufacturer_alias`, `abbreviation`) — key is the namespace, value a list of members (FK public_ids, or bare strings for aliases/abbreviations). The lifecycle field **`status` is not directly assertable** — a raw `status: deleted` would skip the delete planner's blocker check and cascade, so it's rejected; soft-delete via `delete: true` instead.
 
-Distinct from field keys are the **reserved keys** — directives, not claims: `create:`, `delete:`, `retract:` and `remove:` (each covered with its operation above), plus the cross-cutting `expect:`, `note:` and `cite:` (below).
+Distinct from field keys are the **reserved keys** — directives, not claims: `create:`, `delete:`, `retract:` and `remove:` (each covered with its operation above), plus the cross-cutting `expect:`, `note:`, `cite:` and `cites:` (below).
 
 ### Aliases & abbreviations
 
@@ -171,6 +171,54 @@ Two rules tie note/cite to the single changeset an entry produces:
 
 - **One provenance-bearing entry per entity.** Two entries resolving to the same entity that both set `note`/`cite` is an error — combine them into one.
 - **Provenance rides only an actual write (v1).** note/cite attach to what the patch writes. An entry with nothing to attach to (retraction-only, field-less create, empty `tag: []`) is a hard error. And re-asserting a value the entity already has from the same source diffs as unchanged — no claim, no changeset — so its `note`/`cite` are **silently dropped though the patch reports success**. To record provenance, the entry must change a value or create the entity.
+
+### Inline citations in descriptions
+
+A markdown field (a `description`) can carry **inline footnotes** — an `[[cite:…]]` marker placed after a fact, backing the nearby sentence, rendered as a numbered `[1]` footnote. Each distinct footnote is one `CitationInstance` that **floats** (`claim=null`): it's evidence for a passage, not for the whole field, so it isn't tied to any one claim. Markers reference that instance by its handle — repeat a handle and both markers point at the one footnote. A marker comes in two forms, told apart by its handle's grammar:
+
+- **A new footnote** uses a **numeric handle** (`[[cite:1]]`) declared in a `cites:` map on the same entry. The handle is an ephemeral authoring label wiring the marker to its source; it is minted to a durable citation at apply time. Handles are arbitrary **all-digit** labels with **no ordering or contiguity** requirement (`1`, `2` is convention, not a rule) and a handle is **not** the rendered footnote number (render numbers by order of first appearance). A handle may repeat — two `[[cite:1]]` markers point at the one footnote.
+- **An existing footnote** uses the citation's durable **slug** (`[[cite:bqntvkrs]]`) and needs **no** `cites:` entry — it self-resolves. This is the re-edit form you get from rehydration (below).
+
+First authoring — new citations via numeric handles plus a `cites:` map:
+
+```yaml
+attribution: flipcommons-ai-desc-model
+claims:
+  - model.mazatron:
+      expect: { ipdb_id: 4443 }
+      description: >
+        A 1990 solid-state prototype by Mac Pinball.[[cite:1]]
+        Only two units are known to survive.[[cite:2]]
+      cites:
+        "1": ipdb:4443
+        "2": https://pinside.com/thread
+      note: "Narrative compiled from IPDB and Pinside."
+```
+
+`cites:` declares **only new** citations. Each key is a **numeric handle quoted as a string** (`"1":`, never bare `1:` — an unquoted integer key is a hard parse error) and each value is a cite-spec in the **same v1 grammar as `cite:`** — `scheme:identifier`, an `http(s)://` URL or a `{ url, archive }` map (per-citation locators are deferred to v2). The spec resolves through the same source get-or-create as `cite:`, so a URL still needs its [website root seeded](#citation-sources).
+
+**Marker ↔ map correspondence is enforced** (a structural error, no DB lookup): every numeric-handle marker must have a `cites:` entry, and every `cites:` key must be a numeric handle referenced by at least one marker. A `cites:` entry keyed by a slug, or one no marker references, is a misuse. A marker that is neither all-digits nor a bare slug — notably a raw `[[cite:id:1]]` (storage form) — is rejected.
+
+**Inline `cites:` count as provenance**, so the [one-provenance-bearing-entry-per-entity rule](#notes--citations) applies: an entity's cited description must live in a **single entry** — two entries on the same entity where either carries `cites:` (or `note:`/`cite:`) are rejected ("combine them into one entry").
+
+Re-edit (rehydrated) — markers carry durable slugs, untouched cites need no `cites:`:
+
+```yaml
+attribution: flipcommons-ai-desc-model
+claims:
+  - model.mazatron:
+      description: >
+        A 1990 solid-state prototype manufactured by Mac Pinball.[[cite:bqntvkrs]]
+        Only two units are known to survive.[[cite:mwzfprhd]]
+      note: "Reworded the first sentence."
+```
+
+Re-applying a description with only existing slugs mints nothing and produces byte-identical storage, so it diffs as a no-op — reword one sentence and resubmit with every other citation intact. Generate this shape with [`dump_patch_entry`](DataPatchAuthoring.md#rehydrating-a-description-for-re-edit) rather than hand-copying slugs.
+
+Two limitations to know:
+
+- **`--dry-run` skips validating an assertion that references any new handle** (the slug isn't minted yet, so conversion can't resolve it). Such an assertion is counted but not diffed; its existing-slug portion isn't dry-validated either. Real validation is the snapshot+apply loop.
+- **A bad or stale slug fails at apply with a _generic_ message** — `"N claim(s) failed validation"` live, `"Invalid claim: …"` in dry-run. The specific `Cite not found: [[cite:<slug>]]` only reaches the logs, so don't expect a friendly per-marker error.
 
 ### Strict parsing
 
@@ -252,7 +300,7 @@ On localhost, the simplest undo is restoring a pre-apply snapshot (see [DataPatc
 
 ## Limitations
 
-We've been building the patch system on an as-needed basis. These haven't been needed yet.
+We've been building the patch system on an as-needed basis. These haven't been implemented yet.
 
 - **No same-patch reassign-then-delete** — a `delete:`'s referrer check reads live DB state, so a reference reassigned earlier in the _same_ patch isn't yet visible; reassign in an earlier numbered patch, then delete.
 - `expect:` covers scalar + FK only, not relationships. (`retract:` is scalar/FK; relationship members are dropped with `remove:`.)


### PR DESCRIPTION
## Summary

Data patches can now author record descriptions whose individual facts are backed by inline `[[cite:…]]` footnotes, and reword one sentence later without re-supplying every other citation.

- **New footnote** — a numeric handle (`[[cite:1]]`) declared in a per-entry `cites:` map, minted at apply time to a floating (`claim=null`) citation with a durable, author-stable slug.
- **Existing footnote** — the citation's slug (`[[cite:bqntvkrs]]`); it self-resolves and needs no `cites:` entry, so an untouched citation survives a re-edit untouched.
- **`manage.py dump_patch_entry <type.public_id>`** rehydrates an entity's markdown fields back to authoring form (real slugs in place) as a complete, runnable patch. Reapplying the unedited dump produces byte-identical storage and diffs as a no-op (no churn, no orphaned citation). It defaults `attribution:` to the field's owning source so that no-op holds; `--attribution` overrides it (forking a new claim), and is required for a description last edited interactively in-app (user-owned, no source).
- Rides the slug-keyed `cite` wikilink type already on `main`, so marker conversion, render and round-trip all go through the standard machinery rather than a bespoke path.
- Docs updated: `DataPatches.md` (inline-citations section + `cites:` reserved key), `DataPatchAuthoring.md` (authoring guidance + the rehydration command), `DataPatchKit.md` (`entry(cites=)` + the author-time marker/map guard), `Citations.md` (slug-keyed inline marker), `DataPatchReviewing.md` (inline-footnote review item).

## Test plan

- [ ] `cd backend && uv run pytest apps/catalog/tests/ -k "patch or dump or cite"`
- [ ] `uv run mypy` and `make lint` clean
- [ ] Apply a patch with an inline-cited description, confirm `CitationInstance` rows are floating (`claim_id IS NULL`) with slugs, storage holds `[[cite:id:<pk>]]` and render shows numbered footnotes.
- [ ] `dump_patch_entry <ref>` round-trips that description back to `[[cite:<slug>]]`; reapplying the unedited dump mints nothing and changes no claim.
- [ ] Verified end-to-end against the full pindata patch set on a restored snapshot: migrations backfill slugs, all patches apply clean, and the dump round-trips byte-identically on a real cited description.