### PR TITLE
Render edit-history wikilinks in authoring form

### DIFF
--- a/backend/apps/core/markdown/__init__.py
+++ b/backend/apps/core/markdown/__init__.py
@@ -18,10 +18,13 @@ Layout:
 
 from apps.core.markdown.field import (
     MarkdownField,
+    WikilinkAuthoringLookup,
+    apply_storage_to_authoring,
     convert_authoring_to_storage,
     convert_storage_to_authoring,
     get_markdown_fields,
     prepare_markdown_claim_value,
+    resolve_wikilink_authoring,
 )
 from apps.core.markdown.render import (
     RenderedField,
@@ -36,12 +39,15 @@ from apps.core.markdown.render import (
 __all__ = [
     "MarkdownField",
     "RenderedField",
+    "WikilinkAuthoringLookup",
+    "apply_storage_to_authoring",
     "convert_authoring_to_storage",
     "convert_storage_to_authoring",
     "get_markdown_fields",
     "link_preview",
     "prepare_markdown_claim_value",
     "render_all_links",
+    "resolve_wikilink_authoring",
     "render_markdown_field",
     "render_markdown_fields",
     "render_markdown_html",

--- a/backend/apps/core/markdown/field.py
+++ b/backend/apps/core/markdown/field.py
@@ -9,7 +9,8 @@ model never drags in the reference graph.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -149,54 +150,126 @@ def _convert_to_storage(
     return result
 
 
-def convert_storage_to_authoring(content: str) -> str:
-    """Convert storage format links to authoring format for editing.
+class WikilinkRef(NamedTuple):
+    """A storage-form wikilink target: a link type plus the row's pk.
 
-    Only affects public-id-based types; ID-based types are the same in both formats.
+    Mirrors :class:`apps.provenance.display.FkRef` — a named key so the
+    authoring-lookup map isn't a bare ``tuple[str, int]`` whose positions
+    need a comment to read.
     """
-    if not content:
-        return content
+
+    type_name: str
+    pk: int
+
+
+class WikilinkAuthoringLookup:
+    """Authoring keys resolved from :class:`WikilinkRef`\\ s.
+
+    Built once per batch by :func:`resolve_wikilink_authoring`; consulted by
+    :func:`apply_storage_to_authoring` to rewrite ``[[type:id:N]]`` markers
+    without re-querying. Same encapsulated shape as
+    :class:`apps.provenance.display.LabelLookup` — the backing dict stays
+    private so callers go through ``add``/``get``.
+    """
+
+    __slots__ = ("_keys",)
+
+    def __init__(self) -> None:
+        self._keys: dict[WikilinkRef, str] = {}
+
+    def add(self, ref: WikilinkRef, key: str) -> None:
+        self._keys[ref] = key
+
+    def get(self, ref: WikilinkRef) -> str | None:
+        return self._keys.get(ref)
+
+
+def resolve_wikilink_authoring(texts: Iterable[str]) -> WikilinkAuthoringLookup:
+    """Batch-resolve every ``[[type:id:N]]`` marker across ``texts`` to its
+    authoring key.
+
+    One query per enabled public-id link type (bounded by the number of link
+    types, independent of how many texts are passed), so callers rendering
+    many markdown values — edit history, sources — stay query-bounded. Only
+    public-id types are resolved; ID-based types are identical in both formats
+    and need no conversion.
+    """
+    from apps.core.wikilinks import get_enabled_public_id_types, get_patterns
+
+    materialized = [t for t in texts if t]
+    lookup = WikilinkAuthoringLookup()
+    if not materialized:
+        return lookup
+
+    for lt in get_enabled_public_id_types():
+        # public_id_field is non-None for every type get_enabled_public_id_types yields.
+        assert lt.public_id_field is not None
+        pattern = get_patterns(lt)["storage"]
+        ids: set[int] = set()
+        for text in materialized:
+            ids.update(int(m.group(1)) for m in pattern.finditer(text))
+        if not ids:
+            continue
+        model = lt.get_model()
+        for obj in model.objects.filter(pk__in=ids):
+            key = (
+                lt.get_authoring_key(obj)
+                if lt.get_authoring_key
+                else getattr(obj, lt.public_id_field)
+            )
+            lookup.add(WikilinkRef(lt.name, obj.pk), key)
+    return lookup
+
+
+def apply_storage_to_authoring(text: str, lookup: WikilinkAuthoringLookup) -> str:
+    """Rewrite ``[[type:id:N]]`` markers in ``text`` to authoring form using a
+    pre-resolved ``lookup`` — no DB access.
+
+    Broken links (target deleted, so absent from ``lookup``) keep storage
+    form, matching the editor's behavior.
+    """
+    if not text:
+        return text
 
     from apps.core.wikilinks import get_enabled_public_id_types, get_patterns
 
     for lt in get_enabled_public_id_types():
-        pats = get_patterns(lt)
-        content = _convert_to_authoring(content, lt, pats["storage"])
-    return content
+        text = _apply_authoring_one(text, lt, get_patterns(lt)["storage"], lookup)
+    return text
 
 
-def _convert_to_authoring(
-    content: str,
+def _apply_authoring_one(
+    text: str,
     lt: LinkType,
     pattern: re.Pattern[str],
+    lookup: WikilinkAuthoringLookup,
 ) -> str:
-    """Convert ``[[type:id:N]]`` to ``[[type:public_id]]`` for one link type."""
-    if lt.public_id_field is None:
-        raise ValueError(f"LinkType '{lt.name}' is not public-id-based")
-    matches = list(pattern.finditer(content))
+    """Rewrite one link type's storage markers using ``lookup``."""
+    matches = list(pattern.finditer(text))
     if not matches:
-        return content
-
-    model = lt.get_model()
-    ids = [int(m.group(1)) for m in matches]
-    by_id = {obj.pk: obj for obj in model.objects.filter(pk__in=ids)}
-
-    result = content
+        return text
+    result = text
     for match in reversed(matches):
-        obj_id = int(match.group(1))
-        obj = by_id.get(obj_id)
-        if obj:
-            if lt.get_authoring_key:
-                key = lt.get_authoring_key(obj)
-            else:
-                key = getattr(obj, lt.public_id_field)
+        key = lookup.get(WikilinkRef(lt.name, int(match.group(1))))
+        if key is not None:
             result = (
                 result[: match.start()] + f"[[{lt.name}:{key}]]" + result[match.end() :]
             )
-        else:
-            # Keep storage format for broken links (target deleted)
-            result = result[: match.start()] + match.group(0) + result[match.end() :]
+        # else: keep storage form (target deleted)
     return result
+
+
+def convert_storage_to_authoring(content: str) -> str:
+    """Convert storage format links to authoring format for editing.
+
+    Only affects public-id-based types; ID-based types are the same in both
+    formats. Single-text convenience over the batched
+    :func:`resolve_wikilink_authoring` / :func:`apply_storage_to_authoring`
+    pair, so the editor path and batched callers share one code path.
+    """
+    if not content:
+        return content
+    return apply_storage_to_authoring(content, resolve_wikilink_authoring([content]))
 
 
 def prepare_markdown_claim_value(

--- a/backend/apps/provenance/api.py
+++ b/backend/apps/provenance/api.py
@@ -29,7 +29,7 @@ from apps.core.authz.types import Activity
 from apps.core.models import LinkableModel
 from apps.core.schemas import ErrorDetailSchema
 
-from .display import FieldValue, claim_value, resolve_labels
+from .display import FieldValue, claim_value, resolve_display_context
 from .models import CitationInstance, Claim, ClaimControlledModel, Source
 from .page_endpoints import pages_router
 from .schemas import (
@@ -109,7 +109,7 @@ def list_review_claims(request: HttpRequest) -> list[ReviewClaimSchema]:
         .prefetch_related("subject")
         .order_by("-created_at")
     )
-    labels = resolve_labels(FieldValue(c.field_name, c.value) for c in claims)
+    ctx = resolve_display_context(FieldValue(c.field_name, c.value) for c in claims)
 
     results: list[ReviewClaimSchema] = []
     for claim in claims:
@@ -119,6 +119,12 @@ def list_review_claims(request: HttpRequest) -> list[ReviewClaimSchema]:
         assert subject is None or isinstance(subject, ClaimControlledModel)
         subject_name = str(subject) if subject else "Unknown"
         subject_slug = subject.slug if subject is not None else None
+        # Cross-entity loop: the subject model varies per claim and is needed
+        # to dispatch markdown display. content_type is select_related above, so
+        # this is query-free, and it works even when the subject row is deleted.
+        subject_model = claim.content_type.model_class()
+        assert subject_model is not None
+        assert issubclass(subject_model, ClaimControlledModel)
         if claim.field_name == "title":
             review_links, title_slug = _build_claim_review_context(claim)
         else:
@@ -128,7 +134,7 @@ def list_review_claims(request: HttpRequest) -> list[ReviewClaimSchema]:
                 id=claim.pk,
                 source_name=claim.source.name if claim.source else "User",
                 field_name=claim.field_name,
-                value=claim_value(claim.field_name, claim.value, labels),
+                value=claim_value(subject_model, claim.field_name, claim.value, ctx),
                 needs_review_notes=claim.needs_review_notes,
                 created_at=claim.created_at.isoformat(),
                 subject_type=_subject_entity_type(claim),

--- a/backend/apps/provenance/display.py
+++ b/backend/apps/provenance/display.py
@@ -25,16 +25,27 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from typing import NamedTuple
 
 from django.db.models import Model
 
+from apps.core.markdown import (
+    WikilinkAuthoringLookup,
+    apply_storage_to_authoring,
+    get_markdown_fields,
+    resolve_wikilink_authoring,
+)
+
+from .models import ClaimControlledModel
 from .schemas import (
     ClaimDisplayIdentityPartSchema,
     ClaimDisplayIdentityState,
     ClaimDisplayQualifierPartSchema,
+    ClaimDisplaySchema,
     ClaimDisplayValueSchema,
     ClaimValueSchema,
+    MarkdownClaimDisplaySchema,
 )
 from .validation import (
     RelationshipSchema,
@@ -261,14 +272,74 @@ def resolve_labels(items: Iterable[FieldValue]) -> LabelLookup:
     return lookup
 
 
-def build_display_value(
-    field_name: str, value: object, labels: LabelLookup
-) -> ClaimDisplayValueSchema | None:
-    """Return a structured display rendering for a relationship-claim value.
+@dataclass(frozen=True)
+class ClaimDisplayContext:
+    """Pre-resolved references for rendering a batch of claim values.
 
-    Returns ``None`` when ``value`` isn't a relationship-claim dict —
-    direct-field scalars and unknown namespaces fall through, and the
-    frontend renders the raw value.
+    Built once per response by :func:`resolve_display_context` so display
+    rendering issues no per-row queries: ``labels`` resolves relationship FK
+    pks to labels, ``wikilinks`` resolves markdown ``[[type:id:N]]`` markers to
+    their authoring keys.
+    """
+
+    labels: LabelLookup
+    wikilinks: WikilinkAuthoringLookup
+
+
+def resolve_display_context(items: Iterable[FieldValue]) -> ClaimDisplayContext:
+    """Resolve FK labels and wikilink authoring keys for ``items`` in one pass.
+
+    One query per FK target model (via :func:`resolve_labels`) plus one per
+    enabled public-id link type (via :func:`resolve_wikilink_authoring`) —
+    bounded independent of the number of claims. The wikilink scan reads every
+    string value (markers are self-typed, so a non-markdown string simply
+    contributes no markers); only :func:`build_display_value` needs the
+    per-claim model, to decide whether to emit the markdown rendering.
+    """
+    materialized = list(items)
+    return ClaimDisplayContext(
+        labels=resolve_labels(materialized),
+        wikilinks=resolve_wikilink_authoring(
+            value for _, value in materialized if isinstance(value, str)
+        ),
+    )
+
+
+def build_display_value(
+    model: type[ClaimControlledModel],
+    field_name: str,
+    value: object,
+    ctx: ClaimDisplayContext,
+) -> ClaimDisplaySchema | None:
+    """Return the user-facing rendering for a claim value, dispatched by kind.
+
+    Model-driven, three-way dispatch derived from introspection — no
+    hardcoded field names:
+
+    - **relationship** — ``field_name`` is a registered relationship
+      namespace and ``value`` is its dict payload → structured
+      identity/qualifier rendering.
+    - **markdown** — ``field_name`` is a ``MarkdownField`` on ``model`` and
+      ``value`` is a non-empty string → authoring-form text (``[[type:id:N]]``
+      resolved to ``[[type:slug]]``).
+    - otherwise → ``None``; direct-field scalars and unknown namespaces fall
+      through and the frontend renders the raw value.
+    """
+    if isinstance(value, dict):
+        schema = get_relationship_schema(field_name)
+        if schema is not None:
+            return _build_relationship_display(value, schema, ctx.labels)
+    if isinstance(value, str) and value and field_name in get_markdown_fields(model):
+        return MarkdownClaimDisplaySchema(
+            text=apply_storage_to_authoring(value, ctx.wikilinks)
+        )
+    return None
+
+
+def _build_relationship_display(
+    value: dict[str, object], schema: RelationshipSchema, labels: LabelLookup
+) -> ClaimDisplayValueSchema:
+    """Structured rendering for a relationship-claim value.
 
     Generic engine: identity slots are emitted in declaration order via
     :func:`resolve_identity_label`; non-identity, non-display-override
@@ -277,12 +348,6 @@ def build_display_value(
     falsy qualifiers (``None``, ``False``, ``0``, ``""``) are emitted —
     "should this be visible to the user" is the frontend's job.
     """
-    if not isinstance(value, dict):
-        return None
-    schema = get_relationship_schema(field_name)
-    if schema is None:
-        return None
-
     # display_key targets are consumed by their identity spec's rendering;
     # they must not also surface as qualifiers.
     consumed_by_display: set[str] = {
@@ -344,9 +409,12 @@ def build_display_value(
 
 
 def claim_value(
-    field_name: str, value: object, labels: LabelLookup
+    model: type[ClaimControlledModel],
+    field_name: str,
+    value: object,
+    ctx: ClaimDisplayContext,
 ) -> ClaimValueSchema:
-    """Bundle a raw claim value with its structured display rendering."""
+    """Bundle a raw claim value with its user-facing display rendering."""
     return ClaimValueSchema(
-        raw=value, display=build_display_value(field_name, value, labels)
+        raw=value, display=build_display_value(model, field_name, value, ctx)
     )

--- a/backend/apps/provenance/helpers.py
+++ b/backend/apps/provenance/helpers.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import cast
 
-from django.db import models
 from django.db.models import Case, F, IntegerField, Prefetch, QuerySet, Value, When
 
-from .display import FieldValue, claim_value, resolve_labels
-from .models import ChangeSet, CitationInstance, Claim
+from .display import FieldValue, claim_value, resolve_display_context
+from .models import ChangeSet, CitationInstance, Claim, ClaimControlledModel
 from .schemas import (
     ClaimAttributionSchema,
     ClaimAuthorSchema,
@@ -82,7 +81,7 @@ def claims_prefetch(
     return Prefetch("claims", queryset=queryset, to_attr=to_attr)
 
 
-def active_claims(entity: models.Model) -> list[Claim]:
+def active_claims(entity: ClaimControlledModel) -> list[Claim]:
     """Return the list of active claims prefetched onto *entity*.
 
     Raises AssertionError if the queryset wasn't set up with
@@ -110,17 +109,25 @@ def citation_instances(claim: Claim) -> list[CitationInstance]:
     return cast(list[CitationInstance], instances)
 
 
-def build_sources(claims: Iterable[Claim]) -> list[ClaimSchema]:
+def build_sources(
+    model: type[ClaimControlledModel], claims: Iterable[Claim]
+) -> list[ClaimSchema]:
     """Serialize pre-fetched active claims into the sources list format.
+
+    ``model`` is the subject entity's class — all claims belong to one entity,
+    so it is uniform and the caller supplies it (do not hop
+    ``claim.content_type`` per claim: ``claims_prefetch`` does not
+    ``select_related`` it, so that would be an N+1).
 
     Claims should be ordered by claim_key, -priority, -created_at. The first
     claim seen per claim_key is marked as the winner.
 
-    The iterable is materialized to a list internally so FK display labels can
-    be resolved in a single batched pass before the per-claim loop.
+    The iterable is materialized to a list internally so FK labels and
+    wikilink authoring keys can be resolved in a single batched pass before
+    the per-claim loop.
     """
     claims = list(claims)
-    labels = resolve_labels(FieldValue(c.field_name, c.value) for c in claims)
+    ctx = resolve_display_context(FieldValue(c.field_name, c.value) for c in claims)
     winners: set[str] = set()
     sources: list[ClaimSchema] = []
     for claim in claims:
@@ -134,7 +141,7 @@ def build_sources(claims: Iterable[Claim]) -> list[ClaimSchema]:
                     created_at=claim.created_at.isoformat(),
                 ),
                 field_name=claim.field_name,
-                value=claim_value(claim.field_name, claim.value, labels),
+                value=claim_value(model, claim.field_name, claim.value, ctx),
                 citation=claim.citation,
                 is_winner=is_winner,
                 changeset_note=claim.changeset.note if claim.changeset else None,

--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -7,14 +7,19 @@ from collections.abc import Iterable, Mapping, Sequence
 from itertools import chain
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Case, F, IntegerField, Model, Prefetch, Q, Value, When
+from django.db.models import Case, F, IntegerField, Prefetch, Q, Value, When
 
 from apps.citation.models import CitationSourceLink
 from apps.core.authz import PolicyUser, compute_row_capabilities
 
-from .display import FieldValue, LabelLookup, claim_value, resolve_labels
+from .display import (
+    ClaimDisplayContext,
+    FieldValue,
+    claim_value,
+    resolve_display_context,
+)
 from .helpers import changeset_author, citation_instances, citation_instances_prefetch
-from .models import ChangeSet, Claim
+from .models import ChangeSet, Claim, ClaimControlledModel
 from .schemas import (
     ChangeSetSchema,
     ClaimAttributionSchema,
@@ -74,18 +79,22 @@ def _prior_value(claim: Claim, chain: Sequence[Claim]) -> object | None:
 
 
 def build_changes(
+    model: type[ClaimControlledModel],
     own_claims: Iterable[Claim],
     retracted: Iterable[Claim],
     history_by_key: Mapping[str, Sequence[Claim]],
     *,
     winning_ids: set[int] | None = None,
-    labels: LabelLookup | None = None,
+    ctx: ClaimDisplayContext | None = None,
 ) -> tuple[list[FieldChangeSchema], list[RetractionSchema]]:
     """Build per-field changes and retractions for a changeset.
 
-    No per-row DB lookups during display-label building: pass a pre-built ``labels``
+    ``model`` is the subject entity's class — all claims here belong to one
+    entity, so the model is uniform; it lets display dispatch markdown fields.
+
+    No per-row DB lookups during display building: pass a pre-built ``ctx``
     when the caller already has one (e.g. a multi-changeset response that
-    resolved labels across the whole entity); otherwise this builds its
+    resolved references across the whole entity); otherwise this builds its
     own from the union of values referenced here.
 
     ``winning_ids`` is only meaningful for entity-wide history; omit it for
@@ -94,8 +103,8 @@ def build_changes(
     own = list(own_claims)
     rets = list(retracted)
 
-    if labels is None:
-        labels = resolve_labels(
+    if ctx is None:
+        ctx = resolve_display_context(
             FieldValue(c.field_name, c.value)
             for c in chain(own, rets, *history_by_key.values())
         )
@@ -104,9 +113,11 @@ def build_changes(
     for claim in own:
         prior = _prior_value(claim, history_by_key.get(claim.claim_key, []))
         old_value = (
-            claim_value(claim.field_name, prior, labels) if prior is not None else None
+            claim_value(model, claim.field_name, prior, ctx)
+            if prior is not None
+            else None
         )
-        new_value = claim_value(claim.field_name, claim.value, labels)
+        new_value = claim_value(model, claim.field_name, claim.value, ctx)
         changes.append(
             FieldChangeSchema(
                 field_name=claim.field_name,
@@ -129,7 +140,7 @@ def build_changes(
             claim_id=c.pk,
             field_name=c.field_name,
             claim_key=c.claim_key,
-            old_value=claim_value(c.field_name, c.value, labels),
+            old_value=claim_value(model, c.field_name, c.value, ctx),
         )
         for c in rets
     ]
@@ -171,13 +182,16 @@ def _compute_winning_claim_ids(ct: ContentType, entity_pk: int) -> set[int]:
     return winners
 
 
-def build_edit_history(entity: Model, user: PolicyUser) -> list[ChangeSetSchema]:
+def build_edit_history(
+    entity: ClaimControlledModel, user: PolicyUser
+) -> list[ChangeSetSchema]:
     """Build changeset-grouped edit history with old→new diffs for an entity.
 
     Returns ChangeSetSchema rows newest first. Query count is bounded
     independent of changeset count: changesets+prefetches, all claims for
-    the entity (for old-value lookup), winning-claim computation, and one
-    query per distinct FK target model build_display_label needs to resolve.
+    the entity (for old-value lookup), winning-claim computation, one query
+    per distinct FK target model display needs to resolve, and one per
+    public-id link type for markdown wikilink rendering.
 
     ``user`` is the caller (boundary-cast via ``policy_user``) and is
     used to populate the per-row ``capabilities`` map.
@@ -231,20 +245,23 @@ def build_edit_history(entity: Model, user: PolicyUser) -> list[ChangeSetSchema]
     # 3. Compute winning claims for is_winning.
     winning_ids = _compute_winning_claim_ids(ct, entity.pk)
 
-    # 4. Resolve FK labels once across every value any changeset will
-    #    render. ``all_claims`` is the superset (current claims, retracted
-    #    claims, and history chains all draw from it), so one pass suffices.
-    labels = resolve_labels(FieldValue(c.field_name, c.value) for c in all_claims)
+    # 4. Resolve FK labels and wikilink authoring keys once across every value
+    #    any changeset will render. ``all_claims`` is the superset (current
+    #    claims, retracted claims, and history chains all draw from it), so one
+    #    pass suffices.
+    ctx = resolve_display_context(FieldValue(c.field_name, c.value) for c in all_claims)
+    model = type(entity)
 
     # 5. Build response.
     result: list[ChangeSetSchema] = []
     for cs in changesets:
         changes, retractions = build_changes(
+            model,
             cs.claims.all(),
             cs.retracted_claims.all(),
             history,
             winning_ids=winning_ids,
-            labels=labels,
+            ctx=ctx,
         )
         assert cs.pk is not None
         result.append(

--- a/backend/apps/provenance/page_endpoints.py
+++ b/backend/apps/provenance/page_endpoints.py
@@ -38,6 +38,7 @@ from .helpers import (
     claims_prefetch,
 )
 from .history import build_changes, build_edit_history
+from .models import ClaimControlledModel
 from .models.changeset import ChangeSet
 from .schemas import (
     ChangeSetBaseSchema,
@@ -151,6 +152,10 @@ def edit_history_page(
     except ValueError:
         return Status(404, {"detail": f"Unknown entity type: {entity_type}"})
     entity = get_object_or_404(model_class, **{model_class.public_id_field: public_id})
+    # get_linkable_model returns type[LinkableModel]; every catalog entity type
+    # it resolves is also a ClaimControlledModel. Narrow for the typed display
+    # surface (same guard validation uses).
+    assert isinstance(entity, ClaimControlledModel)
     return build_edit_history(entity, policy_user(request.user))
 
 
@@ -178,8 +183,9 @@ def sources_page(
         model_class._default_manager.prefetch_related(claims_prefetch()),
         **{model_class.public_id_field: public_id},
     )
+    assert isinstance(entity, ClaimControlledModel)
     claims = active_claims(entity)
-    sources = build_sources(claims)
+    sources = build_sources(type(entity), claims)
     caller = policy_user(request.user)
     evidence: list[CitedChangeSetSchema] = []
     for row in build_cited_changesets(claims):
@@ -390,7 +396,12 @@ def change_detail(
     for c in history_claims:
         by_key[c.claim_key].append(c)
 
-    changes, retractions = build_changes(claims, retracted, by_key)
+    # Cross-entity site: resolve the subject model from the content type
+    # (process-cached, query-free after warmup — no select_related needed).
+    subject_model = ContentType.objects.get_for_id(ct_id).model_class()
+    assert subject_model is not None
+    assert issubclass(subject_model, ClaimControlledModel)
+    changes, retractions = build_changes(subject_model, claims, retracted, by_key)
 
     assert cs.pk is not None
     return ChangeSetDetailSchema(

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -76,8 +76,15 @@ class ClaimDisplayQualifierPartSchema(Schema):
 
 
 class ClaimDisplayValueSchema(Schema):
-    """Structured user-facing rendering of a relationship-claim value."""
+    """Structured user-facing rendering of a relationship-claim value.
 
+    The ``relationship`` arm of :data:`ClaimDisplaySchema`.
+    """
+
+    kind: Annotated[
+        Literal["relationship"],
+        Field(description='Discriminator; always "relationship".'),
+    ] = "relationship"
     identity: list[ClaimDisplayIdentityPartSchema] = Field(
         description="The claim's identity slots, in display order."
     )
@@ -90,6 +97,34 @@ class ClaimDisplayValueSchema(Schema):
     # frontend falls back to the raw ``old_value`` / ``new_value`` there.
 
 
+class MarkdownClaimDisplaySchema(Schema):
+    """User-facing rendering of a markdown-field claim value.
+
+    The ``markdown`` arm of :data:`ClaimDisplaySchema`. ``text`` is the value
+    in authoring form — ``[[type:id:N]]`` storage markers resolved to their
+    ``[[type:slug]]`` authoring keys — so the edit-history diff and the editor
+    show the same legible representation rather than raw pks. Deleted targets
+    keep storage form.
+    """
+
+    kind: Annotated[
+        Literal["markdown"], Field(description='Discriminator; always "markdown".')
+    ] = "markdown"
+    text: str = Field(description="The claim's markdown value in authoring form.")
+
+
+ClaimDisplaySchema = Annotated[
+    ClaimDisplayValueSchema | MarkdownClaimDisplaySchema,
+    Field(discriminator="kind"),
+]
+"""Tagged union of a claim value's user-facing rendering, keyed on ``kind``.
+
+``relationship`` carries the structured identity/qualifier parts;
+``markdown`` carries the authoring-form text. Direct-field scalars and
+unknown namespaces have no rendering — :class:`ClaimValueSchema.display` is
+null and the frontend falls back to ``raw``."""
+
+
 class ClaimValueSchema(Schema):
     """A claim value paired with its structured user-facing rendering."""
 
@@ -99,12 +134,13 @@ class ClaimValueSchema(Schema):
             "depending on the claim kind."
         )
     )
-    display: ClaimDisplayValueSchema | None = Field(
+    display: ClaimDisplaySchema | None = Field(
         None,
         description=(
-            "Structured rendering for relationship claims, or null when there is "
-            "none (direct-field scalars, unknown namespaces, non-dict values); "
-            "clients fall back to ``raw``."
+            "Structured rendering for relationship claims or authoring-form text "
+            "for markdown fields, or null when there is none (direct-field "
+            "scalars, unknown namespaces, non-dict values); clients fall back to "
+            "``raw``."
         ),
     )
 

--- a/backend/apps/provenance/tests/test_display.py
+++ b/backend/apps/provenance/tests/test_display.py
@@ -1,4 +1,4 @@
-"""Tests for the relationship-claim display engine in apps.provenance.display."""
+"""Tests for the claim-value display engine in apps.provenance.display."""
 
 from __future__ import annotations
 
@@ -13,16 +13,19 @@ from apps.accounts.test_factories import make_user
 from apps.catalog.models import (
     CreditRole,
     GameplayFeature,
+    MachineModel,
+    Manufacturer,
     Person,
     Theme,
 )
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.display import (
+    ClaimDisplayContext,
     FieldValue,
     FkRef,
-    LabelLookup,
     build_display_value,
     claim_value,
+    resolve_display_context,
     resolve_labels,
 )
 from apps.provenance.models import Claim, Source
@@ -30,7 +33,19 @@ from apps.provenance.schemas import (
     ClaimDisplayIdentityPartSchema,
     ClaimDisplayQualifierPartSchema,
     ClaimDisplayValueSchema,
+    MarkdownClaimDisplaySchema,
 )
+
+# Any ClaimControlledModel works for relationship/scalar dispatch: the display
+# kind is derived from field_name + value, not from this model. Markdown tests
+# pass an explicit model (Manufacturer) since markdown dispatch reads the
+# model's MarkdownField set.
+_MODEL = MachineModel
+
+
+def _ctx(*items: FieldValue) -> ClaimDisplayContext:
+    """Build a display context from explicit (field, value) references."""
+    return resolve_display_context(items)
 
 
 def _identity(parts: list[tuple[str, str]]) -> list[ClaimDisplayIdentityPartSchema]:
@@ -55,8 +70,10 @@ class TestBuildDisplayValue:
         role = CreditRole.objects.create(name="Art", slug="art")
         value = {"person": person.pk, "role": role.pk, "exists": True}
 
-        labels = resolve_labels([FieldValue("credit", value)])
-        assert build_display_value("credit", value, labels) == ClaimDisplayValueSchema(
+        ctx = _ctx(FieldValue("credit", value))
+        assert build_display_value(
+            _MODEL, "credit", value, ctx
+        ) == ClaimDisplayValueSchema(
             identity=_identity([("person", "Pat Lawlor"), ("role", "Art")]),
             qualifiers=[],
         )
@@ -67,8 +84,10 @@ class TestBuildDisplayValue:
         # frontend render this case however it wants; ``label`` is null
         # because the backend doesn't choose presentation.
         value = {"person": 999, "role": 888, "exists": True}
-        labels = resolve_labels([FieldValue("credit", value)])
-        assert build_display_value("credit", value, labels) == ClaimDisplayValueSchema(
+        ctx = _ctx(FieldValue("credit", value))
+        assert build_display_value(
+            _MODEL, "credit", value, ctx
+        ) == ClaimDisplayValueSchema(
             identity=[
                 ClaimDisplayIdentityPartSchema(
                     key="person", label=None, state="deleted"
@@ -84,9 +103,10 @@ class TestBuildDisplayValue:
         # source slips one through, the display engine must not 500 the
         # whole page — log, emit state="missing", carry on.
         value = {"person": "not-an-int", "role": 7, "exists": True}
-        labels = resolve_labels([FieldValue("credit", value)])
-        result = build_display_value("credit", value, labels)
+        ctx = _ctx(FieldValue("credit", value))
+        result = build_display_value(_MODEL, "credit", value, ctx)
         assert result is not None
+        assert isinstance(result, ClaimDisplayValueSchema)
         person_part = next(p for p in result.identity if p.key == "person")
         assert person_part.state == "missing"
         assert person_part.label is None
@@ -94,13 +114,13 @@ class TestBuildDisplayValue:
     def test_gameplay_feature_emits_count_qualifier_when_present(self):
         feat = GameplayFeature.objects.create(name="Multiball", slug="multiball")
         value = {"gameplay_feature": feat.pk, "count": 3, "exists": True}
-        labels = resolve_labels([FieldValue("gameplay_feature", value)])
+        ctx = _ctx(FieldValue("gameplay_feature", value))
         # Backend always emits the qualifier when the key is present in the
         # claim dict — including count==1. The frontend's per-qualifier rule
         # decides whether to render ``×N`` (only when N > 1). Wire format
         # stays data-faithful.
         assert build_display_value(
-            "gameplay_feature", value, labels
+            _MODEL, "gameplay_feature", value, ctx
         ) == ClaimDisplayValueSchema(
             identity=_identity([("gameplay_feature", "Multiball")]),
             qualifiers=_qualifiers([("count", 3)]),
@@ -112,9 +132,9 @@ class TestBuildDisplayValue:
         # hide ``count == 1`` belongs on the frontend.
         feat = GameplayFeature.objects.create(name="Multiball", slug="multiball")
         value = {"gameplay_feature": feat.pk, "count": 1, "exists": True}
-        labels = resolve_labels([FieldValue("gameplay_feature", value)])
+        ctx = _ctx(FieldValue("gameplay_feature", value))
         assert build_display_value(
-            "gameplay_feature", value, labels
+            _MODEL, "gameplay_feature", value, ctx
         ) == ClaimDisplayValueSchema(
             identity=_identity([("gameplay_feature", "Multiball")]),
             qualifiers=_qualifiers([("count", 1)]),
@@ -123,10 +143,10 @@ class TestBuildDisplayValue:
     def test_gameplay_feature_omits_count_qualifier_when_missing(self):
         feat = GameplayFeature.objects.create(name="Multiball", slug="multiball")
         value = {"gameplay_feature": feat.pk, "exists": True}
-        labels = resolve_labels([FieldValue("gameplay_feature", value)])
+        ctx = _ctx(FieldValue("gameplay_feature", value))
         # Absent key → no qualifier emitted. Distinct from count==0.
         assert build_display_value(
-            "gameplay_feature", value, labels
+            _MODEL, "gameplay_feature", value, ctx
         ) == ClaimDisplayValueSchema(
             identity=_identity([("gameplay_feature", "Multiball")]),
             qualifiers=[],
@@ -135,17 +155,19 @@ class TestBuildDisplayValue:
     def test_theme_emits_single_identity_part(self):
         theme = Theme.objects.create(name="Sci-Fi", slug="sci-fi")
         value = {"theme": theme.pk, "exists": True}
-        labels = resolve_labels([FieldValue("theme", value)])
-        assert build_display_value("theme", value, labels) == ClaimDisplayValueSchema(
+        ctx = _ctx(FieldValue("theme", value))
+        assert build_display_value(
+            _MODEL, "theme", value, ctx
+        ) == ClaimDisplayValueSchema(
             identity=_identity([("theme", "Sci-Fi")]),
             qualifiers=[],
         )
 
     def test_abbreviation_emits_scalar_identity(self):
         value = {"value": "DW", "exists": True}
-        labels = resolve_labels([FieldValue("abbreviation", value)])
+        ctx = _ctx(FieldValue("abbreviation", value))
         assert build_display_value(
-            "abbreviation", value, labels
+            _MODEL, "abbreviation", value, ctx
         ) == ClaimDisplayValueSchema(
             identity=_identity([("value", "DW")]),
             qualifiers=[],
@@ -157,8 +179,8 @@ class TestBuildDisplayValue:
         # stale row, a fixture, or an ingest source that skipped validation
         # — surface ``state="missing"`` so the frontend can render a
         # placeholder, and log loudly so the integrity issue is observable.
-        labels = LabelLookup()
-        assert build_display_value("credit", {"exists": False}, labels) == (
+        ctx = _ctx()
+        assert build_display_value(_MODEL, "credit", {"exists": False}, ctx) == (
             ClaimDisplayValueSchema(
                 identity=[
                     ClaimDisplayIdentityPartSchema(
@@ -171,7 +193,7 @@ class TestBuildDisplayValue:
                 qualifiers=[],
             )
         )
-        assert build_display_value("theme", {"exists": False}, labels) == (
+        assert build_display_value(_MODEL, "theme", {"exists": False}, ctx) == (
             ClaimDisplayValueSchema(
                 identity=[
                     ClaimDisplayIdentityPartSchema(
@@ -181,7 +203,7 @@ class TestBuildDisplayValue:
                 qualifiers=[],
             )
         )
-        assert build_display_value("abbreviation", {"exists": False}, labels) == (
+        assert build_display_value(_MODEL, "abbreviation", {"exists": False}, ctx) == (
             ClaimDisplayValueSchema(
                 identity=[
                     ClaimDisplayIdentityPartSchema(
@@ -191,7 +213,7 @@ class TestBuildDisplayValue:
                 qualifiers=[],
             )
         )
-        assert build_display_value("person_alias", {"exists": False}, labels) == (
+        assert build_display_value(_MODEL, "person_alias", {"exists": False}, ctx) == (
             ClaimDisplayValueSchema(
                 identity=[
                     ClaimDisplayIdentityPartSchema(
@@ -206,24 +228,24 @@ class TestBuildDisplayValue:
         # Load-bearing assertion: the backend chose the override (alias_display)
         # for the identity slot's ``label``, but kept the identity key name
         # ``alias_value`` so the wire format is self-describing.
-        labels = LabelLookup()
         value = {
             "alias_value": "the patster",
             "alias_display": "The Patster",
             "exists": True,
         }
+        ctx = _ctx(FieldValue("person_alias", value))
         assert build_display_value(
-            "person_alias", value, labels
+            _MODEL, "person_alias", value, ctx
         ) == ClaimDisplayValueSchema(
             identity=_identity([("alias_value", "The Patster")]),
             qualifiers=[],
         )
 
     def test_alias_falls_back_to_canonical_when_display_missing(self):
-        labels = LabelLookup()
         value = {"alias_value": "the patster", "exists": True}
+        ctx = _ctx(FieldValue("person_alias", value))
         assert build_display_value(
-            "person_alias", value, labels
+            _MODEL, "person_alias", value, ctx
         ) == ClaimDisplayValueSchema(
             identity=_identity([("alias_value", "the patster")]),
             qualifiers=[],
@@ -232,10 +254,10 @@ class TestBuildDisplayValue:
     def test_alias_falls_back_to_canonical_when_display_empty(self):
         # Empty string override → fall through to canonical identity.
         # Mirrors the historical ``val.get("alias_display") or alias_val``.
-        labels = LabelLookup()
         value = {"alias_value": "the patster", "alias_display": "", "exists": True}
+        ctx = _ctx(FieldValue("person_alias", value))
         assert build_display_value(
-            "person_alias", value, labels
+            _MODEL, "person_alias", value, ctx
         ) == ClaimDisplayValueSchema(
             identity=_identity([("alias_value", "the patster")]),
             qualifiers=[],
@@ -245,14 +267,15 @@ class TestBuildDisplayValue:
         # The ``alias_display`` spec is named by ``alias_value.display_key``;
         # it MUST NOT also appear in the qualifiers list. Otherwise the
         # frontend would render the value twice.
-        labels = LabelLookup()
         value = {
             "alias_value": "the patster",
             "alias_display": "The Patster",
             "exists": True,
         }
-        result = build_display_value("person_alias", value, labels)
+        ctx = _ctx(FieldValue("person_alias", value))
+        result = build_display_value(_MODEL, "person_alias", value, ctx)
         assert result is not None
+        assert isinstance(result, ClaimDisplayValueSchema)
         assert all(q.key != "alias_display" for q in result.qualifiers)
 
     def test_media_attachment_emits_identity_and_qualifiers(self):
@@ -260,15 +283,16 @@ class TestBuildDisplayValue:
         # (category) + bool qualifier (is_primary, with bool/int distinction).
         # No need to materialize a real MediaAsset — the missing-target
         # ``<deleted>`` fallback is sufficient to exercise the engine.
-        labels = LabelLookup()
         value = {
             "media_asset": 42,
             "category": "flyer",
             "is_primary": True,
             "exists": True,
         }
-        result = build_display_value("media_attachment", value, labels)
+        ctx = _ctx()
+        result = build_display_value(_MODEL, "media_attachment", value, ctx)
         assert result is not None
+        assert isinstance(result, ClaimDisplayValueSchema)
         # pk=42 is synthetic / unresolved → state="deleted".
         assert result.identity == [
             ClaimDisplayIdentityPartSchema(
@@ -284,15 +308,16 @@ class TestBuildDisplayValue:
         # Backend is data-faithful: ``is_primary: false`` and an empty
         # category are emitted with their raw values. The frontend decides
         # whether to hide them.
-        labels = LabelLookup()
         value = {
             "media_asset": 42,
             "category": "",
             "is_primary": False,
             "exists": True,
         }
-        result = build_display_value("media_attachment", value, labels)
+        ctx = _ctx()
+        result = build_display_value(_MODEL, "media_attachment", value, ctx)
         assert result is not None
+        assert isinstance(result, ClaimDisplayValueSchema)
         assert result.qualifiers == _qualifiers(
             [("category", ""), ("is_primary", False)]
         )
@@ -301,10 +326,11 @@ class TestBuildDisplayValue:
         # Guards against Pydantic v2 coercing True → 1 because bool is an int
         # subclass. ClaimDisplayQualifierPartSchema.value declares bool before int
         # so this round-trip should preserve the type.
-        labels = LabelLookup()
         value = {"media_asset": 42, "is_primary": True, "exists": True}
-        result = build_display_value("media_attachment", value, labels)
+        ctx = _ctx()
+        result = build_display_value(_MODEL, "media_attachment", value, ctx)
         assert result is not None
+        assert isinstance(result, ClaimDisplayValueSchema)
         primary = next(q for q in result.qualifiers if q.key == "is_primary")
         assert primary.value is True
         assert type(primary.value) is bool
@@ -312,16 +338,17 @@ class TestBuildDisplayValue:
     def test_unknown_namespace_returns_none(self):
         # Direct-field claims (scalar new_value, not a registered namespace)
         # fall through — frontend renders the raw scalar.
-        labels = LabelLookup()
-        assert build_display_value("year", 1998, labels) is None
+        ctx = _ctx()
+        assert build_display_value(_MODEL, "year", 1998, ctx) is None
         assert (
-            build_display_value("technology_generation", "solid-state", labels) is None
+            build_display_value(_MODEL, "technology_generation", "solid-state", ctx)
+            is None
         )
 
     def test_non_dict_value_returns_none(self):
-        labels = LabelLookup()
-        assert build_display_value("credit", None, labels) is None
-        assert build_display_value("credit", "string", labels) is None
+        ctx = _ctx()
+        assert build_display_value(_MODEL, "credit", None, ctx) is None
+        assert build_display_value(_MODEL, "credit", "string", ctx) is None
 
     def test_resolve_labels_ignores_direct_fields_and_bare_markers(self):
         # Resolve over a mixed batch: a credit dict, a theme dict, a
@@ -350,14 +377,85 @@ class TestBuildDisplayValue:
 
 
 @pytest.mark.django_db
+class TestMarkdownDisplay:
+    """Markdown-field claim values render as authoring-form text."""
+
+    def test_markdown_field_renders_authoring_form(self):
+        # Storage-form [[manufacturer:id:N]] resolves to the slug authoring
+        # form — what the editor shows, so the diff reads the same.
+        man = Manufacturer.objects.create(name="Williams", slug="williams")
+        value = f"Made by [[manufacturer:id:{man.pk}]] here."
+        ctx = _ctx(FieldValue("description", value))
+        result = build_display_value(Manufacturer, "description", value, ctx)
+        assert result == MarkdownClaimDisplaySchema(
+            text="Made by [[manufacturer:williams]] here."
+        )
+
+    def test_markdown_deleted_target_keeps_storage_form(self):
+        # Broken link (target deleted) keeps storage form — same as the editor.
+        value = "Gone [[manufacturer:id:999999]]."
+        ctx = _ctx(FieldValue("description", value))
+        result = build_display_value(Manufacturer, "description", value, ctx)
+        assert result == MarkdownClaimDisplaySchema(
+            text="Gone [[manufacturer:id:999999]]."
+        )
+
+    def test_empty_markdown_value_has_no_display(self):
+        ctx = _ctx(FieldValue("description", ""))
+        assert build_display_value(Manufacturer, "description", "", ctx) is None
+
+    def test_markdown_without_links_passes_through(self):
+        value = "Just plain prose, no links."
+        ctx = _ctx(FieldValue("description", value))
+        result = build_display_value(Manufacturer, "description", value, ctx)
+        assert result == MarkdownClaimDisplaySchema(text="Just plain prose, no links.")
+
+    def test_edit_history_endpoint_renders_authoring_form(self, client):
+        # End-to-end bug reproduction: before the fix the description diff
+        # showed raw [[manufacturer:id:N]] storage form. A user edit authored
+        # in [[manufacturer:slug]] form must round-trip back to that form in
+        # the diff's display.text (raw stays storage form).
+        user = make_user()
+        pm = make_machine_model(name="MM", slug="mm-eh", year=1997)
+        man = Manufacturer.objects.create(name="Gottlieb", slug="gottlieb")
+
+        client.force_login(user)
+        resp = client.patch(
+            f"/api/models/{pm.slug}/claims/",
+            data=json.dumps(
+                {"fields": {"description": "By [[manufacturer:gottlieb]]."}}
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200, resp.content
+        client.logout()
+
+        resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
+        assert resp.status_code == 200
+
+        descr = next(
+            ch
+            for cs in resp.json()
+            for ch in cs["changes"]
+            if ch["field_name"] == "description"
+        )
+        assert descr["new_value"]["display"] == {
+            "kind": "markdown",
+            "text": "By [[manufacturer:gottlieb]].",
+        }
+        # raw stays the stored value — provenance truth is untouched.
+        assert descr["new_value"]["raw"] == f"By [[manufacturer:id:{man.pk}]]."
+
+
+@pytest.mark.django_db
 class TestClaimValue:
     def test_relationship_field_bundles_display(self):
         person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
         role = CreditRole.objects.create(name="Art", slug="art")
         value = {"person": person.pk, "role": role.pk, "exists": True}
 
-        labels = resolve_labels([FieldValue("credit", value)])
-        bundled = claim_value("credit", value, labels)
+        ctx = _ctx(FieldValue("credit", value))
+        bundled = claim_value(_MODEL, "credit", value, ctx)
 
         assert bundled.raw == value
         assert bundled.display == ClaimDisplayValueSchema(
@@ -365,8 +463,20 @@ class TestClaimValue:
             qualifiers=[],
         )
 
+    def test_markdown_field_bundles_authoring_text(self):
+        man = Manufacturer.objects.create(name="Bally", slug="bally")
+        value = f"By [[manufacturer:id:{man.pk}]]."
+        ctx = _ctx(FieldValue("description", value))
+        bundled = claim_value(Manufacturer, "description", value, ctx)
+
+        # raw stays the stored value; display carries the authoring form.
+        assert bundled.raw == value
+        assert bundled.display == MarkdownClaimDisplaySchema(
+            text="By [[manufacturer:bally]]."
+        )
+
     def test_scalar_field_has_null_display(self):
-        bundled = claim_value("name", "Medieval Madness", LabelLookup())
+        bundled = claim_value(_MODEL, "name", "Medieval Madness", _ctx())
         assert bundled.raw == "Medieval Madness"
         assert bundled.display is None
 
@@ -377,10 +487,11 @@ class TestClaimValue:
 
         person.delete()
         # Resolve after deletion to simulate a stale-but-stored FK pk.
-        labels = resolve_labels([FieldValue("credit", value)])
-        bundled = claim_value("credit", value, labels)
+        ctx = _ctx(FieldValue("credit", value))
+        bundled = claim_value(_MODEL, "credit", value, ctx)
 
         assert bundled.display is not None
+        assert isinstance(bundled.display, ClaimDisplayValueSchema)
         states = {part.key: part.state for part in bundled.display.identity}
         assert states["person"] == "deleted"
         assert states["role"] == "resolved"
@@ -461,4 +572,63 @@ class TestQueryCountDoesNotScale:
             f"edit-history query count scales with credit count: {base} -> {scaled}. "
             f"build_display_value is likely resolving FK labels per-row "
             f"instead of via the batched resolve_labels() pass."
+        )
+
+    def test_description_wikilinks_resolved_in_batched_queries(self, client):
+        """Adding more wikilinked description edits must not add per-edit
+        id→slug lookup queries.
+
+        Each edit is a *user* changeset, so the measured request renders N
+        description diffs through ``build_display_value`` (old→new per
+        changeset). Guards the markdown path against a regression that moves
+        storage→authoring conversion into the per-row render: the batched
+        ``resolve_wikilink_authoring`` must resolve all ids in one query per
+        public-id link type, not convert per rendered row.
+        """
+        user = make_user()
+        pm = make_machine_model(name="MM", slug="mm-descr", year=1997)
+
+        counter = 0
+
+        def add_description_edits(n: int) -> None:
+            # Each edit cites a distinct manufacturer (authoring form, converted
+            # to storage on save), so rendering must resolve many distinct ids.
+            nonlocal counter
+            client.force_login(user)
+            for _ in range(n):
+                counter += 1
+                man = Manufacturer.objects.create(
+                    name=f"Maker {counter}", slug=f"maker-{counter}"
+                )
+                resp = client.patch(
+                    f"/api/models/{pm.slug}/claims/",
+                    data=json.dumps(
+                        {
+                            "fields": {
+                                "description": (
+                                    f"Edit {counter} citing [[manufacturer:{man.slug}]]."
+                                )
+                            }
+                        }
+                    ),
+                    content_type="application/json",
+                )
+                assert resp.status_code == 200, (
+                    f"seed PATCH failed with {resp.status_code}: {resp.content!r}"
+                )
+
+        add_description_edits(2)
+        client.logout()
+        url = f"/api/pages/edit-history/model/{pm.slug}/"
+        base = _q(lambda: client.get(url))
+
+        add_description_edits(18)
+        client.logout()
+        scaled = _q(lambda: client.get(url))
+
+        assert scaled == base, (
+            f"edit-history query count scales with description edits: "
+            f"{base} -> {scaled}. The markdown display path is likely "
+            f"converting storage→authoring per rendered row instead of via the "
+            f"batched resolve_wikilink_authoring() pass."
         )

--- a/backend/apps/provenance/tests/test_helpers.py
+++ b/backend/apps/provenance/tests/test_helpers.py
@@ -11,6 +11,7 @@ from apps.provenance.helpers import (
     claims_prefetch,
 )
 from apps.provenance.models import Claim, Source
+from apps.provenance.schemas import ClaimDisplayValueSchema
 
 
 @pytest.fixture
@@ -79,10 +80,10 @@ class TestBuildSources:
         )
 
         loaded = pm.__class__.objects.prefetch_related(claims_prefetch()).get(pk=pm.pk)
-        sources = build_sources(active_claims(loaded))
+        sources = build_sources(type(loaded), active_claims(loaded))
         credit = next(s for s in sources if s.field_name == "credit")
 
-        assert credit.value.display is not None
+        assert isinstance(credit.value.display, ClaimDisplayValueSchema)
         assert [(p.key, p.label) for p in credit.value.display.identity] == [
             ("person", "Pat Lawlor"),
             ("role", "Art"),
@@ -93,7 +94,7 @@ class TestBuildSources:
         Claim.objects.assert_claim(series, "name", "S", source=source)
 
         loaded = Series.objects.prefetch_related(claims_prefetch()).get(pk=series.pk)
-        sources = build_sources(active_claims(loaded))
+        sources = build_sources(type(loaded), active_claims(loaded))
 
         assert sources[0].value.raw == "S"
         assert sources[0].value.display is None

--- a/docs/plans/the_flip/mfgtimeline.md
+++ b/docs/plans/the_flip/mfgtimeline.md
@@ -152,25 +152,17 @@ TBD.
 
 TBD.
 
-### Early Japanese makers: UNDONE
+### Early Japanese makers: DONE
 
-**The issue**: Flipcommons is thin on early Japanese pinball. The Flip cross-checked against the thetastates.com/eremeka catalog of early Japanese flipper games and found makers that Flipcommons doesn't surface at all. Two of them clear The Flip's visibility threshold:
+**The issue**: Flipcommons is thin on early Japanese pinball. The Flip cross-checked against the thetastates.com/eremeka catalog of early Japanese flipper games and found makers that Flipcommons doesn't surface at all.
 
-- `sankyo` — 9 machines, 1969–76
-- `nihon-tenbo` — 6 machines, 1967–72
+**Resolution**: Flipcommons imported the eremeka catalog:
 
-Neither is in Flipcommons (nor IPDB nor OPDB) under those exact names. Flipcommons does carry a handful of early Japanese makers, but with placeholder or missing years, so the coverage is both sparse and low-quality. Here is everything Flipcommons has for them:
+- `nihon-tenbo` now exists as a manufacturer carrying all 6 of its eremeka games
+- The Sankyos were deliberately _not_ merged into one `sankyo` brand; instead all 9 of eremeka's Sankyo games now sit under the existing `sankyo-seiki` spanning 1969–76, with the placeholder/null years fixed.
+- We added gap-fill models and year-fixes under Komaya, Universal, Nihon Gorakuki and Game Mate.
 
-| Manufacturer                           | Corporate Entity                                      | # Machines | Year                       |
-| -------------------------------------- | ----------------------------------------------------- | ---------- | -------------------------- |
-| `sankyo-seiki`                         | `sankyo-precision-equipment-company-ltd`              | 5          | unknown (placeholder 1900) |
-| `sankyo-yuen-setsubi-kabushikigaisha`  | `sankyo-amusement-park-equipment-company-ltd-ofjapan` | 1          | unknown                    |
-| `nihon-goraku-ki-kabushikigaisha`      | `japan-amusement-machine-company-ltd`                 | 1          | unknown                    |
-| `nihon-jidou-hanbaiki-kabushikigaisha` | `japan-automatic-vending-machine-company-ltd`         | 1          | unknown                    |
-
-Bringing in the eremeka records, or fixing the years on what's already there, would close the gap. This is the same early-Japanese EM era as 1970s Sega (item 4), a region Flipcommons covers sparsely.
-
-**Workaround**: The Flip imports `sankyo` and `nihon-tenbo` from the eremeka catalog as curated `asia`-band records.
+Four IPDB-only models still carry null years — `attack-ball`, `circus-16`, `fishing-tengu` (Sankyo Seiki) and `dai-uchuu-ryokou` (Game Mate). These are absent from the eremeka catalog, so this source can't date them — they'd need different evidence (IPDB notes, other research).
 
 ## Bonus: all data changes are cited
 

--- a/frontend/src/lib/components/pages/record/edit-history/EditHistory.svelte
+++ b/frontend/src/lib/components/pages/record/edit-history/EditHistory.svelte
@@ -16,6 +16,7 @@
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { getEntityContext } from '$lib/entity-context';
   import {
+    diffText,
     hasMeaningfulValue,
     isDeletion,
     isDiffable,
@@ -240,8 +241,8 @@
                       {:else if isDiffable(change)}
                         <dd>
                           <InlineDiff
-                            oldValue={change.old_value.raw}
-                            newValue={change.new_value.raw}
+                            oldValue={diffText(change.old_value)}
+                            newValue={diffText(change.new_value)}
                           />
                         </dd>
                       {:else}
@@ -276,8 +277,8 @@
                       <dt>{change.field_name}</dt>
                       <dd>
                         <InlineDiff
-                          oldValue={change.old_value.raw}
-                          newValue={change.new_value.raw}
+                          oldValue={diffText(change.old_value)}
+                          newValue={diffText(change.new_value)}
                         />
                       </dd>
                       {@render revertControls(change)}

--- a/frontend/src/lib/components/provenance/ClaimValue.dom.test.ts
+++ b/frontend/src/lib/components/provenance/ClaimValue.dom.test.ts
@@ -11,6 +11,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { person: 13, role: 9, exists: true },
           display: {
+            kind: 'relationship',
             identity: [
               { key: 'person', label: 'Pat Lawlor', state: 'resolved' },
               { key: 'role', label: 'Art', state: 'resolved' },
@@ -28,6 +29,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { person: 13, role: 9, exists: false },
           display: {
+            kind: 'relationship',
             identity: [
               { key: 'person', label: 'Pat Lawlor', state: 'resolved' },
               { key: 'role', label: 'Art', state: 'resolved' },
@@ -46,6 +48,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { gameplay_feature: 5, count: 3, exists: true },
           display: {
+            kind: 'relationship',
             identity: [{ key: 'gameplay_feature', label: 'Multiball', state: 'resolved' }],
             qualifiers: [{ key: 'count', value: 3 }],
           },
@@ -59,6 +62,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { gameplay_feature: 5, count: 1, exists: true },
           display: {
+            kind: 'relationship',
             identity: [{ key: 'gameplay_feature', label: 'Multiball', state: 'resolved' }],
             qualifiers: [{ key: 'count', value: 1 }],
           },
@@ -72,6 +76,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { theme: 7, exists: true },
           display: {
+            kind: 'relationship',
             identity: [{ key: 'theme', label: 'Horror', state: 'resolved' }],
             qualifiers: [],
           },
@@ -85,6 +90,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { media_asset: 42, category: 'flyer', is_primary: true, exists: true },
           display: {
+            kind: 'relationship',
             identity: [{ key: 'media_asset', label: 'Title cover', state: 'resolved' }],
             qualifiers: [
               { key: 'category', value: 'flyer' },
@@ -101,6 +107,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { media_asset: 42, category: 'flyer', is_primary: false, exists: true },
           display: {
+            kind: 'relationship',
             identity: [{ key: 'media_asset', label: 'Title cover', state: 'resolved' }],
             qualifiers: [
               { key: 'category', value: 'flyer' },
@@ -117,6 +124,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { media_asset: 42, category: null, is_primary: false, exists: true },
           display: {
+            kind: 'relationship',
             identity: [{ key: 'media_asset', label: 'Title cover', state: 'resolved' }],
             qualifiers: [
               { key: 'category', value: null },
@@ -136,6 +144,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { alias_value: 'the patster', alias_display: 'The Patster', exists: true },
           display: {
+            kind: 'relationship',
             identity: [{ key: 'alias_value', label: 'The Patster', state: 'resolved' }],
             qualifiers: [],
           },
@@ -149,6 +158,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { person: 99, role: 9, exists: true },
           display: {
+            kind: 'relationship',
             identity: [
               { key: 'person', label: null, state: 'deleted' },
               { key: 'role', label: 'Art', state: 'resolved' },
@@ -168,6 +178,7 @@ describe('ClaimValue', () => {
         value: {
           raw: { role: 9, exists: true },
           display: {
+            kind: 'relationship',
             identity: [
               { key: 'person', label: null, state: 'missing' },
               { key: 'role', label: 'Art', state: 'resolved' },
@@ -196,6 +207,7 @@ describe('ClaimValue', () => {
           value: {
             raw: { thing: 1, weirdkey: 'hello', exists: true },
             display: {
+              kind: 'relationship',
               identity: [{ key: 'thing', label: 'Widget', state: 'resolved' }],
               qualifiers: [{ key: 'weirdkey', value: 'hello' }],
             },
@@ -211,6 +223,7 @@ describe('ClaimValue', () => {
           value: {
             raw: { thing: 1, weirdkey: null, exists: true },
             display: {
+              kind: 'relationship',
               identity: [{ key: 'thing', label: 'Widget', state: 'resolved' }],
               qualifiers: [{ key: 'weirdkey', value: null }],
             },
@@ -264,6 +277,18 @@ describe('ClaimValue', () => {
         value: { raw: { person: 13, role: 9, exists: true } },
       });
       expect(container.textContent).toBe('{"person":13,"role":9,"exists":true}');
+    });
+  });
+
+  describe('with markdown display', () => {
+    it('renders the authoring-form display.text, not the raw storage form', () => {
+      const { container } = render(ClaimValueFixture, {
+        value: {
+          raw: 'Made by [[manufacturer:id:9]].',
+          display: { kind: 'markdown', text: 'Made by [[manufacturer:bally]].' },
+        },
+      });
+      expect(container.textContent).toBe('Made by [[manufacturer:bally]].');
     });
   });
 });

--- a/frontend/src/lib/components/provenance/ClaimValue.svelte
+++ b/frontend/src/lib/components/provenance/ClaimValue.svelte
@@ -22,12 +22,14 @@
   );
 </script>
 
-{#if display}
+{#if display?.kind === 'relationship'}
   {#if negated}
     <s><ClaimDisplay {display} /></s>
   {:else}
     <ClaimDisplay {display} />
   {/if}
+{:else if display?.kind === 'markdown'}
+  {display.text}
 {:else if simple}
   {#if simple.exists}
     {simple.display}

--- a/frontend/src/lib/components/provenance/change-display.test.ts
+++ b/frontend/src/lib/components/provenance/change-display.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import type { FieldChangeSchema } from '$lib/api/schema';
+import type { ClaimValueSchema, FieldChangeSchema } from '$lib/api/schema';
 import {
+  diffText,
   formatValue,
   hasMeaningfulValue,
   isDeletion,
@@ -8,6 +9,21 @@ import {
   isUnchanged,
   simplifyClaimValue,
 } from './change-display';
+
+/** A markdown claim value: storage-form raw + authoring-form display.text. */
+function md(raw: string, text: string): ClaimValueSchema {
+  return { raw, display: { kind: 'markdown', text } };
+}
+
+/** Build a FieldChangeSchema whose old/new are markdown claim values. */
+function mdFc(oldValue: ClaimValueSchema | null, newValue: ClaimValueSchema): FieldChangeSchema {
+  return {
+    field_name: 'description',
+    claim_key: 'description',
+    old_value: oldValue,
+    new_value: newValue,
+  };
+}
 
 /** Build a minimal FieldChangeSchema with raw-only old/new values. */
 function fc(
@@ -91,6 +107,40 @@ describe('isDiffable', () => {
 
   it('returns true when one string is exactly 81 characters', () => {
     expect(isDiffable(fc('a'.repeat(81), 'short'))).toBe(true);
+  });
+
+  it('thresholds markdown fields on the authoring-form display.text', () => {
+    // Long authoring text → diffable, even though raw differs.
+    expect(isDiffable(mdFc(md('s', 'short'), md('s', 'a'.repeat(81))))).toBe(true);
+  });
+
+  it('returns false when markdown authoring text is short despite long raw', () => {
+    // Storage form can be long while the authoring form is short; threshold
+    // on what's actually rendered (display.text).
+    const longStorage = '[[manufacturer:id:1]]'.repeat(10);
+    expect(isDiffable(mdFc(md(longStorage, 'a'), md(longStorage, 'b')))).toBe(false);
+  });
+});
+
+describe('diffText', () => {
+  it('returns the authoring-form display.text for markdown values', () => {
+    expect(diffText(md('Made by [[manufacturer:id:9]].', 'Made by [[manufacturer:bally]].'))).toBe(
+      'Made by [[manufacturer:bally]].',
+    );
+  });
+
+  it('returns the raw string when there is no markdown display', () => {
+    expect(diffText({ raw: 'plain text' })).toBe('plain text');
+  });
+
+  it('returns empty string for non-string raw with no display', () => {
+    expect(diffText({ raw: 1990 })).toBe('');
+    expect(diffText({ raw: { person: 13 } })).toBe('');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(diffText(null)).toBe('');
+    expect(diffText(undefined)).toBe('');
   });
 });
 

--- a/frontend/src/lib/components/provenance/change-display.ts
+++ b/frontend/src/lib/components/provenance/change-display.ts
@@ -1,33 +1,37 @@
-import type { ClaimDisplayValueSchema, ClaimValueSchema, FieldChangeSchema } from '$lib/api/schema';
+import type { ClaimValueSchema, FieldChangeSchema } from '$lib/api/schema';
 
 type FieldChange = FieldChangeSchema;
 
-/** A `ClaimValueSchema` whose `raw` payload is known to be a string. */
-type StringClaimValue = Omit<ClaimValueSchema, 'raw'> & {
-  raw: string;
-  display?: ClaimDisplayValueSchema | null;
-};
+/**
+ * The text a claim value contributes to a diff. For markdown fields this is
+ * the authoring-form `display.text` (`[[type:slug]]`), so the diff reads the
+ * same legible form the editor shows rather than raw `[[type:id:N]]` storage.
+ * For everything else it's the raw value coerced to a string.
+ */
+export function diffText(value: ClaimValueSchema | null | undefined): string {
+  if (value?.display?.kind === 'markdown') return value.display.text;
+  const raw = value?.raw;
+  return typeof raw === 'string' ? raw : '';
+}
 
 /**
- * True when both old and new values are strings and at least one exceeds
- * 80 characters, meaning the change should render as an InlineDiff rather
- * than a simple old → new display. Operates on `.raw` since long-string
- * diffs only make sense for direct-field scalars (no display struct).
- *
- * Type guard: inside an `isDiffable(change)` branch, callers get
- * `change.old_value.raw` and `change.new_value.raw` narrowed to `string`
- * without needing an `as string` cast.
+ * Whether a value contributes string content to a diff: a raw string, or a
+ * markdown field whose authoring-form `display.text` we diff. Non-string
+ * scalars and relationship dicts don't diff as text.
  */
-export function isDiffable(
-  change: FieldChange,
-): change is FieldChange & { old_value: StringClaimValue; new_value: StringClaimValue } {
-  const oldRaw = change.old_value?.raw;
-  const newRaw = change.new_value.raw;
-  return (
-    typeof oldRaw === 'string' &&
-    typeof newRaw === 'string' &&
-    (oldRaw.length > 80 || newRaw.length > 80)
-  );
+function diffsAsText(value: ClaimValueSchema | null | undefined): boolean {
+  return typeof value?.raw === 'string' || value?.display?.kind === 'markdown';
+}
+
+/**
+ * True when both old and new values diff as text and at least one exceeds 80
+ * characters, meaning the change should render as an InlineDiff rather than a
+ * simple old → new display. Thresholds on `diffText`, so markdown fields use
+ * their authoring form, not the storage form.
+ */
+export function isDiffable(change: FieldChange): boolean {
+  if (!diffsAsText(change.old_value) || !diffsAsText(change.new_value)) return false;
+  return diffText(change.old_value).length > 80 || diffText(change.new_value).length > 80;
 }
 
 /**

--- a/frontend/src/lib/components/provenance/claim-display.test.ts
+++ b/frontend/src/lib/components/provenance/claim-display.test.ts
@@ -9,7 +9,7 @@ import {
 import { _resetQualifierWarnings } from './qualifier-renderers';
 
 function display(partial: Partial<ClaimDisplayValueSchema>): ClaimDisplayValueSchema {
-  return { identity: [], qualifiers: [], ...partial };
+  return { kind: 'relationship', identity: [], qualifiers: [], ...partial };
 }
 
 describe('buildDisplaySegments', () => {

--- a/frontend/src/routes/changesets/+page.svelte
+++ b/frontend/src/routes/changesets/+page.svelte
@@ -8,7 +8,7 @@
   import ClaimValue from '$lib/components/provenance/ClaimValue.svelte';
   import InlineDiff from '$lib/components/ui/InlineDiff.svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
-  import { isDiffable } from '$lib/components/provenance/change-display';
+  import { diffText, isDiffable } from '$lib/components/provenance/change-display';
   import { changesLabel } from './changes';
 
   type ChangeSetSummary = ChangeSetSummarySchema;
@@ -237,8 +237,8 @@
                         <dt>{change.field_name}</dt>
                         <dd>
                           <InlineDiff
-                            oldValue={change.old_value.raw}
-                            newValue={change.new_value.raw}
+                            oldValue={diffText(change.old_value)}
+                            newValue={diffText(change.new_value)}
                           />
                         </dd>
                       </div>


### PR DESCRIPTION
## Why

On a record's edit-history page (e.g. `/manufacturers/universal/edit-history`), wikilinks in the `description` diff rendered raw **storage** form `[[title:id:373]]` instead of the legible **authoring** form `[[title:metallica]]` the editor textarea shows. The provenance display layer only built a structured `display` for relationship claims (FK dicts), so markdown text claims fell through to the raw stored string and were diffed verbatim.

## What

Generalizes the display layer's mental model from *"relationship claim → struct, else raw"* to a **model-driven dispatch over the field's display kind**, derived from introspection — no hardcoded field names.

**Backend**
- `ClaimValueSchema.display` is now a discriminated union — `ClaimDisplayValueSchema` (`kind:"relationship"`) | `MarkdownClaimDisplaySchema` (`kind:"markdown"`). `raw` stays the stored value (provenance truth).
- `build_display_value(model, field_name, value, ctx)` dispatches: registered relationship namespace → identity/qualifier struct; `MarkdownField` on the model (`get_markdown_fields`) → authoring-form text; else `null`.
- New batched `resolve_wikilink_authoring` / `apply_storage_to_authoring` in `core.markdown` rewrite `[[type:id:N]]` → `[[type:slug]]` with **one query per public-id link type**, bundled with FK-label resolution into `ClaimDisplayContext` so the query bound stays independent of changeset count. `convert_storage_to_authoring` (editor path) now composes the same primitives.
- Threaded `model` + `ctx` through `build_changes` / `build_sources` / review-queue / changeset-detail. Tightened the subject-entity type from generic `Model` to `ClaimControlledModel` on `build_edit_history` / `active_claims`, converging the two outliers onto the provenance-wide convention.

**Frontend**
- `diffText()` feeds the authoring form into `InlineDiff`; `isDiffable` thresholds on it. `ClaimValue.svelte` switches on `display.kind`.

Inline citations (`[[cite:slug]]`, now a public-id type) convert too, so citation changes also become legible — consistent with the editor.

## App boundaries

All markdown/wikilink machinery stays in `core`; `provenance` consumes it via `core` only — no `provenance → catalog` import added. `model` is threaded as a generic `type[ClaimControlledModel]` (provenance's own base) and introspected via `get_markdown_fields`. Respects [AppBoundaries.md](docs/AppBoundaries.md).

## Tests

- Backend: markdown display unit tests, an end-to-end round-trip endpoint test, and query-bound tests for **both** edit-history and sources (the description query-bound test renders N user-changeset diffs through the per-row path — verified it fails if conversion is moved per-row).
- Frontend: `diffText` / markdown-`isDiffable` unit tests + a `ClaimValue` markdown component test.
- Full suites green: backend 3527 passed, frontend 1648 passed; mypy + ruff + svelte-check + lint clean. Smoke-tested live against real dev data (`model/doctor-who`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)