### PR TITLE
feat(patches): per-entry ChangeSets for multiple edits per record

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "MD013": false,
+  "MD024": { "siblings_only": true },
   "MD033": false,
   "MD034": false
 }

--- a/backend/apps/catalog/ingestion/apply.py
+++ b/backend/apps/catalog/ingestion/apply.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, NamedTuple, Protocol, cast
 
@@ -27,6 +28,7 @@ from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import models, transaction
 from django.utils import timezone
 
+from apps.core.models import LIFECYCLE_STATUS_FIELD
 from apps.core.types import ClaimIdentity, EntityKey
 from apps.provenance.models import (
     ChangeSet,
@@ -71,6 +73,10 @@ class RetractEntry(NamedTuple):
     pk: int
     content_type_id: int
     object_id: int
+    # Patch runs only: the file-order index of the entry that authored this
+    # retraction, used by ``_persist`` to group retractions into per-entry
+    # ChangeSets. ``None`` for non-patch runs (IPDB/OPDB never retract).
+    entry_index: EntryIndex | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -114,12 +120,20 @@ class CitationRef:
 # to a ``CitationInstance.slug`` at mint, so it never reaches storage.
 type CiteHandle = str
 
-# Per-claim provenance maps produced by ``_collect_plan_provenance`` and
-# consumed by ``_persist`` / ``_attach_plan_citations``. Named so the opaque
-# ``str`` (a ChangeSet note) and the per-claim citation mapping read clearly
-# wherever they recur.
-type EntityNotes = dict[EntityKey, str]
+# A patch entry's file-order index — the grouping unit for per-entry ChangeSets.
+# A transparent alias of ``int`` (like ``CiteHandle`` above) that names the role
+# wherever it recurs — on the plan carriers and in the maps below — so a bare
+# ``int`` ordinal isn't mistaken for a pk or count. ``None`` on non-patch runs.
+type EntryIndex = int
+
+# Per-entry / per-claim provenance maps produced by ``_collect_plan_provenance``
+# and consumed by ``_persist`` / ``_attach_plan_citations``. ``EntryNotes`` keys
+# each entry's note by its ``EntryIndex`` (one ChangeSet, one note per patch
+# entry); ``ClaimEntryIndex`` resolves a built claim back to its entry for
+# per-entry ChangeSet grouping; ``ClaimCitations`` keys per claim identity.
+type EntryNotes = dict[EntryIndex, str]
 type ClaimCitations = dict[ClaimIdentity, CitationRef]
+type ClaimEntryIndex = dict[ClaimIdentity, EntryIndex]
 
 
 @dataclass
@@ -187,6 +201,11 @@ class PlannedClaimAssert:
     # minted slug. Existing-slug markers (``[[cite:<slug>]]``) carry nothing here —
     # they self-resolve through standard conversion. Empty for non-cited fields.
     inline_cites: dict[CiteHandle, CitationRef] = field(default_factory=dict)
+    # Patch runs only: the file-order index of the authoring patch entry. Stamped
+    # by the patch adapter (in ``build_plan``) so ``_persist`` can mint one
+    # ChangeSet per entry; ``None`` for non-patch runs (IPDB/OPDB), which group
+    # per affected entity instead.
+    entry_index: EntryIndex | None = None
     content_type_id: int | None = None
     object_id: int | None = None
     handle: str | None = None
@@ -208,9 +227,12 @@ class PlannedClaimRetract:
     content_type_id: int
     object_id: int
     claim_key: str
-    # Per-entry patch note → the entity's ChangeSet note. A retraction has no
+    # Per-entry patch note → the entry's ChangeSet note. A retraction has no
     # new claim, so it carries no ``citation_ref``.
     note: str = ""
+    # Patch runs only: the file-order index of the authoring patch entry (see
+    # ``PlannedClaimAssert.entry_index``). ``None`` for non-patch runs.
+    entry_index: EntryIndex | None = None
 
 
 @dataclass
@@ -270,6 +292,8 @@ def apply_plan(plan: IngestPlan, *, dry_run: bool = False) -> RunReport:
     _validate_entity_claim_consistency(plan)
     _validate_assertion_targets(plan)
     _validate_handle_refs(plan)
+    # Before the live/dry-run split, so a mis-stamped patch fails at --dry-run too.
+    _validate_entry_index_stamping(plan)
 
     if dry_run:
         return _apply_dry_run(plan, report)
@@ -310,7 +334,9 @@ def apply_plan(plan: IngestPlan, *, dry_run: bool = False) -> RunReport:
             # once now that handles are resolved (so every assertion carries its
             # real ct/obj). Kept out of _build_claims so that helper's signature —
             # and its dry-run call site — stay untouched.
-            entity_notes, claim_citations = _collect_plan_provenance(plan)
+            entry_notes, claim_citations, claim_entry_index = _collect_plan_provenance(
+                plan
+            )
             all_claims = _build_claims(plan.assertions, plan.source)
             valid_claims = _validate_fail_fast(all_claims, report)
 
@@ -326,7 +352,20 @@ def apply_plan(plan: IngestPlan, *, dry_run: bool = False) -> RunReport:
             )
             report.retracted = len(retract_entries)
 
-            _persist(run, to_create, superseded_ids, retract_entries, entity_notes)
+            # A provenance-bearing patch entry that diffs to no change would
+            # silently drop its note/citation — reject it (delete entries exempt).
+            _check_empty_diff_entries(
+                plan, to_create, retract_entries, claim_entry_index
+            )
+
+            _persist(
+                run,
+                to_create,
+                superseded_ids,
+                retract_entries,
+                entry_notes,
+                claim_entry_index,
+            )
             _attach_plan_citations(to_create, claim_citations)
             _resolve(to_create, retract_entries, plan.resolve_hooks)
 
@@ -456,6 +495,32 @@ def _validate_handle_refs(plan: IngestPlan) -> None:
                     f"use one or the other"
                 )
         seen.add(entity.handle)
+
+
+def _validate_entry_index_stamping(plan: IngestPlan) -> None:
+    """Every assertion/retraction in a patch plan must carry an ``entry_index``.
+
+    Patch runs group ChangeSets by ``entry_index`` (``_persist`` patch mode), so a
+    missed stamp — or a hand-built ``patch_id`` plan that forgot to set one —
+    would silently collapse the whole run under a single group. The patch adapter
+    always stamps, so this is an internal invariant: a plain ``ValueError``, not a
+    source-facing ``ValidationError``/``PatchError``. Non-patch plans
+    (``patch_id is None``) group per entity and never read the index, so are exempt.
+    """
+    if plan.patch_id is None:
+        return
+    for pca in plan.assertions:
+        if pca.entry_index is None:
+            raise ValueError(
+                f"Patch plan {plan.patch_id!r} has an assertion without an "
+                f"entry_index (field={pca.field_name!r})"
+            )
+    for pcr in plan.retractions:
+        if pcr.entry_index is None:
+            raise ValueError(
+                f"Patch plan {plan.patch_id!r} has a retraction without an "
+                f"entry_index (claim_key={pcr.claim_key!r})"
+            )
 
 
 def _validate_assertion_targets(plan: IngestPlan) -> None:
@@ -639,6 +704,9 @@ def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
         and id(p) not in fk_to_planned_ids
         and id(p) not in new_inline_cite_ids
     ]
+    # Entry indexes whose existing-entity claim survives the diff (a real change),
+    # for the dry-run empty-diff guard below. Carve-outs are added separately.
+    existing_changed: set[EntryIndex] = set()
     if existing_assertions:
         claims = _build_claims(existing_assertions, plan.source)
         valid = _validate_and_collect_errors(claims, report)
@@ -647,6 +715,23 @@ def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
             report.asserted += len(to_create)
             report.unchanged += len(valid) - len(to_create)
             report.superseded += len(superseded_ids)
+            idx_by_identity: dict[ClaimIdentity, EntryIndex | None] = {}
+            for p in existing_assertions:
+                # Existing-entity assertions (handle is None) carry concrete ct/obj.
+                assert p.content_type_id is not None
+                assert p.object_id is not None
+                key = ClaimIdentity(
+                    p.content_type_id, p.object_id, p.claim_key or p.field_name
+                )
+                idx_by_identity[key] = p.entry_index
+            for claim in to_create:
+                idx = idx_by_identity.get(
+                    ClaimIdentity(
+                        claim.content_type_id, claim.object_id, claim.claim_key
+                    )
+                )
+                if idx is not None:
+                    existing_changed.add(idx)
 
     # Claims targeting planned entities: validate only (all are new by
     # definition).  Build sentinel claims without mutating the plan.
@@ -701,9 +786,37 @@ def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
         report.asserted += len(valid)
 
     # Retractions: verify targets exist, count.
+    retract_entries: list[RetractEntry] = []
     if plan.retractions:
-        entries = _process_retractions(plan.retractions, plan.source, report)
-        report.retracted = len(entries)
+        retract_entries = _process_retractions(plan.retractions, plan.source, report)
+        report.retracted = len(retract_entries)
+
+    # Empty-diff guard (decision 3), same as the live path but with a dry-run
+    # ``changed`` set: assertions this path can't diff — carve-outs (deferred,
+    # new-inline-cite, FK-to-planned) and creates/companions (handle-targeted) —
+    # are *assumed* to change; existing-entity assertions count only when their
+    # claim survived the diff above. So a plain unchanged-value-with-note entry is
+    # rejected at --dry-run too, not only at apply.
+    #
+    # Skip when validation already collected errors: a rejected (invalid) claim
+    # never reaches ``changed``, so the guard would misreport it as a no-op and
+    # mask the real validation error. Live is immune — ``_validate_fail_fast``
+    # raises before the guard — so this keeps dry-run's diagnostic priority equal.
+    if plan.patch_id is not None and not report.errors:
+        changed = set(existing_changed)
+        for p in plan.assertions:
+            assert p.entry_index is not None
+            if (
+                p.relationship_namespace  # deferred member
+                or p.handle is not None  # create or its companion edits
+                or p.inline_cites  # new inline citation
+                or id(p) in fk_to_planned_ids  # existing FK → same-plan create
+            ):
+                changed.add(p.entry_index)
+        for entry in retract_entries:
+            assert entry.entry_index is not None
+            changed.add(entry.entry_index)
+        _reject_empty_diff_provenance(plan, changed)
 
     return report
 
@@ -976,7 +1089,12 @@ def _process_retractions(
         found_pk = found.get(key)
         if found_pk is not None:
             retract_entries.append(
-                RetractEntry(found_pk, key.content_type_id, key.object_id)
+                RetractEntry(
+                    found_pk,
+                    key.content_type_id,
+                    key.object_id,
+                    retract_keys[key].entry_index,
+                )
             )
         else:
             r = retract_keys[key]
@@ -990,41 +1108,145 @@ def _process_retractions(
 
 def _collect_plan_provenance(
     plan: IngestPlan,
-) -> tuple[EntityNotes, ClaimCitations]:
-    """Gather per-claim ``note``/``citation_ref`` carried by the plan into maps.
+) -> tuple[EntryNotes, ClaimCitations, ClaimEntryIndex]:
+    """Gather per-entry ``note``/``citation_ref`` and the claim→entry grouping map.
 
     Source-agnostic — any plan may set these; today only the patch adapter does
     (from a patch entry's ``note:``/``cite:``). Runs after ``_patch_handles``,
-    so every assertion's ct/obj is resolved. ``entity_notes`` (keyed by entity)
-    feeds the per-entity ChangeSet note; ``claim_citations`` (keyed by the exact
-    claim identity) drives per-claim citation attachment in
-    ``_attach_plan_citations``. Citations are keyed per claim — never per
-    entity — so a citation never bleeds onto unrelated claims (or the
-    create-owned scaffolding) that merely share the entity.
+    so every assertion's ct/obj is resolved. Returns three maps:
 
-    The patch adapter's same-entity guard ensures no two entries put conflicting
-    notes on one entity, so last-write-wins here is never reached in practice.
+    * ``entry_notes`` (keyed by the authoring entry's ``entry_index``) feeds each
+      per-entry ChangeSet's note.
+    * ``claim_citations`` (keyed by the exact claim identity) drives per-claim
+      citation attachment in ``_attach_plan_citations``. Keyed per claim — never
+      per entry — so a citation never bleeds onto unrelated claims (or the
+      create-owned scaffolding) that merely share the entity.
+    * ``claim_entry_index`` (keyed by claim identity) lets ``_persist`` group
+      built claims into per-entry ChangeSets. Recorded for *every* patch
+      assertion — note-less ones included — so a multi-entry patch still groups
+      correctly. Skipped when ``entry_index`` is ``None`` (non-patch runs), which
+      keeps the value type a clean ``int``; ``_persist`` reads it only in patch
+      mode, where the coupling check has proven every index non-``None``.
+
+    The disjoint-field guard ensures no two entries assert the same
+    ``ClaimIdentity``, so the map is 1:1 with the deduped claim set and
+    last-write-wins on a note/citation here is never reached in practice.
     """
-    entity_notes: EntityNotes = {}
+    entry_notes: EntryNotes = {}
     claim_citations: ClaimCitations = {}
+    claim_entry_index: ClaimEntryIndex = {}
     for pca in plan.assertions:
-        if not pca.note and pca.citation_ref is None:
-            continue  # the common case (all normal-ingest assertions)
         ct_id = pca.content_type_id
         obj_id = pca.object_id
         # post _patch_handles: handles are resolved to real ct/obj.
         assert ct_id is not None
         assert obj_id is not None
+        ident = ClaimIdentity(ct_id, obj_id, pca.claim_key or pca.field_name)
+        if pca.entry_index is not None:
+            claim_entry_index[ident] = pca.entry_index
+        if not pca.note and pca.citation_ref is None:
+            continue  # the common case (all normal-ingest assertions)
         if pca.note:
-            entity_notes[EntityKey(ct_id, obj_id)] = pca.note
+            # A note only ever rides a patch entry, which always stamps its index.
+            assert pca.entry_index is not None
+            entry_notes[pca.entry_index] = pca.note
         if pca.citation_ref is not None:
-            claim_citations[
-                ClaimIdentity(ct_id, obj_id, pca.claim_key or pca.field_name)
-            ] = pca.citation_ref
+            claim_citations[ident] = pca.citation_ref
     for pcr in plan.retractions:
         if pcr.note:
-            entity_notes[EntityKey(pcr.content_type_id, pcr.object_id)] = pcr.note
-    return entity_notes, claim_citations
+            assert pcr.entry_index is not None
+            entry_notes[pcr.entry_index] = pcr.note
+    return entry_notes, claim_citations, claim_entry_index
+
+
+def _check_empty_diff_entries(
+    plan: IngestPlan,
+    to_create: list[Claim],
+    retract_entries: list[RetractEntry],
+    claim_entry_index: ClaimEntryIndex,
+) -> None:
+    """Live-path empty-diff guard: surviving claims/retractions are the change.
+
+    Maps each surviving built claim back to its authoring entry via
+    ``claim_entry_index`` and delegates to :func:`_reject_empty_diff_provenance`.
+    The dry-run path computes ``changed`` differently (see ``_apply_dry_run``); the
+    rejection logic itself is shared.
+    """
+    if plan.patch_id is None:
+        return
+
+    changed: set[EntryIndex] = set()
+    for claim in to_create:
+        changed.add(
+            claim_entry_index[
+                ClaimIdentity(claim.content_type_id, claim.object_id, claim.claim_key)
+            ]
+        )
+    for entry in retract_entries:
+        assert entry.entry_index is not None
+        changed.add(entry.entry_index)
+
+    _reject_empty_diff_provenance(plan, changed)
+
+
+def _reject_empty_diff_provenance(plan: IngestPlan, changed: set[EntryIndex]) -> None:
+    """Reject a provenance-bearing patch entry absent from *changed* (decision 3).
+
+    A patch entry carrying a ``note``/``cite``/``cites`` (or a ``retract:`` +
+    ``note:``) that diffs to nothing would silently discard that provenance — no
+    ChangeSet is minted for it, so the note/citation just vanishes. Tightening
+    today's silent re-assert no-op into a hard error keeps provenance honest.
+
+    ``changed`` is the set of entry indexes that produced — or, in dry-run, are
+    *assumed* to produce — a real claim change. Both paths share this rejection;
+    they differ only in how ``changed`` is built (the live path diffs every
+    assertion; dry-run can't diff its carve-outs, so it treats new-inline-cite /
+    deferred / FK-to-planned assertions as changed).
+
+    Delete entries are exempt: an idempotent re-delete of an already-deleted
+    entity diffs to a clean no-op by design. A delete emits only ``status``
+    claims, so an entry whose assertions are *all* ``LIFECYCLE_STATUS_FIELD`` is a
+    delete — detected model-drivenly here, since the entry kind isn't threaded
+    into apply.py.
+
+    Patch-only (``patch_id`` set); non-patch runs carry no per-entry provenance.
+    Raises ``ValidationError`` (apply.py is source-agnostic and must not import
+    ``PatchError``); ``_apply_one`` converts it to a clean ``PatchError``.
+    """
+    if plan.patch_id is None:
+        return
+
+    # Per entry: which carry provenance, and which are a pure delete (all-status,
+    # exempt because an idempotent re-delete is a clean no-op by design).
+    has_provenance: set[EntryIndex] = set()
+    only_status: dict[EntryIndex, bool] = {}
+    for pca in plan.assertions:
+        idx = pca.entry_index
+        assert idx is not None  # patch assertions are always stamped
+        if pca.note or pca.citation_ref is not None or pca.inline_cites:
+            has_provenance.add(idx)
+        is_status = pca.field_name == LIFECYCLE_STATUS_FIELD
+        only_status[idx] = only_status.get(idx, True) and is_status
+    # The ``pcr.note`` branch is defensive: a no-op retraction (already-inactive
+    # field) never reaches here — build-time ``_check_provenance_carrier`` rejects
+    # a ``retract:`` + ``note:`` with no carrier — and a real retraction always
+    # yields a ``RetractEntry``, so its ``entry_index`` is already in ``changed``.
+    # Kept so the rule "a note must attach to a change" holds regardless of layer.
+    for pcr in plan.retractions:
+        idx = pcr.entry_index
+        assert idx is not None
+        if pcr.note:
+            has_provenance.add(idx)
+        only_status[idx] = False  # a retraction means the entry isn't a delete
+
+    for idx in has_provenance:
+        if only_status.get(idx, False) or idx in changed:
+            continue
+        raise ValidationError(
+            f"Patch entry at index {idx} carries a note/citation but changes "
+            f"nothing (its value already matches) — remove the no-op entry or "
+            f"correct its value so the provenance attaches to a real change"
+        )
 
 
 def _resolve_cite_source_id(ref: CitationRef, cache: dict[CitationRef, int]) -> int:
@@ -1133,65 +1355,129 @@ def _persist(
     to_create: list[Claim],
     superseded_ids: list[int],
     retract_entries: list[RetractEntry],
-    entity_notes: EntityNotes,
+    entry_notes: EntryNotes,
+    claim_entry_index: ClaimEntryIndex,
 ) -> None:
     """Bulk-create ChangeSets and Claims, deactivate superseded/retracted.
 
-    Superseded claims are deactivated *before* new claims are inserted
-    to satisfy the unique constraint on
-    ``(content_type, object_id, source, claim_key)`` where
-    ``is_active=True``.
+    Superseded claims are deactivated *before* new claims are inserted to satisfy
+    the partial unique index on ``(content_type, object_id, source, claim_key)``
+    where ``is_active=True``. ``superseded_ids`` is always a subset of the
+    entities in ``to_create`` (a superseded claim has a replacement), so the
+    empty-check on ``to_create`` is sufficient.
 
-    ``entity_notes`` carries each affected entity's patch ``note:`` onto its
-    ChangeSet (empty string when the entry set none).
+    Grouping is mode-selected on ``run.patch_id``: patch runs mint one ChangeSet
+    per authoring entry (``entry_index``, carrying that entry's note); normal
+    ingests (IPDB/OPDB) mint one per affected entity. A run is single-adapter, so
+    exactly one mode is in force.
     """
-    # superseded_ids is always a subset of the entities in to_create (a
-    # superseded claim has a replacement in to_create), so checking
-    # to_create is sufficient.
     if not to_create and not retract_entries:
         return
 
-    # One ChangeSet per affected entity.
-    affected: set[EntityKey] = set()
-    for claim in to_create:
-        affected.add(EntityKey(claim.content_type_id, claim.object_id))
-    for entry in retract_entries:
-        affected.add(EntityKey(entry.content_type_id, entry.object_id))
-
-    entity_list = sorted(affected)
-    changesets = [
-        ChangeSet(ingest_run=run, note=entity_notes.get(ek, "")) for ek in entity_list
-    ]
-    ChangeSet.objects.bulk_create(changesets)
-    entity_to_cs: dict[EntityKey, ChangeSet] = dict(
-        zip(entity_list, changesets, strict=True),
-    )
-
-    # Deactivate superseded claims before inserting replacements.
     if superseded_ids:
         Claim.objects.filter(pk__in=superseded_ids).update(is_active=False)
 
-    # Assign changeset and bulk-create new claims.
-    for claim in to_create:
-        claim.changeset_id = entity_to_cs[
-            EntityKey(claim.content_type_id, claim.object_id)
-        ].pk
+    if run.patch_id is not None:
+        _persist_per_entry(
+            run, to_create, retract_entries, entry_notes, claim_entry_index
+        )
+    else:
+        _persist_per_entity(run, to_create, retract_entries)
 
+
+def _link_to_changesets[K](
+    to_create: list[Claim],
+    retract_entries: list[RetractEntry],
+    group_to_cs: dict[K, ChangeSet],
+    claim_group: Callable[[Claim], K],
+    retract_group: Callable[[RetractEntry], K],
+) -> None:
+    """Point each new claim and retraction at its ChangeSet, then write.
+
+    Shared tail of the two ``_persist_*`` modes — they differ only in the grouping
+    key (``entry_index`` vs ``EntityKey``), supplied here as the ``claim_group`` /
+    ``retract_group`` extractors over an already-built ``group_to_cs``. Retracted
+    claims are deactivated in bulk per ChangeSet, stamped ``retracted_by_changeset``.
+    """
+    for claim in to_create:
+        claim.changeset_id = group_to_cs[claim_group(claim)].pk
     if to_create:
         Claim.objects.bulk_create(to_create, batch_size=2000)
 
-    # Deactivate retracted claims with changeset link.
     if retract_entries:
         retract_by_cs: dict[int, list[int]] = defaultdict(list)
         for entry in retract_entries:
-            cs = entity_to_cs[EntityKey(entry.content_type_id, entry.object_id)]
-            retract_by_cs[cs.pk].append(entry.pk)
-
+            retract_by_cs[group_to_cs[retract_group(entry)].pk].append(entry.pk)
         for cs_pk, pks in retract_by_cs.items():
             Claim.objects.filter(pk__in=pks).update(
                 is_active=False,
                 retracted_by_changeset_id=cs_pk,
             )
+
+
+def _persist_per_entry(
+    run: IngestRun,
+    to_create: list[Claim],
+    retract_entries: list[RetractEntry],
+    entry_notes: EntryNotes,
+    claim_entry_index: ClaimEntryIndex,
+) -> None:
+    """One ChangeSet per authoring patch entry, grouped by ``entry_index``.
+
+    Entry indexes are sorted ascending before ``bulk_create`` so ChangeSet pk
+    order matches file order — load-bearing because every ChangeSet in one
+    ``bulk_create`` shares ``created_at`` (db_default ``Now()``), leaving pk as
+    history's only file-order tiebreak (see ``history.py``: ``-created_at, -pk``).
+    A cascade-delete entry stamps one index across several entities, so its whole
+    cascade lands in a single multi-entity ChangeSet — matching the in-app delete.
+    """
+
+    def claim_idx(claim: Claim) -> EntryIndex:
+        return claim_entry_index[
+            ClaimIdentity(claim.content_type_id, claim.object_id, claim.claim_key)
+        ]
+
+    def retract_idx(entry: RetractEntry) -> EntryIndex:
+        assert entry.entry_index is not None  # patch retractions are always stamped
+        return entry.entry_index
+
+    ordered = sorted(
+        {claim_idx(c) for c in to_create} | {retract_idx(e) for e in retract_entries}
+    )
+    changesets = [
+        ChangeSet(ingest_run=run, note=entry_notes.get(idx, "")) for idx in ordered
+    ]
+    ChangeSet.objects.bulk_create(changesets)
+    idx_to_cs = dict(zip(ordered, changesets, strict=True))
+    _link_to_changesets(to_create, retract_entries, idx_to_cs, claim_idx, retract_idx)
+
+
+def _persist_per_entity(
+    run: IngestRun,
+    to_create: list[Claim],
+    retract_entries: list[RetractEntry],
+) -> None:
+    """One ChangeSet per affected entity — the normal-ingest (IPDB/OPDB) path.
+
+    Non-patch runs carry no per-entry notes, so each ChangeSet's note is empty.
+    """
+
+    def claim_entity(claim: Claim) -> EntityKey:
+        return EntityKey(claim.content_type_id, claim.object_id)
+
+    def retract_entity(entry: RetractEntry) -> EntityKey:
+        return EntityKey(entry.content_type_id, entry.object_id)
+
+    ordered = sorted(
+        {claim_entity(c) for c in to_create}
+        | {retract_entity(e) for e in retract_entries}
+    )
+    changesets = [ChangeSet(ingest_run=run, note="") for _ in ordered]
+    ChangeSet.objects.bulk_create(changesets)
+    entity_to_cs = dict(zip(ordered, changesets, strict=True))
+    _link_to_changesets(
+        to_create, retract_entries, entity_to_cs, claim_entity, retract_entity
+    )
 
 
 def _resolve(

--- a/backend/apps/catalog/ingestion/patches.py
+++ b/backend/apps/catalog/ingestion/patches.py
@@ -17,6 +17,7 @@ import math
 import re
 from collections import defaultdict
 from collections.abc import Callable
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
 from typing import NamedTuple, cast
 from urllib.parse import urlparse
@@ -54,6 +55,7 @@ from apps.citation.seed_data.types import SeedLink, SeedSource
 from apps.citation.seeding import ensure_root_source, validate_root_source
 from apps.core.entity_types import get_linkable_model
 from apps.core.markdown import get_markdown_fields
+from apps.core.models import LIFECYCLE_STATUS_FIELD
 from apps.core.types import EntityKey, JsonBody
 from apps.provenance.models import Claim, IdentityPart, Source, get_claim_fields
 from apps.provenance.models.changeset import CHANGESET_NOTE_MAX_LENGTH
@@ -79,11 +81,11 @@ RESERVED_FIELD_KEYS = frozenset(
     {"create", "delete", "expect", "retract", "remove", "note", "cite", "cites"}
 )
 
-# The claim-controlled lifecycle field (``LifecycleStatusModel.status``).
-# Patches never write it directly — it's created as ``active`` and soft-deleted
-# to ``deleted`` via the ``delete:`` directive, which routes through the
-# soft-delete planner. A raw claim would skip that planner's safety checks.
-LIFECYCLE_STATUS_FIELD = "status"
+# The claim-controlled lifecycle field (``LifecycleStatusModel.status``), shared
+# with the apply layer via ``apps.core.models``. Patches never write it directly
+# — it's created as ``active`` and soft-deleted to ``deleted`` via the
+# ``delete:`` directive, which routes through the soft-delete planner. A raw
+# claim would skip that planner's safety checks.
 
 # Allowed keys in a `sources:` node / its links, derived from the seed TypedDicts
 # (the single source of truth). `children` is excluded — v1 sources are flat.
@@ -575,15 +577,22 @@ class _TargetContribution(NamedTuple):
 
     A create contributes nothing (it targets a handle, not an existing entity);
     a delete contributes one of these per soft-deleted entity (root + cascade)
-    with empty field sets; an edit contributes one carrying its retract / assert
-    / remove sets. ``_validate_plan_wide`` merges these across entries.
+    with empty field sets and ``from_delete=True``; an edit contributes one
+    carrying its retract / assert / remove sets. ``_validate_plan_wide`` merges
+    these across entries, enforcing per-entry-ChangeSet disjointness.
+
+    ``deferred_member_ids`` are ``"namespace handle"`` keys for members pointing
+    at a same-patch create — kept apart from ``asserted_members`` (concrete
+    claim_keys) because their real claim_key isn't known until apply time, but
+    still guarded for cross-entry duplication.
     """
 
     ref: str
-    has_provenance: bool
+    from_delete: bool
     retracted_fields: frozenset[str]
     asserted_fields: frozenset[str]
     asserted_members: frozenset[ClaimKey]
+    deferred_member_ids: frozenset[str]
     # claim_key → "namespace public_id" label, for the assert/remove clash error.
     removed_members: dict[ClaimKey, str]
 
@@ -636,13 +645,17 @@ class _MemberEmitResult(NamedTuple):
 
     ``clash_keys`` are the *concrete* claim_keys the assert/remove clash guard
     and ``asserted_members`` consume; a deferred (same-patch-created) member has
-    no concrete claim_key at plan time and contributes none. ``carrier_written``
-    is whether any assertion — concrete or deferred — was emitted, so a
-    ``note:``/``cite:`` on an entry whose members are *all* same-patch creates is
-    not wrongly rejected by the provenance-carrier check.
+    no concrete claim_key at plan time, so its target ``handle`` rides
+    ``deferred_handles`` instead — the cross-entry disjoint guard keys it as
+    ``"namespace handle"`` so two entries asserting the same same-patch member
+    can't silently collapse in ``_build_claims``. ``carrier_written`` is whether
+    any assertion — concrete or deferred — was emitted, so a ``note:``/``cite:``
+    on an entry whose members are *all* same-patch creates is not wrongly rejected
+    by the provenance-carrier check.
     """
 
     clash_keys: list[ClaimKey]
+    deferred_handles: list[str]
     carrier_written: bool
 
 
@@ -854,19 +867,32 @@ def build_plan(doc: PatchDoc, *, source: Source, patch_id: str) -> IngestPlan:
     # plan_parent_claims self-link/cycle check).
     hierarchy_added: dict[type[CatalogModel], list[_HierarchyEdge]] = defaultdict(list)
 
-    results = [
-        _process_entry(
-            plan,
-            entry,
-            source=source,
-            rel_namespaces=rel_namespaces,
-            rel_fields_by_model=rel_fields_by_model,
-            created_refs=created_refs,
-            created=created,
-            hierarchy_added=hierarchy_added,
+    # Stamp each entry's emissions with its file-order index for per-entry
+    # ChangeSet grouping (apply layer). An entry's assertions/retractions are all
+    # appended during its own ``_process_entry`` call and land contiguously at the
+    # end of the plan lists (single-pass, nothing else appends between entries),
+    # so slice-stamping the tail after each call is exact — and avoids threading
+    # ``entry_index`` through every ``_emit_*``/``_add_*`` helper.
+    results: list[_EntryResult] = []
+    for entry_index, entry in enumerate(doc.claims):
+        assert_start = len(plan.assertions)
+        retract_start = len(plan.retractions)
+        results.append(
+            _process_entry(
+                plan,
+                entry,
+                source=source,
+                rel_namespaces=rel_namespaces,
+                rel_fields_by_model=rel_fields_by_model,
+                created_refs=created_refs,
+                created=created,
+                hierarchy_added=hierarchy_added,
+            )
         )
-        for entry in doc.claims
-    ]
+        for pca in plan.assertions[assert_start:]:
+            pca.entry_index = entry_index
+        for pcr in plan.retractions[retract_start:]:
+            pcr.entry_index = entry_index
     plan.records_matched = sum(r.matched for r in results)
     _validate_plan_wide(results)
     _validate_hierarchy_acyclic(hierarchy_added)
@@ -981,18 +1007,11 @@ def _process_entry(
     model_class = _resolve_model_class(entry)
     ct_id = ContentType.objects.get_for_model(model_class).pk
     existing = _lookup_entity(model_class, entry.public_id)
-    # Inline ``cites:`` count as provenance: each mints a per-assertion floating
-    # instance, but two entries asserting one entity's markdown field collapse to
-    # one claim (last-write-wins in _build_claims), which would orphan the
-    # discarded entry's mint. The multi-entry guard rejects that — same rule as
-    # note/cite: an entity's claims belong in a single entry.
-    has_provenance = bool(note) or citation_ref is not None or bool(entry.cites)
 
     # A delete carries no field assertions and no relationship work, so it
     # finishes here, registering every soft-deleted entity (root + cascade) with
-    # the same-entity guard: each carries the entry's note/cite on its
-    # status=deleted claim, so a separate entry on any of them that also carries
-    # provenance is a genuine collision.
+    # the plan-wide guard as a *delete footprint*: decision 5 makes that footprint
+    # exclusive, so any other entry touching one of these entities is rejected.
     if isinstance(entry, DeleteEntry):
         if entry.cites:
             raise PatchError(
@@ -1008,10 +1027,11 @@ def _process_entry(
         contributions = {
             tkey: _TargetContribution(
                 ref=entry.ref,
-                has_provenance=has_provenance,
+                from_delete=True,
                 retracted_fields=frozenset(),
                 asserted_fields=frozenset(),
                 asserted_members=frozenset(),
+                deferred_member_ids=frozenset(),
                 removed_members={},
             )
             for tkey in affected
@@ -1062,6 +1082,7 @@ def _process_entry(
     # and whether any real claim carrier was written (for the provenance check).
     asserted_fields: set[str] = set()
     asserted_members: set[ClaimKey] = set()
+    deferred_member_ids: set[str] = set()
     carrier_written = False
     claim_fields = get_claim_fields(model_class)
     for key, value in entry.fields.items():
@@ -1103,9 +1124,11 @@ def _process_entry(
             if emit.carrier_written:
                 carrier_written = True
             if target.object_id is not None:
-                # Only concrete claim_keys feed the clash guard; a deferred
-                # (same-patch) member has none yet — see _MemberEmitResult.
+                # Concrete claim_keys feed the clash + disjoint guards; a deferred
+                # (same-patch) member has no claim_key yet, so its target handle
+                # rides a separate ``(namespace, handle)`` disjoint key.
                 asserted_members.update(emit.clash_keys)
+                deferred_member_ids.update(f"{key} {h}" for h in emit.deferred_handles)
         else:
             raise PatchError(f"{entry.ref}: unknown field {key!r}")
 
@@ -1145,10 +1168,11 @@ def _process_entry(
     assert existing is not None  # an EditEntry always matched above
     contribution = _TargetContribution(
         ref=entry.ref,
-        has_provenance=has_provenance,
+        from_delete=False,
         retracted_fields=frozenset(entry.retract),
         asserted_fields=frozenset(asserted_fields),
         asserted_members=frozenset(asserted_members),
+        deferred_member_ids=frozenset(deferred_member_ids),
         removed_members=removed_members,
     )
     return _EntryResult(
@@ -1271,40 +1295,75 @@ def _validate_hierarchy_acyclic(
 def _validate_plan_wide(results: list[_EntryResult]) -> None:
     """Run the cross-entry guards over all processed entries.
 
-    Merges each entry's per-entity contributions into accumulators — kept local
-    here, so the per-entry pass stays free of cross-entry state — then enforces:
+    With per-entry ChangeSets, several entries may target one entity — *provided*
+    the claims they touch are disjoint. Each entry mints its own ChangeSet, and a
+    claim_key shared by two entries would collapse in ``_build_claims`` /
+    ``_process_retractions``, silently dropping one entry's grouping. Merges each
+    entry's per-target contributions, enforcing on insert:
 
-    1. one provenance-bearing entry per existing entity (their notes would
-       collide in the shared ChangeSet and their cites would be ambiguous),
-    2. no field both retracted and asserted on one entity by this source (the
-       assert silently wins and the retract is a no-op),
-    3. no relationship member both asserted present and removed on one entity
-       (both write the same claim_key, so one would silently clobber the other).
+    1. **Disjoint claims (decision 2).** No scalar/FK field, concrete or deferred
+       relationship member, or member tombstone may be asserted by two entries on
+       one target; no field retracted by two entries.
+    2. **Delete exclusivity (decision 5).** A delete soft-deletes its root +
+       cascade as one ChangeSet, so no other entry may target any entity in that
+       footprint.
+    3. **No field both retracted and asserted** on one target (the assert wins,
+       the retract is a silent no-op).
+    4. **No member both asserted present and removed** on one target (both write
+       the same claim_key — one would clobber the other).
     """
-    entry_count: dict[EntityKey, int] = defaultdict(int)
-    has_provenance: dict[EntityKey, bool] = defaultdict(bool)
     target_ref: dict[EntityKey, str] = {}
+    is_delete: dict[EntityKey, bool] = defaultdict(bool)
+    entry_count: dict[EntityKey, int] = defaultdict(int)
     retracted_fields: dict[EntityKey, set[str]] = defaultdict(set)
     asserted_fields: dict[EntityKey, set[str]] = defaultdict(set)
     asserted_members: dict[EntityKey, set[ClaimKey]] = defaultdict(set)
+    deferred_members: dict[EntityKey, set[str]] = defaultdict(set)
     removed_members: dict[EntityKey, dict[ClaimKey, str]] = defaultdict(dict)
+
+    def _reject_dup[T](
+        incoming: AbstractSet[T], seen: AbstractSet[T], ref: str, what: str
+    ) -> None:
+        dup = incoming & seen
+        if dup:
+            labels = ", ".join(sorted(str(d) for d in dup))
+            raise PatchError(
+                f"{ref}: {what} {labels} set by more than one entry on this record "
+                f"— each entry is its own changeset, so combine them into one entry"
+            )
+
     for result in results:
         for tkey, c in result.contributions.items():
+            ref = c.ref
             entry_count[tkey] += 1
-            target_ref[tkey] = c.ref
-            if c.has_provenance:
-                has_provenance[tkey] = True
+            target_ref[tkey] = ref
+            if c.from_delete:
+                is_delete[tkey] = True
+            _reject_dup(c.asserted_fields, asserted_fields[tkey], ref, "field")
+            _reject_dup(
+                c.retracted_fields, retracted_fields[tkey], ref, "retracted field"
+            )
+            _reject_dup(c.asserted_members, asserted_members[tkey], ref, "member")
+            _reject_dup(c.deferred_member_ids, deferred_members[tkey], ref, "member")
+            _reject_dup(
+                c.removed_members.keys(),
+                removed_members[tkey].keys(),
+                ref,
+                "removed member",
+            )
             retracted_fields[tkey] |= c.retracted_fields
             asserted_fields[tkey] |= c.asserted_fields
             asserted_members[tkey] |= c.asserted_members
+            deferred_members[tkey] |= c.deferred_member_ids
             removed_members[tkey].update(c.removed_members)
 
-    for tkey, count in entry_count.items():
-        if count > 1 and has_provenance[tkey]:
+    # Decision 5: a delete footprint is exclusive over root + cascade.
+    for tkey, deleting in is_delete.items():
+        if deleting and entry_count[tkey] > 1:
             raise PatchError(
-                f"{target_ref[tkey]}: multiple entries target this entity and at "
-                f"least one carries note/cite/cites — combine them into one entry "
-                f"(an entity's claims share a single changeset)"
+                f"{target_ref[tkey]}: another entry targets an entity this patch "
+                f"deletes (its root or a cascade child) — a delete must be the only "
+                f"entry touching the entities it removes"
             )
 
     for tkey, r_fields in retracted_fields.items():
@@ -1623,6 +1682,7 @@ def _emit_relationship(
             f"{entry.ref}: relationship {namespace!r} value must be a list of members"
         )
     clash_keys: list[ClaimKey] = []
+    deferred_handles: list[str] = []
     seen_keys: set[ClaimKey] = set()
     # Deferred members lack a concrete claim_key, so dedup them on the target
     # handle (the namespace is fixed for this call) to keep the same "duplicate
@@ -1654,6 +1714,7 @@ def _emit_relationship(
                         f"{entry.ref}: duplicate member {member!r} in {namespace!r}"
                     )
                 seen_deferred.add(handle)
+                deferred_handles.append(handle)
                 plan.assertions.append(
                     PlannedClaimAssert(
                         field_name=namespace,
@@ -1691,7 +1752,11 @@ def _emit_relationship(
         )
         clash_keys.append(claim_key)
         carrier_written = True
-    return _MemberEmitResult(clash_keys=clash_keys, carrier_written=carrier_written)
+    return _MemberEmitResult(
+        clash_keys=clash_keys,
+        deferred_handles=deferred_handles,
+        carrier_written=carrier_written,
+    )
 
 
 def _add_removals(

--- a/backend/apps/catalog/tests/test_patch_provenance.py
+++ b/backend/apps/catalog/tests/test_patch_provenance.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 
 from apps.catalog.ingestion.apply import (
     CitationRef,
@@ -26,7 +27,13 @@ from apps.catalog.ingestion.patches import (
 from apps.catalog.models import MachineModel, Manufacturer, Tag
 from apps.catalog.tests.conftest import make_machine_model
 from apps.citation.models import CitationSource
-from apps.provenance.models import ChangeSet, CitationInstance, Claim, Source
+from apps.provenance.models import (
+    ChangeSet,
+    CitationInstance,
+    Claim,
+    IngestRun,
+    Source,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -61,11 +68,11 @@ def prototype_tag(db):
     return Tag.objects.create(name="Prototype", slug="prototype")
 
 
-def _apply(text: str, *, patch_id: str = "0001-test"):
+def _apply(text: str, *, patch_id: str = "0001-test", dry_run: bool = False):
     doc = load_patch(text)
     source = Source.objects.get(slug=doc.attribution)
     plan = build_plan(doc, source=source, patch_id=patch_id)
-    return apply_plan(plan)
+    return apply_plan(plan, dry_run=dry_run)
 
 
 # ── Parsing ────────────────────────────────────────────────────────
@@ -127,19 +134,107 @@ def test_overlong_note_rejected(flipcommons_catalog, pm):
         _apply(text)
 
 
-def test_same_entity_provenance_conflict_rejected(flipcommons_catalog, pm):
-    # Two entries land on one entity and one carries a note → rejected, because
-    # an entity's claims collapse into a single shared changeset.
+def test_multiple_disjoint_edits_one_entity(flipcommons_catalog, ipdb_root, pm):
+    # Per-entry ChangeSets: two entries may edit one entity when their fields are
+    # disjoint. Each entry is its own ChangeSet with its own note + citation; pk
+    # order follows file order.
     text = """
 attribution: flipcommons-catalog
 claims:
   - model.medieval-madness:
-      note: first reason
+      note: corrected year per the flyer
+      cite: ipdb:4443
+      year: 1998
+  - model.medieval-madness:
+      note: production figure from the archive
+      production_quantity: 4000
+"""
+    report = _apply(text)
+    assert report.asserted == 2
+
+    assert IngestRun.objects.filter(patch_id="0001-test").count() == 1
+    changesets = list(
+        ChangeSet.objects.filter(ingest_run__patch_id="0001-test").order_by("pk")
+    )
+    assert len(changesets) == 2
+    assert changesets[0].note == "corrected year per the flyer"
+    assert changesets[1].note == "production figure from the archive"
+
+    year_claim = pm.claims.get(field_name="year", is_active=True)
+    qty_claim = pm.claims.get(field_name="production_quantity", is_active=True)
+    # pk/file order: first entry → first changeset, second entry → second.
+    assert year_claim.changeset_id == changesets[0].pk
+    assert qty_claim.changeset_id == changesets[1].pk
+    # Citation rode only the first entry's claim.
+    assert year_claim.citation_instances.exists()
+    assert not qty_claim.citation_instances.exists()
+
+
+def test_no_note_multi_entry_still_groups_per_entry(flipcommons_catalog, pm):
+    # Two disjoint-field edits, neither carrying a note → still two ChangeSets,
+    # each owning its claim (grouping rides entry_index, not the note).
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
       year: 1998
   - model.medieval-madness:
       production_quantity: 4000
 """
-    with pytest.raises(PatchError, match="combine them into one entry"):
+    _apply(text)
+    assert ChangeSet.objects.filter(ingest_run__patch_id="0001-test").count() == 2
+
+
+def test_same_field_two_entries_rejected(flipcommons_catalog, pm):
+    # Decision 2: two entries asserting the SAME field on one entity would
+    # collapse to a single claim in _build_claims — rejected as non-disjoint.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      note: first
+      year: 1998
+  - model.medieval-madness:
+      year: 1999
+"""
+    with pytest.raises(PatchError, match="more than one entry"):
+        _apply(text)
+
+
+def test_same_field_retracted_twice_rejected(flipcommons_catalog, pm):
+    # Decision 2 (retractions): two entries retracting the same field collapse to
+    # one deactivation, dropping one entry's note — rejected.
+    Claim.objects.assert_claim(pm, "year", 1998, source=flipcommons_catalog)
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      note: drop it
+      retract: [year]
+  - model.medieval-madness:
+      note: drop it again
+      retract: [year]
+"""
+    with pytest.raises(PatchError, match="more than one entry"):
+        _apply(text)
+
+
+def test_same_deferred_member_two_entries_rejected(flipcommons_catalog, pm):
+    # Decision 2 (deferred member): two entries adding the SAME same-patch-created
+    # tag to one model collapse to one membership claim — rejected.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - tag.newtag:
+      create: true
+      name: New Tag
+  - model.medieval-madness:
+      note: first
+      tag: [newtag]
+  - model.medieval-madness:
+      tag: [newtag]
+"""
+    with pytest.raises(PatchError, match="more than one entry"):
         _apply(text)
 
 
@@ -274,29 +369,58 @@ claims:
     assert not status_claim.citation_instances.exists()
 
 
-def test_cite_on_unchanged_value_noops(flipcommons_catalog, ipdb_root, pm):
-    # An already-correct, same-source value diffs as unchanged, so adding a
-    # cite: writes no new claim and attaches no citation (documented v1 limit).
+def test_cite_on_unchanged_value_rejected(flipcommons_catalog, ipdb_root, pm):
+    # Decision 3: an already-correct, same-source value diffs as unchanged, so a
+    # cite: would attach to nothing and silently vanish — now a hard error. The
+    # empty-diff guard runs in the apply layer (ValidationError; the command
+    # converts it to a PatchError for the author).
     Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 2000\n"
-    _apply(text)
-    year_claim = pm.claims.get(
-        field_name="year", is_active=True, source=flipcommons_catalog
-    )
-    assert not year_claim.citation_instances.exists()
+    with pytest.raises(ValidationError, match="changes nothing"):
+        _apply(text)
     assert not CitationInstance.objects.exists()
 
 
-def test_note_on_unchanged_value_noops(flipcommons_catalog, pm):
-    # Same root cause as the cite no-op: an entry that re-asserts an
-    # already-active same-source value diffs as unchanged, so no ChangeSet is
-    # created and the note is silently dropped (documented v1 limit). Build
-    # time can't catch this — it depends on the post-diff result.
+def test_note_on_unchanged_value_rejected(flipcommons_catalog, pm):
+    # Decision 3: re-asserting an already-active same-source value with a note
+    # diffs as unchanged, which would drop the note — now a hard error. Build time
+    # can't catch this (it depends on the post-diff result), so the apply-layer
+    # empty-diff guard does.
     Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: confirmed correct\n      year: 2000\n"
-    report = _apply(text)
-    assert report.asserted == 0  # nothing written
+    with pytest.raises(ValidationError, match="changes nothing"):
+        _apply(text)
     assert not ChangeSet.objects.filter(ingest_run__isnull=False).exists()
+
+
+def test_empty_diff_rejected_at_dry_run(flipcommons_catalog, pm):
+    # The empty-diff guard must fire at --dry-run too, so an author's pre-flight
+    # check catches the no-op note before apply — not only at apply time.
+    Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: confirmed correct\n      year: 2000\n"
+    with pytest.raises(ValidationError, match="changes nothing"):
+        _apply(text, dry_run=True)
+
+
+def test_changing_note_entry_passes_dry_run(flipcommons_catalog, pm):
+    # A real change carrying a note validates clean at --dry-run (no false reject).
+    Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: corrected per the flyer\n      year: 1999\n"
+    report = _apply(text, dry_run=True)
+    assert report.asserted == 1
+
+
+def test_dry_run_invalid_value_reports_validation_not_empty_diff(
+    flipcommons_catalog, pm
+):
+    # An invalid value carrying a note must surface as a validation error at
+    # --dry-run, not be masked by the empty-diff guard as "changes nothing": a
+    # rejected claim never reaches the diff, so the guard would otherwise blame the
+    # entry for a no-op instead of the real problem (year is a positive int).
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: bumping the year\n      year: -5\n"
+    report = _apply(text, dry_run=True)  # must not raise "changes nothing"
+    assert report.rejected == 1
+    assert report.errors
 
 
 def test_attach_citations_is_per_claim(flipcommons_catalog, ipdb_root, pm):
@@ -314,6 +438,7 @@ def test_attach_citations_is_per_claim(flipcommons_catalog, ipdb_root, pm):
             content_type_id=ct.pk,
             object_id=pm.pk,
             citation_ref=CitationRef("ipdb", "4443"),
+            entry_index=0,
         )
     )
     plan.assertions.append(
@@ -322,6 +447,7 @@ def test_attach_citations_is_per_claim(flipcommons_catalog, ipdb_root, pm):
             value=4000,
             content_type_id=ct.pk,
             object_id=pm.pk,
+            entry_index=1,
         )
     )
     apply_plan(plan)
@@ -330,6 +456,36 @@ def test_attach_citations_is_per_claim(flipcommons_catalog, ipdb_root, pm):
     qty_claim = pm.claims.get(field_name="production_quantity", is_active=True)
     assert year_claim.citation_instances.exists()
     assert not qty_claim.citation_instances.exists()
+
+
+def test_patch_plan_missing_entry_index_raises(flipcommons_catalog, pm):
+    # Structural guard: a patch_id plan whose assertion lacks an entry_index would
+    # silently collapse all ChangeSet grouping. The coupling check rejects it
+    # before the live/dry-run split, so --dry-run catches it too. Internal
+    # invariant (the adapter always stamps) → ValueError, not PatchError.
+    ct = ContentType.objects.get_for_model(MachineModel)
+    plan = IngestPlan(
+        source=flipcommons_catalog, input_fingerprint="fp", patch_id="0001-bad"
+    )
+    plan.assertions.append(
+        PlannedClaimAssert(
+            field_name="year",
+            value=1998,
+            content_type_id=ct.pk,
+            object_id=pm.pk,
+        )  # entry_index left unset
+    )
+    with pytest.raises(ValueError, match="without an entry_index"):
+        apply_plan(plan, dry_run=True)
+
+
+def test_retract_note_on_already_inactive_field_rejected(flipcommons_catalog, pm):
+    # Decision 3 (retraction note): a retract: + note: on a field this source does
+    # not actively claim emits no RetractEntry, so the note would vanish. Caught at
+    # build time — a no-op retraction carries nothing.
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: removing a year we never claimed\n      retract: [year]\n"
+    with pytest.raises(PatchError, match="note has nothing to attach to"):
+        _apply(text)
 
 
 def test_missing_citation_root_errors(flipcommons_catalog, pm):

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -1514,11 +1514,10 @@ claims:
     ).exists()
 
 
-def test_delete_cascade_child_same_entity_provenance_guard(machine_model):
-    # Deleting a Title cascades status=deleted onto its MachineModels. A
-    # separate entry that puts note/cite on a cascaded child collides in that
-    # child's single ChangeSet — the same-entity guard must catch it even
-    # though the child was only reached via the cascade.
+def test_delete_cascade_child_other_entry_rejected(machine_model):
+    # Decision 5: deleting a Title cascades status=deleted onto its MachineModels;
+    # the delete footprint is exclusive, so a separate entry touching a cascaded
+    # child (reached only via the cascade) is rejected.
     text = """
 attribution: flipcommons-catalog
 claims:
@@ -1528,8 +1527,26 @@ claims:
       note: 'edit on a machine that the cascade is deleting'
       year: 1998
 """
-    with pytest.raises(PatchError, match="multiple entries target this entity"):
+    with pytest.raises(PatchError, match="another entry targets an entity this patch"):
         _apply(text)
+
+
+def test_cascade_delete_is_one_changeset(machine_model):
+    # Decision 5: a standalone cascading delete (Title → MachineModel) yields ONE
+    # multi-entity ChangeSet spanning root + cascade, matching the in-app delete.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - title.medieval-madness-title:
+      delete: true
+"""
+    _apply(text, patch_id="0009-del")
+    changesets = ChangeSet.objects.filter(ingest_run__patch_id="0009-del")
+    assert changesets.count() == 1
+    cs = changesets.get()
+    deleted = cs.claims.filter(field_name="status", value="deleted")
+    # status=deleted on both the Title (root) and its cascaded MachineModel.
+    assert deleted.count() == 2
 
 
 def test_delete_must_be_boolean():

--- a/backend/apps/core/models/__init__.py
+++ b/backend/apps/core/models/__init__.py
@@ -25,6 +25,7 @@ from .constraints import (
 from .fields import BoundedTextField
 from .license import License
 from .mixins import (
+    LIFECYCLE_STATUS_FIELD,
     DescribedModel,
     EntityStatus,
     IdentifiableModel,
@@ -51,6 +52,7 @@ __all__ = [
     "LabeledIdentityModel",
     "LabeledModel",
     "LastUpdatedModel",
+    "LIFECYCLE_STATUS_FIELD",
     "License",
     "LifecycleManager",
     "LifecycleQuerySet",

--- a/backend/apps/core/models/mixins.py
+++ b/backend/apps/core/models/mixins.py
@@ -125,6 +125,13 @@ class EntityStatus(models.TextChoices):
     DELETED = "deleted", "Deleted"
 
 
+# The claim-controlled lifecycle field name (``LifecycleStatusModel.status``).
+# Named here, beside the model that owns it, so layers that must reason about
+# lifecycle claims without a model instance — the ingest apply layer and the
+# patch adapter — share one source of truth instead of hardcoding ``"status"``.
+LIFECYCLE_STATUS_FIELD = "status"
+
+
 _LifecycleModel = TypeVar("_LifecycleModel", bound="LifecycleStatusModel")
 
 

--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -223,7 +223,10 @@ def build_edit_history(
                 ).order_by("field_name"),
             ),
         )
-        .order_by("-created_at")
+        # All ChangeSets minted in one ingest ``bulk_create`` share ``created_at``
+        # (db_default ``Now()``), so for a per-entry patch run file order lives only
+        # in pk — tiebreak on it to keep the timeline deterministic and ordered.
+        .order_by("-created_at", "-pk")
     )
 
     # 2. Fetch ALL claims for this entity (active + inactive, any author) to


### PR DESCRIPTION
## Summary

Data patches group ChangeSets by the authoring patch entry instead of by affected entity, so one patch file can hold several independently attributed edits to a single record — each its own ChangeSet — mirroring the in-app model where each user action mints one ChangeSet. (Phase 1 of the per-entry-ChangeSets plan; create + companion edits and docs follow.)

- **Threading** — an `EntryIndex` rides the plan carriers; the patch adapter slice-stamps each entry's emissions in `build_plan`. Grouping resolves through a `ClaimIdentity → EntryIndex` side map (no transient attribute on `Claim`; `_build_claims`/`_diff_claims` untouched).
- **`_persist`** mode-selects on `plan.patch_id`: patch runs group per entry; IPDB/OPDB keep per-`EntityKey` (shared apply layer, one adapter per run).
- **Disjointness (decision 2)** — replaces the old "one provenance-bearing entry per entity" rule: no claim_key (scalar/FK, concrete or deferred member, or tombstone) may be asserted by two entries on one target; no field retracted twice.
- **Delete exclusivity (decision 5)** — a delete footprint (root + cascade) is exclusive; a cascade delete now lands as one multi-entity ChangeSet, matching the in-app delete.
- **Empty-diff guard (decision 3)** — a provenance-bearing entry that diffs to nothing is a hard error, enforced on both the live and `--dry-run` paths (dry-run treats its carve-outs as changed and defers to validation errors when present).
- **History** tiebreaks on `-pk` so per-run ChangeSets sharing `created_at` stay in file order.

`LIFECYCLE_STATUS_FIELD` moves to `apps.core.models` so the apply layer and patch adapter share one source of truth.

> ⚠️ Behavior change: a lone create/edit entry that re-asserts an unchanged value with a `note`/`cite` now errors instead of silently no-op'ing. Patch cascade deletes go from N per-entity ChangeSets to one multi-entity ChangeSet.

## Test plan

- [x] `pytest apps/catalog/tests/test_patch_provenance.py apps/catalog/tests/test_patches.py apps/catalog/tests/test_patch_inline_cites.py` — multi-edit grouping, disjointness rejections, decision 3/5, dry-run guard
- [x] Shared-layer regression: `pytest apps/catalog/tests/test_apply.py` + IPDB/OPDB ingest tests — non-patch runs still one ChangeSet per `EntityKey`
- [x] Full suite (`pytest`, 3537 passed / 1 skipped), `mypy` (444 files), `ruff` + format clean
- [ ] Author a scratch patch with two attributed edits on one model; `ingest_patches --dry-run` validates; apply yields 2 ChangeSets under one IngestRun, each with its note + CitationInstance, via the edit-history UI
- [ ] Author a scratch patch deleting a Title with active Models; confirm one ChangeSet spanning the cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)