### PR TITLE
refactor(ingest): name the Handle and Namespace plan-time types

### DIFF
--- a/backend/apps/catalog/ingestion/apply/dry_run.py
+++ b/backend/apps/catalog/ingestion/apply/dry_run.py
@@ -32,6 +32,7 @@ from apps.catalog.ingestion.apply.claims import (
 )
 from apps.catalog.ingestion.plan import (
     EntryIndex,
+    Handle,
     IngestPlan,
     PlannedClaimAssert,
     PlannedEntityCreate,
@@ -185,7 +186,7 @@ def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
 
     # Claims targeting planned entities: validate only (all are new by
     # definition).  Build sentinel claims without mutating the plan.
-    handle_to_model: dict[str, type[ClaimControlledModel]] = {
+    handle_to_model: dict[Handle, type[ClaimControlledModel]] = {
         e.handle: e.model_class for e in plan.entities
     }
     # A create whose FK points at *another* same-plan create carries a concrete,
@@ -211,7 +212,7 @@ def _apply_dry_run(plan: IngestPlan, report: RunReport) -> RunReport:
         and id(p) not in new_inline_cite_ids
     ]
     if planned_assertions:
-        handle_to_ct: dict[str, int] = {
+        handle_to_ct: dict[Handle, int] = {
             e.handle: ContentType.objects.get_for_model(e.model_class).pk
             for e in plan.entities
         }

--- a/backend/apps/catalog/ingestion/apply/persist.py
+++ b/backend/apps/catalog/ingestion/apply/persist.py
@@ -31,6 +31,7 @@ from apps.catalog.ingestion.plan import (
     CitationRef,
     CiteHandle,
     EntryIndex,
+    Handle,
     IngestPlan,
     PlannedClaimAssert,
     PlannedEntityCreate,
@@ -51,7 +52,7 @@ type ClaimEntryIndex = dict[ClaimIdentity, EntryIndex]
 
 def _create_entities(
     entities: list[PlannedEntityCreate],
-) -> dict[str, EntityKey]:
+) -> dict[Handle, EntityKey]:
     """Bulk-create entities.  Returns ``{handle: EntityKey(ct_id, pk)}``.
 
     Processes entities in list order, batching consecutive entries of the
@@ -65,14 +66,14 @@ def _create_entities(
     if not entities:
         return {}
 
-    handle_map: dict[str, EntityKey] = {}
+    handle_map: dict[Handle, EntityKey] = {}
 
     # Group consecutive entities of the same model class into batches.
     # A batch is flushed when the model class changes OR when an entity's
     # handle_refs reference a handle in the current pending batch (those
     # PKs aren't available until the batch is bulk_created).
     batches: list[list[PlannedEntityCreate]] = []
-    current_handles: set[str] = set()
+    current_handles: set[Handle] = set()
     for entity in entities:
         refs_current_batch = any(
             h in current_handles for h in entity.handle_refs.values()
@@ -109,7 +110,7 @@ def _create_entities(
 
 def _patch_handles(
     assertions: list[PlannedClaimAssert],
-    handle_map: dict[str, EntityKey],
+    handle_map: dict[Handle, EntityKey],
 ) -> None:
     """Resolve temporary handles to real PKs after entity creation.
 

--- a/backend/apps/catalog/ingestion/apply/validate.py
+++ b/backend/apps/catalog/ingestion/apply/validate.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 
 from django.db import models
 
-from apps.catalog.ingestion.plan import IngestPlan
+from apps.catalog.ingestion.plan import Handle, IngestPlan
 
 
 def _validate_entity_claim_consistency(plan: IngestPlan) -> None:
@@ -25,7 +25,7 @@ def _validate_entity_claim_consistency(plan: IngestPlan) -> None:
     targeting the same handle."""
     from apps.provenance.models import get_claim_fields
 
-    asserted_by_handle: dict[str, set[str]] = defaultdict(set)
+    asserted_by_handle: dict[Handle, set[str]] = defaultdict(set)
     for pca in plan.assertions:
         if pca.handle is not None:
             asserted_by_handle[pca.handle].add(pca.field_name)
@@ -81,7 +81,7 @@ def _attname_to_field_name(
 
 def _validate_handle_refs(plan: IngestPlan) -> None:
     """Every handle_ref must point to a handle that appears earlier in the list."""
-    seen: set[str] = set()
+    seen: set[Handle] = set()
     for entity in plan.entities:
         for kwarg_name, ref_handle in entity.handle_refs.items():
             if ref_handle not in seen:
@@ -132,7 +132,7 @@ def _validate_assertion_targets(plan: IngestPlan) -> None:
 
     # Duplicate handles.
     if len(valid_handles) != len(plan.entities):
-        seen: set[str] = set()
+        seen: set[Handle] = set()
         for e in plan.entities:
             if e.handle in seen:
                 raise ValueError(

--- a/backend/apps/catalog/ingestion/ipdb/adapter.py
+++ b/backend/apps/catalog/ingestion/ipdb/adapter.py
@@ -50,6 +50,7 @@ from apps.catalog.ingestion.parsers import (
 )
 from apps.catalog.ingestion.person_lookup import build_person_lookup
 from apps.catalog.ingestion.plan import (
+    Handle,
     IngestPlan,
     PlannedClaimAssert,
     PlannedEntityCreate,
@@ -753,7 +754,7 @@ def _process_credits(
 
     # Deduplicate person names and decide which need creation.
     seen_names: set[str] = set()
-    new_person_handles: dict[str, str] = {}  # lower_name → handle
+    new_person_handles: dict[str, Handle] = {}  # lower_name → handle
 
     for entry in credit_queue:
         key = entry.name.lower()
@@ -856,7 +857,7 @@ def _process_themes(
         all_slugs.update(entry.slugs)
 
     # Plan creation for new themes.
-    new_theme_handles: dict[str, str] = {}  # slug → handle
+    new_theme_handles: dict[str, Handle] = {}  # slug → handle
     for slug in sorted(all_slugs - theme_by_slug.keys()):
         name = slug.replace("-", " ").title()
         handle = f"theme:{slug}"

--- a/backend/apps/catalog/ingestion/patches/_types.py
+++ b/backend/apps/catalog/ingestion/patches/_types.py
@@ -12,6 +12,8 @@ from typing import NamedTuple
 
 from django.db import models
 
+from apps.catalog.ingestion.plan import Handle
+
 # The composite key identifying one claim — a scalar/FK field name or a
 # relationship member key from ``build_relationship_claim`` (e.g.
 # ``"location:germany"``). A transparent alias of ``str``: it documents the
@@ -40,7 +42,7 @@ class _Target(NamedTuple):
 
     content_type_id: int | None = None
     object_id: int | None = None
-    handle: str | None = None
+    handle: Handle | None = None
 
 
 class _CreatedKey(NamedTuple):

--- a/backend/apps/catalog/ingestion/patches/emit.py
+++ b/backend/apps/catalog/ingestion/patches/emit.py
@@ -39,7 +39,9 @@ from apps.catalog.ingestion.patches.parsing import (
 from apps.catalog.ingestion.plan import (
     CitationRef,
     CiteHandle,
+    Handle,
     IngestPlan,
+    Namespace,
     PlannedClaimAssert,
     PlannedClaimRetract,
     PlannedEntityCreate,
@@ -80,7 +82,7 @@ class _HierarchyEdge(NamedTuple):
     """
 
     model_class: type[CatalogModel]
-    namespace: str
+    namespace: Namespace
     child: PublicId
     parent: PublicId
     ref: str  # the entry-ref/handle that asserted the edge, for the error message
@@ -103,7 +105,7 @@ class _MemberEmitResult(NamedTuple):
     """
 
     clash_keys: list[ClaimKey]
-    deferred_handles: list[str]
+    deferred_handles: list[Handle]
     carrier_written: bool
     hierarchy_edges: list[_HierarchyEdge]
 
@@ -217,7 +219,7 @@ type _RelationshipMemberSpec = _FkMemberSpec | _StringMemberSpec
 
 def _relationship_member_spec(
     model_class: type[CatalogModel],
-    namespace: str,
+    namespace: Namespace,
     entry: PatchEntry,
 ) -> _RelationshipMemberSpec:
     """Classify *namespace* as a single-identity relationship on *model_class*.
@@ -268,7 +270,7 @@ def _relationship_member_spec(
 
 def _member_identity(
     member: object,
-    namespace: str,
+    namespace: Namespace,
     rel_spec: _RelationshipMemberSpec,
     entry: PatchEntry,
 ) -> dict[str, IdentityPart]:
@@ -327,12 +329,12 @@ def _member_identity(
 def _emit_relationship(
     plan: IngestPlan,
     model_class: type[CatalogModel],
-    namespace: str,
+    namespace: Namespace,
     value: object,
     target: _Target,
     entry: PatchEntry,
     *,
-    created: dict[_CreatedKey, str],
+    created: dict[_CreatedKey, Handle],
     note: str = "",
     citation_ref: CitationRef | None = None,
 ) -> _MemberEmitResult:
@@ -352,13 +354,13 @@ def _emit_relationship(
             f"{entry.ref}: relationship {namespace!r} value must be a list of members"
         )
     clash_keys: list[ClaimKey] = []
-    deferred_handles: list[str] = []
+    deferred_handles: list[Handle] = []
     hierarchy_edges: list[_HierarchyEdge] = []
     seen_keys: set[ClaimKey] = set()
     # Deferred members lack a concrete claim_key, so dedup them on the target
     # handle (the namespace is fixed for this call) to keep the same "duplicate
     # member" strictness as the concrete path's seen_keys.
-    seen_deferred: set[str] = set()
+    seen_deferred: set[Handle] = set()
     carrier_written = False
     # A relationship whose FK identity targets its own subject model is a
     # self-referential hierarchy (theme_parent/gameplay_feature_parent); record
@@ -439,7 +441,7 @@ def _add_removals(
     entry: EditEntry,
     ct_id: int,
     source: Source,
-    rel_namespaces: frozenset[str],
+    rel_namespaces: frozenset[Namespace],
     rel_fields_by_model: dict[type[CatalogModel], set[str]],
     *,
     note: str = "",
@@ -545,9 +547,9 @@ def _add_create(
     plan: IngestPlan,
     model_class: type[CatalogModel],
     entry: CreateEntry,
-    handle: str,
+    handle: Handle,
     *,
-    created: dict[_CreatedKey, str],
+    created: dict[_CreatedKey, Handle],
     note: str = "",
 ) -> None:
     """Emit a ``PlannedEntityCreate`` plus its required identity/status claims.
@@ -623,7 +625,7 @@ def _add_create(
     # the target handle's PK by the apply layer (resolved after the bulk-create).
     # The field loop still emits the concrete provenance claim, which
     # _validate_entity_claim_consistency pairs with this handle_ref.
-    handle_refs: dict[str, str] = {}
+    handle_refs: dict[str, Handle] = {}
 
     for key, value in entry.fields.items():
         if key not in claim_fields:
@@ -791,7 +793,7 @@ def _add_retractions(
     entry: EditEntry,
     ct_id: int,
     source: Source,
-    rel_namespaces: frozenset[str],
+    rel_namespaces: frozenset[Namespace],
     *,
     note: str = "",
 ) -> bool:

--- a/backend/apps/catalog/ingestion/patches/planning.py
+++ b/backend/apps/catalog/ingestion/patches/planning.py
@@ -55,7 +55,9 @@ from apps.catalog.ingestion.patches.parsing import (
 from apps.catalog.ingestion.plan import (
     CitationRef,
     CiteHandle,
+    Handle,
     IngestPlan,
+    Namespace,
     PreWriteHook,
     RunReport,
 )
@@ -69,16 +71,16 @@ from apps.core.types import EntityKey
 from apps.provenance.models import Source, get_claim_fields
 
 # A plan-wide guard target: an existing entity (``EntityKey``) or a same-patch
-# create addressed by its handle (``str``). The two never collide — a 2-int
+# create addressed by its ``Handle``. The two never collide — a 2-int
 # ``NamedTuple`` vs a handle string — so they share one accumulator keyspace.
-type _TargetKey = EntityKey | str
+type _TargetKey = EntityKey | Handle
 
 
 class _TargetContribution(NamedTuple):
     """One entry's contribution to the plan-wide guards for one target.
 
     The target is an existing entity (keyed by ``EntityKey``) or a same-patch
-    create (keyed by its handle ``str``). A create contributes its authored +
+    create (keyed by its ``Handle``). A create contributes its authored +
     identity (slug) claims under its handle, so the disjoint-claims guard spans
     the create and any companion edits that refine it; a delete contributes one
     of these per soft-deleted entity (root + cascade) with empty field sets and
@@ -145,7 +147,7 @@ def build_plan(doc: PatchDoc, *, source: Source, patch_id: str) -> IngestPlan:
     # patch DB lookup; only neither-found errors. (Kept separate from
     # ``created_refs``: that dedups by the entry-ref label; this resolves by
     # concrete class + public_id — different keys, different jobs.)
-    created: dict[_CreatedKey, str] = {}
+    created: dict[_CreatedKey, Handle] = {}
     # Identity of every create in the patch, regardless of file order — a cheap
     # pre-scan so an edit that resolves nowhere can tell *create-appears-below*
     # (decision 6: create-first) from *no-such-record*. The single-pass ``created``
@@ -329,10 +331,10 @@ def _process_entry(
     entry: PatchEntry,
     *,
     source: Source,
-    rel_namespaces: frozenset[str],
+    rel_namespaces: frozenset[Namespace],
     rel_fields_by_model: dict[type[CatalogModel], set[str]],
     created_refs: set[str],
-    created: dict[_CreatedKey, str],
+    created: dict[_CreatedKey, Handle],
     all_created_ids: AbstractSet[_CreatedKey],
 ) -> _EntryResult:
     """Resolve, validate and emit one claim entry; return its cross-entry contribution.

--- a/backend/apps/catalog/ingestion/plan.py
+++ b/backend/apps/catalog/ingestion/plan.py
@@ -88,6 +88,25 @@ type CiteHandle = str
 # ``None`` on non-patch runs.
 type EntryIndex = int
 
+# A plan-local temporary identifier for a not-yet-created entity — the label a
+# ``PlannedClaimAssert`` (or another create's ``handle_refs``) uses to point at a
+# ``PlannedEntityCreate`` before it has a PK, resolved to an ``EntityKey`` once the
+# entity is bulk-created. A transparent alias of ``str`` (like ``CiteHandle``
+# above) that names the role wherever a bare ``str`` — a handle-map key, an
+# FK/identity-ref value, the adapter's same-patch-create registry value — would
+# otherwise be indistinguishable from a public_id or a field name. Used across the
+# contract here, the apply engine and the patch adapter.
+type Handle = str
+
+# A relationship's namespace — the schema key naming a relationship kind
+# (``"location"``, ``"theme_parent"``, ``"credit"``) that a deferred
+# ``PlannedClaimAssert`` carries and ``build_relationship_claim`` keys off. A
+# transparent alias of ``str`` (like ``Handle`` above) that distinguishes a
+# namespace from the other ``str``s it travels with (a handle, a field name, a
+# public_id) where the distinction is otherwise invisible — e.g. a
+# ``frozenset[str]`` of valid namespaces.
+type Namespace = str
+
 
 @dataclass
 class PlannedEntityCreate:
@@ -109,8 +128,9 @@ class PlannedEntityCreate:
     # kwargs are spread into ``model_class(**kwargs)`` — schema varies per
     # model class, so the value type is genuinely heterogeneous.
     kwargs: dict[str, Any]
-    handle: str
-    handle_refs: dict[str, str] = field(default_factory=dict)
+    handle: Handle
+    # attname (FK column) → the handle of the planned entity supplying its PK.
+    handle_refs: dict[str, Handle] = field(default_factory=dict)
 
 
 @dataclass
@@ -161,16 +181,17 @@ class PlannedClaimAssert:
     entry_index: EntryIndex | None = None
     content_type_id: int | None = None
     object_id: int | None = None
-    handle: str | None = None
+    handle: Handle | None = None
     needs_review: bool = False
     needs_review_notes: str = ""
     license_id: int | None = None
     # Deferred relationship claim identity:
-    relationship_namespace: str = ""
+    relationship_namespace: Namespace = ""
     # identity values mix PKs (int) and tag values (str/bool) per the
     # relationship's claim-key schema; truly heterogeneous.
     identity: dict[str, Any] = field(default_factory=dict)
-    identity_refs: dict[str, str] = field(default_factory=dict)
+    # value-key → the handle of the planned entity whose PK fills that identity slot.
+    identity_refs: dict[str, Handle] = field(default_factory=dict)
 
 
 @dataclass


### PR DESCRIPTION
## What

Roots two transparent `str` aliases in [plan.py](backend/apps/catalog/ingestion/plan.py) — next to the existing `CiteHandle`/`EntryIndex`, the shared contract module both the `apply/` and `patches/` packages import from — and threads them through the handle/namespace surface:

- **`Handle`** — the plan-time temporary id for a not-yet-created entity (a handle-map key, an FK/identity-ref value, the patch adapter's same-patch create-registry value).
- **`Namespace`** — a relationship's schema-key namespace.

This is the deferred "Name the latent `Handle` type" follow-up from the same-patch-refs plan. The plan originally hesitated because `Handle` looked owned by `apply.py` — but the recent `apply.py`→`apply/` and `patches.py`→`patches/` package splits moved the plan carriers into `plan.py`, which is now the obvious non-island home (it already hosts the same kind of alias). Folded in `Namespace` as the strongest sibling concept.

## Where it shows

- **plan.py** — `PlannedEntityCreate.handle`/`.handle_refs` value, `PlannedClaimAssert.handle`/`.relationship_namespace`/`.identity_refs` value.
- **apply/** — `_create_entities` return + `handle_map`/`current_handles` (persist), `asserted_by_handle` + `seen` sets (validate), `handle_to_model`/`handle_to_ct` (dry_run).
- **patches/** — `_Target.handle`; `_TargetKey = EntityKey | Handle` (was `| str`), the `created` registry value, `rel_namespaces` (planning); `_HierarchyEdge.namespace`, `_MemberEmitResult.deferred_handles`, the namespace/handle/created/handle_refs surface (emit).
- **ipdb/adapter.py** — `new_person_handles`/`new_theme_handles` values.

Left `ValueKey` (`identity_refs` key) and `Attname` (`handle_refs` key) as bare `str` — too localized / too Django-generic to earn an alias.

## Test

Pure typing, no behavior change. `make mypy` clean (480 files); `test_patches.py` + `test_apply.py` + `test_ingest_ipdb.py` green (237 tests). Pre-commit hooks (ruff, mypy, backend tests) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)