### PR TITLE
feat(ingest): pull data patches from the flippatch repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,11 +311,15 @@ When reviewing code or a PR, read [docs/Reviewing.md](Reviewing.md) first and fo
 
 ## Related Repos
 
-This project has two sister projects:
+This project has three sister projects:
 
 ### Catalog seed records
 
 **[pindata](https://github.com/deanmoses/pindata)**: pre-launch seed canonical catalog records (markdown files + JSON schemas). It publishes the catalog as JSON to Cloudflare R2 and this project pulls it down from R2 via `make pull-ingest`.
+
+### Data patches
+
+**[flippatch](https://github.com/deanmoses/flippatch)**: the numbered `NNNN-slug.yaml` data patches applied on top of the seed (split out of pindata). It publishes them to Cloudflare R2 and this project pulls them via `make pull-patches`, then applies them with `make ingest-patches`. See [DataPatches.md](DataPatches.md).
 
 ### Analytics DB over pinball data
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,11 +305,15 @@ When reviewing code or a PR, read [docs/Reviewing.md](Reviewing.md) first and fo
 
 ## Related Repos
 
-This project has two sister projects:
+This project has three sister projects:
 
 ### Catalog seed records
 
 **[pindata](https://github.com/deanmoses/pindata)**: pre-launch seed canonical catalog records (markdown files + JSON schemas). It publishes the catalog as JSON to Cloudflare R2 and this project pulls it down from R2 via `make pull-ingest`.
+
+### Data patches
+
+**[flippatch](https://github.com/deanmoses/flippatch)**: the numbered `NNNN-slug.yaml` data patches applied on top of the seed (split out of pindata). It publishes them to Cloudflare R2 and this project pulls them via `make pull-patches`, then applies them with `make ingest-patches`. See [DataPatches.md](DataPatches.md).
 
 ### Analytics DB over pinball data
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap dev test lint quality agent-docs codegen ingest-all ingest-patches pull-ingest mypy mypy-warm mypy-restart mypy-status
+.PHONY: bootstrap dev test lint quality agent-docs codegen ingest-all ingest-patches pull-ingest pull-patches mypy mypy-warm mypy-restart mypy-status
 
 bootstrap:
 	./scripts/bootstrap
@@ -29,20 +29,26 @@ codegen:
 # This gives a brand-new database something approaching the production state.
 # Do NOT run this on an already-seeded system — prod and the dev DB are seeded once
 # and from then on ONLY run `make ingest-patches`, never a re-ingest.
-# Run `make pull-ingest` first to fetch the files to ingest.
+# Run `make pull-ingest && make pull-patches` first to fetch the files to ingest.
 ingest-all:
 	cd backend && uv run python manage.py ingest_all --write && uv run python manage.py ingest_patches
 
 # Apply just the pending data patches — the everyday correction path once DB is seeded.
-# Run `make pull-ingest` first to fetch new patch files.
+# Run `make pull-patches` first to fetch new patch files.
 # Idempotent: already-applied patches are skipped.
 # For a preview, run `manage.py ingest_patches --dry-run` directly.
 ingest-patches:
 	cd backend && uv run python manage.py ingest_patches
 
-# Pull ingest source files from Cloudflare R2 to local data/ingest_sources/
+# Pull seed catalog + external ingest sources (pindata, IPDB, OPDB) from R2 to
+# local data/ingest_sources/. Does NOT fetch data patches — see pull-patches.
 pull-ingest:
 	./scripts/pull_ingest_sources.sh
+
+# Pull data patches (the flippatch/ R2 prefix) to local
+# data/ingest_sources/flippatch/patches/ — the dir ingest-patches reads.
+pull-patches:
+	./scripts/pull_patches.sh
 
 mypy:
 	uv run --directory backend mypy --config-file pyproject.toml .

--- a/backend/apps/catalog/ingestion/r2_pull.py
+++ b/backend/apps/catalog/ingestion/r2_pull.py
@@ -1,0 +1,156 @@
+"""Shared Cloudflare R2 manifest-download helper for the ingest pull commands.
+
+Used by the ``pull_ingest_sources`` and ``pull_patches`` management commands.
+Pulls are manifest-driven: a ``manifest.json`` lists ``{path, size, sha256}``
+entries; this downloads the files a caller wants and verifies each checksum.
+
+Uses only stdlib (``urllib.request``) so it works on Railway's slim Python image.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.client
+import json
+import os
+import socket
+import tempfile
+import urllib.request
+from collections.abc import Callable, Collection
+from typing import Any, NamedTuple, cast
+from urllib.error import HTTPError
+
+# Default local download directory, shared by the pull commands.
+DEFAULT_DEST = os.path.join(tempfile.gettempdir(), "ingest_sources")
+
+# Force IPv4 for all socket lookups in this process. stdlib's urllib has no
+# Happy Eyeballs (RFC 8305): when DNS returns both v4 and v6 records and the
+# v6 path is unreachable, urlopen blocks for the full ~30s kernel TCP timeout
+# per request before falling back to v4. Cloudflare R2's v6 anycast prefix is
+# intermittently unreachable from consumer networks; v4 always works. Filtering
+# getaddrinfo to AF_INET takes the working path immediately. Applied at import
+# so every command that imports this helper benefits.
+_orig_getaddrinfo = socket.getaddrinfo
+
+
+def _ipv4_only_getaddrinfo(
+    host: Any,  # noqa: ANN401 - matches socket.getaddrinfo's overloaded signature
+    port: Any,  # noqa: ANN401
+    family: int = 0,
+    *args: Any,  # noqa: ANN401
+    **kwargs: Any,  # noqa: ANN401
+) -> Any:  # noqa: ANN401
+    return _orig_getaddrinfo(host, port, socket.AF_INET, *args, **kwargs)
+
+
+socket.getaddrinfo = _ipv4_only_getaddrinfo
+
+# Hard ceiling on every HTTP read. Without this, urlopen blocks indefinitely
+# on a stalled connection — the symptom that motivated the IPv4 forcing above.
+# 30s is long enough for the largest current manifest entry over a slow link
+# but short enough to surface real network failures as errors, not hangs.
+_TIMEOUT_SECONDS = 30
+
+_OPENER = urllib.request.build_opener()
+_OPENER.addheaders = [("User-Agent", "flipcommons/1.0")]
+
+
+class PullCounts(NamedTuple):
+    """Per-manifest tally rolled up by the calling command for its summary."""
+
+    downloaded: int
+    up_to_date: int
+    ignored: int
+
+
+def _urlopen(url: str) -> http.client.HTTPResponse:
+    # OpenerDirector.open() is typed as Any in typeshed; the concrete return for
+    # http/https URLs is an HTTPResponse.
+    return cast(http.client.HTTPResponse, _OPENER.open(url, timeout=_TIMEOUT_SECONDS))
+
+
+def sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def download_manifest(
+    *,
+    base_url: str,
+    manifest_path: str,
+    local_prefix: str,
+    dest: str,
+    needed_files: Collection[str] | None = None,
+    required: bool = False,
+    log: Callable[[str], None],
+    warn: Callable[[str], None],
+) -> PullCounts:
+    """Fetch one R2 manifest and download the files it lists into ``dest``.
+
+    ``base_url`` is the bucket root; ``manifest_path`` is the manifest's key
+    relative to it (e.g. ``"flippatch/manifest.json"``). Files are stored under
+    ``dest/local_prefix + entry["path"]``. When ``needed_files`` is given, only
+    entries whose path is in it are downloaded (the rest are tallied as
+    ``ignored``); when ``None``, every entry is downloaded.
+
+    A missing manifest (HTTP error) is, by default, reported via ``warn`` and
+    yields all-zero counts rather than raising, so one optional source among
+    several doesn't break the whole pull. Pass ``required=True`` when this is the
+    sole source of its data — the ``HTTPError`` then propagates so the caller can
+    fail loudly instead of silently reporting "0 downloaded".
+    """
+    manifest_url = f"{base_url}/{manifest_path}"
+    log(f"Fetching {manifest_url}")
+    try:
+        with _urlopen(manifest_url) as resp:
+            manifest = json.loads(resp.read())
+    except HTTPError as e:
+        if required:
+            raise
+        warn(f"  Skipped ({e.code})")
+        return PullCounts(0, 0, 0)
+
+    # Files in a manifest are listed relative to that manifest's directory.
+    manifest_base = base_url
+    if "/" in manifest_path:
+        manifest_base = f"{base_url}/{manifest_path.rsplit('/', 1)[0]}"
+
+    downloaded = up_to_date = ignored = 0
+    for entry in manifest:
+        rel_path = entry["path"]
+
+        if needed_files is not None and rel_path not in needed_files:
+            ignored += 1
+            continue
+
+        expected_size = entry["size"]
+        expected_sha = entry["sha256"]
+        local_path = os.path.join(dest, local_prefix + rel_path)
+
+        # Skip if local file already matches size and checksum.
+        if (
+            os.path.exists(local_path)
+            and os.path.getsize(local_path) == expected_size
+            and sha256(local_path) == expected_sha
+        ):
+            up_to_date += 1
+            continue
+
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        file_url = f"{manifest_base}/{rel_path}"
+        log(f"  {local_prefix}{rel_path}")
+        with _urlopen(file_url) as resp, open(local_path, "wb") as f:
+            f.write(resp.read())
+
+        actual_sha = sha256(local_path)
+        if actual_sha != expected_sha:
+            raise RuntimeError(
+                f"Checksum mismatch for {rel_path}: "
+                f"expected {expected_sha}, got {actual_sha}"
+            )
+        downloaded += 1
+
+    return PullCounts(downloaded, up_to_date, ignored)

--- a/backend/apps/catalog/management/commands/ingest_patches.py
+++ b/backend/apps/catalog/management/commands/ingest_patches.py
@@ -44,10 +44,10 @@ class ApplyOutcome(NamedTuple):
     report: RunReport | None
 
 
-# <repo>/data/ingest_sources/pindata/patches — where pull_ingest_sources
-# lands the published patch files.
+# <repo>/data/ingest_sources/flippatch/patches — where pull_patches lands the
+# published patch files (authored in the flippatch repo, separate from pindata).
 DEFAULT_PATCHES_DIR = (
-    Path(__file__).parents[5] / "data" / "ingest_sources" / "pindata" / "patches"
+    Path(__file__).parents[5] / "data" / "ingest_sources" / "flippatch" / "patches"
 )
 
 # Bold black == bright black == gray on most terminals; used to mute the

--- a/backend/apps/catalog/management/commands/pull_and_ingest.py
+++ b/backend/apps/catalog/management/commands/pull_and_ingest.py
@@ -8,7 +8,8 @@ so the database reaches the same state as production.
 production DB — re-running the seed re-asserts the original source claims and
 would clobber same-source patch corrections (and the patch ledger would then
 skip re-applying them). To apply new corrections to a live DB, run
-``pull_ingest_sources`` + ``ingest_patches`` instead (see docs/Ingest.md).
+``pull_ingest_sources`` + ``pull_patches`` + ``ingest_patches`` instead (see
+docs/Ingest.md).
 
 Usage (Railway SSH):
     .venv/bin/python manage.py pull_and_ingest
@@ -65,6 +66,14 @@ class Command(BaseCommand):
             stderr=self.stderr,
         )
 
+        self.stdout.write(self.style.MIGRATE_HEADING("Pulling data patches from R2..."))
+        call_command(
+            "pull_patches",
+            dest=dest,
+            stdout=self.stdout,
+            stderr=self.stderr,
+        )
+
         self.stdout.write(self.style.MIGRATE_HEADING("Running ingest pipeline..."))
         kwargs: dict[str, str | bool] = {
             "ipdb": f"{dest}/ipdb_xantari.json",
@@ -89,7 +98,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.MIGRATE_HEADING("Applying data patches..."))
             call_command(
                 "ingest_patches",
-                patches_dir=f"{dest}/pindata/patches",
+                patches_dir=f"{dest}/flippatch/patches",
                 stdout=self.stdout,
                 stderr=self.stderr,
             )

--- a/backend/apps/catalog/management/commands/pull_ingest_sources.py
+++ b/backend/apps/catalog/management/commands/pull_ingest_sources.py
@@ -1,13 +1,15 @@
-"""Download ingest source files from Cloudflare R2.
+"""Download seed ingest source files from Cloudflare R2.
 
-Uses only stdlib (urllib.request) so it works on Railway's slim Python image.
+The R2 bucket has several manifests:
+  - manifest.json            — root-level ingest sources (IPDB, OPDB, etc.),
+                               published by pinexplore.
+  - pindata/manifest.json    — catalog seed export files, published by pindata.
 
-The R2 bucket has two manifests:
-  - manifest.json          — root-level ingest sources (IPDB, OPDB, etc.),
-                             published by pinexplore.
-  - pindata/manifest.json  — catalog export files, published by pindata.
+This command fetches both and downloads the files the seed ingest needs. Data
+patches are published separately by flippatch and pulled by `pull_patches`.
 
-This command fetches both and downloads the files the ingest pipeline needs.
+The shared R2 download/checksum logic lives in
+``apps.catalog.ingestion.r2_pull``.
 
 Usage (local):
     uv run python manage.py pull_ingest_sources --dest ../data/ingest_sources
@@ -19,49 +21,12 @@ Usage (Railway):
 from __future__ import annotations
 
 import argparse
-import hashlib
-import http.client
-import json
 import os
-import socket
-import tempfile
-import urllib.request
-from typing import Any, cast
-from urllib.error import HTTPError
+from typing import Any
 
 from django.core.management.base import BaseCommand
 
-# Force IPv4 for all socket lookups in this command. stdlib's urllib has no
-# Happy Eyeballs (RFC 8305): when DNS returns both v4 and v6 records and the
-# v6 path is unreachable, urlopen blocks for the full ~30s kernel TCP timeout
-# per request before falling back to v4. Cloudflare R2's v6 anycast prefix is
-# intermittently unreachable from consumer networks; v4 always works. Filtering
-# getaddrinfo to AF_INET takes the working path immediately.
-_orig_getaddrinfo = socket.getaddrinfo
-
-
-def _ipv4_only_getaddrinfo(
-    host: Any,  # noqa: ANN401 - matches socket.getaddrinfo's overloaded signature
-    port: Any,  # noqa: ANN401
-    family: int = 0,
-    *args: Any,  # noqa: ANN401
-    **kwargs: Any,  # noqa: ANN401
-) -> Any:  # noqa: ANN401
-    return _orig_getaddrinfo(host, port, socket.AF_INET, *args, **kwargs)
-
-
-socket.getaddrinfo = _ipv4_only_getaddrinfo
-
-# Hard ceiling on every HTTP read. Without this, urlopen blocks indefinitely
-# on a stalled connection — the symptom that motivated the IPv4 forcing above.
-# 30s is long enough for the largest current manifest entry over a slow link
-# but short enough to surface real network failures as errors, not hangs.
-_TIMEOUT_SECONDS = 30
-
-_OPENER = urllib.request.build_opener()
-_OPENER.addheaders = [("User-Agent", "flipcommons/1.0")]
-
-_DEFAULT_DEST = os.path.join(tempfile.gettempdir(), "ingest_sources")
+from apps.catalog.ingestion.r2_pull import DEFAULT_DEST, download_manifest
 
 # Only download these root-level files from the ingest-sources manifest.
 _NEEDED_FILES = {
@@ -70,31 +35,17 @@ _NEEDED_FILES = {
     "opdb_changelog.json",
 }
 
-# Manifests to fetch: (url_path, local_prefix)
-# - Root manifest entries are stored as-is under dest.
-# - pindata/ manifest entries are stored under pindata/ locally.
+# Manifests to fetch: (manifest path, local prefix, needed-files filter).
+# - Root manifest: store entries as-is under dest, but only _NEEDED_FILES.
+# - pindata/ manifest: store under pindata/ locally, download everything.
 _MANIFESTS = [
-    ("manifest.json", ""),
-    ("pindata/manifest.json", "pindata/"),
+    ("manifest.json", "", _NEEDED_FILES),
+    ("pindata/manifest.json", "pindata/", None),
 ]
 
 
-def _urlopen(url: str) -> http.client.HTTPResponse:
-    # OpenerDirector.open() is typed as Any in typeshed; the concrete return for
-    # http/https URLs is an HTTPResponse.
-    return cast(http.client.HTTPResponse, _OPENER.open(url, timeout=_TIMEOUT_SECONDS))
-
-
-def _sha256(path: str) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1 << 16), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
 class Command(BaseCommand):
-    help = "Download ingest source files from Cloudflare R2."
+    help = "Download seed ingest source files from Cloudflare R2."
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -106,8 +57,8 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--dest",
-            default=_DEFAULT_DEST,
-            help=f"Local directory to download into (default: {_DEFAULT_DEST}).",
+            default=DEFAULT_DEST,
+            help=f"Local directory to download into (default: {DEFAULT_DEST}).",
         )
 
     def handle(
@@ -117,62 +68,20 @@ class Command(BaseCommand):
         base_url = options["url"].rstrip("/")
         dest = options["dest"]
 
-        downloaded = 0
-        up_to_date = 0
-        ignored = 0
-
-        for manifest_path, local_prefix in _MANIFESTS:
-            manifest_url = f"{base_url}/{manifest_path}"
-            self.stdout.write(f"Fetching {manifest_url}")
-            try:
-                with _urlopen(manifest_url) as resp:
-                    manifest = json.loads(resp.read())
-            except HTTPError as e:
-                self.stdout.write(self.style.WARNING(f"  Skipped ({e.code})"))
-                continue
-
-            # Determine the base URL for files in this manifest.
-            # pindata/manifest.json lists files relative to pindata/.
-            manifest_base = base_url
-            if "/" in manifest_path:
-                manifest_base = f"{base_url}/{manifest_path.rsplit('/', 1)[0]}"
-
-            for entry in manifest:
-                rel_path = entry["path"]
-
-                # For the root manifest, only download _NEEDED_FILES.
-                # For prefixed manifests, download everything.
-                if not local_prefix and rel_path not in _NEEDED_FILES:
-                    ignored += 1
-                    continue
-
-                expected_size = entry["size"]
-                expected_sha = entry["sha256"]
-                local_path = os.path.join(dest, local_prefix + rel_path)
-
-                # Skip if local file matches size and checksum
-                if (
-                    os.path.exists(local_path)
-                    and os.path.getsize(local_path) == expected_size
-                    and _sha256(local_path) == expected_sha
-                ):
-                    up_to_date += 1
-                    continue
-
-                os.makedirs(os.path.dirname(local_path), exist_ok=True)
-                file_url = f"{manifest_base}/{rel_path}"
-                self.stdout.write(f"  {local_prefix}{rel_path}")
-                with _urlopen(file_url) as resp, open(local_path, "wb") as f:
-                    f.write(resp.read())
-
-                # Verify checksum after download
-                actual_sha = _sha256(local_path)
-                if actual_sha != expected_sha:
-                    raise RuntimeError(
-                        f"Checksum mismatch for {rel_path}: "
-                        f"expected {expected_sha}, got {actual_sha}"
-                    )
-                downloaded += 1
+        downloaded = up_to_date = ignored = 0
+        for manifest_path, local_prefix, needed in _MANIFESTS:
+            counts = download_manifest(
+                base_url=base_url,
+                manifest_path=manifest_path,
+                local_prefix=local_prefix,
+                dest=dest,
+                needed_files=needed,
+                log=self.stdout.write,
+                warn=lambda msg: self.stdout.write(self.style.WARNING(msg)),
+            )
+            downloaded += counts.downloaded
+            up_to_date += counts.up_to_date
+            ignored += counts.ignored
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/backend/apps/catalog/management/commands/pull_patches.py
+++ b/backend/apps/catalog/management/commands/pull_patches.py
@@ -1,0 +1,84 @@
+"""Download data patches from Cloudflare R2.
+
+Data patches are authored and published by the **flippatch** repo, separately
+from the seed catalog (pindata). flippatch's `make push` ships them under the
+``flippatch/`` prefix of the shared bucket, with ``flippatch/manifest.json``
+listing the patch files at ``flippatch/patches/NNNN-slug.yaml``.
+
+This command fetches that manifest and downloads the patches into
+``<dest>/flippatch/patches/`` — the default dir `ingest_patches` reads from.
+The seed catalog and external sources are pulled separately by
+`pull_ingest_sources`.
+
+The shared R2 download/checksum logic lives in
+``apps.catalog.ingestion.r2_pull``.
+
+Usage (local):
+    uv run python manage.py pull_patches --dest ../data/ingest_sources
+
+Usage (Railway):
+    .venv/bin/python manage.py pull_patches --dest /tmp/ingest_sources
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any
+from urllib.error import HTTPError
+
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.catalog.ingestion.r2_pull import DEFAULT_DEST, download_manifest
+
+
+class Command(BaseCommand):
+    help = "Download data patches from Cloudflare R2 (the flippatch/ prefix)."
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--url",
+            default=os.environ.get(
+                "R2_PUBLIC_URL", "https://pub-8a5220445534421c879b6ff9ede350f1.r2.dev"
+            ),
+            help="Base URL of the R2 public bucket (default: R2_PUBLIC_URL env var).",
+        )
+        parser.add_argument(
+            "--dest",
+            default=DEFAULT_DEST,
+            help=f"Local directory to download into (default: {DEFAULT_DEST}).",
+        )
+
+    def handle(
+        self,
+        **options: Any,  # noqa: ANN401 - argparse-driven Django command kwargs
+    ) -> None:
+        base_url = options["url"].rstrip("/")
+        dest = options["dest"]
+
+        # flippatch/manifest.json lists files relative to flippatch/ (e.g.
+        # "patches/0001-foo.yaml"); store them under flippatch/ locally.
+        # required=True: this manifest is the sole source of patches, so a 404
+        # is a real failure — fail loudly rather than report "0 downloaded".
+        try:
+            counts = download_manifest(
+                base_url=base_url,
+                manifest_path="flippatch/manifest.json",
+                local_prefix="flippatch/",
+                dest=dest,
+                needed_files=None,
+                required=True,
+                log=self.stdout.write,
+                warn=lambda msg: self.stdout.write(self.style.WARNING(msg)),
+            )
+        except HTTPError as e:
+            raise CommandError(
+                f"Could not fetch flippatch/manifest.json from {base_url} "
+                f"(HTTP {e.code}). The patches were not pulled."
+            ) from e
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done. {counts.downloaded} downloaded, {counts.up_to_date} up-to-date."
+            )
+        )

--- a/docs/AGENTS.src.md
+++ b/docs/AGENTS.src.md
@@ -344,11 +344,15 @@ When reviewing code or a PR, read [docs/Reviewing.md](Reviewing.md) first and fo
 
 ## Related Repos
 
-This project has two sister projects:
+This project has three sister projects:
 
 ### Catalog seed records
 
 **[pindata](https://github.com/deanmoses/pindata)**: pre-launch seed canonical catalog records (markdown files + JSON schemas). It publishes the catalog as JSON to Cloudflare R2 and this project pulls it down from R2 via `make pull-ingest`.
+
+### Data patches
+
+**[flippatch](https://github.com/deanmoses/flippatch)**: the numbered `NNNN-slug.yaml` data patches applied on top of the seed (split out of pindata). It publishes them to Cloudflare R2 and this project pulls them via `make pull-patches`, then applies them with `make ingest-patches`. See [DataPatches.md](DataPatches.md).
 
 ### Analytics DB over pinball data
 

--- a/docs/Data.md
+++ b/docs/Data.md
@@ -2,21 +2,20 @@
 
 This is the index doc for working with the pinball catalog data: where it comes from, how it gets into the database, how to correct it, and where to explore it.
 
-## Three repos
+## Four repos
 
-The catalog data ecosystem spans three sibling repos. This project (flipcommons) serves the data; the other two source and analyze it.
+The catalog data ecosystem spans four sibling repos. This project (flipcommons) serves the data; the others source, patch, and analyze it.
 
-- **flipcommons** (this repo) — serves the catalog. Pulls pindata's published JSON, ingests it as the seed baseline, replays numbered data patches on top, exposes the API and frontend.
-- **[pindata](https://github.com/deanmoses/pindata)** — the canonical data source. It contains two types of data:
-  - _seed data_: the bulk of the catalog, for bootstrapping a new database. One Markdown file per entity (YAML frontmatter + prose), validated against JSON schemas, exported to JSON and published to Cloudflare R2.
-  - _patch data_: numbered **data patches** in YAML format, to apply incremental updates to a running database. See [DataPatches.md](DataPatches.md).
+- **flipcommons** (this repo) — serves the catalog. Pulls pindata's published seed JSON, ingests it as the baseline, replays the numbered data patches published by flippatch on top, exposes the API and frontend.
+- **[pindata](https://github.com/deanmoses/pindata)** — the canonical **seed catalog**: the bulk of the catalog, for bootstrapping a new database. One Markdown file per entity (YAML frontmatter + prose), validated against JSON schemas, exported to JSON and published to Cloudflare R2. Seed only — data patches used to live here too, but now live in flippatch.
+- **[flippatch](https://github.com/deanmoses/flippatch)** — the **data patches**: numbered `NNNN-slug.yaml` corrections applied incrementally on top of a seeded database. Authored and validated there, published to Cloudflare R2. See [DataPatches.md](DataPatches.md).
 - **[pinexplore](https://github.com/deanmoses/pinexplore)** — read-only analysis. Builds a DuckDB database from pindata records plus external dumps (Wikidata, IPDB, OPDB etc) and runs integrity checks, cross-source comparisons and gap analysis. Not part of the serving path.
 
-pindata is upstream of both; flipcommons and pinexplore are independent consumers of it.
+pindata and flippatch are upstream; flipcommons and pinexplore are independent consumers.
 
 ### Local layout convention
 
-By convention, these repos live side by side under one parent directory on localhost dev, so `../pindata` and `../pinexplore` resolve from this repo. Tooling and docs assume that layout when they reference a sister project by relative path.
+By convention, these repos live side by side under one parent directory on localhost dev, so `../pindata`, `../flippatch` and `../pinexplore` resolve from this repo. Tooling and docs assume that layout when they reference a sister project by relative path.
 
 ## How data reaches the database
 
@@ -26,7 +25,8 @@ Two stages, both manual — there is no auto-ingest on deploy or startup.
 2. **Patches — append-only corrections.** Every fix or ongoing source update is a small, numbered, replayable [data patch](DataPatches.md) applied on top of the seed. A fresh database reaches production's state by replaying seed → `0001` → `0002` → …. This is the everyday path once a database is seeded. See [DataPatches.md](DataPatches.md).
 
 ```bash
-make pull-ingest      # fetch pindata's JSON + patches from R2 → data/ingest_sources/
+make pull-ingest      # fetch pindata's seed JSON + external sources from R2
+make pull-patches     # fetch flippatch's data patches from R2
 make ingest-all       # fresh dev DB only: seed, then replay all patches
 make ingest-patches   # everyday path: apply pending patches to an already-seeded DB
 ```
@@ -36,6 +36,6 @@ make ingest-patches   # everyday path: apply pending patches to an already-seede
 - **Explore, validate or compare the data** → use [pinexplore](https://github.com/deanmoses/pinexplore) (DuckDB, read-only).
 - **Understand the catalog model** (titles, models, variants, manufacturers, taxonomy) → [DomainModel.md](DomainModel.md).
 - **Correct or update a catalog value** → author a [data patch](DataPatches.md), attributed to the source the fact came from. Snapshot localhost first so you can iterate.
-- **Bootstrap a fresh local database** → `make pull-ingest && make ingest-all`.
-- **Apply pending corrections** to a seeded DB → `make pull-ingest && make ingest-patches`.
+- **Bootstrap a fresh local database** → `make pull-ingest && make pull-patches && make ingest-all`.
+- **Apply pending corrections** to a seeded DB → `make pull-patches && make ingest-patches`.
 - **Understand how a field's value is resolved** and audited → [Provenance.md](Provenance.md) (claims and resolution).

--- a/docs/DataPatchAuthoring.md
+++ b/docs/DataPatchAuthoring.md
@@ -157,7 +157,7 @@ Because a patch is immutable once applied (see [DataPatches.md → The ledger](D
 
 ```bash
 cd backend
-mkdir -p /tmp/p && cp ../../pindata/patches/00NN-*.yaml /tmp/p/
+mkdir -p /tmp/p && cp ../../flippatch/patches/00NN-*.yaml /tmp/p/
 cp db.sqlite3 db.pre-00NN.sqlite3                      # snapshot (.sqlite3 -> gitignored)
 uv run python manage.py ingest_patches --patches-dir /tmp/p
 # verify in the running app / Django admin ...
@@ -186,4 +186,4 @@ print(c.changeset.note)
 
 ### Hand off to user
 
-Committing and `make push` in pindata are the user's call — never do either yourself.
+Committing and `make push` in flippatch are the user's call — never do either yourself.

--- a/docs/DataPatchKit.md
+++ b/docs/DataPatchKit.md
@@ -17,10 +17,10 @@ Every good curated patch session converges on these steps:
 
 ## Where the work lives
 
-Authoring artifacts are committed in **pindata**, next to the patches they produce — not in `/tmp` or `~/.claude/plans`, which lose the audit trail:
+Authoring artifacts are committed in **flippatch**, next to the patches they produce — not in `/tmp` or `~/.claude/plans`, which lose the audit trail:
 
 ```text
-pindata/patches/
+flippatch/patches/
   0010-game-formats.yaml              # the shipped patch(es)
   0011-...
   authoring/

--- a/docs/DataPatches.md
+++ b/docs/DataPatches.md
@@ -14,11 +14,11 @@ A patch is **attributed to a source** — usually `flipcommons-catalog`, Flipcom
 - **remove** — drop a relationship _member_ (a tag, a location) by superseding it with an `exists=false` tombstone. Distinct from retract: the claim stays active, resolving to "absent" — the same mechanism the in-app editor uses.
 - **delete** — soft-delete an entity (the `status=deleted` lifecycle), distinct from a claim retract.
 
-## Patches live in pindata
+## Patches live in flippatch
 
-Data patches live in the [pindata](https://github.com/deanmoses/pindata) repo in the `patches/` directory. They are numbered files `NNNN-slug.yaml`, like `0001-prototype-tags`.
+Data patches live in the [flippatch](https://github.com/deanmoses/flippatch) repo in the `patches/` directory. They are numbered files `NNNN-slug.yaml`, like `0001-prototype-tags`. (They used to live in pindata alongside the seed catalog; they were split out into flippatch, which is now the patch authoring home and transport.)
 
-From there they are exported via pindata's `make pull-ingest` to R2, under the path `data/ingest_sources/pindata/patches/`.
+flippatch's `make push` publishes them to Cloudflare R2 under the `flippatch/` prefix. This repo fetches them with `make pull-patches`, which lands them at `data/ingest_sources/flippatch/patches/` — the directory `ingest_patches` reads by default.
 
 ## File format
 
@@ -314,11 +314,11 @@ This is deliberate: a user can create a source through the app, so a same-identi
 
 Patches don't auto-apply; there's no deploy or startup hook — you run the command manually. Applying patches is the everyday correction path once a database is seeded (production never re-ingests the seed data).
 
-Run `make pull-ingest` first to fetch new patch files:
+Run `make pull-patches` first to fetch new patch files:
 
 ```bash
 # Everyday path — applies pending patches from the default dir
-# (data/ingest_sources/pindata/patches/):
+# (data/ingest_sources/flippatch/patches/):
 make ingest-patches
 
 # That just wraps the management command. Run the mgt cmd directly to preview or

--- a/docs/Ingest.md
+++ b/docs/Ingest.md
@@ -6,13 +6,15 @@ enrichment commands (Fandom, Wikidata) run separately.
 
 ## Data sources
 
-Catalog data and external source files are maintained in the
+The seed catalog and external source files are maintained in the
 [pindata](https://github.com/deanmoses/pindata) repo and published to
 Cloudflare R2. This project pulls them locally before running the ingest pipeline:
 
 ```bash
-make pull-ingest   # download R2 → local data/ingest_sources/
+make pull-ingest   # download seed catalog + external sources from R2 → local data/ingest_sources/
 ```
+
+Data patches are maintained separately in [flippatch](https://github.com/deanmoses/flippatch) and pulled with `make pull-patches` (see [DataPatches.md](DataPatches.md)).
 
 ## Pipeline overview
 
@@ -157,8 +159,8 @@ patch files, then apply only the pending ones (the ledger skips the rest):
 
 ```bash
 railway ssh --service flip-commons
-.venv/bin/python manage.py pull_ingest_sources --dest /tmp/ingest_sources
-.venv/bin/python manage.py ingest_patches --patches-dir /tmp/ingest_sources/pindata/patches
+.venv/bin/python manage.py pull_patches --dest /tmp/ingest_sources
+.venv/bin/python manage.py ingest_patches --patches-dir /tmp/ingest_sources/flippatch/patches
 ```
 
 Add `--dry-run` to `ingest_patches` to preview the claims without writing. See

--- a/scripts/pull_patches.sh
+++ b/scripts/pull_patches.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Pull data patches from Cloudflare R2 (the flippatch/ prefix) to local
+# data/ingest_sources/flippatch/. Thin wrapper around the Django mgmt command.
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+DEST="$(pwd)/${1:-data/ingest_sources}"
+
+# Load .env if present
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+exec uv run --directory backend python manage.py pull_patches --dest "$DEST"


### PR DESCRIPTION
## Summary

Data patches have been split out of **pindata** into the new **[flippatch](https://github.com/deanmoses/flippatch)** sister repo, which publishes them to Cloudflare R2 under the `flippatch/` prefix. This wires flipcommons up to the new source.

- **New `pull_patches` command** (+ `make pull-patches` wrapper / `scripts/pull_patches.sh`) — fetches `flippatch/manifest.json` and downloads the patches into `data/ingest_sources/flippatch/patches/`, the dir `ingest_patches` reads by default.
- **Extracted shared R2 logic** into `apps.catalog.ingestion.r2_pull` (`download_manifest` + `PullCounts` + the IPv4-forcing / read-timeout workaround), now reused by both `pull_ingest_sources` and `pull_patches`. `pull_ingest_sources` shrank ~80 lines.
- **`required=True` on the patch pull** — `pull_patches` fails loudly with a `CommandError` if `flippatch/manifest.json` 404s (it's the sole patch source), instead of silently reporting "0 downloaded". `pull_ingest_sources` keeps the soft-skip for its optional manifests.
- **Repointed paths** — `ingest_patches` default dir and `pull_and_ingest` now use `flippatch/patches`; `pull_and_ingest` runs `pull_patches` as a step.
- **Docs** — updated to describe four sibling repos and the new `make pull-patches` step across Data.md, DataPatches.md, Ingest.md, DataPatchAuthoring.md, DataPatchKit.md, AGENTS.src.md.

## Test plan

- `ruff`, `mypy` clean on touched files
- Full pre-commit suite (incl. backend tests) passed on commit
- `manage.py pull_patches --help` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)