### PR TITLE
feat(patches): support gameplay-feature count in data patches

### DIFF
--- a/backend/apps/catalog/claims.py
+++ b/backend/apps/catalog/claims.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.validators import MinValueValidator
 
 from apps.media.models import MediaSupportedModel
 from apps.provenance.claims import RelationshipClaim, build_relationship_claim
@@ -45,6 +46,7 @@ def register_catalog_relationship_schemas() -> None:
         GameplayFeature,
         Location,
         MachineModel,
+        MachineModelGameplayFeature,
         ModelAbbreviation,
         Person,
         RewardType,
@@ -80,7 +82,29 @@ def register_catalog_relationship_schemas() -> None:
         valid_subjects={MachineModel, Series},
     )
 
-    # Gameplay feature M2M on MachineModel — with optional integer count.
+    # Gameplay feature M2M on MachineModel — with optional integer count. The
+    # count's lower bound is the through-model field's own explicit
+    # MinValueValidator, so the patch adapter rejects a too-small count (0,
+    # negative) at plan time instead of deferring to the DB CHECK as an opaque
+    # IntegrityError (see ValueKeySpec.min_value). No symmetric upper bound:
+    # PositiveSmallIntegerField declares no explicit MaxValueValidator, only the
+    # backend integer range — which SQLite (the patch author's local DB) reports
+    # as the full 64-bit range, not Postgres's 32767. A meaningful max therefore
+    # isn't model-derivable here (the same reason max_length is the only string
+    # bound we pre-check), so an over-large count falls through to a Postgres range
+    # error in prod.
+    count_field = MachineModelGameplayFeature._meta.get_field("count")
+    count_min = max(
+        (
+            int(v.limit_value)
+            for v in count_field.validators
+            if isinstance(v, MinValueValidator)
+        ),
+        default=None,
+    )
+    assert count_min is not None, (
+        "MachineModelGameplayFeature.count must declare a MinValueValidator"
+    )
     register_relationship_schema(
         namespace="gameplay_feature",
         value_keys=(
@@ -96,6 +120,7 @@ def register_catalog_relationship_schemas() -> None:
                 scalar_type=int,
                 required=False,
                 nullable=True,
+                min_value=count_min,
             ),
         ),
         valid_subjects={MachineModel},

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -19,6 +19,7 @@ from apps.catalog.models import (
     GameplayFeature,
     Location,
     MachineModel,
+    MachineModelGameplayFeature,
     Manufacturer,
     Person,
     Series,
@@ -749,6 +750,154 @@ claims:
     assert report.rejected == 0
     child = GameplayFeature.objects.get(slug="center-ramp")
     assert list(child.parents.values_list("slug", flat=True)) == ["ramps"]
+
+
+def _feature_counts(machine_model: MachineModel) -> dict[str, int | None]:
+    """slug → count for a model's materialized gameplay-feature through rows."""
+    return {
+        row.gameplayfeature.slug: row.count
+        for row in MachineModelGameplayFeature.objects.filter(
+            machinemodel=machine_model
+        ).select_related("gameplayfeature")
+    }
+
+
+def test_gameplay_feature_count_via_mapping(machine_model):
+    # Format A: a bare slug ⇒ count NULL, a one-key ``{slug: count}`` map ⇒ count.
+    GameplayFeature.objects.create(name="Multiball", slug="multiball")
+    GameplayFeature.objects.create(name="Flippers", slug="flippers")
+    text = f"""
+attribution: flipcommons-catalog
+description: gameplay features with a count
+claims:
+  - model.{machine_model.slug}:
+      gameplay_feature:
+        - multiball
+        - flippers: 2
+"""
+    report = _apply(text)
+    assert report.rejected == 0
+    assert _feature_counts(machine_model) == {"multiball": None, "flippers": 2}
+
+
+def test_gameplay_feature_count_same_patch_create(machine_model):
+    # A counted member whose feature is created earlier in the same patch must
+    # still carry the count through the deferred (identity_refs) path.
+    text = f"""
+attribution: flipcommons-catalog
+claims:
+  - gameplay-feature.flippers:
+      create: true
+      name: Flippers
+  - model.{machine_model.slug}:
+      gameplay_feature:
+        - flippers: 2
+"""
+    report = _apply(text, patch_id="0001-flippers")
+    assert report.rejected == 0
+    assert _feature_counts(machine_model) == {"flippers": 2}
+
+
+def test_gameplay_feature_remove_by_bare_slug(machine_model):
+    # count is not part of identity, so removal stays a bare slug.
+    GameplayFeature.objects.create(name="Flippers", slug="flippers")
+    _apply(
+        f"""
+attribution: flipcommons-catalog
+claims:
+  - model.{machine_model.slug}:
+      gameplay_feature:
+        - flippers: 2
+""",
+        patch_id="0001-add",
+    )
+    assert _feature_counts(machine_model) == {"flippers": 2}
+    _apply(
+        f"""
+attribution: flipcommons-catalog
+claims:
+  - model.{machine_model.slug}:
+      remove:
+        gameplay_feature:
+          - flippers
+""",
+        patch_id="0002-remove",
+    )
+    assert _feature_counts(machine_model) == {}
+
+
+def test_tag_rejects_count_mapping(machine_model):
+    # A relationship with no payload slot (tag) rejects the mapping form.
+    Tag.objects.create(name="Prototype", slug="prototype")
+    text = f"""
+attribution: flipcommons-catalog
+claims:
+  - model.{machine_model.slug}:
+      tag:
+        - prototype: 2
+"""
+    with pytest.raises(PatchError, match="must be a public_id string"):
+        _apply(text)
+
+
+def test_gameplay_feature_explicit_null_count(machine_model):
+    # An explicit ``null`` on the nullable count slot ⇒ NULL, identical to the
+    # bare-slug form. (A bare empty ``flippers:`` is the string '' — rejected below.)
+    GameplayFeature.objects.create(name="Flippers", slug="flippers")
+    text = f"""
+attribution: flipcommons-catalog
+claims:
+  - model.{machine_model.slug}:
+      gameplay_feature:
+        - flippers: null
+"""
+    report = _apply(text)
+    assert report.rejected == 0
+    assert _feature_counts(machine_model) == {"flippers": None}
+
+
+def test_gameplay_feature_empty_count_rejected(machine_model):
+    # ``- flippers:`` parses as the empty string, not null — rejected as non-int
+    # rather than silently treated as "no count".
+    GameplayFeature.objects.create(name="Flippers", slug="flippers")
+    text = f"""
+attribution: flipcommons-catalog
+claims:
+  - model.{machine_model.slug}:
+      gameplay_feature:
+        - flippers:
+"""
+    with pytest.raises(PatchError, match="count must be int"):
+        _apply(text)
+
+
+@pytest.mark.parametrize("bad_count", [0, -1])
+def test_gameplay_feature_count_must_be_positive(machine_model, bad_count):
+    # The count's lower bound is the through-model field's MinValueValidator, so a
+    # 0/negative count is a plan-time PatchError, not a deferred IntegrityError.
+    GameplayFeature.objects.create(name="Flippers", slug="flippers")
+    text = f"""
+attribution: flipcommons-catalog
+claims:
+  - model.{machine_model.slug}:
+      gameplay_feature:
+        - flippers: {bad_count}
+"""
+    with pytest.raises(PatchError, match="count must be >= 1"):
+        _apply(text)
+
+
+def test_gameplay_feature_count_must_be_int(machine_model):
+    GameplayFeature.objects.create(name="Flippers", slug="flippers")
+    text = f"""
+attribution: flipcommons-catalog
+claims:
+  - model.{machine_model.slug}:
+      gameplay_feature:
+        - flippers: lots
+"""
+    with pytest.raises(PatchError, match="count"):
+        _apply(text)
 
 
 def test_backward_unresolvable_ref_errors(_bootstrap_source):
@@ -2786,6 +2935,97 @@ def test_more_than_two_fk_slots_not_authorable():
     )
     with pytest.raises(PatchError, match="only 2-slot members are authorable"):
         _unpack_credit_member({"a": "b"}, spec, "fake_three_fk", entry)
+
+
+def test_payload_on_non_single_fk_rejected(monkeypatch):
+    # A non-identity payload slot is authorable only via the one-key
+    # '{public_id: value}' form, which only a single-FK shape uses. A multi-FK
+    # (or any non-single-FK) shape carrying one has no syntax for it. No prod
+    # schema does this, so craft one and confirm registration-time rejection.
+    crafted = RelationshipSchema(
+        namespace="fake_multikey_payload",
+        value_keys=(
+            ValueKeySpec(
+                name="person",
+                scalar_type=int,
+                required=True,
+                identity="person",
+                fk_target=FkTarget(Person, "pk"),
+            ),
+            ValueKeySpec(
+                name="role",
+                scalar_type=int,
+                required=True,
+                identity="role",
+                fk_target=FkTarget(CreditRole, "pk"),
+            ),
+            ValueKeySpec(name="weight", scalar_type=int, required=False, nullable=True),
+        ),
+        valid_subjects=frozenset({Manufacturer}),
+    )
+    monkeypatch.setattr(
+        "apps.claim_ingest.patches.emit.get_relationship_schema",
+        lambda namespace: crafted if namespace == "fake_multikey_payload" else None,
+    )
+    entry = EditEntry(
+        entity_type="manufacturer",
+        public_id="stern",
+        retract=[],
+        remove={},
+        fields={},
+    )
+    with pytest.raises(PatchError, match="no authoring syntax"):
+        _relationship_member_spec(Manufacturer, "fake_multikey_payload", entry)
+
+
+def test_multiple_payload_slots_rejected(monkeypatch):
+    # The one-key '{public_id: value}' form encodes exactly one extra value, so a
+    # single-FK shape can carry at most one payload slot. Craft a two-payload one.
+    crafted = RelationshipSchema(
+        namespace="fake_two_payload",
+        value_keys=(
+            ValueKeySpec(
+                name="feature",
+                scalar_type=int,
+                required=True,
+                identity="feature",
+                fk_target=FkTarget(GameplayFeature, "pk"),
+            ),
+            ValueKeySpec(name="count", scalar_type=int, required=False, nullable=True),
+            ValueKeySpec(name="note", scalar_type=str, required=False, nullable=True),
+        ),
+        valid_subjects=frozenset({Manufacturer}),
+    )
+    monkeypatch.setattr(
+        "apps.claim_ingest.patches.emit.get_relationship_schema",
+        lambda namespace: crafted if namespace == "fake_two_payload" else None,
+    )
+    entry = EditEntry(
+        entity_type="manufacturer",
+        public_id="stern",
+        retract=[],
+        remove={},
+        fields={},
+    )
+    with pytest.raises(PatchError, match="not patch-authorable"):
+        _relationship_member_spec(Manufacturer, "fake_two_payload", entry)
+
+
+def test_media_attachment_not_patch_authorable():
+    # media_attachment is a *real* registered single-FK schema (media_asset)
+    # carrying two non-identity slots — category and is_primary. It is authored
+    # through the media API, never via data patches, so the multi-payload guard
+    # must reject it. Pinned on the real schema, not a synthetic stand-in, so a
+    # future media-schema change that made it look patch-authorable is caught here.
+    entry = EditEntry(
+        entity_type="model",
+        public_id="x",
+        retract=[],
+        remove={},
+        fields={},
+    )
+    with pytest.raises(PatchError, match="not patch-authorable"):
+        _relationship_member_spec(MachineModel, "media_attachment", entry)
 
 
 # ── Credits (multi-key: person + role) ─────────────────────────────

--- a/backend/apps/claim_ingest/patches/emit.py
+++ b/backend/apps/claim_ingest/patches/emit.py
@@ -247,11 +247,36 @@ def _emit_direct(
     )
 
 
+class _PayloadSlot(NamedTuple):
+    """A single non-identity scalar a counted FK member carries.
+
+    Surfaced from the schema's lone non-identity, non-``display_key`` value-key so
+    nothing here names ``count``. The one-key ``{public_id: value}`` authoring form
+    encodes exactly one extra value, so only a single-FK relationship with exactly
+    one such slot yields a ``_PayloadSlot`` — today just gameplay_feature.count.
+    A relationship with two (media_attachment) is rejected upstream in
+    ``_relationship_member_spec`` before any slot is built, so this stays singular.
+    """
+
+    value_key: str  # the value-dict key carrying the payload (``spec.name``)
+    scalar_type: type  # int/str — the authored value is type-checked against it
+    nullable: bool  # whether an explicit ``null`` is allowed (else omit ⇒ NULL)
+    # Inclusive lower bound for an int payload (the model field's own
+    # ``MinValueValidator``), or ``None`` if unbounded. Enforced at plan time so an
+    # out-of-range value is a clear ``PatchError``, not a deferred ``IntegrityError``.
+    min_value: int | None
+
+
 class _FkMemberSpec(NamedTuple):
     """Member is a public_id resolving to an FK on another entity (tag, theme, location)."""
 
     value_key: str  # the value-dict key carrying the member FK (``spec.name``)
     target_model: type[models.Model]  # what a member public_id resolves to
+    # An optional non-identity scalar carried alongside the FK via the one-key
+    # ``{public_id: value}`` form (gameplay_feature's ``count``). ``None`` ⇒ the
+    # member is a bare public_id string (tag, theme, location). Always ``None``
+    # for the slots of a ``_MultiFkMemberSpec`` (identity slots carry no payload).
+    payload: _PayloadSlot | None = None
 
 
 class _StringMemberSpec(NamedTuple):
@@ -328,6 +353,42 @@ def _relationship_member_spec(
             f"{model_class.__name__}"
         )
     identity_specs = [s for s in schema.value_keys if s.identity is not None]
+    # Non-identity slots split in two: a ``display_key`` (derived from the member
+    # itself, e.g. alias_display) is never authored separately, so exclude it. What
+    # remains is independently-authored payload. Two real schemas have it:
+    # gameplay_feature (one slot, ``count`` — patch-authorable below) and
+    # media_attachment (two slots, ``category`` + ``is_primary`` — rejected by the
+    # guards below; media is authored through the media API, not data patches).
+    display_keys = {
+        s.display_key for s in schema.value_keys if s.display_key is not None
+    }
+    payload_specs = [
+        s
+        for s in schema.value_keys
+        if s.identity is None and s.name not in display_keys
+    ]
+    # A payload slot is authored only via the one-key ``{public_id: value}`` form,
+    # which is also how a multi-FK identity is authored — so payload is exclusive to
+    # a single-FK relationship, and that form encodes exactly one extra value. Reject
+    # every other shape loudly here rather than silently dropping the slot, so the
+    # single-FK branch below can read ``payload_specs[0]`` knowing it is the only one.
+    is_single_fk = len(identity_specs) == 1 and identity_specs[0].fk_target is not None
+    if payload_specs and not is_single_fk:
+        raise PatchError(
+            f"{entry.ref}: relationship {namespace!r} carries non-identity "
+            f"slot(s) {[s.name for s in payload_specs]!r} on a shape that has "
+            f"no authoring syntax for them (unsupported)"
+        )
+    if len(payload_specs) >= 2:
+        # The one-key mapping form carries exactly one extra value, so a relationship
+        # with >1 payload slot (today only media_attachment) has no patch member
+        # syntax at all — not "use one slot", but "not patch-authorable".
+        raise PatchError(
+            f"{entry.ref}: relationship {namespace!r} carries "
+            f"{len(payload_specs)} non-identity slots "
+            f"({[s.name for s in payload_specs]!r}); the patch member syntax "
+            f"encodes at most one, so it is not patch-authorable"
+        )
     if len(identity_specs) >= 2:
         # A multi-key relationship is authorable only when every identity slot is
         # an FK (the one-key ``{a: b}`` mapping form maps public_ids onto slots).
@@ -350,7 +411,21 @@ def _relationship_member_spec(
         )
     spec = identity_specs[0]
     if spec.fk_target is not None:
-        return _FkMemberSpec(value_key=spec.name, target_model=spec.fk_target.model)
+        payload = (
+            _PayloadSlot(
+                value_key=payload_specs[0].name,
+                scalar_type=payload_specs[0].scalar_type,
+                nullable=payload_specs[0].nullable,
+                min_value=payload_specs[0].min_value,
+            )
+            if payload_specs
+            else None
+        )
+        return _FkMemberSpec(
+            value_key=spec.name,
+            target_model=spec.fk_target.model,
+            payload=payload,
+        )
     if spec.scalar_type is str:
         if spec.max_length is None:
             raise PatchError(
@@ -368,6 +443,87 @@ def _relationship_member_spec(
     )
 
 
+def _unpack_fk_member(
+    member: object,
+    rel_spec: _FkMemberSpec,
+    namespace: Namespace,
+    entry: PatchEntry,
+) -> tuple[PublicId, dict[str, IdentityPart]]:
+    """Split an FK member into its public_id and optional non-identity payload.
+
+    A bare ``str`` ⇒ ``(member, {})`` — the universal form (tag, theme, location,
+    and the no-count gameplay_feature case). When the spec declares a payload slot,
+    a one-key ``{public_id: value}`` mapping ⇒ ``(public_id, {payload_key: value})``
+    with the value type-checked against the slot. An omitted or explicit-null value
+    yields an empty payload dict, so the resolver writes NULL — identical to the
+    bare-string form. Shared by ``_member_identity`` (committed assert + remove) and
+    the deferred-create branch in ``_emit_relationship``, so a counted member can
+    still reference a same-patch create.
+
+    ``member`` is untyped parsed YAML, so this re-checks the shape at the boundary.
+    """
+    empty: dict[str, IdentityPart] = {}
+    if isinstance(member, str):
+        return member, empty
+    if rel_spec.payload is not None and isinstance(member, dict) and len(member) == 1:
+        ((public_id, raw),) = member.items()
+        if isinstance(public_id, str):
+            value = _coerce_payload_value(
+                rel_spec.payload, raw, public_id, namespace, entry
+            )
+            if value is None:
+                return public_id, empty
+            return public_id, {rel_spec.payload.value_key: value}
+    suffix = (
+        f" or a single '{{<public_id>: <{rel_spec.payload.value_key}>}}' mapping"
+        if rel_spec.payload is not None
+        else ""
+    )
+    raise PatchError(
+        f"{entry.ref}: relationship {namespace!r} member {member!r} "
+        f"must be a public_id string{suffix}"
+    )
+
+
+def _coerce_payload_value(
+    payload: _PayloadSlot,
+    raw: object,
+    public_id: str,
+    namespace: Namespace,
+    entry: PatchEntry,
+) -> IdentityPart:
+    """Validate one authored payload value against its slot, or raise.
+
+    Returns ``None`` for an explicit ``null`` on a nullable slot (the caller omits
+    the key, so the resolver writes NULL). ``bool`` is rejected where an ``int`` is
+    expected — YAML ``true``/``false`` are ``int`` subclasses but never a count.
+    """
+    if raw is None:
+        if payload.nullable:
+            return None
+        raise PatchError(
+            f"{entry.ref}: relationship {namespace!r} member {public_id!r} "
+            f"{payload.value_key} must not be null"
+        )
+    if (
+        payload.scalar_type is int
+        and isinstance(raw, int)
+        and not isinstance(raw, bool)
+    ):
+        if payload.min_value is not None and raw < payload.min_value:
+            raise PatchError(
+                f"{entry.ref}: relationship {namespace!r} member {public_id!r} "
+                f"{payload.value_key} must be >= {payload.min_value}, got {raw}"
+            )
+        return raw
+    if payload.scalar_type is str and isinstance(raw, str):
+        return raw
+    raise PatchError(
+        f"{entry.ref}: relationship {namespace!r} member {public_id!r} "
+        f"{payload.value_key} must be {payload.scalar_type.__name__}, got {raw!r}"
+    )
+
+
 def _member_identity(
     member: object,
     namespace: Namespace,
@@ -381,23 +537,24 @@ def _member_identity(
     non-identity key (e.g. ``alias_display``) to produce the canonical
     tombstone — so this stays the one authoritative identity builder.
 
-    ``member`` is untyped parsed YAML, so each branch re-checks it is a ``str``
-    at this boundary (a parse-edge guard, not a model-type branch).
+    ``member`` is untyped parsed YAML, so the shape is re-checked at this boundary
+    (a parse-edge guard, not a model-type branch): the FK branch delegates that to
+    ``_unpack_fk_member`` (bare public_id, or the ``{public_id: count}`` form), the
+    string branches re-check ``str`` inline.
     """
     match rel_spec:
         case _FkMemberSpec(value_key, target_model):
-            if not isinstance(member, str):
-                raise PatchError(
-                    f"{entry.ref}: relationship {namespace!r} member {member!r} "
-                    f"must be a public_id string"
-                )
-            member_pk = _lookup_pk(target_model, member)
+            public_id, payload = _unpack_fk_member(member, rel_spec, namespace, entry)
+            member_pk = _lookup_pk(target_model, public_id)
             if member_pk is None:
                 raise PatchError(
-                    f"{entry.ref}: relationship {namespace!r} member {member!r} "
+                    f"{entry.ref}: relationship {namespace!r} member {public_id!r} "
                     f"does not resolve to a {target_model.__name__}"
                 )
-            return {value_key: member_pk}
+            # ``payload`` (e.g. count) is non-identity: it rides the assert value
+            # and is dropped by ``build_relationship_claim(..., exists=False)`` on
+            # the remove path, so the same builder serves both.
+            return {value_key: member_pk, **payload}
         case _StringMemberSpec(value_key, max_length, display_key):
             if not isinstance(member, str):
                 raise PatchError(
@@ -609,9 +766,10 @@ def _emit_relationship(
                 carrier_written = True
                 continue
             identity = resolved.concrete
-        elif isinstance(rel_spec, _FkMemberSpec) and isinstance(member, str):
+        elif isinstance(rel_spec, _FkMemberSpec):
+            public_id, payload = _unpack_fk_member(member, rel_spec, namespace, entry)
             handle = registry.created_handle(
-                rel_spec.target_model, normalize_fk_value(member)
+                rel_spec.target_model, normalize_fk_value(public_id)
             )
             if handle is not None:
                 member_key = (
@@ -627,6 +785,10 @@ def _emit_relationship(
                     PlannedClaimAssert(
                         field_name=namespace,
                         relationship_namespace=namespace,
+                        # ``payload`` (e.g. count) is non-identity; it rides
+                        # ``identity`` and is merged into the value at apply time,
+                        # after the FK handle resolves (see persist._patch_handles).
+                        identity=payload,
                         identity_refs={rel_spec.value_key: handle},
                         note=note,
                         citation_ref=citation_ref,

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -74,6 +74,13 @@ class ValueKeySpec:
     ``CharField(max_length=...)``, so an over-long string would pass every
     local check and only fail as an ``IntegrityError`` on Postgres in prod.
     ``None`` for FK and non-length-bounded keys.
+
+    ``min_value`` (optional, int payload specs only) carries the inclusive lower
+    bound the through-model field already declares (its ``MinValueValidator``),
+    derived from the model at registration. Consumed by the data-patch adapter so
+    an out-of-range payload (e.g. ``count: 0``) fails as a clear ``PatchError`` at
+    plan time rather than deferring to the DB CHECK as an opaque ``IntegrityError``
+    when the resolver materializes the row. ``None`` for unbounded keys.
     """
 
     name: str
@@ -84,6 +91,7 @@ class ValueKeySpec:
     fk_target: FkTarget | None = None
     display_key: str | None = None
     max_length: int | None = None
+    min_value: int | None = None
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary

Gameplay-feature **counts** could not be set via data patches. The patch authoring layer classified a relationship by its identity slots only, so `gameplay_feature`'s non-identity `count` slot was silently dropped — every patch wrote `count = NULL`, even though the model, resolver and in-app editor all carry it. (Flagged by AI review.)

This adds the `{public_id: count}` member form to patch YAML:

```yaml
gameplay_feature:
  - multiball       # count = NULL
  - flippers: 2     # count = 2
```

## Approach

`build_relationship_claim` already threads non-identity keys into the claim value, the deferred-create finalizer already merges them at apply time, and the resolver already reads `val.get("count")` — so nothing downstream needed changing. The work is confined to the patch authoring layer:

- A relationship's lone non-identity, non-`display_key` value-key is surfaced as a `_PayloadSlot` on the FK member spec — **model-driven**, nothing names `count`.
- `_unpack_fk_member` parses the `{public_id: value}` form, shared by the committed/remove and deferred-create paths, so a count on a same-patch-created feature carries through too.

## Validation

- **Lower bound** derived from the through-model field's explicit `MinValueValidator` and enforced at plan time — a non-positive count is a clear `PatchError`, not a deferred `IntegrityError` at resolve.
- **No symmetric max:** SQLite (the patch author's local DB) reports the full 64-bit integer range, so a meaningful max isn't model-derivable locally — the same reason only `max_length` is pre-checked. Documented at the extraction site; an over-large count still falls through to a Postgres range error in prod.
- **Unauthorable shapes rejected loudly** instead of silently dropping a slot: payload on a multi-FK/string relationship, or >1 payload slot (today `media_attachment`, which is authored via the media API, not patches).

## Tests

Mapping form, same-patch-create, removal by bare slug, explicit `null` vs rejected empty, non-int and non-positive (0/−1) counts, the two synthetic guard shapes, and the **real** `media_attachment` schema's rejection (pinned on the actual schema, not a stand-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)