### PR TITLE
chore(deps): ignore @testing-library/svelte 5.4.1 (runes regression)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,17 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
+    ignore:
+      # @testing-library/svelte 5.4.1 ships svelte-core@1.1.2, whose
+      # wrapper-scaffold.svelte still uses legacy `export let`. Our
+      # svelte.config.js sets compilerOptions.runes:true globally, which
+      # vite-plugin-svelte applies to that node_modules component too, so
+      # every *.dom.test.ts fails to compile ("Cannot use `export let` in
+      # runes mode"). Upstream is fixing it —
+      # https://github.com/testing-library/svelte-testing-library/issues/496.
+      # Ignore only this version so we pick up the next (fixed) release.
+      - dependency-name: "@testing-library/svelte"
+        versions: ["5.4.1"]
     groups:
       # Packages that must move together (framework + its ecosystem plugins).
       svelte:


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` for **only** `@testing-library/svelte` `5.4.1`.

## Why

5.4.1 pulls in `@testing-library/svelte-core@1.1.2`, whose internal `wrapper-scaffold.svelte` still uses legacy `export let`. Our [svelte.config.js](frontend/svelte.config.js) sets `compilerOptions.runes: true` globally, which `vite-plugin-svelte` applies to that `node_modules` component too — so all 216 `*.dom.test.ts` suites fail to compile with `Cannot use \`export let\` in runes mode`. This is what broke CI on the Dependabot bump PR #544.

Reproduced locally: baseline 5.3.1 green → bump to 5.4.1 → exact CI error.

Upstream is fixing it: testing-library/svelte-testing-library#496. The maintainer's recommended consumer workaround is to ignore this version until a fixed release ships. Pinning to a single version (not a range) means the next release flows in automatically.

Closes #544 (superseded by this ignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)