### PR TITLE
feat(citation): citation subdomain recognition

### DIFF
--- a/backend/apps/catalog/tests/test_patch_provenance.py
+++ b/backend/apps/catalog/tests/test_patch_provenance.py
@@ -761,13 +761,13 @@ def test_url_cite_nests_under_domain_matched_root(
     assert year_claim.citation_instances.get().citation_source_id == child.pk
 
 
-def test_url_cite_on_subdomain_raises_under_exact_matching(
+def test_url_cite_on_subdomain_nests_under_domain_matched_root(
     flipcommons_catalog, kineticist_root, pm
 ):
-    # SUBDOMAIN-MATCHING-DISABLED (re-enabled in DomainGovernance G3)
-    # Exact matching: an asset/subdomain host (static.kineticist.com) does not
-    # match the seeded kineticist.com root, so the patch path raises rather than
-    # nesting a child under it or minting a new root.
+    # Suffix matching: an asset/subdomain host (static.kineticist.com) resolves
+    # to the seeded kineticist.com root through the shared read path, so the
+    # patch path nests a child under it just like a bare-domain cite — proving
+    # the flip fixes the patch surface too, not only cite-url.
     url = "https://static.kineticist.com/manuals/medieval-madness.pdf"
     text = (
         "attribution: flipcommons-catalog\n"
@@ -776,10 +776,18 @@ def test_url_cite_on_subdomain_raises_under_exact_matching(
         f"      cite: {url}\n"
         "      year: 1998\n"
     )
-    # Wrapped into a ValidationError naming the URL.
-    with pytest.raises(ValidationError) as exc_info:
-        _apply(text)
-    assert url in "; ".join(exc_info.value.messages)
+    _apply(text)
+
+    child = CitationSource.objects.get(parent=kineticist_root)
+    assert child.links.get().url == url
+    # No stray root was minted at the subdomain.
+    assert (
+        not CitationSource.objects.filter(source_type="web", parent__isnull=True)
+        .exclude(pk=kineticist_root.pk)
+        .exists()
+    )
+    year_claim = pm.claims.get(field_name="year", is_active=True)
+    assert year_claim.citation_instances.get().citation_source_id == child.pk
 
 
 def test_url_cite_under_root_dedups_and_separates(

--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import asdict
-from typing import Protocol, cast
-from urllib.parse import urlparse
+from typing import Protocol, assert_never, cast
 
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, models, transaction
@@ -35,12 +34,12 @@ from .extractors import (
     get_or_create_scheme_child,
     recognize_url,
 )
-from .hosts import normalize_host
 from .models import (
     CitationSource,
     CitationSourceLink,
     CitationSourceRootDomain,
 )
+from .psl import HostError, HostRejection, root_host_from_url
 from .schemas import (
     CitationCiteUrlSchema,
     CitationExtractDraftSchema,
@@ -334,20 +333,47 @@ def _mint_web_child(
         raise HttpError(422, _validation_detail(exc)) from exc
 
 
+def _host_error_detail(reason: HostRejection) -> str:
+    """The 422 message for a funnel rejection. Exhaustive over ``HostRejection``."""
+    match reason:
+        case HostRejection.NO_HOST:
+            return "That URL has no host to create a site from."
+        case HostRejection.NOT_DNS:
+            return (
+                "That URL's host isn't a domain name — an IP address or malformed "
+                "host can't root a site."
+            )
+        case HostRejection.RESERVED_TLD:
+            return (
+                "That URL's host is a reserved test domain, so it can't root a "
+                "real site."
+            )
+        case HostRejection.PUBLIC_SUFFIX:
+            return (
+                "That URL's host is a public suffix (like gov.uk); cite a page on "
+                "a specific site under it instead."
+            )
+    assert_never(reason)
+
+
 def _create_root_and_child(
     url: str, data: CitationCiteUrlSchema, user: User
 ) -> CitationSource:
     """Create a new site root (homepage link + recognition domain) and a child.
 
-    Roots at the normalized pasted host. The root-create runs in a savepoint: on
-    a concurrent ``host`` ``unique`` violation the savepoint rolls back, the URL
-    is re-recognized against the now-committed root, and the child nests under
-    it.
+    Roots at the URL's **registrable domain** — :func:`root_host_from_url` rounds
+    a fuzzy subdomain paste (``s4.american-pinball.com``) down to one root
+    (``american-pinball.com``) so future cites under the same site collapse
+    together, and 422s a host that can't root a site (no host, IP literal,
+    reserved TLD, bare public suffix) before any write. The root-create then runs
+    in a savepoint: on a concurrent ``host`` ``unique`` violation the savepoint
+    rolls back, the URL is re-recognized against the now-committed root, and the
+    child nests under it.
     """
-    hostname = urlparse(url).hostname
-    if hostname is None:
-        raise HttpError(422, "That URL has no host to create a site from.")
-    host = normalize_host(hostname)
+    try:
+        host = root_host_from_url(url)
+    except HostError as exc:
+        raise HttpError(422, _host_error_detail(exc.reason)) from exc
 
     try:
         with transaction.atomic():
@@ -404,7 +430,8 @@ def cite_url(
     re-recognized server-side and routed to one of four outcomes, all returning
     the **web child** to cite (never the abstract root):
 
-    * **no match** → create the site root (at the raw host) and a page child;
+    * **no match** → create the site root (at the URL's registrable domain, or
+      422 if the host can't root a site) and a page child;
     * **domain match** → create a page child under the existing root, ignoring
       ``site_*`` (the root already exists and is never renamed from here);
     * **exact child** → reuse it;

--- a/backend/apps/citation/extractors.py
+++ b/backend/apps/citation/extractors.py
@@ -235,9 +235,14 @@ def _recognize_by_host(url: str) -> Recognition | None:
     (``www..american-pinball.com`` → ``.american-pinball.com`` →
     ``american-pinball.com``), so without this gate ``/search/`` would surface a
     confident-but-wrong match for garbage input. Recognition must not claim a
-    page it can't honestly resolve; the host's shape is checked once, here.
+    page it can't honestly resolve; the host's shape is checked once, here. A URL
+    too malformed for ``urlparse`` itself (an unterminated IPv6 bracket raises
+    ``ValueError``) abstains the same way.
     """
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
     if not parsed.hostname:
         return None
 

--- a/backend/apps/citation/extractors.py
+++ b/backend/apps/citation/extractors.py
@@ -19,7 +19,14 @@ from urllib.parse import urlparse
 
 from django.db import transaction
 
-from apps.citation.hosts import normalize_host
+from apps.citation.hosts import (
+    Host,
+    RootDomainMatch,
+    is_dns_host,
+    label_suffixes,
+    longest_suffix_match,
+    normalize_host,
+)
 from apps.citation.models import (
     CITATION_SOURCE_NAME_MAX_LENGTH,
     CitationSource,
@@ -207,49 +214,59 @@ def _recognize_by_child_link(url: str) -> Recognition | None:
 
 
 def _recognize_by_host(url: str) -> Recognition | None:
-    """Recognizer 3 — recognition-host match (exact host).
+    """Recognizer 3 — recognition-host match (longest label-boundary suffix).
 
     Resolve the URL's normalized host to the root that owns it via
-    ``CitationSourceRootDomain`` — returns parent only, no identifier. The
-    recognition host is an owned fact on the root, decoupled from the
-    display ``homepage`` link — declared deliberately, never inferred and
-    never via external HTTP. See ``docs/Citations.md``.
+    ``CitationSourceRootDomain``, by **longest label-boundary suffix** — an
+    asset subdomain (``s4.american-pinball.com``) resolves to its registrable
+    root, while a more-specific seeded host (``twip.kineticist.com``) still
+    wins over its parent domain for its own subtree. Returns parent only, no
+    identifier. The recognition host is an owned fact on the root, decoupled
+    from the display ``homepage`` link — declared deliberately, never inferred
+    and never via external HTTP. See ``docs/Citations.md``.
 
-    SUBDOMAIN-MATCHING-DISABLED (re-enabled in DomainGovernance G3): match
-    the normalized host exactly, not by longest label-boundary suffix.
-    Exact matching can't over-match, so it ships with no public-suffix
-    guard; the ``label_suffixes``/``longest_suffix_match`` helpers stay
-    built and tested in ``hosts.py``, dormant, until G3 re-points this step
-    at them.
+    Suffix matching is safe because ``CitationSourceRootDomain.clean()`` rejects
+    any bare public suffix, so no stored host can over-match the unrelated sites
+    beneath a public suffix (``gov.uk`` could never be a root that swallows
+    ``dvla.gov.uk``).
+
+    A syntactically-invalid host abstains: a malformed host (empty label,
+    underscore, IP literal) can still yield a *valid ancestor* suffix
+    (``www..american-pinball.com`` → ``.american-pinball.com`` →
+    ``american-pinball.com``), so without this gate ``/search/`` would surface a
+    confident-but-wrong match for garbage input. Recognition must not claim a
+    page it can't honestly resolve; the host's shape is checked once, here.
     """
     parsed = urlparse(url)
     if not parsed.hostname:
         return None
 
     host = normalize_host(parsed.hostname)
-
-    # The root-only filter is defense-in-depth for the app-level clean()
-    # invariant (rows inserted via raw SQL / bulk that bypass it).
-    row = (
-        CitationSourceRootDomain.objects.filter(
-            host=host,
-            source__parent__isnull=True,
-        )
-        .values_list("source_id", "source__name")
-        .first()
-    )
-    if row is None:
+    if not is_dns_host(host):
         return None
-    source_id, source_name = row
-    return Recognition(parent_id=source_id, parent_name=source_name)
+
+    # Narrow to the host's own label-boundary suffixes (a handful of rows at
+    # most), then let longest_suffix_match pick the most specific. The root-only
+    # filter is defense-in-depth for the app-level clean() invariant (rows
+    # inserted via raw SQL / bulk that bypass it).
+    candidates = [
+        RootDomainMatch(source_id=row[0], source_name=row[1], host=Host(row[2]))
+        for row in CitationSourceRootDomain.objects.filter(
+            host__in=label_suffixes(host),
+            source__parent__isnull=True,
+        ).values_list("source_id", "source__name", "host")
+    ]
+    best = longest_suffix_match(host, candidates)
+    if best is None:
+        return None
+    return Recognition(parent_id=best.source_id, parent_name=best.source_name)
 
 
 # The ordered recognizer pipeline: each tries one resolution mechanism over the
 # shared EXTRACTORS + host machinery; the first to return a Recognition wins.
 # Resolution order is load-bearing (scheme identity before exact link before
-# host) — see each recognizer's docstring. A future suffix recognizer re-points
-# _recognize_by_host; a new pre-processing step (archive-peel, DOI) becomes one
-# more entry here.
+# host suffix) — see each recognizer's docstring. A new pre-processing step
+# (archive-peel, DOI) becomes one more entry here.
 _RECOGNIZERS: tuple[Recognizer, ...] = (
     _recognize_by_extractor,
     _recognize_by_child_link,
@@ -261,7 +278,7 @@ def recognize_url(url: str) -> Recognition | None:
     """Try to recognize a pasted URL against known sources.
 
     Runs the ordered ``_RECOGNIZERS`` pipeline — scheme extractor, then exact
-    child-link, then exact host — and returns the first non-``None``
+    child-link, then host suffix — and returns the first non-``None``
     ``Recognition``, or ``None`` if every recognizer abstains.
     """
     for recognizer in _RECOGNIZERS:

--- a/backend/apps/citation/hosts.py
+++ b/backend/apps/citation/hosts.py
@@ -11,10 +11,19 @@ subdomain (``s4.american-pinball.com``) resolves to its registrable root, while
 a more-specific seeded host (``twip.kineticist.com``) still beats its parent
 domain for its own subtree. The intended consumer is citation-source
 recognition; on their own these are pure string ops — deterministic and offline.
+
+This module also carries the **syntactic** host predicates
+(:func:`is_dns_host`, :func:`is_reserved_tld`) that the write-time guard and the
+derive funnel gate on — pure string / ``ipaddress`` checks, no DNS lookup. The
+two **PSL-backed** predicates (``is_public_suffix``, ``registrable_domain``)
+deliberately live in :mod:`apps.citation.psl` instead, so this module stays
+dependency-free and the recognition read path never imports the snapshot.
 """
 
 from __future__ import annotations
 
+import ipaddress
+import re
 from collections.abc import Sequence
 from typing import NamedTuple, NewType
 
@@ -49,6 +58,61 @@ def normalize_host(hostname: str) -> Host:
     while host.startswith("www."):
         host = host.removeprefix("www.")
     return Host(host)
+
+
+# A single DNS label: ASCII ``[a-z0-9-]``, 1–63 chars, no leading/trailing
+# hyphen. The charset is pinned ASCII on purpose — ``str.isalnum()`` is
+# unicode-true and would admit raw IDN. ``normalize_host`` lowercases first, so
+# the class needs no uppercase range.
+_DNS_LABEL = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+
+# RFC 6761 / 6762 special-use top-level names: reserved by the standards bodies
+# to *never* be real registrable domains. A standards constant, not a denylist.
+_RESERVED_TLDS = frozenset({"localhost", "invalid", "test", "example", "local"})
+
+
+def is_dns_host(host: Host) -> bool:
+    """Whether *host* is syntactically a DNS hostname (not an IP literal).
+
+    Syntactic only — no DNS lookup, no PSL. Rejects IP literals (``127.0.0.1``,
+    ``::1``, bracket-stripped) and requires dot-separated :data:`_DNS_LABEL`
+    labels — at least one dot, a total length within the 253-char hostname
+    limit, and a non-all-numeric rightmost label (an all-numeric TLD is an IPv4
+    shape that slipped the literal check). Accepts punycode (``xn--…``);
+    raw-unicode IDN is rejected by the ASCII label charset — a known limitation
+    (an internationalized recognition host must be punycode). Expects a
+    normalized :data:`Host`.
+    """
+    # The full presentation hostname tops out at 253 chars (the RFC 1035
+    # 255-octet wire limit minus the length/root bytes). Owned here so the
+    # syntactic contract is complete, not delegated to the storage column.
+    if not host or len(host) > 253:
+        return False
+    try:
+        ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        pass
+    else:
+        return False
+    labels = host.split(".")
+    if len(labels) < 2:
+        return False
+    if not all(_DNS_LABEL.fullmatch(label) for label in labels):
+        return False
+    return not labels[-1].isdigit()
+
+
+def is_reserved_tld(host: Host) -> bool:
+    """Whether *host*'s rightmost label is an RFC special-use TLD.
+
+    ``foo.test``, ``bar.localhost`` and a bare ``invalid`` are reserved; a real
+    registrable domain is not. The derive funnel (``cite-url``) rejects these so
+    a fuzzy contributor paste can't mint a root that could never match a real
+    cite; the declare path (``clean()``) deliberately does **not** — declaring a
+    host is curator-trusted, and the citation test fixtures lean on ``.example``.
+    Expects a normalized :data:`Host`.
+    """
+    return host.split(".")[-1] in _RESERVED_TLDS
 
 
 def label_suffixes(host: Host) -> list[Host]:

--- a/backend/apps/citation/models.py
+++ b/backend/apps/citation/models.py
@@ -7,7 +7,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
-from apps.citation.hosts import normalize_host
+from apps.citation.hosts import is_dns_host, normalize_host
+from apps.citation.psl import is_public_suffix
 from apps.citation.source_type_traits import SourceType, source_type_traits
 from apps.core.models import (
     BoundedTextField,
@@ -420,9 +421,12 @@ class CitationSourceRootDomain(TimeStampedModel):
     same recognition host. ``clean()`` canonicalizes ``host`` through
     ``hosts.normalize_host`` (lowercase, ``www.``-strip, trailing-dot), so every
     validated write — admin inline, API, patches — stores a normalized value
-    without the caller having to remember. The DB lowercase CHECK is a backstop
-    for writes that bypass validation (raw SQL / bulk), which it can only
-    partially cover (case, not ``www.``-stripping).
+    without the caller having to remember. ``clean()`` also rejects a host that
+    isn't a syntactic DNS name (an IP literal) or that is a bare public suffix
+    (``com``, ``co.uk``) — the latter would over-match every site beneath it
+    under longest-suffix recognition. The DB lowercase CHECK is a backstop for
+    writes that bypass validation (raw SQL / bulk), which it can only partially
+    cover (case, not ``www.``-stripping or the host-shape guard).
 
     **Root-only.** A domain may attach only to a root (a parentless source). A
     CHECK constraint cannot reach ``source.parent_id`` across the FK, so the
@@ -452,6 +456,27 @@ class CitationSourceRootDomain(TimeStampedModel):
     def clean(self) -> None:
         super().clean()
         self.host = normalize_host(self.host)
+        # The universal recognition-host guard, on every validated write (cite-url,
+        # admin inline, patch declare). A bare public suffix is the dangerous one:
+        # under longest-suffix matching it would resolve every unrelated site
+        # beneath it. is_reserved_tld is deliberately NOT checked here — declaring
+        # a host is curator-trusted; only the derive funnel rejects reserved TLDs.
+        if not is_dns_host(self.host):
+            raise ValidationError(
+                {
+                    "host": "Enter a valid domain name (not an IP address or malformed host)."
+                }
+            )
+        if is_public_suffix(self.host):
+            raise ValidationError(
+                {
+                    "host": (
+                        "A bare public suffix (e.g. com, co.uk) can't be a "
+                        "recognition host — it would match every site beneath it. "
+                        "Use a specific domain such as example.com."
+                    )
+                }
+            )
         if self.source_id is not None and not self.source.is_root:
             raise ValidationError(
                 {

--- a/backend/apps/citation/psl.py
+++ b/backend/apps/citation/psl.py
@@ -14,15 +14,26 @@ names are still rejected separately by :func:`apps.citation.hosts.is_reserved_tl
 ``only_icann=False`` (the default) honors the PRIVATE section, so ``github.io``
 is itself a public suffix and ``foo.github.io`` is one whole site.
 
-Everything here takes a :data:`~apps.citation.hosts.Host` (already normalized);
-the dependency is one-way (``psl`` → ``hosts``, never back).
+The two predicates take a :data:`~apps.citation.hosts.Host` (already normalized).
+The one exception is :func:`root_host_from_url` — the *derive funnel*, which
+takes a raw URL and is the single place that parses, validates and rounds an
+untrusted contributor paste into a storable recognition host. The dependency is
+one-way (``psl`` → ``hosts``, never back).
 """
 
 from __future__ import annotations
 
+import enum
+from urllib.parse import urlparse
+
 from publicsuffixlist import PublicSuffixList
 
-from apps.citation.hosts import Host
+from apps.citation.hosts import (
+    Host,
+    is_dns_host,
+    is_reserved_tld,
+    normalize_host,
+)
 
 # Built once at import — parsing the bundled snapshot is a cost paid a single
 # time, and this is the module's only ``Any`` boundary (publicsuffixlist ships
@@ -57,3 +68,81 @@ def registrable_domain(host: Host) -> Host | None:
     """
     private = _PSL.privatesuffix(host)
     return Host(private) if private else None
+
+
+class HostRejection(enum.Enum):
+    """Why :func:`root_host_from_url` refused to round a pasted URL to a host.
+
+    One member per gate in the funnel, in gate order. The cite-url boundary maps
+    each to a specific 422 message; the value is a stable machine reason.
+    """
+
+    NO_HOST = "no_host"
+    """The URL has no host component to root a site on."""
+    NOT_DNS = "not_dns"
+    """The host isn't a DNS hostname — an IP literal or a malformed/raw-IDN host."""
+    RESERVED_TLD = "reserved_tld"
+    """The host's TLD is an RFC special-use name (``.test``, ``.example``, …)."""
+    PUBLIC_SUFFIX = "public_suffix"
+    """The host is a bare public suffix (``gov.uk``, ``co.uk``) with no domain below."""
+
+
+class HostError(Exception):
+    """A pasted URL could not be rounded to a storable recognition host.
+
+    Raised only by :func:`root_host_from_url`, and carries a typed
+    :class:`HostRejection` so the ``cite-url`` boundary can map each rejection to
+    a specific 422. Deliberately **not** an ``HttpError`` — this module is
+    HTTP-free, so the funnel stays unit-testable apart from the API layer.
+    """
+
+    def __init__(self, reason: HostRejection) -> None:
+        super().__init__(reason.value)
+        self.reason = reason
+
+
+def root_host_from_url(url: str) -> Host:
+    """Round a pasted page URL to the registrable domain to root a new site on.
+
+    The **derive funnel**: the one place the system turns an untrusted
+    contributor URL into a stored recognition host. HTTP-free — it parses and
+    validates only, never fetches. Gates run in this order, each raising
+    :class:`HostError` with the matching :class:`HostRejection`:
+
+    1. ``urlparse(url).hostname`` parses and is present — a parser failure
+       (e.g. an unterminated IPv6 bracket, which raises ``ValueError``) maps to
+       ``NOT_DNS``; a missing host maps to ``NO_HOST``.
+    2. :func:`~apps.citation.hosts.is_dns_host` after
+       :func:`~apps.citation.hosts.normalize_host` — else ``NOT_DNS`` (IP
+       literal, raw-unicode IDN, malformed host).
+    3. **not** :func:`~apps.citation.hosts.is_reserved_tld` — else
+       ``RESERVED_TLD``. This reject is funnel-only: a fuzzy paste must not mint
+       a root that could never match a real cite. The declare path
+       (``CitationSourceRootDomain.clean``) skips it — declaring is curator-trusted.
+    4. :func:`registrable_domain` is not ``None`` — else ``PUBLIC_SUFFIX`` (a
+       bare public suffix has no registrable label to round to).
+
+    Returns the **registrable domain** (``s4.american-pinball.com`` →
+    ``american-pinball.com``), so future cites under the same site collapse to
+    one root — the anti-fragmentation goal. The order is intentional:
+    ``is_reserved_tld`` runs before :func:`registrable_domain` because
+    ``accept_unknown=True`` would otherwise round a reserved name to itself.
+    """
+    try:
+        hostname = urlparse(url).hostname
+    except ValueError as exc:
+        # urlparse rejects some malformed URLs (e.g. an unterminated IPv6
+        # bracket) by raising rather than returning a host. Surface it as a
+        # typed reject so the API boundary 422s instead of 500-ing.
+        raise HostError(HostRejection.NOT_DNS) from exc
+    if hostname is None:
+        raise HostError(HostRejection.NO_HOST)
+    host = normalize_host(hostname)
+    if not is_dns_host(host):
+        raise HostError(HostRejection.NOT_DNS)
+    if is_reserved_tld(host):
+        raise HostError(HostRejection.RESERVED_TLD)
+    rounded = registrable_domain(host)
+    if rounded is None:
+        raise HostError(HostRejection.PUBLIC_SUFFIX)
+    return rounded

--- a/backend/apps/citation/psl.py
+++ b/backend/apps/citation/psl.py
@@ -1,0 +1,59 @@
+"""Public Suffix List boundary for citation-source recognition.
+
+The one module that depends on the bundled Public Suffix List
+(``publicsuffixlist``). Kept separate from :mod:`apps.citation.hosts` — which is
+deliberately pure and PSL-free — so the recognition *read* path
+(:mod:`apps.citation.extractors`) never pulls the snapshot in transitively. Only
+the *write-time* guard (``CitationSourceRootDomain.clean``) and the *derive*
+funnel (``cite-url``'s no-match branch) consult the PSL.
+
+The list is loaded **once at import** into a module-level ``PublicSuffixList``.
+``accept_unknown=True`` fails open on a gTLD newer than the bundled snapshot — a
+genuinely-unknown but real TLD rounds rather than 422-ing; the RFC special-use
+names are still rejected separately by :func:`apps.citation.hosts.is_reserved_tld`.
+``only_icann=False`` (the default) honors the PRIVATE section, so ``github.io``
+is itself a public suffix and ``foo.github.io`` is one whole site.
+
+Everything here takes a :data:`~apps.citation.hosts.Host` (already normalized);
+the dependency is one-way (``psl`` → ``hosts``, never back).
+"""
+
+from __future__ import annotations
+
+from publicsuffixlist import PublicSuffixList
+
+from apps.citation.hosts import Host
+
+# Built once at import — parsing the bundled snapshot is a cost paid a single
+# time, and this is the module's only ``Any`` boundary (publicsuffixlist ships
+# no py.typed). ``accept_unknown`` fails open on unknown-but-real TLDs;
+# ``only_icann`` stays False so PRIVATE-section suffixes (``github.io``) count.
+_PSL = PublicSuffixList(accept_unknown=True, only_icann=False)
+
+
+def is_public_suffix(host: Host) -> bool:
+    """Whether *host* is itself a public suffix (no registrable label below it).
+
+    ``gov.uk``, ``co.uk``, ``com`` and PRIVATE-section names like ``github.io``
+    are public suffixes; ``dvla.gov.uk`` and ``american-pinball.com`` are not. A
+    bare public suffix must never be stored as a recognition host — under
+    longest-suffix matching it would over-match every unrelated site beneath it,
+    which is exactly what the ``CitationSourceRootDomain.clean`` guard prevents.
+
+    Equivalent to ``registrable_domain(host) is None`` for any DNS-valid host;
+    the two are cross-checked by test against the bundled snapshot.
+    """
+    return bool(host) and _PSL.publicsuffix(host) == host
+
+
+def registrable_domain(host: Host) -> Host | None:
+    """The registrable domain of *host* — its public suffix plus one label.
+
+    ``s4.american-pinball.com`` → ``american-pinball.com``; ``a.b.co.uk`` →
+    ``b.co.uk``; ``foo.github.io`` → ``foo.github.io`` (PRIVATE section). Returns
+    ``None`` when *host* is itself a bare public suffix (:func:`is_public_suffix`)
+    — there is no domain to round to. This is the rounding step the derive funnel
+    uses to collapse a fuzzy subdomain cite to one root.
+    """
+    private = _PSL.privatesuffix(host)
+    return Host(private) if private else None

--- a/backend/apps/citation/tests/test_api.py
+++ b/backend/apps/citation/tests/test_api.py
@@ -628,13 +628,13 @@ class TestCiteUrl:
         resp = _post(client, self.URL, {"url": "https://example.com/page"})
         assert resp.status_code in (401, 403)
 
-    def test_no_match_creates_root_and_child_at_raw_host(self, client, user):
+    def test_no_match_rounds_to_registrable_root_and_creates_child(self, client, user):
         client.force_login(user)
         resp = _post(
             client,
             self.URL,
             {
-                "url": "https://blog.newsite.example/post",
+                "url": "https://blog.newsite.org/post",
                 "site_name": "New Site",
                 "site_description": "A site.",
                 "page_name": "A Post",
@@ -644,18 +644,19 @@ class TestCiteUrl:
         child = CitationSource.objects.get(pk=resp.json()["id"])
         assert child.name == "A Post"
         assert child.parent is not None
-        # Roots at the RAW pasted host (PR 2 rounds to the registrable domain).
+        # The funnel rounds the fuzzy subdomain paste down to the registrable
+        # domain, so the root (and its homepage) sit at newsite.org — future
+        # cites under any subdomain collapse to this one root.
         root = child.parent
         assert root.name == "New Site"
         assert root.description == "A site."
         assert root.parent_id is None
         domain = CitationSourceRootDomain.objects.get(source=root)
-        assert domain.host == "blog.newsite.example"
-        assert (
-            root.links.get(link_type="homepage").url == "https://blog.newsite.example/"
-        )
+        assert domain.host == "newsite.org"
+        assert root.links.get(link_type="homepage").url == "https://newsite.org/"
+        # The child still references the full pasted URL, not the rounded host.
         assert child.links.get(link_type="reference").url == (
-            "https://blog.newsite.example/post"
+            "https://blog.newsite.org/post"
         )
 
     def test_no_match_attributes_every_row_to_caller(self, client, user):
@@ -663,7 +664,7 @@ class TestCiteUrl:
         resp = _post(
             client,
             self.URL,
-            {"url": "https://newsite.example/x", "page_name": "X"},
+            {"url": "https://newsite.org/x", "page_name": "X"},
         )
         assert resp.status_code == 201
         child = CitationSource.objects.get(pk=resp.json()["id"])
@@ -679,24 +680,42 @@ class TestCiteUrl:
             assert link.created_by == user
             assert link.updated_by == user
 
-    def test_blank_site_name_falls_back_to_host(self, client, user):
+    def test_blank_site_name_falls_back_to_rounded_host(self, client, user):
         client.force_login(user)
-        resp = _post(client, self.URL, {"url": "https://newsite.example/p"})
+        resp = _post(client, self.URL, {"url": "https://blog.newsite.org/p"})
         assert resp.status_code == 201
         root = CitationSource.objects.get(pk=resp.json()["id"]).parent
         assert root is not None
-        assert root.name == "newsite.example"
+        # Falls back to the rounded registrable host, not the raw subdomain.
+        assert root.name == "newsite.org"
 
     def test_response_is_the_web_child(self, client, user):
         client.force_login(user)
         resp = _post(
-            client, self.URL, {"url": "https://newsite.example/p", "page_name": "P"}
+            client, self.URL, {"url": "https://newsite.org/p", "page_name": "P"}
         )
         assert resp.status_code == 201
         data = resp.json()
         assert data["name"] == "P"
         # A web child skips the locator stage — its URL is the locator.
         assert data["skip_locator"] is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://127.0.0.1/page",  # IP literal — can't root a site
+            "http://foo.test/page",  # reserved RFC special-use TLD
+            "https://gov.uk/page",  # bare public suffix — over-matches if stored
+            "https://[::1/page",  # malformed URL — must 422, not 500
+        ],
+    )
+    def test_unroundable_host_is_422_with_no_write(self, client, user, url):
+        client.force_login(user)
+        resp = _post(client, self.URL, {"url": url})
+        assert resp.status_code == 422
+        # The funnel rejects before any write, so nothing was created.
+        assert not CitationSource.objects.exists()
+        assert not CitationSourceRootDomain.objects.exists()
 
     def test_domain_match_nests_child_and_ignores_site_fields(self, client, user):
         client.force_login(user)
@@ -816,14 +835,16 @@ class TestCiteUrl:
         assert CitationSource.objects.count() == 0
 
     def test_root_domain_guard_failure_returns_422_not_500(self, client, user):
-        """A domain-model guard surfaces as the declared 422 and rolls back.
+        """A domain-model guard failure surfaces as the declared 422 and rolls back.
 
-        No ``clean()`` rule rejects a normalized parentless host in this PR, so
-        we stand in for the forthcoming PR-2 public-suffix guard by making the
-        domain's ``full_clean`` raise: the point is that a ``ValidationError``
-        on the root-domain row becomes a 422 (Django ValidationError has no API
-        exception handler, so an uncaught one would 500) and the whole create
-        rolls back.
+        The root-domain row is ``full_clean``d in its own ``try/except`` so a
+        model guard (the public-suffix / DNS-host ``clean()`` rules) becomes a
+        422 rather than a 500 — Django's ``ValidationError`` has no API exception
+        handler, so an uncaught one would 500. We force ``full_clean`` to raise
+        to exercise that wrapper directly, decoupled from any specific rule. The
+        URL uses a real registrable domain so the ``root_host_from_url`` funnel
+        passes and the mocked ``full_clean`` actually fires; the whole create
+        then rolls back.
         """
         client.force_login(user)
 
@@ -831,7 +852,7 @@ class TestCiteUrl:
             raise ValidationError({"host": "Not an allowed recognition host."})
 
         with patch.object(CitationSourceRootDomain, "full_clean", reject):
-            resp = _post(client, self.URL, {"url": "https://blocked.example/p"})
+            resp = _post(client, self.URL, {"url": "https://blocked.org/p"})
         assert resp.status_code == 422
         assert CitationSource.objects.count() == 0
 
@@ -856,7 +877,7 @@ class TestCiteUrl:
             patch("apps.citation.api.recognize_url", side_effect=[None, rematch]),
         ):
             resp = _post(
-                client, self.URL, {"url": "https://raced.example/p", "page_name": "P"}
+                client, self.URL, {"url": "https://raced.org/p", "page_name": "P"}
             )
         assert resp.status_code == 201
         child = CitationSource.objects.get(pk=resp.json()["id"])
@@ -864,8 +885,9 @@ class TestCiteUrl:
         assert child.parent_id == racer.pk
         assert CitationSource.objects.filter(name="P").count() == 1
         # The savepoint rolled back the attempted root + its homepage link (blank
-        # site_name → it was named after the host), leaving only the racer root.
-        assert not CitationSource.objects.filter(name="raced.example").exists()
+        # site_name → it was named after the rounded host), leaving only the
+        # racer root.
+        assert not CitationSource.objects.filter(name="raced.org").exists()
         assert CitationSource.objects.filter(parent__isnull=True).count() == 1
 
 
@@ -1510,7 +1532,7 @@ class TestExtractEndpoint:
         assert data["match"] is None
 
     def test_extract_url_classifies_correctly(self, client, user):
-        """URL input no longer returns 422 (unsupported)."""
+        """URL input is classified and routed to extract_url, not rejected as 422."""
         cache.clear()
         client.force_login(user)
         with patch("apps.citation.api.extract_url") as mock_extract:

--- a/backend/apps/citation/tests/test_api.py
+++ b/backend/apps/citation/tests/test_api.py
@@ -246,6 +246,20 @@ class TestSearchRecognition:
         data = resp.json()
         assert data["recognition"] is None
 
+    def test_malformed_host_url_no_recognition(self, client, user, db):
+        """A malformed host whose ancestor suffix matches a seeded root still
+        yields no recognition — /search/ must not surface a confident-but-wrong
+        page for garbage input (the read surface has no write-time URL guard)."""
+        root = CitationSource.objects.create(name="American Pinball", source_type="web")
+        CitationSourceRootDomain.objects.create(
+            source=root, host="american-pinball.com"
+        )
+        client.force_login(user)
+        resp = client.get(
+            "/api/citation-sources/search/?q=https://www..american-pinball.com/m.pdf"
+        )
+        assert resp.json()["recognition"] is None
+
     def test_plain_text_no_recognition(self, client, user, citation_source):
         """Plain text searches return no recognition."""
         client.force_login(user)
@@ -716,11 +730,10 @@ class TestCiteUrl:
         # No second root was created.
         assert CitationSource.objects.filter(parent__isnull=True).count() == 1
 
-    def test_subdomain_mints_new_root_under_exact_matching(self, client, user):
-        # SUBDOMAIN-MATCHING-DISABLED (re-enabled in DomainGovernance G3)
-        # Exact matching: an asset subdomain doesn't recognize the seeded
-        # registrable root, so the no-match branch mints a new root at the raw
-        # host instead of nesting under american-pinball.com.
+    def test_subdomain_nests_under_existing_registrable_root(self, client, user):
+        # Suffix matching: an asset subdomain resolves to the seeded registrable
+        # root, so the cite nests a child *under* american-pinball.com rather
+        # than minting a second root.
         client.force_login(user)
         root = CitationSource.objects.create(name="American Pinball", source_type="web")
         CitationSourceRootDomain.objects.create(
@@ -733,12 +746,9 @@ class TestCiteUrl:
         )
         assert resp.status_code == 201
         child = CitationSource.objects.get(pk=resp.json()["id"])
-        assert child.parent_id != root.pk
-        new_root = child.parent
-        assert new_root is not None
-        assert CitationSourceRootDomain.objects.filter(
-            source=new_root, host="s4.american-pinball.com"
-        ).exists()
+        assert child.parent_id == root.pk
+        # No second root was minted.
+        assert CitationSource.objects.filter(parent__isnull=True).count() == 1
         # No page_name sent → the child name falls back to the URL.
         assert child.name == "https://s4.american-pinball.com/manual.pdf"
 

--- a/backend/apps/citation/tests/test_db_constraints.py
+++ b/backend/apps/citation/tests/test_db_constraints.py
@@ -460,6 +460,39 @@ class TestCitationSourceRootDomain:
         rd = CitationSourceRootDomain(source=root, host="example.com")
         rd.full_clean()  # must not raise
 
+    def test_clean_rejects_public_suffix_host(self, db):
+        """A bare public suffix must never be stored: under longest-suffix
+        matching it would over-match every unrelated site beneath it."""
+        root = CitationSource.objects.create(name="Root", source_type="web")
+        for host in ("gov.uk", "co.uk"):
+            rd = CitationSourceRootDomain(source=root, host=host)
+            with pytest.raises(ValidationError):
+                rd.full_clean()
+
+    def test_clean_rejects_non_dns_host(self, db):
+        """An IP literal is not a syntactic DNS recognition host."""
+        root = CitationSource.objects.create(name="Root", source_type="web")
+        rd = CitationSourceRootDomain(source=root, host="127.0.0.1")
+        with pytest.raises(ValidationError):
+            rd.full_clean()
+
+    def test_clean_accepts_subdomain_and_registrable(self, db):
+        """A curator may declare a subdomain verbatim; a registrable domain is
+        the ordinary case. Neither is a public suffix."""
+        root = CitationSource.objects.create(name="Root", source_type="web")
+        for host in ("twip.kineticist.com", "american-pinball.com"):
+            rd = CitationSourceRootDomain(source=root, host=host)
+            rd.full_clean()  # must not raise
+
+    def test_clean_github_io_canary(self, db):
+        """PRIVATE-section boundary at the model edge: ``github.io`` is itself a
+        public suffix (rejected), ``foo.github.io`` is one whole site (accepted)."""
+        root = CitationSource.objects.create(name="Root", source_type="web")
+        with pytest.raises(ValidationError):
+            CitationSourceRootDomain(source=root, host="github.io").full_clean()
+        # A whole site under the PRIVATE suffix — must not raise.
+        CitationSourceRootDomain(source=root, host="foo.github.io").full_clean()
+
     def test_clean_normalizes_host(self, db):
         """clean() canonicalizes the owned value: lower, www-strip, trailing dot."""
         root = CitationSource.objects.create(name="Root", source_type="web")

--- a/backend/apps/citation/tests/test_extractors.py
+++ b/backend/apps/citation/tests/test_extractors.py
@@ -166,10 +166,10 @@ class TestRootDomainRecognition:
         assert rec.parent_id == ap.id
 
     def test_public_suffix_cannot_be_seeded_so_no_overmatch(self, db):
-        # Ties the G2 guard to G3's matching: longest-suffix matching would let a
-        # bare public-suffix host swallow every site beneath it — but clean()
-        # forbids seeding one, so that root can't exist. Declaring "co.uk" is
-        # rejected, and an unrelated *.co.uk cite stays unrecognized.
+        # Ties the clean() guard to suffix matching: longest-suffix matching
+        # would let a bare public-suffix host swallow every site beneath it — but
+        # clean() forbids seeding one, so that root can't exist. Declaring "co.uk"
+        # is rejected, and an unrelated *.co.uk cite stays unrecognized.
         root = CitationSource.objects.create(name="Bad", source_type="web")
         with pytest.raises(ValidationError):
             CitationSourceRootDomain(source=root, host="co.uk").full_clean()
@@ -188,6 +188,9 @@ class TestRootDomainRecognition:
             # suffix is the seeded american-pinball.com — must NOT match.
             "https://www..american-pinball.com/manual.pdf",
             "https://foo_bar.american-pinball.com/x",  # underscore label
+            # Too malformed for urlparse itself (unterminated IPv6 bracket) — it
+            # raises ValueError; recognition must abstain, not propagate it.
+            "https://[::1/american-pinball.com",
         ],
     )
     def test_malformed_host_is_not_recognized(self, db, url):

--- a/backend/apps/citation/tests/test_extractors.py
+++ b/backend/apps/citation/tests/test_extractors.py
@@ -126,11 +126,10 @@ class TestYouTubeRecognition:
 
 
 class TestRootDomainRecognition:
-    """``recognize_url`` resolves a host to its root by exact match.
+    """``recognize_url`` resolves a host to its root by longest label suffix.
 
-    SUBDOMAIN-MATCHING-DISABLED (re-enabled in DomainGovernance G3): step 3
-    matches the host exactly; subdomain (longest-suffix) cases assert the
-    deferred no-match behavior until G3 re-enables suffix matching.
+    An asset subdomain collapses to its registrable root, while a deliberately
+    seeded more-specific host still wins over its parent for its own subtree.
     """
 
     def _root(self, name: str, host: str) -> CitationSource:
@@ -138,38 +137,65 @@ class TestRootDomainRecognition:
         CitationSourceRootDomain.objects.create(source=root, host=host)
         return root
 
-    def test_subdomain_not_recognized_under_exact_matching(self, db):
-        # SUBDOMAIN-MATCHING-DISABLED (re-enabled in DomainGovernance G3)
-        self._root("American Pinball", "american-pinball.com")
-        assert (
-            recognize_url("http://s4.american-pinball.com/games/gtf/manual.pdf") is None
-        )
+    def test_subdomain_resolves_to_registrable_root(self, db):
+        ap = self._root("American Pinball", "american-pinball.com")
+        rec = recognize_url("http://s4.american-pinball.com/games/gtf/manual.pdf")
+        assert rec is not None
+        assert rec.parent_id == ap.id
 
-    def test_exact_root_host_resolves(self, db):
-        # twip.kineticist.com is itself a seeded host → exact match wins even
-        # with kineticist.com also seeded (the "most specific" framing is moot
-        # under exact matching, but the assertion holds).
+    def test_most_specific_host_wins(self, db):
+        # twip.kineticist.com is itself a seeded host → it beats its parent
+        # kineticist.com for its own subtree (longest label-boundary suffix).
         self._root("Kineticist", "kineticist.com")
         twip = self._root("TWiP", "twip.kineticist.com")
         rec = recognize_url("https://twip.kineticist.com/some-article")
         assert rec is not None
         assert rec.parent_id == twip.id
 
-    def test_subdomain_does_not_resolve_to_parent_under_exact_matching(self, db):
-        # SUBDOMAIN-MATCHING-DISABLED (re-enabled in DomainGovernance G3)
-        self._root("Kineticist", "kineticist.com")
-        assert recognize_url("https://twip.kineticist.com/some-article") is None
+    def test_subdomain_resolves_to_parent_root(self, db):
+        # No twip.* root seeded → the subdomain falls to its parent domain.
+        kin = self._root("Kineticist", "kineticist.com")
+        rec = recognize_url("https://twip.kineticist.com/some-article")
+        assert rec is not None
+        assert rec.parent_id == kin.id
 
-    def test_deeper_subdomain_not_recognized_under_exact_matching(self, db):
-        # SUBDOMAIN-MATCHING-DISABLED (re-enabled in DomainGovernance G3)
-        self._root("American Pinball", "american-pinball.com")
-        assert recognize_url("https://cdn.assets.american-pinball.com/logo.png") is None
+    def test_deeper_subdomain_resolves_to_nearest_root(self, db):
+        ap = self._root("American Pinball", "american-pinball.com")
+        rec = recognize_url("https://cdn.assets.american-pinball.com/logo.png")
+        assert rec is not None
+        assert rec.parent_id == ap.id
+
+    def test_public_suffix_cannot_be_seeded_so_no_overmatch(self, db):
+        # Ties the G2 guard to G3's matching: longest-suffix matching would let a
+        # bare public-suffix host swallow every site beneath it — but clean()
+        # forbids seeding one, so that root can't exist. Declaring "co.uk" is
+        # rejected, and an unrelated *.co.uk cite stays unrecognized.
+        root = CitationSource.objects.create(name="Bad", source_type="web")
+        with pytest.raises(ValidationError):
+            CitationSourceRootDomain(source=root, host="co.uk").full_clean()
+        assert recognize_url("https://example.co.uk/page") is None
 
     def test_www_prefixed_input_matches(self, db):
         ap = self._root("American Pinball", "american-pinball.com")
         rec = recognize_url("https://www.american-pinball.com/about")
         assert rec is not None
         assert rec.parent_id == ap.id
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Empty label: normalizes to .american-pinball.com, whose ancestor
+            # suffix is the seeded american-pinball.com — must NOT match.
+            "https://www..american-pinball.com/manual.pdf",
+            "https://foo_bar.american-pinball.com/x",  # underscore label
+        ],
+    )
+    def test_malformed_host_is_not_recognized(self, db, url):
+        # A malformed host can still produce a valid ancestor suffix; the
+        # is_dns_host gate makes recognition abstain rather than claim a match a
+        # read surface (/search/) would then surface as a confident page.
+        self._root("American Pinball", "american-pinball.com")
+        assert recognize_url(url) is None
 
     def test_lookalike_host_does_not_match(self, db):
         self._root("American Pinball", "american-pinball.com")
@@ -338,3 +364,12 @@ class TestGetOrCreateWebSourceRootHomepage:
         with pytest.raises(ValidationError):
             get_or_create_web_source(page, archive_url="not a url")
         assert not CitationSource.objects.children().exists()
+
+    def test_malformed_subdomain_host_not_recognized_nor_nested(self, db):
+        # A malformed host (empty leading label) yields a valid ancestor suffix
+        # (american-pinball.com), but recognition's is_dns_host gate abstains, so
+        # the URL resolves to no root and nests nothing under the matched domain.
+        root = self._root(db)
+        with pytest.raises(CitationSource.DoesNotExist):
+            get_or_create_web_source("https://www..american-pinball.com/manual.pdf")
+        assert not CitationSource.objects.filter(parent=root).exists()

--- a/backend/apps/citation/tests/test_hosts.py
+++ b/backend/apps/citation/tests/test_hosts.py
@@ -10,6 +10,8 @@ import pytest
 from apps.citation.hosts import (
     Host,
     RootDomainMatch,
+    is_dns_host,
+    is_reserved_tld,
     label_suffixes,
     longest_suffix_match,
     normalize_host,
@@ -85,6 +87,65 @@ class TestLabelSuffixes:
     )
     def test_suffixes(self, host, expected):
         assert label_suffixes(host) == expected
+
+
+class TestIsDnsHost:
+    """``is_dns_host`` accepts syntactic DNS names, rejects IPs and junk."""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "american-pinball.com",
+            "s4.american-pinball.com",
+            "a.b.c.example.com",
+            "gov.uk",  # syntactically a host; the public-suffix guard is separate
+            "x.co",  # single-char label is valid
+            "xn--80ak6aa92e.com",  # punycode IDN
+        ],
+    )
+    def test_accepts(self, host):
+        assert is_dns_host(Host(host)) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1",  # IPv4 literal
+            "::1",  # IPv6 literal
+            "192.168.0.1",
+            "localhost",  # no dot
+            "com",  # no dot
+            "",  # empty
+            "-leading.com",  # leading hyphen
+            "trailing-.com",  # trailing hyphen
+            "under_score.com",  # underscore not in DNS charset
+            "münchen.de",  # raw-unicode IDN (must be punycode)
+            "example.123",  # all-numeric TLD
+            "a" * 64 + ".com",  # label over 63 chars
+            "a." * 127 + "com",  # whole hostname over 253 chars (labels valid)
+        ],
+    )
+    def test_rejects(self, host):
+        assert is_dns_host(Host(host)) is False
+
+
+class TestIsReservedTld:
+    """``is_reserved_tld`` flags RFC special-use rightmost labels."""
+
+    @pytest.mark.parametrize(
+        "host",
+        ["foo.test", "bar.localhost", "invalid", "site.example", "printer.local"],
+    )
+    def test_reserved(self, host):
+        assert is_reserved_tld(Host(host)) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        ["american-pinball.com", "gov.uk", "twip.kineticist.com", "example.com", ""],
+    )
+    def test_not_reserved(self, host):
+        # ``example.com`` is a normal .com domain — only a bare ``.example`` TLD
+        # is reserved, not the second-level label.
+        assert is_reserved_tld(Host(host)) is False
 
 
 # A handful of seeded recognition rows to resolve against.

--- a/backend/apps/citation/tests/test_psl.py
+++ b/backend/apps/citation/tests/test_psl.py
@@ -1,0 +1,102 @@
+"""Tests for the Public Suffix List boundary (``apps.citation.psl``).
+
+DB-free: these exercise the bundled snapshot through pure functions. The
+``github.io`` canary and the ``registrable_domain``/``is_public_suffix``
+equivalence are deliberately pinned so a snapshot bump that changes either
+surfaces here rather than silently in production recognition.
+"""
+
+import pytest
+
+from apps.citation.hosts import Host, is_dns_host
+from apps.citation.psl import is_public_suffix, registrable_domain
+
+
+class TestIsPublicSuffix:
+    """A bare public suffix is one with no registrable label below it."""
+
+    @pytest.mark.parametrize("host", ["com", "co.uk", "gov.uk", "github.io"])
+    def test_public_suffix(self, host):
+        assert is_public_suffix(Host(host)) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "american-pinball.com",
+            "dvla.gov.uk",
+            "s4.american-pinball.com",
+            "foo.github.io",  # PRIVATE-section: a whole site under github.io
+            "",
+        ],
+    )
+    def test_not_public_suffix(self, host):
+        assert is_public_suffix(Host(host)) is False
+
+
+class TestRegistrableDomain:
+    """Rounds a host down to its registrable domain (public suffix + 1 label)."""
+
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("s4.american-pinball.com", "american-pinball.com"),
+            ("american-pinball.com", "american-pinball.com"),
+            ("cdn.s4.american-pinball.com", "american-pinball.com"),
+            ("a.b.co.uk", "b.co.uk"),
+            ("dvla.gov.uk", "dvla.gov.uk"),
+            # PRIVATE section: github.io is the suffix, so the whole site rounds
+            # to itself rather than collapsing to github.io.
+            ("foo.github.io", "foo.github.io"),
+            ("blog.foo.github.io", "foo.github.io"),
+        ],
+    )
+    def test_rounds(self, host, expected):
+        assert registrable_domain(Host(host)) == expected
+
+    @pytest.mark.parametrize("host", ["com", "co.uk", "gov.uk", "github.io"])
+    def test_bare_public_suffix_has_no_registrable_domain(self, host):
+        assert registrable_domain(Host(host)) is None
+
+
+def test_github_io_canary():
+    """Two-directional PRIVATE-section canary, pinned against a snapshot bump.
+
+    ``github.io`` itself is a public suffix (a user can't own it), while
+    ``foo.github.io`` is one whole site (registrable on its own). If a snapshot
+    update ever demotes the PRIVATE section, both assertions flip together.
+    """
+    assert is_public_suffix(Host("github.io")) is True
+    assert registrable_domain(Host("github.io")) is None
+    assert is_public_suffix(Host("foo.github.io")) is False
+    assert registrable_domain(Host("foo.github.io")) == "foo.github.io"
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "com",
+        "co.uk",
+        "gov.uk",
+        "github.io",
+        "american-pinball.com",
+        "s4.american-pinball.com",
+        "dvla.gov.uk",
+        "foo.github.io",
+        "a.b.co.uk",
+    ],
+)
+def test_registrable_none_iff_public_suffix(host):
+    """``registrable_domain(h) is None ⟺ is_public_suffix(h)`` for non-empty hosts.
+
+    Both ``clean()`` (the guard) and the funnel lean on this equivalence; it is
+    cross-checked here against the bundled snapshot so a bump that breaks it
+    fails the build. The lone exception is the empty host (no registrable domain
+    yet not a public suffix), which ``is_dns_host`` rejects upstream before
+    either function is ever called.
+    """
+    h = Host(host)
+    # The empty host is the lone exception (no registrable domain, yet not a
+    # public suffix); is_dns_host rejects it upstream, so it must never enter
+    # this list. This guard fails loudly if someone adds it.
+    assert is_dns_host(h) or is_public_suffix(h)
+    assert (registrable_domain(h) is None) == is_public_suffix(h)

--- a/backend/apps/citation/tests/test_psl.py
+++ b/backend/apps/citation/tests/test_psl.py
@@ -9,7 +9,13 @@ surfaces here rather than silently in production recognition.
 import pytest
 
 from apps.citation.hosts import Host, is_dns_host
-from apps.citation.psl import is_public_suffix, registrable_domain
+from apps.citation.psl import (
+    HostError,
+    HostRejection,
+    is_public_suffix,
+    registrable_domain,
+    root_host_from_url,
+)
 
 
 class TestIsPublicSuffix:
@@ -100,3 +106,59 @@ def test_registrable_none_iff_public_suffix(host):
     # this list. This guard fails loudly if someone adds it.
     assert is_dns_host(h) or is_public_suffix(h)
     assert (registrable_domain(h) is None) == is_public_suffix(h)
+
+
+class TestRootHostFromUrl:
+    """The derive funnel: round an untrusted page URL to a storable root host."""
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            # A fuzzy subdomain paste rounds to the registrable domain, so future
+            # cites under any subdomain collapse to one root.
+            (
+                "https://s4.american-pinball.com/games/gtf/manual.pdf",
+                "american-pinball.com",
+            ),
+            ("http://american-pinball.com/", "american-pinball.com"),
+            ("https://www.american-pinball.com/x", "american-pinball.com"),
+            ("https://a.b.co.uk/page", "b.co.uk"),
+            # PRIVATE section: a per-publisher github.io site stays its own root.
+            ("https://foo.github.io/post", "foo.github.io"),
+            # Port, path and query are stripped by urlparse.hostname.
+            ("https://blog.newsite.org:8443/p?q=1", "newsite.org"),
+        ],
+    )
+    def test_rounds_to_registrable_host(self, url, expected):
+        assert root_host_from_url(url) == expected
+
+    @pytest.mark.parametrize(
+        ("url", "reason"),
+        [
+            ("https:///just-a-path", HostRejection.NO_HOST),
+            ("https://127.0.0.1/page", HostRejection.NOT_DNS),
+            ("https://[::1]/page", HostRejection.NOT_DNS),
+            # A malformed URL whose host can't be parsed (unterminated IPv6
+            # bracket) — urlparse raises ValueError; the funnel must catch it and
+            # surface a typed reason, never leak the raw exception.
+            ("https://[::1/page", HostRejection.NOT_DNS),
+            ("http://foo.test/page", HostRejection.RESERVED_TLD),
+            ("http://bar.localhost/page", HostRejection.RESERVED_TLD),
+            ("https://gov.uk/page", HostRejection.PUBLIC_SUFFIX),
+            ("https://co.uk/page", HostRejection.PUBLIC_SUFFIX),
+            # A bare single-label host (``com``) has no dot, so is_dns_host
+            # rejects it as NOT_DNS before rounding ever runs.
+            ("https://com/page", HostRejection.NOT_DNS),
+        ],
+    )
+    def test_unroundable_host_raises_typed_reason(self, url, reason):
+        with pytest.raises(HostError) as exc:
+            root_host_from_url(url)
+        assert exc.value.reason is reason
+
+    def test_reserved_tld_rejected_before_rounding(self):
+        # is_reserved_tld must run before registrable_domain — accept_unknown=True
+        # would otherwise round ``.example`` to itself instead of rejecting it.
+        with pytest.raises(HostError) as exc:
+            root_host_from_url("https://blog.newsite.example/p")
+        assert exc.value.reason is HostRejection.RESERVED_TLD

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -103,8 +103,7 @@ indent-style = "space"
 line-ending = "lf"
 
 # Import boundary enforcement — see docs/AppBoundaries.md for the prose spec.
-# Run with `lint-imports` (wired into scripts/lint). Contracts translate the
-# app dependency tiers and peer-isolation rules into checkable form.
+# Run with `lint-imports` (wired into scripts/lint).
 [tool.importlinter]
 root_packages = ["apps"]
 
@@ -229,6 +228,27 @@ source_modules = [
     "apps.citation.extractors",
 ]
 forbidden_modules = ["apps.citation.psl"]
+
+# The citation app's internal module stack, top to bottom. Higher layers may
+# import lower; a lower layer importing a higher one is an inversion. Modules
+# sharing a layer (pipe-separated) are independent — they may not import each
+# other. This pins the architecture that holds today: the data layer (models)
+# imports nothing above it, and the domain services stay mutually decoupled, so a
+# future stray edge fails CI instead of sliding in. It does NOT subsume the
+# PSL-free contract above — layers permits a higher module (extractors) to import
+# a lower one (psl); only the forbidden contract bans that specific edge.
+[[tool.importlinter.contracts]]
+name = "Citation internal layers"
+type = "layers"
+containers = ["apps.citation"]
+layers = [
+    "api | admin",
+    "url_extraction",
+    "extractors | extraction | seeding | schemas",
+    "models",
+    "psl",
+    "hosts | source_type_traits | safe_fetch",
+]
 
 # Test-only helpers must never be imported by production code. test_factories
 # encode test-fixture invariants; importing them from app code ships test
@@ -498,6 +518,61 @@ layers = [
     "processing | storage | schemas | helpers",
     "models",
     "constants",
+]
+
+# Provenance internal layering: an exhaustive acyclic internal stack, so a new
+# submodule left unplaced — or an inversion like
+# the data layer reaching up into a read service — fails the build. Top to
+# bottom: the HTTP/admin edges, page-payload assembly, the read/query services
+# (history/evidence over helpers over display), the claim-write + revert tier, the
+# schema/validation/ranking support tier, then models and the dependency-free
+# leaves. apps (the AppConfig's ready() wiring), migrations and tests/test_factories
+# are exhaustive_ignores — bootstrap and test scaffolding, not layerable units.
+[[tool.importlinter.contracts]]
+name = "Provenance internal layers"
+type = "layers"
+exhaustive = true
+exhaustive_ignores = ["apps", "migrations", "tests", "test_factories"]
+containers = ["apps.provenance"]
+layers = [
+    "api | admin",
+    "page_endpoints",
+    "evidence | history",
+    "helpers",
+    "claims | display | revert",
+    "validation | schemas | claim_ranking_in_db | licensing | resolution | rate_limits",
+    "models | claim_presence | constants | entity_resolution | pagination | authz | typing",
+]
+ignore_imports = [
+    # The one sanctioned cycle break, and it can't be removed by moving code.
+    # validation imports models at module level (it introspects model structure to
+    # classify claims), while ClaimManager.assert_claim — the chokepoint that
+    # guarantees no invalid claim is ever written — must validate at write time, so
+    # it imports validation lazily. Hoisting that call up out of the model would
+    # break the cycle but weaken the self-validation invariant (a caller could then
+    # persist an unvalidated claim); pulling the introspection helpers below
+    # validation just relocates the cycle. So the lazy import stays.
+    # See apps/provenance/models/claim.py.
+    "apps.provenance.models.claim -> apps.provenance.validation",
+]
+
+# Accounts' internal stack: the api subpackage plus the admin/middleware/management
+# edges on top; the model, its wire schemas and the auth-error mapping in the
+# middle; and the dependency-free leaves at the base — backends, the
+# pending/reserved-name policy, the username grammar and the WorkOS client.
+# Exhaustive, like the contracts above, so a new submodule left unplaced fails the
+# build. Acyclic with no cycle break needed: usernames is the shared leaf every
+# middle-tier module reads.
+[[tool.importlinter.contracts]]
+name = "Accounts internal layers"
+type = "layers"
+exhaustive = true
+exhaustive_ignores = ["apps", "migrations", "tests", "test_factories"]
+containers = ["apps.accounts"]
+layers = [
+    "api | admin | management | middleware",
+    "models | schemas | auth_errors",
+    "backends | pending | reserved | usernames | workos_client",
 ]
 
 [tool.mypy]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -144,8 +144,11 @@ disallow_untyped_calls = false
 module = ["pillow_heif", "constance", "constance.*", "publicsuffixlist", "publicsuffixlist.*"]
 ignore_missing_imports = true
 
-# Import boundary enforcement — see docs/AppBoundaries.md for the prose spec.
+# ===========================================================================
+# Import boundary enforcement
+# See docs/AppBoundaries.md for the prose spec.
 # Run with `lint-imports` (wired into scripts/lint).
+# ===========================================================================
 [tool.importlinter]
 root_packages = ["apps"]
 
@@ -245,10 +248,9 @@ forbidden_modules = ["apps.claim_edit"]
 
 # --- Media peer-isolation ---
 
-# Media internals (selectors/processing/storage/schemas/helpers/models) are
-# peer-isolated from the citation/provenance data apps. The one sanctioned crack
-# is media.models -> provenance.models for ClaimControlledModel; because this is
-# a forbidden contract (indirect imports counted), the ignore_imports below
+# Media internals are peer-isolated from the citation/provenance data apps.
+# The one sanctioned crack is media.models -> provenance.models for ClaimControlledModel;
+# because this is a forbidden contract (indirect imports counted), the ignore_imports below
 # severs that edge for every source — including selectors/helpers, which reach
 # media.models transitively.
 [[tool.importlinter.contracts]]
@@ -364,24 +366,10 @@ ignore_imports = ["apps.*.tests.** -> apps.provenance.test_factories"]
 
 # ----- catalog -----
 
-# Catalog's whole internal stack as one exhaustive layered contract: api/admin/
-# management on top (leaf consumers — the domain must not import them), down
-# through the read/claim/signal tier and the walk/cache/service tier, to
-# models/authz, and finally the domain-neutral `engine` at the bottom. `engine`
-# sits below `models` because the concrete alias models in `models/` subclass
-# `engine.models.AliasModel` (models → engine, the sanctioned downward edge); the
-# generic HTTP-surface substrate the domain mounts also lives there. The former
-# `naming` and `_alias_registry` layers are gone — both emigrated into `engine`.
-# `exhaustive = true` requires every catalog submodule to appear as a layer (or
-# in exhaustive_ignores): a new module left unplaced fails the build, closing the
-# gaps the old enumerated "api is a leaf" forbidden left (it never covered
-# _walks / admin). This subsumes that contract AND documents the domain layering
-# in one place. Both catalog and core have acyclic top-level graphs, which is
-# what makes a clean layer order possible (see "Core internal layers" below).
 [[tool.importlinter.contracts]]
-name = "Catalog internal layers"
+name = "Catalog app internal stack"
 type = "layers"
-exhaustive = true
+exhaustive = true # so a new submodule left unplaced fails the build
 exhaustive_ignores = ["apps", "migrations", "tests"]
 containers = ["apps.catalog"]
 layers = [
@@ -389,23 +377,19 @@ layers = [
     "claims | resolve | signals",
     "_walks | cache | services",
     "models | authz",
-    "engine",
+    "engine", # domain-neutral; will eventually be moved out of catalog
 ]
 
 # The generic resolver core — scalar/bulk claim projection (_entities), its
 # coercion/FK/constraint helpers (_helpers), and the read-side payload
 # vocabulary (_claim_values) — is domain-agnostic substrate that merely lives
 # in catalog: it names no concrete model and drives entirely off claim-field
-# introspection (get_claim_fields, _meta). Forbidding it from importing the
-# catalog domain turns the claim-resolution plan's load-bearing premise ("Tier
-# 1 is already fully generic") into an enforced invariant, so a stray `from
-# ..models import …` can't silently re-couple it, and the eventual hoist to the
-# substrate stays a near-trivial move. This is a ratchet on what is already
-# true today (green, no baselines) — NOT the model-driven resolver engine,
-# which awaits the deferred relationship-declaration vocabulary. The
-# relationship/dispatch resolvers (_relationships, _dispatch, __init__) still
-# bind MachineModel and are deliberately out of scope; the dispatch seam is
-# restructured by ModelDrivenClaimWrite.md's "Invert resolution" step. See
+# introspection (get_claim_fields, _meta).
+#
+# This will eventually be hoisted to the substrate, but the model-driven resolver
+# engine is still coupled: it awaits the deferred relationship declaration
+# vocabulary. The relationship/dispatch resolvers (_relationships, _dispatch,
+# __init__) still bind MachineModel. See
 # docs/plans/model_driven_metadata/ModelDrivenClaimResolution.md.
 [[tool.importlinter.contracts]]
 name = "Generic resolver core does not import the catalog domain"
@@ -429,39 +413,32 @@ forbidden_modules = [
 # The domain-neutral engine — the generic HTTP-surface substrate plus the generic
 # bases (AliasModel, the wire schema bases, naming, the model-registry walk) the
 # concrete domain mounts and subclasses — must never reach back up into the
-# catalog domain. This is the in-app mirror of the resolver-core rule above and
-# the load-bearing invariant behind the deferred app extraction: once enforced,
-# lifting `engine/` to its own top-level app is a `git mv`. The "Catalog internal
-# layers" contract already forbids this structurally (engine is the bottom
-# layer), but the explicit forbid is a durable, self-documenting ratchet that
-# survives any future layer reshuffle. Whole-package source with a wildcard
-# ignore for engine's own internal edges (e.g. aliases → models) is more concise
-# and more complete than enumerating the sibling domain modules — it catches a
-# new coupling to ANY catalog domain module, present or future.
+# catalog domain.
+#
+# This is the in-app mirror of the resolver-core rule and the load-bearing invariant
+# behind the deferred app extraction: once enforced, lifting `engine/` to its own
+# top-level app is a `git mv`. The "Catalog internal layers" contract already forbids
+# this structurally (engine is the bottom layer), but the explicit forbid is a
+# durable, self-documenting ratchet that survives any future layer reshuffle.
 [[tool.importlinter.contracts]]
 name = "Engine does not import the catalog domain"
 type = "forbidden"
 allow_indirect_imports = "true"
 source_modules = ["apps.catalog.engine"]
 forbidden_modules = ["apps.catalog"]
+# Whole-package source with a wildcard
+# ignore for engine's own internal edges (e.g. aliases → models) is more concise
+# and more complete than enumerating the sibling domain modules — it catches a
+# new coupling to ANY catalog domain module, present or future.
 ignore_imports = ["apps.catalog.engine.** -> apps.catalog.engine.**"]
 
-# The engine's own internal stack, exhaustively layered like the catalog and core
-# contracts so a new engine submodule left unplaced fails the build. The HTTP
-# registrars (`entity_api`) sit on top; the generic query fold and the alias
-# registry below them (`aliases` reads `models`); the cross-cutting wire bases and
-# the leaf substrate (`schemas`, `models`, `naming`, `rich_text`, `walks`) at the
-# base (`rich_text` builds the description ``RichTextSchema`` for the domain
-# serializers; like `naming` it has no engine consumer — a leaf the domain calls). The
-# `entity_api ⊄ export_api` seam joins this contract in Phase E, when the public
-# export surface (`export_api`) is extracted alongside `entity_api`. `tests` is
-# the only ignore needed (engine has no `apps.py` and no migrations, so the
-# `apps`/`migrations` ignores the catalog/core contracts carry don't apply): a
-# co-located `engine/tests/` is test scaffolding, not a layerable unit.
+# The catalog engine's own internal stack.
+# TODO: `entity_api ⊄ export_api` seam joins this contract when the public
+# export surface (`export_api`) is extracted alongside `entity_api`.
 [[tool.importlinter.contracts]]
-name = "Engine internal layers"
+name = "Catalog engine internal stack"
 type = "layers"
-exhaustive = true
+exhaustive = true # so new submodule left unplaced fails build
 exhaustive_ignores = ["tests"]
 containers = ["apps.catalog.engine"]
 layers = [
@@ -473,13 +450,10 @@ layers = [
 # ----- claim_ingest -----
 
 # The apply engine is the source-agnostic IR consumer: it turns an IngestPlan
-# (the carriers in apps.claim_ingest.plan) into DB writes and must not know which
-# front end built it. apps.claim_ingest.patches is the patch *adapter* — its
-# format parsing and its PatchError live there. The engine raises plain
-# ValidationError and lets _apply_one map it to PatchError, so the engine never
-# imports the adapter. That rule is asserted only in docstrings (claims.py,
-# persist.py) today; forbidding the edge makes it self-defending. Green now —
-# apply imports nothing from patches.
+# (apps.claim_ingest.plan) into DB writes and must not know which front end built
+# it. apps.claim_ingest.patches is the patch adapter — format parsing and
+# PatchError live there. The engine raises plain ValidationError and never imports
+# the adapter, keeping apply source-agnostic.
 [[tool.importlinter.contracts]]
 name = "Apply engine stays source-agnostic (no patch adapter)"
 type = "forbidden"
@@ -499,18 +473,10 @@ forbidden_modules = ["apps.claim_ingest.apply"]
 
 # ----- provenance -----
 
-# Provenance internal layering: an exhaustive acyclic internal stack, so a new
-# submodule left unplaced — or an inversion like
-# the data layer reaching up into a read service — fails the build. Top to
-# bottom: the HTTP/admin edges, page-payload assembly, the read/query services
-# (history/evidence over helpers over display), the claim-write + revert tier, the
-# schema/validation/ranking support tier, then models and the dependency-free
-# leaves. apps (the AppConfig's ready() wiring), migrations and tests/test_factories
-# are exhaustive_ignores — bootstrap and test scaffolding, not layerable units.
 [[tool.importlinter.contracts]]
-name = "Provenance internal layers"
+name = "Provenance app internal stack"
 type = "layers"
-exhaustive = true
+exhaustive = true # so new submodule left unplaced fails build
 exhaustive_ignores = ["apps", "migrations", "tests", "test_factories"]
 containers = ["apps.provenance"]
 layers = [
@@ -523,19 +489,27 @@ layers = [
     "models | claim_presence | constants | entity_resolution | pagination | authz | typing",
 ]
 ignore_imports = [
-    # The one sanctioned cycle break, and it can't be removed by moving code.
-    # validation imports models at module level (it introspects model structure to
-    # classify claims), while ClaimManager.assert_claim — the chokepoint that
-    # guarantees no invalid claim is ever written — must validate at write time, so
-    # it imports validation lazily. Hoisting that call up out of the model would
-    # break the cycle but weaken the self-validation invariant (a caller could then
-    # persist an unvalidated claim); pulling the introspection helpers below
-    # validation just relocates the cycle. So the lazy import stays.
-    # See apps/provenance/models/claim.py.
+    # validation imports models, so ClaimManager (models/claim.py) calls it lazily
+    # at write time; hoisting that out would weaken self-validation.
     "apps.provenance.models.claim -> apps.provenance.validation",
 ]
 
 # ----- citation -----
+
+[[tool.importlinter.contracts]]
+name = "Citation app internal stack"
+type = "layers"
+exhaustive = true # so new submodule left unplaced fails build
+exhaustive_ignores = ["apps", "migrations", "tests", "management"]
+containers = ["apps.citation"]
+layers = [
+    "api | admin",
+    "url_extraction",
+    "extractors | extraction | seeding | schemas",
+    "models",
+    "psl",
+    "hosts | source_type_traits | safe_fetch | authz | seed_data",
+]
 
 # psl.py is the lone Public Suffix List gateway. The pure hosts module must stay
 # dependency-free, and the recognition read path (extractors) must resolve by
@@ -554,40 +528,12 @@ source_modules = [
 ]
 forbidden_modules = ["apps.citation.psl"]
 
-# The citation app's internal module stack, top to bottom. Higher layers may
-# import lower; a lower layer importing a higher one is an inversion. Modules
-# sharing a layer (pipe-separated) are independent — they may not import each
-# other. This pins the architecture that holds today: the data layer (models)
-# imports nothing above it, and the domain services stay mutually decoupled, so a
-# future stray edge fails CI instead of sliding in. It does NOT subsume the
-# PSL-free contract above — layers permits a higher module (extractors) to import
-# a lower one (psl); only the forbidden contract bans that specific edge.
-[[tool.importlinter.contracts]]
-name = "Citation internal layers"
-type = "layers"
-containers = ["apps.citation"]
-layers = [
-    "api | admin",
-    "url_extraction",
-    "extractors | extraction | seeding | schemas",
-    "models",
-    "psl",
-    "hosts | source_type_traits | safe_fetch",
-]
-
 # ----- accounts -----
 
-# Accounts' internal stack: the api subpackage plus the admin/middleware/management
-# edges on top; the model, its wire schemas and the auth-error mapping in the
-# middle; and the dependency-free leaves at the base — backends, the
-# pending/reserved-name policy, the username grammar and the WorkOS client.
-# Exhaustive, like the contracts above, so a new submodule left unplaced fails the
-# build. Acyclic with no cycle break needed: usernames is the shared leaf every
-# middle-tier module reads.
 [[tool.importlinter.contracts]]
-name = "Accounts internal layers"
+name = "Accounts app internal stack"
 type = "layers"
-exhaustive = true
+exhaustive = true # so new submodule left unplaced fails build
 exhaustive_ignores = ["apps", "migrations", "tests", "test_factories"]
 containers = ["apps.accounts"]
 layers = [
@@ -598,20 +544,10 @@ layers = [
 
 # ----- core -----
 
-# Core, like catalog, is an exhaustive layered contract over its whole acyclic
-# internal stack — a new submodule left unplaced fails the build, which the old
-# enumerated "core api is a leaf" forbidden never did (it silently omitted admin,
-# checks and soft_delete). apps/migrations/tests stay exhaustive_ignores as in
-# catalog — bootstrap wiring (the AppConfig's ready() imports across layers by
-# design), generated code and test scaffolding, none meaningfully layerable.
-# Core's graph was made acyclic by moving MarkdownField down into models (it was
-# the models → markdown edge) and deleting the dead bulk_create_validated helper
-# (the validators → models edge). api/ is still a leaf — it sits at the top and
-# nothing imports back up into it — but now as one tier of the full stack.
 [[tool.importlinter.contracts]]
-name = "Core internal layers"
+name = "Core app internal stack"
 type = "layers"
-exhaustive = true
+exhaustive = true # so new submodule left unplaced fails build
 exhaustive_ignores = ["apps", "migrations", "tests"]
 containers = ["apps.core"]
 layers = [
@@ -625,21 +561,16 @@ layers = [
 
 # ----- media -----
 
-# Media internal layering: a vertical stack from constants/models at the bottom
-# up to the api composition layer. `selectors` sits above the
-# storage/schemas/helpers peer-group because it composes storage + schemas into
-# wire schemas, which the peer-isolated `helpers` tier may not do. This also
-# enforces that media.api is a leaf (nothing below it imports it). The cross-app
-# media.models -> provenance.models crack is governed by the media peer-isolation
-# contract above, not here.
 [[tool.importlinter.contracts]]
-name = "Media internal layers"
+name = "Media app internal stack"
 type = "layers"
+exhaustive = true # so new submodule left unplaced fails build
+exhaustive_ignores = ["apps", "migrations", "tests"]
 containers = ["apps.media"]
 layers = [
-    "api",
+    "api | admin",
     "authz",
-    "selectors",
+    "selectors", # selectors gets its own tier above the storage/schemas/helpers peers because it composes storage + schemas into wire schemas, which helpers may not.
     "processing | storage | schemas | helpers",
     "models",
     "constants",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
     "workos>=5.0",
     "sentry-sdk[django]>=2.0",
     "pyyaml>=6.0",
+    # Pinned exactly: the package bundles a Public Suffix List snapshot in its
+    # version, so `==` keeps the snapshot deliberate — it moves only via a
+    # reviewed dependabot bump, never a silent `uv sync`. See apps/citation/psl.py.
+    "publicsuffixlist==1.0.2.20260623",
 ]
 
 [dependency-groups]
@@ -208,6 +212,23 @@ forbidden_modules = [
     "apps.media.schemas",
     "apps.provenance.schemas",
 ]
+
+# psl.py is the lone Public Suffix List gateway. The pure hosts module must stay
+# dependency-free, and the recognition read path (extractors) must resolve by
+# exact-stored-host suffix match only — never by consulting the PSL. So neither
+# may import psl. Direct-only: models.py legitimately imports psl for the
+# write-time clean() guard, and extractors imports models, so the indirect
+# extractors -> models -> psl edge is fine — only a *direct* dependency is the
+# leak this forbids.
+[[tool.importlinter.contracts]]
+name = "hosts and the recognition read path stay PSL-free"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "apps.citation.hosts",
+    "apps.citation.extractors",
+]
+forbidden_modules = ["apps.citation.psl"]
 
 # Test-only helpers must never be imported by production code. test_factories
 # encode test-fixture invariants; importing them from app code ships test
@@ -518,5 +539,5 @@ disallow_untyped_calls = false
 # Suppresses import-untyped errors at the import site; the libraries themselves
 # are still treated as Any at use sites.
 [[tool.mypy.overrides]]
-module = ["pillow_heif", "constance", "constance.*"]
+module = ["pillow_heif", "constance", "constance.*", "publicsuffixlist", "publicsuffixlist.*"]
 ignore_missing_imports = true

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -102,10 +102,56 @@ quote-style = "double"
 indent-style = "space"
 line-ending = "lf"
 
+[tool.mypy]
+python_version = "3.14"
+strict = true
+plugins = ["mypy_django_plugin.main"]
+explicit_package_bases = true
+exclude = [
+    "migrations/",
+    "\\.venv/",
+    "^media/",  # MEDIA_ROOT at backend/media — anchored so apps/media/ is still type-checked
+    "^cache/",
+]
+warn_unused_ignores = true
+warn_redundant_casts = true
+# Barrel __init__.py files re-export symbols via `from X import Y`. Treat these
+# as intentional public API rather than requiring `__all__` on every barrel.
+implicit_reexport = true
+
+[tool.django-stubs]
+django_settings_module = "config.settings"
+strict_settings = true
+
+# Migrations are generated; don't type-check them.
+[[tool.mypy.overrides]]
+module = "*.migrations.*"
+ignore_errors = true
+
+# Tests and conftest: relax annotation requirements for fixtures. Type correctness
+# of the code under test still matters; per-function annotations in tests do not.
+[[tool.mypy.overrides]]
+module = ["*.tests.*", "tests.*", "conftest"]
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_decorators = false
+disallow_untyped_calls = false
+
+# Third-party libraries without py.typed markers or upstream stubs.
+# Suppresses import-untyped errors at the import site; the libraries themselves
+# are still treated as Any at use sites.
+[[tool.mypy.overrides]]
+module = ["pillow_heif", "constance", "constance.*", "publicsuffixlist", "publicsuffixlist.*"]
+ignore_missing_imports = true
+
 # Import boundary enforcement — see docs/AppBoundaries.md for the prose spec.
 # Run with `lint-imports` (wired into scripts/lint).
 [tool.importlinter]
 root_packages = ["apps"]
+
+# ===========================================================================
+# Cross-app boundaries
+# ===========================================================================
 
 # The vertical dependency spine. Higher tiers may import lower ones; lower may
 # not import higher; pipe-separated names are independent siblings at one level.
@@ -139,182 +185,7 @@ ignore_imports = [
     "apps.core.middleware.sentry_scope -> apps.accounts.models",
 ]
 
-# Media internals (selectors/processing/storage/schemas/helpers/models) are
-# peer-isolated from the citation/provenance data apps. The one sanctioned crack
-# is media.models -> provenance.models for ClaimControlledModel; because this is
-# a forbidden contract (indirect imports counted), the ignore_imports below
-# severs that edge for every source — including selectors/helpers, which reach
-# media.models transitively.
-[[tool.importlinter.contracts]]
-name = "Media internals do not reach into the data apps"
-type = "forbidden"
-source_modules = [
-    "apps.media.selectors",
-    "apps.media.processing",
-    "apps.media.storage",
-    "apps.media.schemas",
-    "apps.media.helpers",
-    "apps.media.models",
-]
-forbidden_modules = [
-    "apps.provenance",
-    "apps.citation",
-]
-ignore_imports = [
-    # Surgical exception: media_attachment is a claim field, so every
-    # MediaSupportedModel is structurally a ClaimControlledModel.
-    "apps.media.models.base -> apps.provenance.models",
-]
-
-# The reverse direction: the data apps must not depend on media. Direct-only:
-# the indirect chain provenance -> catalog -> media is the provenance -> catalog
-# baseline issue above, not a provenance -> media dependency.
-[[tool.importlinter.contracts]]
-name = "Data apps do not depend on media"
-type = "forbidden"
-allow_indirect_imports = "true"
-source_modules = [
-    "apps.provenance",
-    "apps.citation",
-    "apps.claim_edit",
-    "apps.claim_ingest",
-]
-forbidden_modules = ["apps.media"]
-
-# Domain models are the bottom of each app's internal stack: they must not reach
-# up into the HTTP/serialization layer. Direct-only — an indirect models -> X ->
-# api chain is X's problem, caught by the api-leaf contract below.
-[[tool.importlinter.contracts]]
-name = "Domain models do not import the api/schema layer"
-type = "forbidden"
-allow_indirect_imports = "true"
-source_modules = [
-    "apps.core.models",
-    "apps.accounts.models",
-    "apps.catalog.models",
-    "apps.provenance.models",
-    "apps.citation.models",
-    "apps.media.models",
-    "apps.kiosk.models",
-]
-forbidden_modules = [
-    "apps.core.api",
-    "apps.accounts.api",
-    "apps.catalog.api",
-    "apps.provenance.api",
-    "apps.citation.api",
-    "apps.media.api",
-    "apps.kiosk.api",
-    "apps.core.schemas",
-    "apps.accounts.schemas",
-    "apps.citation.schemas",
-    "apps.media.schemas",
-    "apps.provenance.schemas",
-]
-
-# psl.py is the lone Public Suffix List gateway. The pure hosts module must stay
-# dependency-free, and the recognition read path (extractors) must resolve by
-# exact-stored-host suffix match only — never by consulting the PSL. So neither
-# may import psl. Direct-only: models.py legitimately imports psl for the
-# write-time clean() guard, and extractors imports models, so the indirect
-# extractors -> models -> psl edge is fine — only a *direct* dependency is the
-# leak this forbids.
-[[tool.importlinter.contracts]]
-name = "hosts and the recognition read path stay PSL-free"
-type = "forbidden"
-allow_indirect_imports = "true"
-source_modules = [
-    "apps.citation.hosts",
-    "apps.citation.extractors",
-]
-forbidden_modules = ["apps.citation.psl"]
-
-# The citation app's internal module stack, top to bottom. Higher layers may
-# import lower; a lower layer importing a higher one is an inversion. Modules
-# sharing a layer (pipe-separated) are independent — they may not import each
-# other. This pins the architecture that holds today: the data layer (models)
-# imports nothing above it, and the domain services stay mutually decoupled, so a
-# future stray edge fails CI instead of sliding in. It does NOT subsume the
-# PSL-free contract above — layers permits a higher module (extractors) to import
-# a lower one (psl); only the forbidden contract bans that specific edge.
-[[tool.importlinter.contracts]]
-name = "Citation internal layers"
-type = "layers"
-containers = ["apps.citation"]
-layers = [
-    "api | admin",
-    "url_extraction",
-    "extractors | extraction | seeding | schemas",
-    "models",
-    "psl",
-    "hosts | source_type_traits | safe_fetch",
-]
-
-# Test-only helpers must never be imported by production code. test_factories
-# encode test-fixture invariants; importing them from app code ships test
-# scaffolding into the runtime path. One contract per factory: a forbidden
-# module cannot be a descendant of its source, so each sources all apps EXCEPT
-# the one that owns the factory (which covers every cross-app leak; a same-app
-# self-import is the only residual gap and is trivially caught in review).
-[[tool.importlinter.contracts]]
-name = "Production code does not import accounts test factories"
-type = "forbidden"
-source_modules = [
-    "apps.core",
-    "apps.catalog",
-    "apps.claim_edit",
-    "apps.claim_ingest",
-    "apps.citation",
-    "apps.provenance",
-    "apps.media",
-    "apps.kiosk",
-]
-forbidden_modules = ["apps.accounts.test_factories"]
-ignore_imports = ["apps.*.tests.** -> apps.accounts.test_factories"]
-
-[[tool.importlinter.contracts]]
-name = "Production code does not import provenance test factories"
-type = "forbidden"
-source_modules = [
-    "apps.core",
-    "apps.accounts",
-    "apps.catalog",
-    "apps.claim_edit",
-    "apps.claim_ingest",
-    "apps.citation",
-    "apps.media",
-    "apps.kiosk",
-]
-forbidden_modules = ["apps.provenance.test_factories"]
-ignore_imports = ["apps.*.tests.** -> apps.provenance.test_factories"]
-
-# Catalog's whole internal stack as one exhaustive layered contract: api/admin/
-# management on top (leaf consumers — the domain must not import them), down
-# through the read/claim/signal tier and the walk/cache/service tier, to
-# models/authz, and finally the domain-neutral `engine` at the bottom. `engine`
-# sits below `models` because the concrete alias models in `models/` subclass
-# `engine.models.AliasModel` (models → engine, the sanctioned downward edge); the
-# generic HTTP-surface substrate the domain mounts also lives there. The former
-# `naming` and `_alias_registry` layers are gone — both emigrated into `engine`.
-# `exhaustive = true` requires every catalog submodule to appear as a layer (or
-# in exhaustive_ignores): a new module left unplaced fails the build, closing the
-# gaps the old enumerated "api is a leaf" forbidden left (it never covered
-# _walks / admin). This subsumes that contract AND documents the domain layering
-# in one place. Both catalog and core have acyclic top-level graphs, which is
-# what makes a clean layer order possible (see "Core internal layers" below).
-[[tool.importlinter.contracts]]
-name = "Catalog internal layers"
-type = "layers"
-exhaustive = true
-exhaustive_ignores = ["apps", "migrations", "tests"]
-containers = ["apps.catalog"]
-layers = [
-    "api | admin | management",
-    "claims | resolve | signals",
-    "_walks | cache | services",
-    "models | authz",
-    "engine",
-]
+# --- Inter-app boundaries outside the linear spine ---
 
 # The ingest system (apps.claim_ingest) is the bulk catalog write path — a
 # top-level consumer, not a dependency. The whole catalog domain must not import
@@ -372,20 +243,154 @@ allow_indirect_imports = "true"
 source_modules = ["apps.claim_ingest"]
 forbidden_modules = ["apps.claim_edit"]
 
-# The apply engine is the source-agnostic IR consumer: it turns an IngestPlan
-# (the carriers in apps.claim_ingest.plan) into DB writes and must not know which
-# front end built it. apps.claim_ingest.patches is the patch *adapter* — its
-# format parsing and its PatchError live there. The engine raises plain
-# ValidationError and lets _apply_one map it to PatchError, so the engine never
-# imports the adapter. That rule is asserted only in docstrings (claims.py,
-# persist.py) today; forbidding the edge makes it self-defending. Green now —
-# apply imports nothing from patches.
+# --- Media peer-isolation ---
+
+# Media internals (selectors/processing/storage/schemas/helpers/models) are
+# peer-isolated from the citation/provenance data apps. The one sanctioned crack
+# is media.models -> provenance.models for ClaimControlledModel; because this is
+# a forbidden contract (indirect imports counted), the ignore_imports below
+# severs that edge for every source — including selectors/helpers, which reach
+# media.models transitively.
 [[tool.importlinter.contracts]]
-name = "Apply engine stays source-agnostic (no patch adapter)"
+name = "Media internals do not reach into the data apps"
+type = "forbidden"
+source_modules = [
+    "apps.media.selectors",
+    "apps.media.processing",
+    "apps.media.storage",
+    "apps.media.schemas",
+    "apps.media.helpers",
+    "apps.media.models",
+]
+forbidden_modules = [
+    "apps.provenance",
+    "apps.citation",
+]
+ignore_imports = [
+    # Surgical exception: media_attachment is a claim field, so every
+    # MediaSupportedModel is structurally a ClaimControlledModel.
+    "apps.media.models.base -> apps.provenance.models",
+]
+
+# The reverse direction: the data apps must not depend on media. Direct-only:
+# the indirect chain provenance -> catalog -> media is the provenance -> catalog
+# baseline issue above, not a provenance -> media dependency.
+[[tool.importlinter.contracts]]
+name = "Data apps do not depend on media"
 type = "forbidden"
 allow_indirect_imports = "true"
-source_modules = ["apps.claim_ingest.apply"]
-forbidden_modules = ["apps.claim_ingest.patches"]
+source_modules = [
+    "apps.provenance",
+    "apps.citation",
+    "apps.claim_edit",
+    "apps.claim_ingest",
+]
+forbidden_modules = ["apps.media"]
+
+# --- Cross-cutting invariants ---
+
+# Domain models are the bottom of each app's internal stack: they must not reach
+# up into the HTTP/serialization layer. Direct-only — an indirect models -> X ->
+# api chain is X's problem, caught by the api-leaf contract below.
+[[tool.importlinter.contracts]]
+name = "Domain models do not import the api/schema layer"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "apps.core.models",
+    "apps.accounts.models",
+    "apps.catalog.models",
+    "apps.provenance.models",
+    "apps.citation.models",
+    "apps.media.models",
+    "apps.kiosk.models",
+]
+forbidden_modules = [
+    "apps.core.api",
+    "apps.accounts.api",
+    "apps.catalog.api",
+    "apps.provenance.api",
+    "apps.citation.api",
+    "apps.media.api",
+    "apps.kiosk.api",
+    "apps.core.schemas",
+    "apps.accounts.schemas",
+    "apps.citation.schemas",
+    "apps.media.schemas",
+    "apps.provenance.schemas",
+]
+
+# Test-only helpers must never be imported by production code. test_factories
+# encode test-fixture invariants; importing them from app code ships test
+# scaffolding into the runtime path. One contract per factory: a forbidden
+# module cannot be a descendant of its source, so each sources all apps EXCEPT
+# the one that owns the factory (which covers every cross-app leak; a same-app
+# self-import is the only residual gap and is trivially caught in review).
+[[tool.importlinter.contracts]]
+name = "Production code does not import accounts test factories"
+type = "forbidden"
+source_modules = [
+    "apps.core",
+    "apps.catalog",
+    "apps.claim_edit",
+    "apps.claim_ingest",
+    "apps.citation",
+    "apps.provenance",
+    "apps.media",
+    "apps.kiosk",
+]
+forbidden_modules = ["apps.accounts.test_factories"]
+ignore_imports = ["apps.*.tests.** -> apps.accounts.test_factories"]
+
+[[tool.importlinter.contracts]]
+name = "Production code does not import provenance test factories"
+type = "forbidden"
+source_modules = [
+    "apps.core",
+    "apps.accounts",
+    "apps.catalog",
+    "apps.claim_edit",
+    "apps.claim_ingest",
+    "apps.citation",
+    "apps.media",
+    "apps.kiosk",
+]
+forbidden_modules = ["apps.provenance.test_factories"]
+ignore_imports = ["apps.*.tests.** -> apps.provenance.test_factories"]
+
+# ===========================================================================
+# Per-app internal structure (dependency order: consumers first, core last)
+# ===========================================================================
+
+# ----- catalog -----
+
+# Catalog's whole internal stack as one exhaustive layered contract: api/admin/
+# management on top (leaf consumers — the domain must not import them), down
+# through the read/claim/signal tier and the walk/cache/service tier, to
+# models/authz, and finally the domain-neutral `engine` at the bottom. `engine`
+# sits below `models` because the concrete alias models in `models/` subclass
+# `engine.models.AliasModel` (models → engine, the sanctioned downward edge); the
+# generic HTTP-surface substrate the domain mounts also lives there. The former
+# `naming` and `_alias_registry` layers are gone — both emigrated into `engine`.
+# `exhaustive = true` requires every catalog submodule to appear as a layer (or
+# in exhaustive_ignores): a new module left unplaced fails the build, closing the
+# gaps the old enumerated "api is a leaf" forbidden left (it never covered
+# _walks / admin). This subsumes that contract AND documents the domain layering
+# in one place. Both catalog and core have acyclic top-level graphs, which is
+# what makes a clean layer order possible (see "Core internal layers" below).
+[[tool.importlinter.contracts]]
+name = "Catalog internal layers"
+type = "layers"
+exhaustive = true
+exhaustive_ignores = ["apps", "migrations", "tests"]
+containers = ["apps.catalog"]
+layers = [
+    "api | admin | management",
+    "claims | resolve | signals",
+    "_walks | cache | services",
+    "models | authz",
+    "engine",
+]
 
 # The generic resolver core — scalar/bulk claim projection (_entities), its
 # coercion/FK/constraint helpers (_helpers), and the read-side payload
@@ -465,30 +470,22 @@ layers = [
     "schemas | models | naming | rich_text | walks",
 ]
 
-# Core, like catalog, is an exhaustive layered contract over its whole acyclic
-# internal stack — a new submodule left unplaced fails the build, which the old
-# enumerated "core api is a leaf" forbidden never did (it silently omitted admin,
-# checks and soft_delete). apps/migrations/tests stay exhaustive_ignores as in
-# catalog — bootstrap wiring (the AppConfig's ready() imports across layers by
-# design), generated code and test scaffolding, none meaningfully layerable.
-# Core's graph was made acyclic by moving MarkdownField down into models (it was
-# the models → markdown edge) and deleting the dead bulk_create_validated helper
-# (the validators → models edge). api/ is still a leaf — it sits at the top and
-# nothing imports back up into it — but now as one tier of the full stack.
+# ----- claim_ingest -----
+
+# The apply engine is the source-agnostic IR consumer: it turns an IngestPlan
+# (the carriers in apps.claim_ingest.plan) into DB writes and must not know which
+# front end built it. apps.claim_ingest.patches is the patch *adapter* — its
+# format parsing and its PatchError live there. The engine raises plain
+# ValidationError and lets _apply_one map it to PatchError, so the engine never
+# imports the adapter. That rule is asserted only in docstrings (claims.py,
+# persist.py) today; forbidding the edge makes it self-defending. Green now —
+# apply imports nothing from patches.
 [[tool.importlinter.contracts]]
-name = "Core internal layers"
-type = "layers"
-exhaustive = true
-exhaustive_ignores = ["apps", "migrations", "tests"]
-containers = ["apps.core"]
-layers = [
-    "api",
-    "markdown",
-    "wikilinks | middleware",
-    "admin | api_helpers | authz | autocomplete | checks | entity_types | licensing | rate_limits | sitemap | soft_delete",
-    "exceptions | models",
-    "admin_apps | admin_site | pagination | schemas | search | types | validators",
-]
+name = "Apply engine stays source-agnostic (no patch adapter)"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = ["apps.claim_ingest.apply"]
+forbidden_modules = ["apps.claim_ingest.patches"]
 
 # The patch system is a compiler front end: it lowers YAML patches to an
 # IngestPlan (the IR), which the ingest back end (apply/) executes. The split is
@@ -500,25 +497,7 @@ type = "forbidden"
 source_modules = ["apps.claim_ingest.patches"]
 forbidden_modules = ["apps.claim_ingest.apply"]
 
-# Media internal layering: a vertical stack from constants/models at the bottom
-# up to the api composition layer. `selectors` sits above the
-# storage/schemas/helpers peer-group because it composes storage + schemas into
-# wire schemas, which the peer-isolated `helpers` tier may not do. This also
-# enforces that media.api is a leaf (nothing below it imports it). The cross-app
-# media.models -> provenance.models crack is governed by the media peer-isolation
-# contract above, not here.
-[[tool.importlinter.contracts]]
-name = "Media internal layers"
-type = "layers"
-containers = ["apps.media"]
-layers = [
-    "api",
-    "authz",
-    "selectors",
-    "processing | storage | schemas | helpers",
-    "models",
-    "constants",
-]
+# ----- provenance -----
 
 # Provenance internal layering: an exhaustive acyclic internal stack, so a new
 # submodule left unplaced — or an inversion like
@@ -556,6 +535,48 @@ ignore_imports = [
     "apps.provenance.models.claim -> apps.provenance.validation",
 ]
 
+# ----- citation -----
+
+# psl.py is the lone Public Suffix List gateway. The pure hosts module must stay
+# dependency-free, and the recognition read path (extractors) must resolve by
+# exact-stored-host suffix match only — never by consulting the PSL. So neither
+# may import psl. Direct-only: models.py legitimately imports psl for the
+# write-time clean() guard, and extractors imports models, so the indirect
+# extractors -> models -> psl edge is fine — only a *direct* dependency is the
+# leak this forbids.
+[[tool.importlinter.contracts]]
+name = "hosts and the recognition read path stay PSL-free"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "apps.citation.hosts",
+    "apps.citation.extractors",
+]
+forbidden_modules = ["apps.citation.psl"]
+
+# The citation app's internal module stack, top to bottom. Higher layers may
+# import lower; a lower layer importing a higher one is an inversion. Modules
+# sharing a layer (pipe-separated) are independent — they may not import each
+# other. This pins the architecture that holds today: the data layer (models)
+# imports nothing above it, and the domain services stay mutually decoupled, so a
+# future stray edge fails CI instead of sliding in. It does NOT subsume the
+# PSL-free contract above — layers permits a higher module (extractors) to import
+# a lower one (psl); only the forbidden contract bans that specific edge.
+[[tool.importlinter.contracts]]
+name = "Citation internal layers"
+type = "layers"
+containers = ["apps.citation"]
+layers = [
+    "api | admin",
+    "url_extraction",
+    "extractors | extraction | seeding | schemas",
+    "models",
+    "psl",
+    "hosts | source_type_traits | safe_fetch",
+]
+
+# ----- accounts -----
+
 # Accounts' internal stack: the api subpackage plus the admin/middleware/management
 # edges on top; the model, its wire schemas and the auth-error mapping in the
 # middle; and the dependency-free leaves at the base — backends, the
@@ -575,44 +596,51 @@ layers = [
     "backends | pending | reserved | usernames | workos_client",
 ]
 
-[tool.mypy]
-python_version = "3.14"
-strict = true
-plugins = ["mypy_django_plugin.main"]
-explicit_package_bases = true
-exclude = [
-    "migrations/",
-    "\\.venv/",
-    "^media/",  # MEDIA_ROOT at backend/media — anchored so apps/media/ is still type-checked
-    "^cache/",
+# ----- core -----
+
+# Core, like catalog, is an exhaustive layered contract over its whole acyclic
+# internal stack — a new submodule left unplaced fails the build, which the old
+# enumerated "core api is a leaf" forbidden never did (it silently omitted admin,
+# checks and soft_delete). apps/migrations/tests stay exhaustive_ignores as in
+# catalog — bootstrap wiring (the AppConfig's ready() imports across layers by
+# design), generated code and test scaffolding, none meaningfully layerable.
+# Core's graph was made acyclic by moving MarkdownField down into models (it was
+# the models → markdown edge) and deleting the dead bulk_create_validated helper
+# (the validators → models edge). api/ is still a leaf — it sits at the top and
+# nothing imports back up into it — but now as one tier of the full stack.
+[[tool.importlinter.contracts]]
+name = "Core internal layers"
+type = "layers"
+exhaustive = true
+exhaustive_ignores = ["apps", "migrations", "tests"]
+containers = ["apps.core"]
+layers = [
+    "api",
+    "markdown",
+    "wikilinks | middleware",
+    "admin | api_helpers | authz | autocomplete | checks | entity_types | licensing | rate_limits | sitemap | soft_delete",
+    "exceptions | models",
+    "admin_apps | admin_site | pagination | schemas | search | types | validators",
 ]
-warn_unused_ignores = true
-warn_redundant_casts = true
-# Barrel __init__.py files re-export symbols via `from X import Y`. Treat these
-# as intentional public API rather than requiring `__all__` on every barrel.
-implicit_reexport = true
 
-[tool.django-stubs]
-django_settings_module = "config.settings"
-strict_settings = true
+# ----- media -----
 
-# Migrations are generated; don't type-check them.
-[[tool.mypy.overrides]]
-module = "*.migrations.*"
-ignore_errors = true
-
-# Tests and conftest: relax annotation requirements for fixtures. Type correctness
-# of the code under test still matters; per-function annotations in tests do not.
-[[tool.mypy.overrides]]
-module = ["*.tests.*", "tests.*", "conftest"]
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-disallow_untyped_decorators = false
-disallow_untyped_calls = false
-
-# Third-party libraries without py.typed markers or upstream stubs.
-# Suppresses import-untyped errors at the import site; the libraries themselves
-# are still treated as Any at use sites.
-[[tool.mypy.overrides]]
-module = ["pillow_heif", "constance", "constance.*", "publicsuffixlist", "publicsuffixlist.*"]
-ignore_missing_imports = true
+# Media internal layering: a vertical stack from constants/models at the bottom
+# up to the api composition layer. `selectors` sits above the
+# storage/schemas/helpers peer-group because it composes storage + schemas into
+# wire schemas, which the peer-isolated `helpers` tier may not do. This also
+# enforces that media.api is a leaf (nothing below it imports it). The cross-app
+# media.models -> provenance.models crack is governed by the media peer-isolation
+# contract above, not here.
+[[tool.importlinter.contracts]]
+name = "Media internal layers"
+type = "layers"
+containers = ["apps.media"]
+layers = [
+    "api",
+    "authz",
+    "selectors",
+    "processing | storage | schemas | helpers",
+    "models",
+    "constants",
+]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -52,6 +52,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pillow-heif" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "publicsuffixlist" },
     { name = "pyyaml" },
     { name = "sentry-sdk", extra = ["django"] },
     { name = "whitenoise" },
@@ -85,6 +86,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.0" },
     { name = "pillow-heif", specifier = ">=1.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
+    { name = "publicsuffixlist", specifier = "==1.0.2.20260623" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.0" },
     { name = "whitenoise", specifier = ">=6.8" },
@@ -769,6 +771,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
     { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
     { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "publicsuffixlist"
+version = "1.0.2.20260623"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/6c/de8185fcf1b12db5a04fb28560d108cae3f0f68659b9b41ddd40008caad5/publicsuffixlist-1.0.2.20260623.tar.gz", hash = "sha256:780df36b759117663e135bf0b69e9f242f0298db3f15d13cdeb3d40e0541cf0b", size = 108780, upload-time = "2026-06-23T06:56:46.35Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/99/f1ab89cb40024dfb1ed35d795cb837c6651994b88cba4fecf1a056b5564c/publicsuffixlist-1.0.2.20260623-py2.py3-none-any.whl", hash = "sha256:f5defc77fc7ffebb2c768f58ed2d604c99e916e01cec6478badb63b352911e62", size = 108576, upload-time = "2026-06-23T06:56:45.017Z" },
 ]
 
 [[package]]

--- a/docs/plans/citations/CitationDomainGovernance.md
+++ b/docs/plans/citations/CitationDomainGovernance.md
@@ -66,7 +66,7 @@ The safety half of WebCitationDomains2 P2.2. Lands **before** `G3` and never shi
 
 🛑 STOP.
 
-### G3 — enable subdomain matching — `extractors.py`, tests
+### ✅ DONE: G3 — enable subdomain matching — `extractors.py`, tests
 
 Reverse WebCitationDomainDisablement's DISABLE1: re-point `recognize_url` step 3 at the dormant suffix helpers. Safe now because `G2` rejects public-suffix recognition hosts.
 

--- a/docs/plans/citations/CitationDomainGovernance.md
+++ b/docs/plans/citations/CitationDomainGovernance.md
@@ -1,6 +1,10 @@
 # Plan: citation domain governance
 
-Enable **subdomain (longest-suffix) recognition matching** safely, then layer the anti-fragmentation features on top: PSL rounding of fuzzy cite URLs and a `domains:` verb for multi-host roots. It builds on the cleaned write layer ([CitationsCleanup.md](CitationsCleanup.md)) and turns on the subdomain matching that [WebCitationDomainDisablement.md](WebCitationDomainDisablement.md) shipped dormant.
+Enable **subdomain (longest-suffix) recognition matching** safely, then layer the anti-fragmentation features on top: PSL rounding of fuzzy cite URLs and a `domains:` verb for multi-host roots.
+
+## Context
+
+This builds on the cleaned write layer ([CitationsCleanup.md](CitationsCleanup.md)) and turns on the subdomain matching that [WebCitationDomainDisablement.md](WebCitationDomainDisablement.md) shipped dormant.
 
 This supersedes Phase 2 of [WebCitationDomains2.md](WebCitationDomains2.md) (P2.1–P2.4), re-homed and reordered around one fact that changed after it was written: **subdomain matching is no longer live.** [WebCitationDomainDisablement.md](WebCitationDomainDisablement.md) shipped _exact_ host matching (current prod behavior) with the suffix machinery built but unused, precisely because enabling it without a guard is a footgun. So this plan's first job is to install that guard and flip matching on — together.
 
@@ -35,16 +39,18 @@ This plan rides on the foundation the disablement and cleanup straightened, so e
 
 ## The commit sequence
 
-Dependency-ordered. 🛑 STOP after each for review before committing. Commit messages: no ephemera.
+Sections are in build order, one commit each. 🛑 STOP after each for review before committing. In commit messages, do NOT reference ephemera that future readers will not understand, such as step numbers, PR numbers, links to this plan.
 
-### G1 — PSL + host predicates — `pyproject.toml`, `hosts.py`
+### ✅ DONE: G1 — host predicates (pure) + the PSL boundary (isolated) — `pyproject.toml`, `hosts.py`, `psl.py`
 
-WebCitationDomains2 P2.1. Pure additions to `hosts.py`; no caller yet.
+WebCitationDomains2 P2.1. Pure additions; no caller yet. **Split by dependency**: the pure string predicates extend `hosts.py`; the two PSL-backed functions live in a **new `psl.py`**, so `hosts.py` keeps its stated "model-free and dependency-free (no Public Suffix List)" contract ([hosts.py:1-14](backend/apps/citation/hosts.py#L1-L14)) and the recognition read path — which imports `hosts.py` — never pulls the snapshot in transitively.
 
-- Add `publicsuffixlist` — `uv add publicsuffixlist==<pinned>`, commit `uv.lock` (CI runs `uv sync --frozen`). Per-module `[[tool.mypy.overrides]]`, not a global flag. Renovate/dependabot entry — a snapshot rots.
-- `is_public_suffix(host: Host) -> bool` and `registrable_domain(host: Host) -> Host | None` — `Host` in/out. Build `PublicSuffixList` **once at module load** (the single `Any` boundary). **Honor the PRIVATE section** (`github.io` stays a public suffix → `foo.github.io` is one whole site). `accept_unknown=True` — fail open on a gTLD newer than the bundled snapshot.
-- `is_dns_host(host: Host) -> bool` — syntactic only: reject IP literals (`ipaddress`, bracket-stripped `::1`); dot-separated labels (1–63 chars, ≥1 dot, no leading/trailing hyphen, TLD not all-numeric). Pin the charset ASCII `[a-z0-9-]`, **not** `str.isalnum()` (unicode-true). ASCII-only accepts punycode, rejects raw-unicode IDN (a known limitation).
-- `is_reserved_tld(host: Host) -> bool` — rightmost label in a frozen RFC-6761/6762 set (`localhost`, `invalid`, `test`, `example`, `local`). A standards constant, not a denylist.
+- Add `publicsuffixlist` — `uv add publicsuffixlist==<pinned>`, commit `uv.lock` (CI runs `uv sync --frozen`). Per-module `[[tool.mypy.overrides]]`, not a global flag. Pinned exactly (`==`): the version _is_ the bundled snapshot, so it moves only via a reviewed bump. The repo's `.github/dependabot.yml` already covers it (backend `pip` group, `*` pattern) — a snapshot rots otherwise.
+- **`hosts.py` (pure, no new dep):**
+  - `is_dns_host(host: Host) -> bool` — syntactic only: reject IP literals (`ipaddress`, bracket-stripped `::1`); dot-separated labels (1–63 chars, ≥1 dot, no leading/trailing hyphen, TLD not all-numeric). Pin the charset ASCII `[a-z0-9-]`, **not** `str.isalnum()` (unicode-true). ASCII-only accepts punycode, rejects raw-unicode IDN (a known limitation).
+  - `is_reserved_tld(host: Host) -> bool` — rightmost label in a frozen RFC-6761/6762 set (`localhost`, `invalid`, `test`, `example`, `local`). A standards constant, not a denylist.
+- **`psl.py` (new — the single PSL/`Any` boundary):** `is_public_suffix(host: Host) -> bool` and `registrable_domain(host: Host) -> Host | None` — `Host` in/out. Build `PublicSuffixList` **once at module load**. **Honor the PRIVATE section** (`github.io` stays a public suffix → `foo.github.io` is one whole site). `accept_unknown=True` — fail open on a gTLD newer than the bundled snapshot. One-way import: `psl` → `hosts` (for `Host`), never back. `models.clean()` (`G2`) imports `is_public_suffix` from here; `extractors.py` (recognition) imports only `hosts.py` and stays PSL-free.
+- **Import-linter contract** — forbid `apps.citation.hosts` and `apps.citation.extractors` from importing `apps.citation.psl`, so the boundary is enforced, not just documented. **Direct-only** (`allow_indirect_imports`): `G2`'s `clean()` puts `models → psl`, and `extractors → models`, so the indirect `extractors → models → psl` edge is legitimate; only a _direct_ read-path dependency on the PSL is the leak.
 - **Tests (no DB):** each helper; the two-directional `github.io` canary (`foo.github.io` whole, `github.io` a suffix); the `registrable_domain(h) is None ⟺ is_public_suffix(h)` equivalence (the funnel and `clean()` both lean on it — pin it against a snapshot bump).
 
 🛑 STOP.
@@ -71,11 +77,11 @@ Reverse WebCitationDomainDisablement's DISABLE1: re-point `recognize_url` step 3
 
 🛑 STOP.
 
-### G4 — the funnel + cite-url rounding — `hosts.py`, `api.py`
+### G4 — the funnel + cite-url rounding — `psl.py`, `api.py`
 
 The funnel half of WebCitationDomains2 P2.2 + P2.3. Anti-fragmentation: a contributor pasting a fuzzy subdomain URL with **no** existing root mints a root at the _registrable domain_, not the bare subdomain, so future cites under the same site collapse to one root.
 
-- `root_host_from_url(url) -> Host` in `hosts.py`, HTTP-free: `urlparse(url).hostname` → `normalize_host` → `is_dns_host` → `is_reserved_tld` reject → `registrable_domain` (`None` = bare public suffix → reject) → return the rounded `Host`. Each gate raises a typed `HostError(reason)` — never `HttpError`. Kept pure for unit-testability and one documented validate-before-round order.
+- `root_host_from_url(url) -> Host` in `psl.py` (it composes `registrable_domain`, so it lives with the PSL boundary, not in pure `hosts.py`), HTTP-free: `urlparse(url).hostname` → `normalize_host` → `is_dns_host` → `is_reserved_tld` reject → `registrable_domain` (`None` = bare public suffix → reject) → return the rounded `Host`. Each gate raises a typed `HostError(reason)` — never `HttpError`. Kept pure for unit-testability and one documented validate-before-round order.
 - `cite-url`'s no-match branch ([api.py:445](backend/apps/citation/api.py#L445)): `try: host = root_host_from_url(url) except HostError → HttpError(422, …)`, at the **top**, before any write; synthesize `https://{host}/`; mint the `CitationSourceRootDomain` at `host`; `create_web_child` under it (the cleanup C4 leaf). The funnel's only caller — the patch path _raises_ on no match, it never derives.
 - **Migrate the `cite-url` rooting tests off `.example`** (the funnel `HostError`s reserved TLDs) → real registrable domains. Declare-path / `recognize_url` `.example` fixtures don't hit the funnel and stay.
 - **Tests:** no-match rounds `s4.american-pinball.com/…` → an `american-pinball.com` root (assert `CitationSourceRootDomain.host` **and** synthesized `homepage.url == "https://american-pinball.com/"`); 422 on IP / reserved-TLD / bare-suffix before any write.
@@ -95,7 +101,8 @@ WebCitationDomains2 P2.4. A diff, not a rebuild: `_roots_owning_hosts`, `_ensure
 
 ## Decisions
 
-- **Recognition is longest-suffix and PSL-free.** Rounding (PSL) is a write-time concern, in the funnel only (`G4`). The read path (`G3`) never consults the PSL — it suffix-matches stored hosts, every one of which is canonical-from-`cite-url` or verbatim-from-a-curator, so dedup stays exact-host.
+- **Recognition is longest-suffix and PSL-free.** Rounding (PSL) is a write-time concern, in the funnel only (`G4`). The read path (`G3`) never consults the PSL — it suffix-matches stored hosts, every one of which is canonical-from-`cite-url` or verbatim-from-a-curator, so dedup stays exact-host. **Enforced by import-linter, not convention:** the PSL lives in `psl.py` (`G1`); a `forbidden` contract bars `hosts` and `extractors` from importing it (direct-only), so the read path can't accidentally grow a PSL dependency.
+- **Reserved-TLD reject is funnel-only — declare is trusted.** `G4`'s funnel rejects RFC special-use TLDs (`.test`, `.example`, …) because it ingests untrusted contributor paste; `G2`'s `clean()` does **not**, because declaring a host is curator/admin gardening (the threat model below). The only cost is a curator could declare a `.test` host that can never match a real cite — a dead row, harmless. This asymmetry is also what lets the existing declare-path / `recognize_url` `.example` test fixtures stand (only the `cite-url` rooting tests migrate off `.example`, `G4`).
 - **Own the recognition host as a fact** (`CitationSourceRootDomain`), decoupled from the display `homepage` link. Set at creation; thereafter independent of display-link edits. A root's recognition hosts are the `homepage:` host (if any) ∪ the `domains:` list (declare), or the rounded host (`cite-url` derive). Never read back out of a link.
 - **`accept_unknown=True`** for `registrable_domain` — fail open on a TLD newer than the bundled PSL snapshot. `is_reserved_tld` still rejects RFC special-use names, so the only accepted-junk case is a genuinely-unknown **real** gTLD — intended.
 - **Right-size to the threat model.** Volunteer-run museum catalog, Activity-gated contributors, admin gardening — not a hostile public API. `clean()` is the gate for every real writer; no CHECK constraints, re-normalizing migration or audit migration.
@@ -104,7 +111,7 @@ WebCitationDomains2 P2.4. A diff, not a rebuild: `_roots_owning_hosts`, `_ensure
 
 - **Asset hosts on a different registrable domain** (a third-party CDN outside the publisher's domain) won't suffix-match — longest-suffix only collapses within one registrable domain. Fix: a `domains:` row (`G5`) or an admin-inline domain.
 - **Non-PSL "subdomain-per-publisher" platforms** collapse to one shared registrable-domain root under `cite-url` rounding until a curator splits them with `domains:` rows.
-- **A genuinely-unknown real gTLD** rounds via `accept_unknown=True` rather than 422-ing — accepted fail-open; the renovate bump keeps the snapshot current.
+- **A genuinely-unknown real gTLD** rounds via `accept_unknown=True` rather than 422-ing — accepted fail-open; the dependabot snapshot bump keeps the list current.
 - **Raw-unicode IDN hosts are rejected** (`is_dns_host` is ASCII-only) — an internationalized recognition host must be punycode (`xn--…`). Revisit (`idna` in `normalize_host`) only if a real publisher needs it.
 - **Admin "promote a subdomain into its own root" gardening tool** — creates a more-specific root and reparents the children that route to it. Orthogonal to _declaring_ a host; this is _reparenting_ at gardening time. Until then, creating a more-specific root leaves existing children under the ancestor (a temporary split).
 
@@ -124,5 +131,17 @@ make mypy && make quality
 uv sync --frozen            # G1 adds publicsuffixlist; the lockfile must satisfy a frozen sync
 ```
 
-- **Before enabling the flip on prod** (`G3`): spot-check that every existing `CitationSourceRootDomain.host` value is non-public-suffix and DNS-valid (a one-line query). Existing rows predate the `G2` guard, and turning on suffix matching is what makes a stray public-suffix row dangerous — this is the gate.
+- **Before enabling the flip on prod** (`G3`): every existing `CitationSourceRootDomain.host` must be non-public-suffix and DNS-valid. Existing rows predate the `G2` guard, and turning on suffix matching is what makes a stray public-suffix row dangerous — this is the gate. Run it (must print `OK`):
+
+```bash
+uv run python manage.py shell -c "
+from apps.citation.models import CitationSourceRootDomain
+from apps.citation.hosts import Host, is_dns_host
+from apps.citation.psl import is_public_suffix
+bad = [d.host for d in CitationSourceRootDomain.objects.all()
+       if is_public_suffix(Host(d.host)) or not is_dns_host(Host(d.host))]
+print('UNSAFE — do not flip G3:', bad) if bad else print('OK: all recognition hosts safe to flip')
+"
+```
+
 - **Dev rebuild:** reset the dev DB, `migrate`, re-apply patches — re-runs every host through the `G2` guard and every subdomain cite through `G3`'s matching. Confirm 0073 (or its interim form) resolves under suffix matching.

--- a/docs/plans/citations/CitationDomainGovernance.md
+++ b/docs/plans/citations/CitationDomainGovernance.md
@@ -55,7 +55,7 @@ WebCitationDomains2 P2.1. Pure additions; no caller yet. **Split by dependency**
 
 🛑 STOP.
 
-### G2 — the universal `clean()` guard (the safety prerequisite) — `models.py`
+### ✅ DONE: G2 — the universal `clean()` guard (the safety prerequisite) — `models.py`
 
 The safety half of WebCitationDomains2 P2.2. Lands **before** `G3` and never ships without it.
 

--- a/docs/plans/citations/CitationDomainGovernance.md
+++ b/docs/plans/citations/CitationDomainGovernance.md
@@ -77,7 +77,7 @@ Reverse WebCitationDomainDisablement's DISABLE1: re-point `recognize_url` step 3
 
 🛑 STOP.
 
-### G4 — the funnel + cite-url rounding — `psl.py`, `api.py`
+### ✅ DONE: G4 — the funnel + cite-url rounding — `psl.py`, `api.py`
 
 The funnel half of WebCitationDomains2 P2.2 + P2.3. Anti-fragmentation: a contributor pasting a fuzzy subdomain URL with **no** existing root mints a root at the _registrable domain_, not the bare subdomain, so future cites under the same site collapse to one root.
 

--- a/docs/plans/citations/CitationInstanceModel.md
+++ b/docs/plans/citations/CitationInstanceModel.md
@@ -1,0 +1,204 @@
+# Citation Instance Model
+
+Future-facing plan for the next citation model migration. This consolidates the target shape from [CitationUrlModel.md](CitationUrlModel.md), [CitationModelUnification.md](CitationModelUnification.md), and the durable conclusions from [CitationSystemAudit.md](CitationSystemAudit.md). The older docs remain in place for now, but this is the document to use when planning the migration.
+
+## Goal
+
+Make `CitationInstance` the structured reference object for both field edits and inline prose citations.
+
+Today the citation system already has the right source-side split: `CitationSource` is the reusable work or evidence object, `CitationSourceLink` is a way to inspect that source, and `CitationInstance` is one use of the source. The missing piece is that the per-use evidence still leaks through other fields: consulted URLs live on source links, verbatim quotes are smuggled into `ChangeSet.note`, and edit-level citations are fanned out across claims instead of being owned by the edit that used them.
+
+The target model makes one reference row carry the per-use evidence:
+
+```text
+CitationInstance
+  source: CitationSource        required
+  locator: string               optional
+  quote: string                 optional verbatim excerpt
+  access_url: URL               optional URL actually consulted
+  owner: ChangeSet or Claim     exactly one
+```
+
+This keeps source identity shared while making the evidence attached to a specific edit or inline marker explicit.
+
+## Current Problem
+
+The current model has three competing text/evidence channels:
+
+- `ChangeSet.note` is shown as an edit rationale, but data patches often use it to store the supporting quote.
+- `Claim.citation` is a free-text ingest-only citation field that the interactive editor does not set.
+- `CitationInstance` points at a structured source and locator, but has no quote, no access URL, and no changeset owner.
+
+That split makes citation behavior harder to explain and harder to migrate. A structured field edit can have a citation, but internally the code clones the same `CitationInstance` across changed claims. Inline prose footnotes can be minted with `claim=null`, which means they are not visible from edit-history paths that follow the claim FK. The authoring UI tells contributors to explain why they are editing, while patch authoring asks them to put evidence text in the same field.
+
+The cleanup should make one distinction clear:
+
+- `ChangeSet.note` is an optional edit summary about the act of editing.
+- `CitationInstance` is the structured evidence reference.
+
+## Target Model
+
+### CitationInstance fields
+
+`CitationInstance` keeps its name. It becomes the reference row, not just a source-plus-locator join.
+
+Required:
+
+- `citation_source`: the work or evidence object being cited.
+
+Optional:
+
+- `locator`: page, timestamp, section, fragment, or other within-source pointer.
+- `quote`: verbatim excerpt from the source.
+- `access_url`: the URL actually consulted for this use.
+
+Ownership:
+
+- `changeset`: set when the citation supports a structured field edit.
+- `claim`: set when the citation is an inline prose footnote attached to a markdown claim.
+
+Exactly one owner is set: `changeset` XOR `claim`.
+
+The row should stay immutable after creation. Corrections mint a replacement citation instance through an ordinary edit instead of mutating history in place.
+
+### Quote
+
+`quote` is a typed verbatim excerpt, not a general note. It replaces the current pattern where data patches put source text into `note:` using prose like `<source> says "..."`.
+
+Only exact source text belongs in `quote`. Editorial rationale, uncertainty, cleanup comments, and merge explanations stay in `ChangeSet.note`.
+
+The source pointer is always required. The locator-or-quote requirement is source-type-aware:
+
+- Fine-grained web page children are independently checkable from the source pointer and optional `access_url`; locator and quote can be blank.
+- Coarse sources such as books and magazine issues should normally require a locator or quote to be useful.
+
+The exact validation rule can be implemented at the form/service layer first, then tightened once existing data has been audited.
+
+### Access URL
+
+`access_url` is the URL actually consulted for this citation instance. It is per-use evidence, so it lives on `CitationInstance`, not on `CitationSource`.
+
+This is distinct from identity URLs:
+
+- Identity URL: where the source or page canonically lives; shared source-level fact.
+- Access URL: the specific URL consulted for this claim; per-instance fact.
+- Archive URL: future snapshot of the access URL; deferred.
+
+For a normal web page, the identity URL and access URL are often the same. They must still be modeled separately because archive and mirror cases differ: a contributor may cite a Wayback URL as the consulted copy while the source identity remains the original page.
+
+### Archive tier
+
+The archive tier is deferred. Do not add `archive_url`, `archived_at`, URL status, dead-link sweeping, or Wayback submission in this migration.
+
+Deferring archive is safe because `access_url` is the lower rung the archive tier hangs from later. A future archive migration can add archive fields to the same citation instance without reworking source identity.
+
+Human-pasted archive URLs are still useful in v1: they can be stored as `access_url`. Recognition needs archive peeling before that becomes good UX, because a raw Wayback URL otherwise recognizes against `web.archive.org` instead of the embedded original page.
+
+## Ownership Model
+
+### Structured field edits
+
+Editing granularity is the `ChangeSet`. One save creates one changeset and can carry one edit-level citation.
+
+That citation should attach once to the `ChangeSet`, not be cloned onto every claim written by the save. Each claim reaches its edit-level evidence through `claim.changeset`.
+
+This matches the existing UI discipline: a single citation panel applies to all fields changed in the save, and unrelated fields needing distinct evidence should be split into separate saves.
+
+### Inline prose footnotes
+
+Inline citations remain per-marker. A markdown marker points at one `CitationInstance`, and that instance is owned by the markdown claim containing the marker.
+
+This fixes the current orphan behavior where inline footnotes can exist with `claim=null` and then disappear from history surfaces that follow claim ownership.
+
+### Owner guard
+
+The database should enforce the ownership invariant:
+
+```text
+(changeset_id IS NOT NULL AND claim_id IS NULL)
+OR
+(changeset_id IS NULL AND claim_id IS NOT NULL)
+```
+
+Use `PROTECT` for both FKs. A claim or changeset with citation history should not silently delete its evidence.
+
+## URL Recognition Followups
+
+`access_url` does not by itself solve URL recognition. The migration should leave room for these additive followups:
+
+- Archive peeling: recognize Wayback and archive.today long-form URLs by extracting the embedded original URL while storing the pasted archive URL as `access_url`.
+- Child identity URL normalization: recognize reusable web children through a normalized identity-URL table rather than exact raw `CitationSourceLink.url` matching.
+- Child URL deduplication: prevent `http` vs `https`, trailing slash, and tracking-param variants from fragmenting into multiple children.
+
+These followups belong near the recognizer pipeline, not in the ownership migration, unless the migration already creates the normalized identity URL table.
+
+## Data Patch Shape
+
+Patch authoring should stop using `note:` for source quotes.
+
+Target shape:
+
+```yaml
+note: Optional edit summary, rarely needed
+cite:
+  url: https://example.com/source-page
+  locator: Optional section or page
+  quote: Exact quoted source text
+  access_url: Optional consulted URL when different from the source identity URL
+```
+
+Scheme citations keep their scheme form and gain the same per-use fields:
+
+```yaml
+cite:
+  source: ipdb:4443
+  locator: Optional locator
+  quote: Exact quoted source text
+```
+
+The migration does not need to backfill quotes out of old `note:` prose. That would be heuristic and likely wrong. Existing notes can remain edit summaries or historical text; new patches should write `quote:` explicitly once the field exists.
+
+## Read And Write Surfaces
+
+The migration affects these areas:
+
+- Claim write path: stop fan-out cloning citation instances per claim; mint one changeset-owned citation for the edit-level citation.
+- Inline citation path: mint claim-owned citation instances for markdown markers.
+- Evidence/read helpers: collect changeset-owned citations for structured claims and claim-owned citations for inline prose.
+- Description attribution: stop depending on `Claim.citation` free text once structured evidence is available.
+- Editor UI: add a quote field to the citation panel and keep `note` labeled as edit summary.
+- Data patch parsing: parse `quote:` and optional `access_url` inside `cite:`.
+- API schemas: expose `quote` and `access_url` wherever citation instances are rendered or created.
+
+The quote UI is the largest frontend change. `access_url` is mostly a field addition once the backend can store it. Retiring `Claim.citation` is a model/read-path change more than a UI change.
+
+## Migration Shape
+
+This should be one planned migration cluster, not two unrelated migrations, because `access_url`, `quote`, ownership, and `Claim.citation` retirement all touch the meaning of `CitationInstance`.
+
+Suggested phases:
+
+1. Add nullable `quote`, nullable `access_url`, nullable `changeset`, and the owner constraint in a form that tolerates existing rows during backfill.
+2. Backfill existing citation ownership where it is unambiguous.
+3. Change the write paths to mint changeset-owned edit citations and claim-owned inline citations.
+4. Change read paths and schemas to consume the new shape.
+5. Stop writing `Claim.citation` and update patch authoring to use `cite.quote`.
+6. Tighten constraints after existing rows and tests prove the new ownership rules.
+7. Retire `Claim.citation` once no read path depends on it.
+
+Backfill caution: mapping existing per-claim citation clones back to one changeset-level citation is not always provably correct. Prefer a conservative backfill that handles obvious cases and leaves ambiguous historical rows readable rather than inventing evidence relationships.
+
+## Deferred
+
+- Archive URL tier and archive-date/status machinery.
+- Precise access dates for data patches. `created_at` is good enough for interactive access time but fabricated for rebuild-applied patches.
+- Automatic quote extraction or quote backfill from old notes.
+- Admin tooling for repairing orphaned or ambiguous historical citation instances.
+- Normalized identity URL table, unless it is explicitly pulled into this migration.
+
+## Open Questions
+
+- Should the locator-or-quote rule for coarse sources be enforced server-side at first, or only surfaced as UI validation until existing data has been audited?
+- What is the exact conservative backfill for current per-claim citation clones?
+- Should `access_url` be accepted in the interactive UI immediately, or only stored through patch/import paths until archive peeling exists?
+- Does the normalized identity URL table belong in this migration, or in the recognizer followup?

--- a/docs/plans/citations/WebCitationDomains2.md
+++ b/docs/plans/citations/WebCitationDomains2.md
@@ -64,7 +64,7 @@ Why this is the simplest shape:
 - **Phase 1 — stabilize the creation layer.** Behavior-preserving refactors (plus two flagged behavior changes) that converge the tangled, inconsistently-validated write paths onto a few named pieces. Lands and verifies **first**, so the new behavior never rides on the shaky parts. This is the get-well work, scoped to exactly the debt the feature touches.
 - **Phase 2 — domain governance.** PSL rounding (`cite-url` derive) + the `domains:` verb — the anti-fragmentation layer and multi-host capability. New behavior on the clean foundation; **more deferrable**, since the Context bugs are already closed.
 
-One commit each, 🛑 STOP for user review before committing. Commit messages: no ephemera.
+One commit each, 🛑 STOP for user review before committing. In commit messages, do NOT reference ephemera that future readers will not understand, such as step numbers, PR numbers, links to this plan.
 
 ## Phase 1 — Stabilize the creation layer
 


### PR DESCRIPTION
## Summary

Enable subdomain (longest-suffix) recognition matching for citation source domains, guarded so it can't over-match, plus PSL-backed rounding of fuzzy cite-url pastes to the registrable domain. Implements G1–G4 of [CitationDomainGovernance.md](docs/plans/citations/CitationDomainGovernance.md); G5 (`domains:` verb) is deferred to a follow-up.

- **G1** — pure host predicates (`is_dns_host`, `is_reserved_tld`) in `hosts.py`; a new isolated `psl.py` for the Public Suffix List boundary (`is_public_suffix`, `registrable_domain`). An import-linter contract bars the recognition read path from importing the PSL, so `hosts`/`extractors` stay PSL-free.
- **G2** — universal `CitationSourceRootDomain.clean()` guard: rejects IP literals and bare public suffixes on every write path. Lands before the flip and never ships without it.
- **G3** — re-point recognition step 3 at the dormant longest-suffix helpers, so an asset subdomain (`s4.american-pinball.com`) resolves to its registrable root while a more-specific seeded host still wins for its own subtree.
- **G4** — `root_host_from_url` funnel: a fuzzy contributor paste with no existing root mints a root at the registrable domain (not the bare subdomain), 422-ing hosts that can't root a site (no host, IP literal, reserved TLD, bare public suffix) before any write.

## Test plan

- [x] `cd backend && uv run pytest apps/citation apps/claim_ingest -q` — 532 passed
- [x] `make mypy` — clean
- [x] `make quality` — lint + codegen + svelte-check pass, no codegen drift
- [x] `uv sync --frozen` — lockfile satisfies frozen sync (`publicsuffixlist` pinned)
- [x] `lint-imports` — 22/22 contracts kept, incl. the PSL boundary
- [x] `recognize_url('http://s4.american-pinball.com/...')` resolves to American Pinball
- [ ] **Deploy gate:** run the prod host audit ([plan §Verification](docs/plans/citations/CitationDomainGovernance.md)) and confirm `OK` before flipping G3 on prod — turning on suffix matching is what makes a stray public-suffix row dangerous
- [ ] **Cross-repo ordering:** flippatch 0073's `s4.american-pinball.com` cites are uncommented; deploy this branch before re-ingesting 0073 so the subdomain cites resolve

## Notes

- G5 (`domains:` verb) is intentionally split per the plan — G1–G4 close the subdomain-match story end to end.
- Bundles two pre-existing planning-doc commits (`CitationInstanceModel.md`, `WebCitationDomains2.md`) at the branch base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
