### PR TITLE
refactor(provenance): isolate the abstract claim-control bases in a model_bases leaf

### DIFF
--- a/backend/apps/provenance/model_bases/__init__.py
+++ b/backend/apps/provenance/model_bases/__init__.py
@@ -1,0 +1,18 @@
+"""The abstract claim-control base layer — see :mod:`.models`.
+
+Re-exports the bases so callers import ``from apps.provenance.model_bases import
+…`` (and the legacy ``from apps.provenance.models import …`` re-export keeps
+working) without reaching into the submodule.
+"""
+
+from .models import (
+    ClaimControlledModel,
+    LinkableClaimModel,
+    LinkableLifecycleClaimModel,
+)
+
+__all__ = [
+    "ClaimControlledModel",
+    "LinkableClaimModel",
+    "LinkableLifecycleClaimModel",
+]

--- a/backend/apps/provenance/model_bases/models.py
+++ b/backend/apps/provenance/model_bases/models.py
@@ -1,4 +1,17 @@
-"""Abstract bases for claim-controlled entities and addressable claim subjects."""
+"""Abstract bases for claim-controlled entities and addressable claim subjects.
+
+The citation-agnostic substrate every claim-controlled model inherits — catalog
+and media today, citation eventually. Kept a dependency-free leaf on purpose: it
+imports only ``apps.core`` (and names ``provenance.Claim`` solely through the
+string label of a ``GenericRelation``). Two import-linter contracts pin that:
+the ``Provenance app internal stack`` layer keeps it from reaching up into the
+provenance *domain* (``Claim``, ``ChangeSet``, ``Source``), and the
+``Claim-control bases stay a core-only leaf`` forbidden contract blocks the
+cross-app edges the global tiers would otherwise permit (provenance sits above
+citation/accounts). When a lower-tier app needs to inherit these bases, this
+package lifts out to a top-level app via ``git mv`` — still migration-free,
+because every base is abstract.
+"""
 
 from __future__ import annotations
 

--- a/backend/apps/provenance/models/__init__.py
+++ b/backend/apps/provenance/models/__init__.py
@@ -4,7 +4,7 @@ Re-exports all public names so existing ``from apps.provenance.models import …
 continues to work unchanged.
 """
 
-from .base import (
+from ..model_bases import (
     ClaimControlledModel,
     LinkableClaimModel,
     LinkableLifecycleClaimModel,

--- a/backend/apps/provenance/models/claim.py
+++ b/backend/apps/provenance/models/claim.py
@@ -12,7 +12,7 @@ from django.db.models.functions import Now
 
 from apps.core.models import BoundedTextField, field_not_blank
 
-from .base import ClaimControlledModel
+from ..model_bases import ClaimControlledModel
 from .changeset import ChangeSet
 from .source import Source
 

--- a/backend/apps/provenance/models/introspection.py
+++ b/backend/apps/provenance/models/introspection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django.db import models
 
-from .base import ClaimControlledModel
+from ..model_bases import ClaimControlledModel
 
 __all__ = ["get_claim_fields"]
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -487,11 +487,34 @@ layers = [
     "claims | display | revert",
     "validation | schemas | claim_ranking_in_db | licensing | resolution | rate_limits",
     "models | claim_presence | constants | entity_resolution | pagination | authz | typing",
+    # The abstract claim-control bases every claim-controlled model inherits.
+    # Pinned to the bottom so it can't reach UP into the provenance domain
+    # (Claim, ChangeSet, Source). Its core-only-leaf guarantee — no cross-app
+    # imports either — is enforced separately by the forbidden contract below,
+    # since the global tiers would otherwise let it import down into citation /
+    # accounts. Together they keep the package lift-out-ready (below citation).
+    "model_bases",
 ]
 ignore_imports = [
     # validation imports models, so ClaimManager (models/claim.py) calls it lazily
     # at write time; hoisting that out would weaken self-validation.
     "apps.provenance.models.claim -> apps.provenance.validation",
+]
+
+[[tool.importlinter.contracts]]
+name = "Claim-control bases stay a core-only leaf"
+type = "forbidden"
+# model_bases is the substrate every claim-controlled model inherits, meant to
+# lift out to a top-level app below citation; it must import nothing but
+# apps.core. The other boundaries are already covered — the internal-stack layer
+# blocks reaching up into the provenance domain, the global tiers block the apps
+# above provenance, and "Data apps do not depend on media" blocks media. The one
+# gap is the apps the tiers let provenance import DOWNWARD (citation, accounts):
+# a bare tiers check would allow model_bases -> citation, which would later cycle.
+source_modules = ["apps.provenance.model_bases"]
+forbidden_modules = [
+    "apps.citation",
+    "apps.accounts",
 ]
 
 # ----- citation -----


### PR DESCRIPTION
## What

Move the abstract claim-control bases (`ClaimControlledModel`, `LinkableClaimModel`, `LinkableLifecycleClaimModel`) out of the provenance domain into a new `apps.provenance.model_bases` package, and pin it as a dependency-free leaf.

Today the bases live in `apps/provenance/models/base.py`, co-packaged with the citation-dependent domain (`Claim`, `ChangeSet`, `Source`, `CitationInstance`). That's fine until a lower-tier app (citation) wants to become claim-controlled by inheriting `ClaimControlledModel` — which would force it to import the provenance app, inverting the tier and creating a cycle. Separating the bases into a leaf removes that latent cycle and is a cleaner mechanism-below-domain factoring regardless.

## How

- New `apps/provenance/model_bases/` — `models.py` holds the three abstract bases (moved verbatim from `models/base.py`), `__init__.py` re-exports them.
- The three in-package importers (`models/__init__.py`, `models/claim.py`, `models/introspection.py`) point at `..model_bases`. **Every external consumer is unchanged** — `apps.provenance.models` still re-exports the bases.
- Two import-linter contracts pin the leaf:
  - `model_bases` added as the **bottom layer** of the *Provenance app internal stack* — it can't reach up into the domain.
  - New **forbidden** contract *Claim-control bases stay a core-only leaf* — blocks the one gap the global tiers would otherwise permit (provenance sits above `citation`/`accounts`, so a bare tiers check would allow `model_bases -> citation`, which would later cycle). The other apps are already covered (tiers for those above provenance; the media contract for media).

## Why it's safe

The bases are abstract, so relocating them between modules keeps every `(app_label, model_name)` key — **zero migrations**.

## Verification

- `makemigrations --check` → no changes
- `lint-imports` → 23 kept, 0 broken (both new contracts enforced; the forbidden one verified to break on a probe import)
- `mypy .` → clean, 486 files
- `pytest` (provenance, catalog, citation, claim_ingest, claim_edit, media) → 2726 passed, 1 skipped

## Out of scope

Making citation claim-controlled, and the eventual `git mv` promotion of `model_bases` to a top-level app below citation — both deferred until citation actually needs the substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)