### PR TITLE
fix(media): attribute media claims through ChangeSets

### DIFF
--- a/backend/apps/catalog/tests/test_api_claims.py
+++ b/backend/apps/catalog/tests/test_api_claims.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from apps.catalog.resolve import resolve_model
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.models import Claim, Source
+from apps.provenance.test_factories import user_changeset
 
 User = get_user_model()
 
@@ -201,7 +202,9 @@ class TestUserClaimResolution:
             pm, "name", "Medieval Madness", source=low_priority_source
         )
         Claim.objects.assert_claim(pm, "year", 1990, source=low_priority_source)
-        Claim.objects.assert_claim(pm, "year", 2000, user=user)  # priority 10000 > 10
+        Claim.objects.assert_claim(
+            pm, "year", 2000, user=user, changeset=user_changeset(user)
+        )  # priority 10000 > 10
 
         resolved = resolve_model(pm)
         assert resolved.year == 2000
@@ -213,7 +216,7 @@ class TestUserClaimResolution:
         Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=high_source)
         Claim.objects.assert_claim(pm, "year", 1990, source=high_source)
         Claim.objects.assert_claim(
-            pm, "year", 2000, user=user
+            pm, "year", 2000, user=user, changeset=user_changeset(user)
         )  # priority 10000 < 50000
 
         resolved = resolve_model(pm)

--- a/backend/apps/catalog/tests/test_source_enabled.py
+++ b/backend/apps/catalog/tests/test_source_enabled.py
@@ -19,6 +19,7 @@ from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.claims import build_relationship_claim
 from apps.provenance.helpers import active_claims
 from apps.provenance.models import Claim, Source, get_claim_fields
+from apps.provenance.test_factories import user_changeset
 
 
 @pytest.fixture
@@ -106,7 +107,9 @@ class TestIsEnabledUserClaims:
     def test_user_claims_unaffected_by_source_enabled(self, source_a, user):
         """User claims (source=None) should not be filtered by is_enabled."""
         mfr = Manufacturer.objects.create(name="Test Mfr", slug="test-mfr")
-        Claim.objects.assert_claim(mfr, "name", "User Claim", user=user)
+        Claim.objects.assert_claim(
+            mfr, "name", "User Claim", user=user, changeset=user_changeset(user)
+        )
 
         # Disable source_a (irrelevant — the claim is user-owned, not source-owned).
         source_a.is_enabled = False

--- a/backend/apps/media/api.py
+++ b/backend/apps/media/api.py
@@ -17,6 +17,7 @@ from ninja import File, Form, Router, Status, UploadedFile
 from ninja.errors import HttpError
 from ninja.security import django_auth
 
+from apps.accounts.models import User
 from apps.catalog.claims import build_media_attachment_claim
 from apps.catalog.resolve import resolve_media_attachments
 from apps.core.api_helpers import authed_user
@@ -57,11 +58,38 @@ from apps.media.storage import (
     delete_from_storage,
     upload_to_storage,
 )
-from apps.provenance.models import Claim
+from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 logger = logging.getLogger(__name__)
 
 media_router = Router(tags=["media", "private"])
+
+
+def _assert_media_claim(
+    entity: MediaSupportedModel,
+    *,
+    claim_key: str,
+    claim_value: object,
+    user: User,
+) -> Claim:
+    """Assert a ``media_attachment`` claim inside a fresh user ChangeSet.
+
+    Every media mutation is one user action, so it gets its own
+    ``action=EDIT`` ChangeSet — the single attribution path through
+    provenance. Callers must already hold a ``transaction.atomic()`` block so
+    the ChangeSet and claim commit together. See docs/plans/auth/Actors.md
+    ("Fix Media Claims").
+    """
+    changeset = ChangeSet.objects.create(user=user, action=ChangeSetAction.EDIT)
+    return Claim.objects.assert_claim(
+        entity,
+        "media_attachment",
+        claim_value,
+        user=user,
+        claim_key=claim_key,
+        changeset=changeset,
+    )
+
 
 # Extensions that require optional codecs.
 _CODEC_EXTENSIONS: dict[str, str] = {
@@ -263,12 +291,8 @@ def upload_media(
                 category=category,
                 is_primary=False,
             )
-            Claim.objects.assert_claim(
-                entity,
-                "media_attachment",
-                claim_value,
-                user=user,
-                claim_key=claim_key,
+            _assert_media_claim(
+                entity, claim_key=claim_key, claim_value=claim_value, user=user
             )
             resolve_media_attachments(
                 content_type_id=ct.id,
@@ -335,12 +359,8 @@ def detach_media(request: HttpRequest, body: MediaAssetInputSchema) -> Status[No
             asset.pk,
             exists=False,
         )
-        Claim.objects.assert_claim(
-            entity,
-            "media_attachment",
-            claim_value,
-            user=user,
-            claim_key=claim_key,
+        _assert_media_claim(
+            entity, claim_key=claim_key, claim_value=claim_value, user=user
         )
         resolve_media_attachments(
             content_type_id=ct.id,
@@ -386,12 +406,8 @@ def set_primary(request: HttpRequest, body: MediaAssetInputSchema) -> Status[Non
             category=em.category,
             is_primary=True,
         )
-        Claim.objects.assert_claim(
-            entity,
-            "media_attachment",
-            claim_value,
-            user=user,
-            claim_key=claim_key,
+        _assert_media_claim(
+            entity, claim_key=claim_key, claim_value=claim_value, user=user
         )
         resolve_media_attachments(
             content_type_id=ct.id,
@@ -446,12 +462,8 @@ def set_category(
         except ValueError as exc:
             raise HttpError(400, str(exc)) from exc
 
-        Claim.objects.assert_claim(
-            entity,
-            "media_attachment",
-            claim_value,
-            user=user,
-            claim_key=claim_key,
+        _assert_media_claim(
+            entity, claim_key=claim_key, claim_value=claim_value, user=user
         )
         resolve_media_attachments(
             content_type_id=ct.id,

--- a/backend/apps/media/tests/test_detach.py
+++ b/backend/apps/media/tests/test_detach.py
@@ -13,6 +13,7 @@ from apps.catalog.tests.conftest import make_machine_model
 from apps.media.models import EntityMedia, MediaAsset, MediaRendition
 from apps.media.storage import build_storage_key
 from apps.provenance.models import Claim
+from apps.provenance.test_factories import user_changeset
 
 User = get_user_model()
 
@@ -69,6 +70,7 @@ def _attach_via_claims(entity, asset, user, category="backglass", is_primary=Tru
         claim_value,
         user=user,
         claim_key=claim_key,
+        changeset=user_changeset(user),
     )
     ct = ContentType.objects.get_for_model(type(entity))
     resolve_media_attachments(content_type_id=ct.id, subject_ids={entity.pk})

--- a/backend/apps/media/tests/test_media_changeset_attribution.py
+++ b/backend/apps/media/tests/test_media_changeset_attribution.py
@@ -1,0 +1,148 @@
+"""Every MEDIA_EDIT mutation must attribute its claim to a user ChangeSet.
+
+Regression for the Actors "Fix Media Claims" leak: the four media endpoints
+(upload/attach, detach, set-primary, set-category) minted user claims via
+``assert_claim`` with no ``changeset``, leaving them unattributed. Each
+mutation must now open a user-attributed ChangeSet (``action=EDIT``) and link
+its claim to it.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.test import Client
+
+from apps.catalog.tests.conftest import make_machine_model
+from apps.media.models import MediaAsset
+from apps.provenance.models import ChangeSetAction, Claim
+
+# Upload needs storage; reuse the in-memory backend the upload tests use.
+_TEST_STORAGE = {
+    "default": {"BACKEND": "django.core.files.storage.InMemoryStorage"},
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    },
+}
+
+UPLOAD_URL = "/api/media/upload/"
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _media_settings(settings):
+    settings.STORAGES = _TEST_STORAGE
+    settings.MEDIA_PUBLIC_BASE_URL = "https://test-media.example.com/"
+    from django.core.cache import cache
+
+    cache.clear()
+
+
+@pytest.fixture
+def client(user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+@pytest.fixture
+def machine_model(db):
+    return make_machine_model(name="Test Machine", slug="test-machine")
+
+
+def _image(name: str = "test.jpg") -> BytesIO:
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (100, 100), color="red").save(buf, format="JPEG")
+    buf.seek(0)
+    buf.name = name
+    return buf
+
+
+def _upload(client: Client, machine_model, category: str = "backglass") -> MediaAsset:
+    resp = client.post(
+        UPLOAD_URL,
+        data={
+            "file": _image(),
+            "entity_type": "model",
+            "public_id": machine_model.public_id,
+            "category": category,
+        },
+    )
+    assert resp.status_code == 200, resp.content
+    asset = MediaAsset.objects.latest("pk")
+    return asset
+
+
+def _latest_active_media_claim(machine_model) -> Claim:
+    ct = ContentType.objects.get_for_model(type(machine_model))
+    return Claim.objects.filter(
+        content_type=ct,
+        object_id=machine_model.pk,
+        field_name="media_attachment",
+        is_active=True,
+    ).latest("created_at")
+
+
+def _assert_attributed(claim: Claim, user) -> None:
+    cs = claim.changeset
+    assert cs is not None, "media claim was minted with no ChangeSet"
+    assert cs.user_id == user.id
+    assert cs.action == ChangeSetAction.EDIT
+
+
+class TestMediaMutationsAreAttributed:
+    def test_upload_attaches_with_changeset(self, client, machine_model, user):
+        _upload(client, machine_model)
+        _assert_attributed(_latest_active_media_claim(machine_model), user)
+
+    def test_detach_records_changeset(self, client, machine_model, user):
+        asset = _upload(client, machine_model)
+        resp = client.post(
+            "/api/media/detach/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 204
+        # The detach tombstone (exists=False) is the active claim now.
+        claim = _latest_active_media_claim(machine_model)
+        assert claim.value.get("exists") is False
+        _assert_attributed(claim, user)
+
+    def test_set_primary_records_changeset(self, client, machine_model, user):
+        _upload(client, machine_model, category="backglass")
+        asset2 = _upload(client, machine_model, category="backglass")
+        resp = client.post(
+            "/api/media/set-primary/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset2.uuid),
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 204
+        _assert_attributed(_latest_active_media_claim(machine_model), user)
+
+    def test_set_category_records_changeset(self, client, machine_model, user):
+        asset = _upload(client, machine_model, category="backglass")
+        resp = client.post(
+            "/api/media/set-category/",
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+                "category": "playfield",
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 204
+        _assert_attributed(_latest_active_media_claim(machine_model), user)

--- a/backend/apps/media/tests/test_media_claims.py
+++ b/backend/apps/media/tests/test_media_claims.py
@@ -15,10 +15,30 @@ from apps.catalog.models import MachineModel
 from apps.catalog.tests.conftest import make_machine_model
 from apps.media.models import EntityMedia, MediaAsset
 from apps.provenance.models import Claim, Source
+from apps.provenance.test_factories import user_changeset
 
 User = get_user_model()
 
 pytestmark = pytest.mark.django_db
+
+
+def _assert_claim(subject, field_name, value, *, user=None, source=None, claim_key=""):
+    """``assert_claim`` wrapper that opens a throwaway user ChangeSet (tests only).
+
+    User-attributed claims now require a changeset; these resolver tests don't
+    care which one, so each user call gets a fresh ``EDIT`` changeset. Source
+    calls pass through unchanged.
+    """
+    changeset = user_changeset(user) if user is not None else None
+    return Claim.objects.assert_claim(
+        subject,
+        field_name,
+        value,
+        user=user,
+        source=source,
+        claim_key=claim_key,
+        changeset=changeset,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +150,7 @@ class TestClaimAssertion:
         claim_key, value = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=True
         )
-        claim = Claim.objects.assert_claim(
+        claim = _assert_claim(
             machine_model,
             "media_attachment",
             value,
@@ -146,7 +166,7 @@ class TestClaimAssertion:
         claim_key, value1 = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass"
         )
-        old = Claim.objects.assert_claim(
+        old = _assert_claim(
             machine_model,
             "media_attachment",
             value1,
@@ -157,7 +177,7 @@ class TestClaimAssertion:
         _key, value2 = build_media_attachment_claim(
             machine_model, asset.pk, category="playfield"
         )
-        new = Claim.objects.assert_claim(
+        new = _assert_claim(
             machine_model,
             "media_attachment",
             value2,
@@ -180,7 +200,7 @@ class TestResolutionHappyPath:
         claim_key, value = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             value,
@@ -203,7 +223,7 @@ class TestResolutionHappyPath:
         claim_key, value = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass"
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             value,
@@ -217,7 +237,7 @@ class TestResolutionHappyPath:
         claim_key, retract_value = build_media_attachment_claim(
             machine_model, asset.pk, exists=False
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             retract_value,
@@ -231,7 +251,7 @@ class TestResolutionHappyPath:
         claim_key, value = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass"
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             value,
@@ -245,7 +265,7 @@ class TestResolutionHappyPath:
         _key, new_value = build_media_attachment_claim(
             machine_model, asset.pk, category="playfield"
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             new_value,
@@ -262,13 +282,13 @@ class TestResolutionHappyPath:
         key1, val1 = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=False
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model, "media_attachment", val1, user=user, claim_key=key1
         )
         key2, val2 = build_media_attachment_claim(
             machine_model, asset2.pk, category="backglass", is_primary=False
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model, "media_attachment", val2, user=user, claim_key=key2
         )
         _resolve_media(machine_model)
@@ -279,7 +299,7 @@ class TestResolutionHappyPath:
         _key, new_value = build_media_attachment_claim(
             machine_model, asset2.pk, category="backglass", is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model, "media_attachment", new_value, user=user, claim_key=key2
         )
         _resolve_media(machine_model)
@@ -299,9 +319,7 @@ class TestPrimaryAutoPromotion:
         key, val = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=False
         )
-        Claim.objects.assert_claim(
-            machine_model, "media_attachment", val, user=user, claim_key=key
-        )
+        _assert_claim(machine_model, "media_attachment", val, user=user, claim_key=key)
         _resolve_media(machine_model)
 
         em = EntityMedia.objects.get()
@@ -312,14 +330,14 @@ class TestPrimaryAutoPromotion:
         key1, val1 = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=False
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model, "media_attachment", val1, user=user, claim_key=key1
         )
 
         key2, val2 = build_media_attachment_claim(
             machine_model, asset2.pk, category="backglass", is_primary=False
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model, "media_attachment", val2, user=user, claim_key=key2
         )
 
@@ -335,14 +353,14 @@ class TestPrimaryAutoPromotion:
         key1, val1 = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=False
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model, "media_attachment", val1, user=user, claim_key=key1
         )
 
         key2, val2 = build_media_attachment_claim(
             machine_model, asset2.pk, category="backglass", is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model, "media_attachment", val2, user=user, claim_key=key2
         )
 
@@ -360,14 +378,14 @@ class TestPrimaryAutoPromotion:
         key1, val1 = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=False
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model, "media_attachment", val1, user=user, claim_key=key1
         )
 
         key2, val2 = build_media_attachment_claim(
             machine_model, asset2.pk, category="playfield", is_primary=False
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model, "media_attachment", val2, user=user, claim_key=key2
         )
 
@@ -385,7 +403,7 @@ class TestPrimaryEnforcement:
         key1, val1 = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val1,
@@ -396,7 +414,7 @@ class TestPrimaryEnforcement:
         key2, val2 = build_media_attachment_claim(
             machine_model, asset2.pk, category="backglass", is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val2,
@@ -420,7 +438,7 @@ class TestPrimaryEnforcement:
             machine_model, asset.pk, category="backglass", is_primary=True
         )
         # Low priority claims first
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val1,
@@ -432,7 +450,7 @@ class TestPrimaryEnforcement:
             machine_model, asset2.pk, category="backglass", is_primary=True
         )
         # High priority claims second
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val2,
@@ -452,7 +470,7 @@ class TestPrimaryEnforcement:
         key1, val1 = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val1,
@@ -463,7 +481,7 @@ class TestPrimaryEnforcement:
         key2, val2 = build_media_attachment_claim(
             machine_model, asset2.pk, category="playfield", is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val2,
@@ -485,7 +503,7 @@ class TestPrimaryEnforcement:
         key1, val1 = build_media_attachment_claim(
             machine_model, asset.pk, category=None, is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val1,
@@ -496,7 +514,7 @@ class TestPrimaryEnforcement:
         key2, val2 = build_media_attachment_claim(
             machine_model, asset2.pk, category=None, is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val2,
@@ -523,12 +541,12 @@ class TestResolveModelIntegration:
         from apps.catalog.resolve import resolve_model
 
         # Need a name claim so resolve_model can save
-        Claim.objects.assert_claim(machine_model, "name", "Test Machine", source=source)
+        _assert_claim(machine_model, "name", "Test Machine", source=source)
 
         key, val = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass", is_primary=True
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val,
@@ -546,12 +564,12 @@ class TestResolveModelIntegration:
         """Retracting a media claim through resolve_model deletes EntityMedia."""
         from apps.catalog.resolve import resolve_model
 
-        Claim.objects.assert_claim(machine_model, "name", "Test Machine", source=source)
+        _assert_claim(machine_model, "name", "Test Machine", source=source)
 
         key, val = build_media_attachment_claim(
             machine_model, asset.pk, category="backglass"
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             val,
@@ -565,7 +583,7 @@ class TestResolveModelIntegration:
         _key, retract_val = build_media_attachment_claim(
             machine_model, asset.pk, exists=False
         )
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             retract_val,
@@ -594,7 +612,7 @@ class TestResolverValidation:
             "is_primary": False,
             "exists": True,
         }
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             value,
@@ -617,7 +635,7 @@ class TestResolverValidation:
             "is_primary": False,
             "exists": True,
         }
-        Claim.objects.assert_claim(
+        _assert_claim(
             machine_model,
             "media_attachment",
             value,
@@ -645,7 +663,7 @@ class TestResolverValidation:
             "exists": True,
         }
         with pytest.raises(ValidationError, match="media_attachment"):
-            Claim.objects.assert_claim(
+            _assert_claim(
                 theme,
                 "media_attachment",
                 value,

--- a/backend/apps/media/tests/test_set_category.py
+++ b/backend/apps/media/tests/test_set_category.py
@@ -12,6 +12,7 @@ from apps.catalog.resolve import resolve_media_attachments
 from apps.catalog.tests.conftest import make_machine_model
 from apps.media.models import EntityMedia, MediaAsset
 from apps.provenance.models import Claim
+from apps.provenance.test_factories import user_changeset
 
 User = get_user_model()
 
@@ -46,6 +47,7 @@ def _attach_via_claims(entity, asset, user, category="backglass", is_primary=Fal
         claim_value,
         user=user,
         claim_key=claim_key,
+        changeset=user_changeset(user),
     )
     ct = ContentType.objects.get_for_model(type(entity))
     resolve_media_attachments(content_type_id=ct.id, subject_ids={entity.pk})

--- a/backend/apps/media/tests/test_set_primary.py
+++ b/backend/apps/media/tests/test_set_primary.py
@@ -11,6 +11,7 @@ from apps.catalog.resolve import resolve_media_attachments
 from apps.catalog.tests.conftest import make_machine_model
 from apps.media.models import EntityMedia, MediaAsset
 from apps.provenance.models import Claim
+from apps.provenance.test_factories import user_changeset
 
 User = get_user_model()
 
@@ -53,6 +54,7 @@ def _attach_via_claims(entity, asset, user, category="backglass", is_primary=Fal
         claim_value,
         user=user,
         claim_key=claim_key,
+        changeset=user_changeset(user),
     )
     ct = ContentType.objects.get_for_model(type(entity))
     resolve_media_attachments(content_type_id=ct.id, subject_ids={entity.pk})

--- a/backend/apps/provenance/migrations/0009_backfill_user_claim_changesets.py
+++ b/backend/apps/provenance/migrations/0009_backfill_user_claim_changesets.py
@@ -1,0 +1,50 @@
+"""Backfill ChangeSets for user-attributed claims that have none.
+
+The four MEDIA_EDIT endpoints used to mint user claims via ``assert_claim``
+with no ``changeset``, leaving them unattributed (see the Actors "Fix Media
+Claims" work). Now that every user write goes through a ChangeSet, give each
+pre-existing user-attributed orphan its own user ChangeSet (``action=edit``),
+timestamped to match the claim it carries. On dev this is the 4 ``user=moses``
+media claims; on prod it is the handful of equivalents.
+
+Scope is only user-attributed orphans (``user__isnull=False``). The ~104K
+source-attributed changeset-less claims are deliberately untouched: a source
+ChangeSet needs an ``ingest_run`` to satisfy the user-XOR-ingest_run check, so
+those belong to the later "Backfill ingest runs" + "Backfill changesets" PRs.
+
+Each orphan is a single-claim media mutation (one endpoint call writes exactly
+one ``media_attachment`` claim), so per-claim grouping is intentional — there
+is no multi-claim "Save" to reconstruct, unlike the source-seed backfill.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+
+
+def backfill_user_changesets(apps, schema_editor):
+    Claim = apps.get_model("provenance", "Claim")
+    ChangeSet = apps.get_model("provenance", "ChangeSet")
+
+    orphaned = Claim.objects.filter(user__isnull=False, changeset__isnull=True)
+    for claim in orphaned.iterator():
+        # Each orphaned media mutation was its own user action → its own
+        # ChangeSet (grouping them would misrepresent separate edits as one).
+        cs = ChangeSet.objects.create(user_id=claim.user_id, action="edit")
+        # auto_now_add stamps "now" on insert; realign to the claim's time.
+        ChangeSet.objects.filter(pk=cs.pk).update(created_at=claim.created_at)
+        claim.changeset = cs
+        claim.save(update_fields=["changeset"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("provenance", "0008_citationinstance_prov_citinst_slug_length"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_user_changesets,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/apps/provenance/models/claim.py
+++ b/backend/apps/provenance/models/claim.py
@@ -88,11 +88,18 @@ class ClaimManager(models.Manager["Claim"]):
         Exactly one of ``source`` or ``user`` must be provided.
         ``claim_key`` defaults to ``field_name`` for scalar claims.
         ``license`` is an optional per-claim License override (null inherits from source).
-        ``changeset`` is an optional ChangeSet to group this claim with others.
+        ``changeset`` groups this claim with others; it is **required** for
+        user-attributed claims (every user write is an attributed ChangeSet)
+        and optional for source-attributed (ingest) claims.
         Runs in a transaction to ensure the old claim is deactivated atomically.
         """
         if (source is None) == (user is None):
             raise ValueError("Exactly one of source or user must be provided.")
+        if user is not None and changeset is None:
+            raise ValueError(
+                "A user-attributed claim requires a changeset "
+                "(every user write must be an attributed ChangeSet)."
+            )
         if changeset is not None:
             if (
                 user is not None

--- a/backend/apps/provenance/tests/test_changeset.py
+++ b/backend/apps/provenance/tests/test_changeset.py
@@ -56,10 +56,10 @@ class TestChangeSetClaimGrouping:
         assert c2.changeset == cs
         assert set(cs.claims.values_list("pk", flat=True)) == {c1.pk, c2.pk}
 
-    def test_claim_without_changeset(self, user, mfr):
-        """Claims without a changeset still work (backwards compatible)."""
-        claim = Claim.objects.assert_claim(mfr, "name", "Williams", user=user)
-        assert claim.changeset is None
+    def test_user_claim_without_changeset_rejected(self, user, mfr):
+        """A user-attributed claim must carry a ChangeSet — no unattributed user writes."""
+        with pytest.raises(ValueError, match="requires a changeset"):
+            Claim.objects.assert_claim(mfr, "name", "Williams", user=user)
 
     def test_source_claim_with_changeset_accepted(self, source, mfr):
         """Source-attributed claims can use ChangeSets linked to matching ingest run."""
@@ -162,7 +162,8 @@ class TestClaimProtect:
         """PROTECT prevents deleting a user who has claims."""
         from django.db.models import ProtectedError
 
-        Claim.objects.assert_claim(mfr, "name", "Williams", user=user)
+        cs = ChangeSet.objects.create(user=user, action="edit")
+        Claim.objects.assert_claim(mfr, "name", "Williams", user=user, changeset=cs)
         with pytest.raises(ProtectedError):
             user.delete()
 

--- a/backend/apps/provenance/tests/test_undo_changeset.py
+++ b/backend/apps/provenance/tests/test_undo_changeset.py
@@ -59,7 +59,9 @@ class TestEligibility:
         # Supersede the status=deleted claim with a status=active claim.
         from apps.provenance.models import Claim
 
-        Claim.objects.assert_claim(t, "status", "active", user=author)
+        Claim.objects.assert_claim(
+            t, "status", "active", user=author, changeset=user_changeset(author)
+        )
         with pytest.raises(UndoError):
             execute_undo_changeset(_require_changeset(cs), user=author)
 
@@ -101,7 +103,9 @@ class TestInverseBehavior:
     def test_reactivates_prior_user_claim_if_any(self, author, bootstrap_source):
         t = _title("g", bootstrap_source)
         # User first asserts status=active (their own prior claim).
-        prior = Claim.objects.assert_claim(t, "status", "active", user=author)
+        prior = Claim.objects.assert_claim(
+            t, "status", "active", user=author, changeset=user_changeset(author)
+        )
         # Then deletes.
         delete_cs, _ = execute_soft_delete(t, user=author)
         prior.refresh_from_db()

--- a/docs/plans/auth/Actors.md
+++ b/docs/plans/auth/Actors.md
@@ -355,7 +355,7 @@ Every live write path that mints a `Claim` has been audited; only the media path
 
 `Claim.objects.assert_claim` takes `changeset` as an optional kwarg — that optionality is the hole. Every non-media caller threads a changeset through; the four media endpoints don't. No other surface mints claims: nothing in admin actions, management commands or signals writes claims. The ~104K changeset-less rows are all from the historical seed ingests (no live code path) and are handled by the backfill PRs below.
 
-##### Fix Media Claims
+##### ✅ DONE: Fix Media Claims
 
 ###### Fix the leaks
 
@@ -370,6 +370,18 @@ They're user claims, so they need a user changeset (with an action, per action I
 ###### PR
 
 This will be its own PR.
+
+##### Enforce single claims write path
+
+The media leak wasn't a one-off bug, it was a symptom that the claim-write chokepoint is bypassable. Fix the class.
+
+The sanctioned write path already exists: `execute_claims` / `execute_multi_entity_claims`. The hole is one level down: `assert_claim` is public and takes changeset as optional. So any caller can reach past the chokepoint and write a changeset-less, loosely-attributed claim — which is precisely what the four media endpoints did. The audit found one such caller; nothing stops the fifth.
+
+Tighten these:
+
+- changeset becomes required on the write primitive. A changeset-less claim becomes unrepresentable at the type level, not just discouraged.
+- assert_claim goes internal to provenance — not a public API. Every writer (interactive, ingest, revert, media) goes through an execute_claims-style helper that creates-or-takes a changeset and writes the claims atomically. One funnel; you can't have a claim without the changeset that attributes it.
+- Enforce it stays the only path. Either an import-linter contract (only the write-helper module may import assert_claim) or a test that asserts no other call site touches the primitive — the same "route-inventory" discipline the authz layer already uses. The leak audit becomes a standing test, not a one-time sweep.
 
 #### Backfill ingest runs
 

--- a/docs/plans/auth/Actors.md
+++ b/docs/plans/auth/Actors.md
@@ -338,11 +338,25 @@ In the UI, to display attribution, the system must find the actor(s) for the Cha
 
 In order:
 
+#### Enforce single claims write path
+
+The media leak wasn't a one-off bug, it was a symptom that the claim-write chokepoint is bypassable. Fix the class.
+
+There isn't one wrapper everything goes through — interactive edits use `execute_claims` (and `execute_multi_entity_claims`, only for the soft-delete cascade), ingest uses its own `claim_ingest/apply/persist.py`, revert uses `provenance/revert.py`. What they **do** share is the primitive they all call: `assert_claim`. That's the real narrow waist — and the hole is that `assert_claim` is public and takes `changeset` as optional, so any caller can reach past it and write a changeset-less, loosely-attributed claim. The four media endpoints did exactly that; the audit found those, nothing stops the fifth.
+
+Tighten the primitive, not the wrappers:
+
+- **`changeset` becomes required on `assert_claim`.** A changeset-less claim becomes unrepresentable at the type level, not just discouraged. The existing wrappers already pass one; media must too.
+- **`assert_claim` becomes the sole Claim writer.** Nothing else does raw `Claim.objects.create`/`.save`. The wrappers (`execute_claims`, ingest persist, revert) create-or-take a changeset and funnel into it; media routes through `execute_claims` like every other interactive write rather than calling the primitive directly.
+- **Enforce it stays the only path** — an import-linter contract (only the sanctioned wrappers may import `assert_claim`) or a test that asserts no other call site touches it, the same "route-inventory" discipline the authz layer uses. The leak audit becomes a standing test, not a one-time sweep.
+
+Doing this before the Actor work pays off twice: it makes "attribute every claim write" true by construction, and it gives the post-Actor invariant (`Claim.actor == changeset.actor`) a single enforcement point — `assert_claim` derives `Claim.actor` from the changeset — instead of four wrappers to audit.
+
 #### Fix all leaks
 
 Backfill can't chase moving targets. Every write path that mints a `Claim` must create a `ChangeSet`.
 
-##### ✅ DONE: Audit for more leaks
+##### Audit for more leaks
 
 Every live write path that mints a `Claim` has been audited; only the media path leaks.
 
@@ -355,7 +369,7 @@ Every live write path that mints a `Claim` has been audited; only the media path
 
 `Claim.objects.assert_claim` takes `changeset` as an optional kwarg — that optionality is the hole. Every non-media caller threads a changeset through; the four media endpoints don't. No other surface mints claims: nothing in admin actions, management commands or signals writes claims. The ~104K changeset-less rows are all from the historical seed ingests (no live code path) and are handled by the backfill PRs below.
 
-##### ✅ DONE: Fix Media Claims
+##### Fix Media Claims
 
 ###### Fix the leaks
 
@@ -370,20 +384,6 @@ They're user claims, so they need a user changeset (with an action, per action I
 ###### PR
 
 This will be its own PR.
-
-##### Enforce single claims write path
-
-The media leak wasn't a one-off bug, it was a symptom that the claim-write chokepoint is bypassable. Fix the class.
-
-There isn't one wrapper everything goes through — interactive edits use `execute_claims` (and `execute_multi_entity_claims`, only for the soft-delete cascade), ingest uses its own `claim_ingest/apply/persist.py`, revert uses `provenance/revert.py`. What they **do** share is the primitive they all call: `assert_claim`. That's the real narrow waist — and the hole is that `assert_claim` is public and takes `changeset` as optional, so any caller can reach past it and write a changeset-less, loosely-attributed claim. The four media endpoints did exactly that; the audit found those, nothing stops the fifth.
-
-Tighten the primitive, not the wrappers:
-
-- **`changeset` becomes required on `assert_claim`.** A changeset-less claim becomes unrepresentable at the type level, not just discouraged. The existing wrappers already pass one; media must too.
-- **`assert_claim` becomes the sole Claim writer.** Nothing else does raw `Claim.objects.create`/`.save`. The wrappers (`execute_claims`, ingest persist, revert) create-or-take a changeset and funnel into it; media routes through `execute_claims` like every other interactive write rather than calling the primitive directly.
-- **Enforce it stays the only path** — an import-linter contract (only the sanctioned wrappers may import `assert_claim`) or a test that asserts no other call site touches it, the same "route-inventory" discipline the authz layer uses. The leak audit becomes a standing test, not a one-time sweep.
-
-Doing this before the Actor work pays off twice: it makes "attribute every claim write" true by construction, and it gives the post-Actor invariant (`Claim.actor == changeset.actor`) a single enforcement point — `assert_claim` derives `Claim.actor` from the changeset — instead of four wrappers to audit.
 
 #### Backfill ingest runs
 

--- a/docs/plans/auth/Actors.md
+++ b/docs/plans/auth/Actors.md
@@ -375,13 +375,15 @@ This will be its own PR.
 
 The media leak wasn't a one-off bug, it was a symptom that the claim-write chokepoint is bypassable. Fix the class.
 
-The sanctioned write path already exists: `execute_claims` / `execute_multi_entity_claims`. The hole is one level down: `assert_claim` is public and takes changeset as optional. So any caller can reach past the chokepoint and write a changeset-less, loosely-attributed claim — which is precisely what the four media endpoints did. The audit found one such caller; nothing stops the fifth.
+There isn't one wrapper everything goes through — interactive edits use `execute_claims` (and `execute_multi_entity_claims`, only for the soft-delete cascade), ingest uses its own `claim_ingest/apply/persist.py`, revert uses `provenance/revert.py`. What they **do** share is the primitive they all call: `assert_claim`. That's the real narrow waist — and the hole is that `assert_claim` is public and takes `changeset` as optional, so any caller can reach past it and write a changeset-less, loosely-attributed claim. The four media endpoints did exactly that; the audit found those, nothing stops the fifth.
 
-Tighten these:
+Tighten the primitive, not the wrappers:
 
-- changeset becomes required on the write primitive. A changeset-less claim becomes unrepresentable at the type level, not just discouraged.
-- assert_claim goes internal to provenance — not a public API. Every writer (interactive, ingest, revert, media) goes through an execute_claims-style helper that creates-or-takes a changeset and writes the claims atomically. One funnel; you can't have a claim without the changeset that attributes it.
-- Enforce it stays the only path. Either an import-linter contract (only the write-helper module may import assert_claim) or a test that asserts no other call site touches the primitive — the same "route-inventory" discipline the authz layer already uses. The leak audit becomes a standing test, not a one-time sweep.
+- **`changeset` becomes required on `assert_claim`.** A changeset-less claim becomes unrepresentable at the type level, not just discouraged. The existing wrappers already pass one; media must too.
+- **`assert_claim` becomes the sole Claim writer.** Nothing else does raw `Claim.objects.create`/`.save`. The wrappers (`execute_claims`, ingest persist, revert) create-or-take a changeset and funnel into it; media routes through `execute_claims` like every other interactive write rather than calling the primitive directly.
+- **Enforce it stays the only path** — an import-linter contract (only the sanctioned wrappers may import `assert_claim`) or a test that asserts no other call site touches it, the same "route-inventory" discipline the authz layer uses. The leak audit becomes a standing test, not a one-time sweep.
+
+Doing this before the Actor work pays off twice: it makes "attribute every claim write" true by construction, and it gives the post-Actor invariant (`Claim.actor == changeset.actor`) a single enforcement point — `assert_claim` derives `Claim.actor` from the changeset — instead of four wrappers to audit.
 
 #### Backfill ingest runs
 


### PR DESCRIPTION
## Summary

All four `MEDIA_EDIT` mutations (attach, detach, set-primary, set-category) minted user `Claim` rows via `assert_claim` with **no ChangeSet**, leaving them unattributed — the same leak class the Actors plan calls out. Route every media mutation through a fresh user `EDIT` ChangeSet, make `assert_claim` require a `changeset` on the user branch so a fifth leak can't be introduced, and backfill the existing changeset-less media claims.

- `apps/media/api.py`: each media mutation opens an `action=EDIT` ChangeSet and threads it into `assert_claim`, so the ChangeSet and claim commit together inside the existing `transaction.atomic()`.
- `apps/provenance/models/claim.py`: `assert_claim` now raises if a user-attributed claim is minted without a `changeset` (source/ingest claims stay optional — they get their structural lock later, after the changeset backfill).
- Migration `0009`: gives each pre-existing changeset-less **user** claim its own user ChangeSet (`action=edit`), timestamp copied from the claim. Source-attributed orphans are deliberately untouched — they belong to the later ingest-run + changeset backfill PRs.
- `docs/plans/auth/Actors.md`: planning updates for the single-claims-write-path sequencing.

## Test plan

- [ ] `cd backend && uv run pytest apps/media apps/provenance` passes
- [ ] New `apps/media/tests/test_media_changeset_attribution.py` asserts every media mutation produces an attributed ChangeSet
- [ ] Attach/detach/set-primary/set-category a media asset in the app; confirm the resulting claim carries a ChangeSet