### PR TITLE
feat(provenance): backfill synthetic seed IngestRuns

### DIFF
--- a/backend/apps/provenance/migrations/0010_backfill_seed_ingest_runs.py
+++ b/backend/apps/provenance/migrations/0010_backfill_seed_ingest_runs.py
@@ -1,0 +1,92 @@
+"""Mint a synthetic "seed" IngestRun per baseline source.
+
+The initial data seed (``flipcommons-catalog``, the ``ai-desc-*`` sources,
+``web-scrape``, …) wrote ~104K source-attributed claims with no ``ChangeSet``
+and no ``IngestRun`` — they predate that machinery. Those claims were all
+written within seconds of each other, so each source's seed claims are
+conceptually one ingest run.
+
+The next PR ("Backfill changesets") will give those claims ChangeSets, but a
+source-attributed ChangeSet needs an ``ingest_run`` to satisfy the
+``provenance_changeset_user_xor_ingest_run`` CHECK. This migration mints the
+anchor runs those ChangeSets will point at — one per baseline source that has
+changeset-less claims. Scope here is ONLY creating ``IngestRun`` rows; no
+claims or changesets are touched. Migration 0009 did the user-attributed half
+and deferred this source half here.
+
+The source set is derived dynamically from the claims that actually lack a
+changeset — the ``ai-desc-*`` / ``web-scrape`` slugs live only in the baseline
+data export, never in code, so enumerating them would be fragile.
+
+``input_fingerprint = "seed-backfill:<slug>"`` is a migration-owned, reserved
+sentinel. No other code path writes it. It is (a) the get_or_create idempotency
+key, (b) what the reverse deletes, and (c) the cross-PR handoff contract: the
+next PR finds the synthetic anchor among a source's runs via
+``input_fingerprint__startswith="seed-backfill:"`` (catalog will have ~49 runs;
+exactly one is this synthetic anchor).
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+from django.db.models import Count, Max, Min
+
+SEED_FINGERPRINT_PREFIX = "seed-backfill:"
+
+NOTE = (
+    "Synthetic seed IngestRun backfilled to anchor source-attributed claims "
+    "that predate the ChangeSet/IngestRun machinery."
+)
+
+
+def _forward(apps, schema_editor):
+    Claim = apps.get_model("provenance", "Claim")
+    Source = apps.get_model("provenance", "Source")
+    IngestRun = apps.get_model("provenance", "IngestRun")
+
+    orphans = Claim.objects.filter(user__isnull=True, changeset__isnull=True)
+    # source XOR user means source is set whenever user is null; drop any None
+    # defensively rather than minting an orphan run.
+    source_ids = [
+        s for s in orphans.values_list("source_id", flat=True).distinct() if s
+    ]
+    # Fetch only slugs (the one field we need) in one query — avoids an N+1 and
+    # any unrelated columns a drifted dev DB might be missing.
+    slugs = dict(Source.objects.filter(pk__in=source_ids).values_list("pk", "slug"))
+    for source_id in source_ids:
+        stats = orphans.filter(source_id=source_id).aggregate(
+            n=Count("pk"), ts_min=Min("created_at"), ts_max=Max("created_at")
+        )
+        run, created = IngestRun.objects.get_or_create(
+            source_id=source_id,
+            input_fingerprint=f"{SEED_FINGERPRINT_PREFIX}{slugs[source_id]}",
+            defaults={
+                # String literal, not IngestRun.Status.SUCCESS: historical
+                # models carry fields but not nested TextChoices classes.
+                "status": "success",
+                "finished_at": stats["ts_max"],
+                "claims_asserted": stats["n"],
+                "note": NOTE,
+            },
+        )
+        if created:
+            # started_at is auto_now_add (stamped "now" on insert); realign to
+            # the earliest seed claim so the run spans first-to-last claim.
+            IngestRun.objects.filter(pk=run.pk).update(started_at=stats["ts_min"])
+
+
+def _reverse(apps, schema_editor):
+    IngestRun = apps.get_model("provenance", "IngestRun")
+    IngestRun.objects.filter(
+        input_fingerprint__startswith=SEED_FINGERPRINT_PREFIX
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("provenance", "0009_backfill_user_claim_changesets"),
+    ]
+
+    operations = [
+        migrations.RunPython(_forward, _reverse),
+    ]

--- a/backend/apps/provenance/tests/test_seed_ingest_run_backfill.py
+++ b/backend/apps/provenance/tests/test_seed_ingest_run_backfill.py
@@ -1,0 +1,166 @@
+"""Guards for the seed-IngestRun backfill migration (0010).
+
+The migration mints one synthetic "seed" IngestRun per baseline source that
+owns changeset-less, source-attributed claims, so the next PR can give those
+claims source ChangeSets (which need an ingest_run to satisfy the
+user-XOR-ingest_run CHECK). The risks worth pinning:
+
+- one run per source, keyed/timestamped/counted correctly;
+- a source whose claims already have changesets gets none;
+- the prod shape — a source with both seed claims and real patch runs — gets
+  exactly one new synthetic run, leaving the real runs untouched;
+- idempotent forward; reverse removes only the synthetic rows.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime
+
+import pytest
+from django.apps import apps as django_apps
+from django.contrib.contenttypes.models import ContentType
+
+from apps.provenance.models import Claim, IngestRun, Source
+from apps.provenance.test_factories import ingest_changeset
+
+_migration = importlib.import_module(
+    "apps.provenance.migrations.0010_backfill_seed_ingest_runs"
+)
+
+T_EARLY = datetime(2024, 1, 1, 17, 33, 13, tzinfo=UTC)
+T_LATE = datetime(2024, 1, 1, 17, 33, 28, tzinfo=UTC)
+
+
+def _source(slug: str) -> Source:
+    return Source.objects.create(name=slug.title(), slug=slug, source_type="editorial")
+
+
+def _orphan_claim(subject, source: Source, claim_key: str, *, created_at) -> Claim:
+    """A source-attributed claim with no changeset, stamped at ``created_at``."""
+    claim = Claim.objects.create(
+        content_type=ContentType.objects.get_for_model(type(subject)),
+        object_id=subject.pk,
+        source=source,
+        field_name=claim_key,
+        claim_key=claim_key,
+        value="x",
+    )
+    # created_at is auto_now_add; realign so min/max are deterministic.
+    Claim.objects.filter(pk=claim.pk).update(created_at=created_at)
+    return claim
+
+
+def _real_run(source: Source, patch_id: str) -> IngestRun:
+    return IngestRun.objects.create(
+        source=source,
+        input_fingerprint=f"sha256:{patch_id}",
+        status="success",
+        finished_at=T_LATE,
+        patch_id=patch_id,
+    )
+
+
+@pytest.fixture
+def mfr():
+    from apps.catalog.models import Manufacturer
+
+    return Manufacturer.objects.create(name="Acme", slug="acme")
+
+
+@pytest.mark.django_db
+def test_one_run_per_source_with_orphans(mfr):
+    src_a = _source("seed-a")
+    src_b = _source("seed-b")
+    _orphan_claim(mfr, src_a, "name", created_at=T_EARLY)
+    _orphan_claim(mfr, src_a, "url", created_at=T_LATE)
+    _orphan_claim(mfr, src_b, "name", created_at=T_LATE)
+
+    _migration._forward(django_apps, None)
+
+    run_a = IngestRun.objects.get(input_fingerprint="seed-backfill:seed-a")
+    assert run_a.source_id == src_a.pk
+    assert run_a.status == "success"
+    assert run_a.patch_id is None
+    assert run_a.claims_asserted == 2
+    assert run_a.started_at == T_EARLY  # min
+    assert run_a.finished_at == T_LATE  # max
+
+    run_b = IngestRun.objects.get(input_fingerprint="seed-backfill:seed-b")
+    assert run_b.claims_asserted == 1
+    assert run_b.started_at == T_LATE
+    assert run_b.finished_at == T_LATE
+
+
+@pytest.mark.django_db
+def test_source_with_only_changesetted_claims_gets_no_run(mfr):
+    src = _source("seed-c")
+    real = _real_run(src, "0001-foo")
+    cs = ingest_changeset(real)
+    claim = Claim.objects.create(
+        content_type=ContentType.objects.get_for_model(type(mfr)),
+        object_id=mfr.pk,
+        source=src,
+        field_name="name",
+        claim_key="name",
+        value="x",
+        changeset=cs,
+    )
+    assert claim.changeset_id == cs.pk
+
+    _migration._forward(django_apps, None)
+
+    assert not IngestRun.objects.filter(
+        input_fingerprint="seed-backfill:seed-c"
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_mixed_source_prod_shape(mfr):
+    """A source with both seed claims and real patch runs (the catalog case)."""
+    src = _source("seed-d")
+    real = _real_run(src, "0001-foo")
+    _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+
+    _migration._forward(django_apps, None)
+
+    seed_runs = IngestRun.objects.filter(input_fingerprint="seed-backfill:seed-d")
+    assert seed_runs.count() == 1
+    real.refresh_from_db()
+    assert real.input_fingerprint == "sha256:0001-foo"  # untouched
+
+    # Idempotent against the mix: re-running adds no second synthetic run and
+    # still leaves the real run alone.
+    _migration._forward(django_apps, None)
+    assert seed_runs.count() == 1
+    assert IngestRun.objects.filter(source=src).count() == 2  # one real, one seed
+
+
+@pytest.mark.django_db
+def test_forward_is_idempotent(mfr):
+    src = _source("seed-e")
+    _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+
+    _migration._forward(django_apps, None)
+    _migration._forward(django_apps, None)
+
+    assert (
+        IngestRun.objects.filter(input_fingerprint="seed-backfill:seed-e").count() == 1
+    )
+
+
+@pytest.mark.django_db
+def test_reverse_removes_only_synthetic_runs(mfr):
+    src = _source("seed-f")
+    real = _real_run(src, "0001-foo")
+    _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+
+    _migration._forward(django_apps, None)
+    assert IngestRun.objects.filter(input_fingerprint="seed-backfill:seed-f").exists()
+
+    _migration._reverse(django_apps, None)
+
+    assert not IngestRun.objects.filter(
+        input_fingerprint__startswith="seed-backfill:"
+    ).exists()
+    assert IngestRun.objects.filter(pk=real.pk).exists()  # real run survives


### PR DESCRIPTION
## What

First PR in the [Actors.md](docs/plans/auth/Actors.md) sequencing. Mints one synthetic "seed" `IngestRun` per baseline source that owns changeset-less, source-attributed claims.

The initial data seed (`flipcommons-catalog`, the `ai-desc-*` sources, `web-scrape`, …) wrote ~104K source-attributed claims with **no `ChangeSet` and no `IngestRun`** — they predate that machinery.

## Why

The next PR ("Backfill changesets") will give those claims source ChangeSets. But a source-attributed `ChangeSet` needs an `ingest_run` to satisfy the `provenance_changeset_user_xor_ingest_run` CHECK. This migration mints the anchor runs those ChangeSets will point at. Migration `0009` did the user-attributed half and explicitly deferred this source half here.

**Scope: only creating `IngestRun` rows. No claims or changesets are touched.**

## How

`0010_backfill_seed_ingest_runs.py`:
- Derives the source set **dynamically** from claims lacking a changeset — the `ai-desc-*`/`web-scrape` slugs live only in the baseline export, never in code.
- `get_or_create` keyed on `input_fingerprint = "seed-backfill:<slug>"` — a migration-owned reserved sentinel that is the idempotency key, the reverse filter, **and** the cross-PR handoff contract (the next PR finds the synthetic anchor among a source's runs by this prefix).
- Per run: `status="success"` (string literal — historical models lack the nested `Status` enum), `finished_at`=max claim time, `started_at`=min, `claims_asserted`=orphan count.
- Reverse deletes only `seed-backfill:`-prefixed rows; real patch runs untouched.

## Verification

- New test suite (5 tests) covers: one-run-per-source, no-run-when-all-changesetted, the **prod-shape mixed source** (seed claims + real patch runs → one synthetic run, reals untouched, idempotent), idempotent forward, reverse-removes-only-synthetic.
- Full provenance suite: 335 passed. ruff + mypy clean.
- **Applied to a real dev DB** (restored from a clean baseline snapshot): 17 runs for 17 sources — `flipcommons-catalog`=103,575, `web-scrape`=16, ai-desc-* ≈487 — and **104,078 orphan claims untouched**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)