### PR TITLE
feat(provenance): backfill ChangeSets for seed claims

### DIFF
--- a/backend/apps/provenance/migrations/0011_backfill_seed_changesets.py
+++ b/backend/apps/provenance/migrations/0011_backfill_seed_changesets.py
@@ -1,0 +1,153 @@
+"""Give the source-attributed seed claims their ChangeSets.
+
+The initial data seed wrote ~104K source-attributed claims with no ``ChangeSet``
+— they predate that machinery. Migration 0009 backfilled the user-attributed
+half; 0010 minted one synthetic "seed" ``IngestRun`` per baseline source (the
+anchor a source ChangeSet needs to satisfy the user-XOR-ingest_run CHECK). This
+migration creates the ChangeSets themselves and links every changeset-less seed
+claim to one, completing the "every claim belongs to a ChangeSet" milestone that
+the later Actor work depends on.
+
+Grouping rule (from docs/plans/auth/Actors.md): one ChangeSet per (record,
+source) — every changeset-less claim on a given record from a given source
+collapses into a single ChangeSet pointing at that source's seed run, timestamped
+to the earliest claim in the group. Inactive/superseded seed claims ride along in
+the same group: collapsing a historical assert+supersede into one synthetic
+ChangeSet is a benign fiction (the seed carries no edit-boundary data to split
+them), and every claim still gets the ChangeSet it needs.
+
+The seed run for a source is found via ``input_fingerprint__startswith=
+"seed-backfill:"`` — the cross-PR handoff contract 0010 defines. Reverse detaches
+and deletes exactly the ChangeSets attached to those synthetic runs; it relies on
+0011 being the only writer of ChangeSets onto seed runs (true by construction —
+the live ingest path mints its own non-seed runs).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import NamedTuple
+
+from django.db import migrations
+
+SEED_FINGERPRINT_PREFIX = "seed-backfill:"
+
+SEED_NOTE = "Seed import (backfilled)."
+
+
+class _Group(NamedTuple):
+    """The (record, source) identity that defines one synthetic ChangeSet."""
+
+    content_type_id: int
+    object_id: int
+    source_id: int
+
+
+def _forward(apps, schema_editor):
+    Claim = apps.get_model("provenance", "Claim")
+    ChangeSet = apps.get_model("provenance", "ChangeSet")
+    IngestRun = apps.get_model("provenance", "IngestRun")
+
+    # The seed runs 0010 minted: the contract is exactly one synthetic anchor
+    # per source. A duplicate (0010 drift, a slug change minting a second run, a
+    # hand-created row) makes the anchor ambiguous — refuse rather than pick one.
+    seed_run_by_source: dict[int, int] = {}
+    for source_id, run_id in IngestRun.objects.filter(
+        input_fingerprint__startswith=SEED_FINGERPRINT_PREFIX
+    ).values_list("source_id", "pk"):
+        if source_id in seed_run_by_source:
+            raise RuntimeError(
+                f"Source {source_id} has multiple {SEED_FINGERPRINT_PREFIX!r} "
+                "IngestRuns; the synthetic anchor must be exactly one per source."
+            )
+        seed_run_by_source[source_id] = run_id
+
+    # Group changeset-less source claims by (record, source). Hold pk tuples,
+    # not model instances — there are ~104K rows.
+    groups: dict[_Group, list[int]] = {}
+    group_ts: dict[_Group, datetime] = {}
+    orphans = Claim.objects.filter(
+        user__isnull=True, changeset__isnull=True
+    ).values_list("pk", "content_type_id", "object_id", "source_id", "created_at")
+    for pk, content_type_id, object_id, source_id, created_at in orphans.iterator():
+        key = _Group(content_type_id, object_id, source_id)
+        groups.setdefault(key, []).append(pk)
+        # min(created_at) per group — deterministic; the seed claims are all
+        # within seconds anyway, so which one wins doesn't matter.
+        if key not in group_ts or created_at < group_ts[key]:
+            group_ts[key] = created_at
+
+    if groups:
+        # Every grouped source must have a seed run (0010 covers them all). A
+        # gap means 0010 didn't run or didn't cover it — never mint an
+        # unanchored ChangeSet (it would fail the user-XOR-ingest_run CHECK).
+        missing = sorted({key.source_id for key in groups} - seed_run_by_source.keys())
+        if missing:
+            raise RuntimeError(
+                f"Source(s) {missing} have changeset-less seed claims but no "
+                f"{SEED_FINGERPRINT_PREFIX!r} IngestRun; apply "
+                "0010_backfill_seed_ingest_runs first."
+            )
+
+        # Build the ChangeSets and aligned metadata in one loop so the pairing
+        # is structural (zip), not a bet on bulk_create's return order.
+        cs_objs = []
+        meta: list[tuple[_Group, datetime]] = []
+        for key in groups:
+            cs_objs.append(
+                ChangeSet(
+                    ingest_run_id=seed_run_by_source[key.source_id], note=SEED_NOTE
+                )
+            )
+            meta.append((key, group_ts[key]))
+        ChangeSet.objects.bulk_create(cs_objs, batch_size=1000)
+
+        # auto_now_add stamped "now" on insert; realign each ChangeSet to its
+        # group's earliest claim, exactly as 0009/0010 do.
+        for cs, (_key, ts) in zip(cs_objs, meta, strict=True):
+            cs.created_at = ts
+        ChangeSet.objects.bulk_update(cs_objs, ["created_at"], batch_size=1000)
+
+        # Link each orphan claim to its group's ChangeSet. Construct lightweight
+        # instances (pk + changeset_id only) to avoid reloading 104K rows.
+        claim_updates = [
+            Claim(pk=pk, changeset_id=cs.pk)
+            for cs, (key, _ts) in zip(cs_objs, meta, strict=True)
+            for pk in groups[key]
+        ]
+        Claim.objects.bulk_update(claim_updates, ["changeset"], batch_size=2000)
+
+    # Milestone checkpoint: combined with 0009, every claim now has a ChangeSet.
+    # This migration only processes source-attributed orphans, so a leftover is
+    # an unexpected orphan (e.g. a user one 0009 missed) — fix it upstream, not
+    # here. The raise routes the failure to the right PR.
+    remaining = Claim.objects.filter(changeset__isnull=True).count()
+    if remaining:
+        raise RuntimeError(
+            f"{remaining} changeset-less claim(s) remain after the seed backfill. "
+            "0011 only fills source-attributed orphans; a leftover means an "
+            "unexpected changeset-less claim (likely user-attributed) that 0009 "
+            "or the media fix should have handled. Resolve it there, not here."
+        )
+
+
+def _reverse(apps, schema_editor):
+    Claim = apps.get_model("provenance", "Claim")
+    ChangeSet = apps.get_model("provenance", "ChangeSet")
+
+    seed_changesets = ChangeSet.objects.filter(
+        ingest_run__input_fingerprint__startswith=SEED_FINGERPRINT_PREFIX
+    )
+    # Claim.changeset is PROTECT — detach the claims before deleting.
+    Claim.objects.filter(changeset__in=seed_changesets).update(changeset=None)
+    seed_changesets.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("provenance", "0010_backfill_seed_ingest_runs"),
+    ]
+
+    operations = [
+        migrations.RunPython(_forward, _reverse),
+    ]

--- a/backend/apps/provenance/tests/test_seed_changeset_backfill.py
+++ b/backend/apps/provenance/tests/test_seed_changeset_backfill.py
@@ -1,0 +1,266 @@
+"""Guards for the seed-ChangeSet backfill migration (0011).
+
+The migration gives every changeset-less, source-attributed seed claim a
+ChangeSet — one per (record, source), pointing at that source's synthetic seed
+IngestRun (minted by 0010), timestamped to the group's earliest claim. The risks
+worth pinning:
+
+- grouping: one ChangeSet per (record, source), holding every claim on that
+  record from that source — including inactive/superseded ones;
+- attribution: the ChangeSet is an ingest ChangeSet (ingest_run set, user/action
+  NULL) anchored to the right seed run, consistent with the claim's source;
+- the milestone: zero changeset-less claims remain afterwards;
+- idempotent forward; reverse detaches and removes only the synthetic
+  ChangeSets, leaving the seed runs and the claims behind;
+- fail-fast on the broken shapes: no seed run, duplicate seed run, or an
+  unexpected orphan this migration doesn't own.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime
+
+import pytest
+from django.apps import apps as django_apps
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+
+from apps.provenance.models import ChangeSet, Claim, IngestRun, Source
+
+_migration = importlib.import_module(
+    "apps.provenance.migrations.0011_backfill_seed_changesets"
+)
+
+T_EARLY = datetime(2024, 1, 1, 17, 33, 13, tzinfo=UTC)
+T_LATE = datetime(2024, 1, 1, 17, 33, 28, tzinfo=UTC)
+
+
+def _source(slug: str) -> Source:
+    return Source.objects.create(name=slug.title(), slug=slug, source_type="editorial")
+
+
+def _seed_run(source: Source) -> IngestRun:
+    """Mimic the synthetic seed run 0010 mints for a source."""
+    return IngestRun.objects.create(
+        source=source,
+        input_fingerprint=f"{_migration.SEED_FINGERPRINT_PREFIX}{source.slug}",
+        status="success",
+        finished_at=T_LATE,
+    )
+
+
+def _orphan_claim(
+    subject, source: Source, claim_key: str, *, created_at, is_active: bool = True
+) -> Claim:
+    """A source-attributed claim with no changeset, stamped at ``created_at``."""
+    claim = Claim.objects.create(
+        content_type=ContentType.objects.get_for_model(type(subject)),
+        object_id=subject.pk,
+        source=source,
+        field_name=claim_key,
+        claim_key=claim_key,
+        value="x",
+        is_active=is_active,
+    )
+    # created_at is auto_now_add; realign so min/max are deterministic.
+    Claim.objects.filter(pk=claim.pk).update(created_at=created_at)
+    claim.refresh_from_db()
+    return claim
+
+
+@pytest.fixture
+def mfr():
+    from apps.catalog.models import Manufacturer
+
+    return Manufacturer.objects.create(name="Acme", slug="acme")
+
+
+@pytest.fixture
+def mfr2():
+    from apps.catalog.models import Manufacturer
+
+    return Manufacturer.objects.create(name="Beta", slug="beta")
+
+
+@pytest.mark.django_db
+def test_grouping_one_changeset_per_record_source(mfr, mfr2):
+    src = _source("seed-a")
+    _seed_run(src)
+    # Two claims on one record from one source → one ChangeSet holding both.
+    _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+    _orphan_claim(mfr, src, "url", created_at=T_LATE)
+    # A second record from the same source → its own ChangeSet.
+    _orphan_claim(mfr2, src, "name", created_at=T_LATE)
+
+    _migration._forward(django_apps, None)
+
+    assert ChangeSet.objects.count() == 2
+    mfr_cs_ids = set(
+        Claim.objects.filter(object_id=mfr.pk, source=src).values_list(
+            "changeset_id", flat=True
+        )
+    )
+    mfr2_cs_ids = set(
+        Claim.objects.filter(object_id=mfr2.pk, source=src).values_list(
+            "changeset_id", flat=True
+        )
+    )
+    assert len(mfr_cs_ids) == 1  # both of mfr's claims share one ChangeSet
+    assert len(mfr2_cs_ids) == 1
+    assert mfr_cs_ids != mfr2_cs_ids  # the two records get distinct ChangeSets
+
+
+@pytest.mark.django_db
+def test_superseded_claim_rides_along(mfr):
+    src = _source("seed-b")
+    _seed_run(src)
+    # A historical assert + supersede on the same field: both changeset-less,
+    # both must land in the one (record, source) ChangeSet.
+    superseded = _orphan_claim(mfr, src, "name", created_at=T_EARLY, is_active=False)
+    active = _orphan_claim(mfr, src, "name", created_at=T_LATE, is_active=True)
+
+    _migration._forward(django_apps, None)
+
+    superseded.refresh_from_db()
+    active.refresh_from_db()
+    assert superseded.changeset_id is not None
+    assert superseded.changeset_id == active.changeset_id
+
+
+@pytest.mark.django_db
+def test_attribution_is_ingest_changeset(mfr):
+    src = _source("seed-c")
+    run = _seed_run(src)
+    claim = _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+
+    _migration._forward(django_apps, None)
+
+    claim.refresh_from_db()
+    cs = claim.changeset
+    assert cs is not None
+    assert cs.ingest_run_id == run.pk
+    assert cs.user_id is None
+    assert cs.action is None
+    assert cs.note == _migration.SEED_NOTE
+
+
+@pytest.mark.django_db
+def test_changeset_timestamp_is_group_min(mfr):
+    src = _source("seed-d")
+    _seed_run(src)
+    _orphan_claim(mfr, src, "name", created_at=T_LATE)
+    _orphan_claim(mfr, src, "url", created_at=T_EARLY)
+
+    _migration._forward(django_apps, None)
+
+    # One record + one source → exactly one ChangeSet.
+    cs = ChangeSet.objects.get()
+    assert cs.created_at == T_EARLY  # min across the group
+
+
+@pytest.mark.django_db
+def test_consistency_changeset_run_source_matches_claim_source(mfr, mfr2):
+    src_a = _source("seed-e")
+    src_b = _source("seed-f")
+    _seed_run(src_a)
+    _seed_run(src_b)
+    _orphan_claim(mfr, src_a, "name", created_at=T_EARLY)
+    _orphan_claim(mfr2, src_b, "name", created_at=T_EARLY)
+
+    _migration._forward(django_apps, None)
+
+    for claim in Claim.objects.select_related("changeset__ingest_run"):
+        assert claim.changeset is not None
+        assert claim.changeset.ingest_run is not None
+        assert claim.changeset.ingest_run.source_id == claim.source_id
+
+
+@pytest.mark.django_db
+def test_post_condition_no_changeset_less_claims(mfr):
+    src = _source("seed-g")
+    _seed_run(src)
+    _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+
+    _migration._forward(django_apps, None)
+
+    assert not Claim.objects.filter(changeset__isnull=True).exists()
+
+
+@pytest.mark.django_db
+def test_forward_is_idempotent(mfr):
+    src = _source("seed-h")
+    _seed_run(src)
+    _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+    _orphan_claim(mfr, src, "url", created_at=T_LATE)
+
+    _migration._forward(django_apps, None)
+    first = set(ChangeSet.objects.values_list("pk", flat=True))
+    _migration._forward(django_apps, None)
+
+    assert set(ChangeSet.objects.values_list("pk", flat=True)) == first
+
+
+@pytest.mark.django_db
+def test_reverse_detaches_and_deletes_only_seed_changesets(mfr):
+    src = _source("seed-i")
+    run = _seed_run(src)
+    claim = _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+
+    _migration._forward(django_apps, None)
+    assert ChangeSet.objects.filter(ingest_run=run).exists()
+
+    _migration._reverse(django_apps, None)
+
+    claim.refresh_from_db()
+    assert claim.changeset_id is None
+    assert not ChangeSet.objects.filter(ingest_run=run).exists()
+    assert IngestRun.objects.filter(pk=run.pk).exists()  # seed run survives
+
+
+@pytest.mark.django_db
+def test_fail_fast_when_source_has_no_seed_run(mfr):
+    src = _source("seed-j")  # deliberately no seed run
+    _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+
+    with pytest.raises(RuntimeError, match="no .*IngestRun"):
+        _migration._forward(django_apps, None)
+
+    assert not ChangeSet.objects.exists()
+
+
+@pytest.mark.django_db
+def test_fail_fast_on_duplicate_seed_run(mfr):
+    src = _source("seed-k")
+    _seed_run(src)
+    # A second synthetic run for the same source (e.g. a slug change) — ambiguous.
+    IngestRun.objects.create(
+        source=src,
+        input_fingerprint=f"{_migration.SEED_FINGERPRINT_PREFIX}seed-k-old",
+        status="success",
+        finished_at=T_LATE,
+    )
+    _orphan_claim(mfr, src, "name", created_at=T_EARLY)
+
+    with pytest.raises(RuntimeError, match="multiple"):
+        _migration._forward(django_apps, None)
+
+    assert not ChangeSet.objects.exists()
+
+
+@pytest.mark.django_db
+def test_fail_fast_on_unexpected_orphan(mfr):
+    # A user-attributed changeset-less claim — outside 0011's scope (it only
+    # processes source orphans), so it must trip the milestone checkpoint.
+    user = get_user_model().objects.create(username="moses", email="moses@example.com")
+    Claim.objects.create(
+        content_type=ContentType.objects.get_for_model(type(mfr)),
+        object_id=mfr.pk,
+        user=user,
+        field_name="name",
+        claim_key="name",
+        value="x",
+    )
+
+    with pytest.raises(RuntimeError, match="changeset-less claim"):
+        _migration._forward(django_apps, None)


### PR DESCRIPTION
## What

Gives every changeset-less, source-attributed **seed claim** a `ChangeSet`, completing the **"every claim belongs to a ChangeSet"** milestone the [Actor work](docs/plans/auth/Actors.md) depends on. This is the source-attributed counterpart to #555 (which minted the synthetic seed `IngestRun`s) and a prerequisite for the later `Claim.changeset` NOT NULL tightening.

On dev that's **104,078** changeset-less claims (103,575 `flipcommons-catalog`, ~480 `flipcommons-ai-desc-*`, 16 `web-scrape`); prod is ~similar.

## How

Migration `0011_backfill_seed_changesets`:

- Groups the changeset-less source claims by **(record, source)** — one `ChangeSet` per group, per the Actor doc's grouping rule.
- Anchors each group's `ChangeSet` to that source's synthetic seed `IngestRun` (found via `input_fingerprint__startswith="seed-backfill:"`, the cross-PR contract from #555), so it satisfies the `user`-XOR-`ingest_run` CHECK and stays consistent with `assert_claim`'s same-source rule.
- Timestamps the `ChangeSet` to the group's earliest claim; `user`/`action` stay NULL (ingest changeset).
- Inactive/superseded seed claims ride along in the same group — collapsing a historical assert+supersede into one synthetic `ChangeSet` is a benign fiction (the seed carries no edit-boundary data to split them).
- **Post-condition** asserts zero changeset-less claims remain afterwards (combined with #553/0009's user-claim half). A leftover means an unexpected orphan outside this migration's scope — it fails loudly and routes the fix to the right place.
- **Reverse** detaches the claims and deletes only the seed-run `ChangeSet`s, leaving the runs (#555's domain) and claims intact.

Pinned with three fail-fast guards: no seed run for a source, duplicate seed run per source, and an unexpected (e.g. user-attributed) orphan.

## Testing

- `test_seed_changeset_backfill.py` — 11 tests: grouping, supersede ride-along, ingest-changeset attribution, min-timestamp, run/source consistency, milestone post-condition, idempotency, reverse, and the three fail-fast guards.
- Green: ruff, mypy, import-linter, the full provenance suite (346 tests).
- E2e apply → reverse → re-apply on the local SQLite dev DB (104,078 → 0 → 104,078 → 0; 16,834 seed ChangeSets).
- Migration tests re-run against **Postgres 16** to confirm engine-specific behavior (`bulk_create` PK population, batch sizes). Note: the full-volume 104K run was SQLite-only — production will be the first at that scale on Postgres.

> Doc note: marking the "Backfill changesets" section ✅ DONE in `docs/plans/auth/Actors.md` is left out of this PR — that file has unrelated cross-PR working-tree edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)