### PR TITLE
feat(provenance): populate actor FKs on every claim/changeset write

### DIFF
--- a/backend/apps/accounts/tests/test_user_profile.py
+++ b/backend/apps/accounts/tests/test_user_profile.py
@@ -6,7 +6,8 @@ from django.test import Client
 from apps.accounts.test_factories import make_user
 from apps.catalog.models import Manufacturer
 from apps.catalog.tests.conftest import make_machine_model
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -24,21 +25,21 @@ def bootstrap_source(db):
 @pytest.fixture
 def manufacturer(db, bootstrap_source):
     mfr = Manufacturer.objects.create(name="Williams", slug="williams")
-    Claim.objects.assert_claim(mfr, "name", "Williams", source=bootstrap_source)
+    make_claim(mfr, "name", "Williams", source=bootstrap_source)
     return mfr
 
 
 @pytest.fixture
 def model_a(db, bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
     return pm
 
 
 @pytest.fixture
 def model_b(db, bootstrap_source):
     pm = make_machine_model(name="Attack from Mars", slug="attack-from-mars", year=1995)
-    Claim.objects.assert_claim(pm, "name", "Attack from Mars", source=bootstrap_source)
+    make_claim(pm, "name", "Attack from Mars", source=bootstrap_source)
     return pm
 
 
@@ -200,10 +201,10 @@ class TestEditHistoryIngestAttribution:
 
         ingest_run = IngestRun.objects.create(source=source, input_fingerprint="abc123")
         ingest_cs = ingest_changeset(ingest_run)
-        Claim.objects.assert_claim(pm, "year", 1979, source=source, changeset=ingest_cs)
+        make_claim(pm, "year", 1979, source=source, changeset=ingest_cs)
 
         user_cs = user_changeset(user)
-        Claim.objects.assert_claim(
+        make_claim(
             pm,
             "description",
             "First talking pinball machine",

--- a/backend/apps/accounts/tests/test_user_profile.py
+++ b/backend/apps/accounts/tests/test_user_profile.py
@@ -215,7 +215,10 @@ class TestEditHistoryIngestAttribution:
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
         data = resp.json()
         attributions = {e["id"]: e["attribution"] for e in data}
-        assert len(attributions) == 2
+        # The model also carries a Bootstrap-source seed name claim from
+        # make_machine_model (its own ingest changeset); assert on the two
+        # changesets under test rather than the total.
+        assert {ingest_cs.pk, user_cs.pk} <= attributions.keys()
 
         ingest_attr = attributions[ingest_cs.pk]
         assert ingest_attr["author"] == {"kind": "source", "name": "IPDB"}

--- a/backend/apps/accounts/tests/test_user_profile.py
+++ b/backend/apps/accounts/tests/test_user_profile.py
@@ -16,13 +16,6 @@ def client():
 
 
 @pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
-
-
-@pytest.fixture
 def manufacturer(db, bootstrap_source):
     mfr = Manufacturer.objects.create(name="Williams", slug="williams")
     make_claim(mfr, "name", "Williams", source=bootstrap_source)
@@ -191,16 +184,18 @@ class TestEditHistoryIngestAttribution:
     """Verify that build_edit_history attributes ingest changesets correctly."""
 
     def test_ingest_and_user_changesets_attributed_correctly(self, client, user):
-        from apps.provenance.models import IngestRun
-        from apps.provenance.test_factories import ingest_changeset, user_changeset
+        from apps.provenance.test_factories import (
+            ingest_changeset,
+            ingest_run,
+            user_changeset,
+        )
 
         source = Source.objects.create(
             name="IPDB", slug="ipdb", source_type="database", priority=10
         )
         pm = make_machine_model(name="Gorgar", slug="gorgar", year=1979)
 
-        ingest_run = IngestRun.objects.create(source=source, input_fingerprint="abc123")
-        ingest_cs = ingest_changeset(ingest_run)
+        ingest_cs = ingest_changeset(ingest_run(source))
         make_claim(pm, "year", 1979, source=source, changeset=ingest_cs)
 
         user_cs = user_changeset(user)

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from apps.core.types import JsonBody
 from apps.provenance.claim_ranking_in_db import ranked_claims
 from apps.provenance.models import Claim, ClaimControlledModel
+from apps.provenance.validation import get_relationship_namespaces
 
 from ._helpers import (
     _coerce,
@@ -85,7 +86,12 @@ def _resolve_single(
     # Apply winners.
     has_extra_data = hasattr(obj, "extra_data")
     extra_data: JsonBody | None = {} if has_extra_data else None
+    relationship_ns = get_relationship_namespaces()
     for field_name, claim in winners.items():
+        # Relationship-namespace claims (media_attachment, credit, …) resolve
+        # into their own tables, never extra_data — mirrors resolve_model().
+        if field_name in relationship_ns:
+            continue
         if field_name in direct_fields:
             attr = direct_fields[field_name]
             field = model_class._meta.get_field(attr)
@@ -194,6 +200,7 @@ def _resolve_bulk(
 
     # 4. Resolve each object in memory.
     now = timezone.now()
+    relationship_ns = get_relationship_namespaces()
     for obj in all_objs:
         winners = claims_by_obj.get(obj.pk, {})
 
@@ -208,6 +215,10 @@ def _resolve_bulk(
         # Apply winners.
         extra_data: JsonBody | None = {} if has_extra_data else None
         for field_name, claim in winners.items():
+            # Relationship-namespace claims (media_attachment, credit, …)
+            # resolve into their own tables, never extra_data.
+            if field_name in relationship_ns:
+                continue
             if field_name in direct_fields:
                 attr = direct_fields[field_name]
                 if attr in fk_info.fk_fields:

--- a/backend/apps/catalog/resolve/tests/test_lifecycle_resolution.py
+++ b/backend/apps/catalog/resolve/tests/test_lifecycle_resolution.py
@@ -30,7 +30,8 @@ from apps.core.models import (
     is_live,
 )
 from apps.provenance.claim_ranking_in_db import ranked_claims
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 pytestmark = pytest.mark.django_db
 
@@ -129,15 +130,15 @@ def test_delete_drops_referrer_only_when_the_delete_wins(
     """A ``status=deleted`` claim makes the entity not-live iff it wins the pick."""
     # Delete wins: high-priority source deletes, low-priority keeps it active.
     winning = Manufacturer.objects.create(name="Del Wins", slug="del-wins")
-    Claim.objects.assert_claim(winning, "status", "active", source=sources["low"])
-    Claim.objects.assert_claim(winning, "status", "deleted", source=sources["high"])
+    make_claim(winning, "status", "active", source=sources["low"])
+    make_claim(winning, "status", "deleted", source=sources["high"])
     assert _resolved_status(winning) == "deleted"
     assert not is_live(_resolved_status(winning))
 
     # Delete loses: a lower-priority delete must not unblock — entity stays live.
     losing = Manufacturer.objects.create(name="Del Loses", slug="del-loses")
-    Claim.objects.assert_claim(losing, "status", "active", source=sources["high"])
-    Claim.objects.assert_claim(losing, "status", "deleted", source=sources["low"])
+    make_claim(losing, "status", "active", source=sources["high"])
+    make_claim(losing, "status", "deleted", source=sources["low"])
     assert _resolved_status(losing) == "active"
     assert is_live(_resolved_status(losing))
 

--- a/backend/apps/catalog/resolve/tests/test_source_scoped_presence.py
+++ b/backend/apps/catalog/resolve/tests/test_source_scoped_presence.py
@@ -45,6 +45,7 @@ from apps.provenance.claim_presence import member_is_present
 from apps.provenance.claim_ranking_in_db import ranked_claims
 from apps.provenance.claims import build_relationship_claim
 from apps.provenance.models import Claim, Source
+from apps.provenance.test_factories import make_claim
 
 _ALIAS_NS = "manufacturer_alias"
 
@@ -128,7 +129,7 @@ def test_scalar_present_and_absent_agree(source: Source) -> None:
     _assert_scalar_agrees(source, mfr, "name")
 
     # Source holds an active scalar claim → both read present.
-    Claim.objects.assert_claim(mfr, "name", "Gottlieb Inc", source=source)
+    make_claim(mfr, "name", "Gottlieb Inc", source=source)
     _assert_scalar_agrees(source, mfr, "name")
 
 
@@ -145,7 +146,7 @@ def test_scalar_dict_value_reads_present_not_as_a_tombstone(source: Source) -> N
     loc = Location.objects.create(
         location_path="usa", slug="usa", name="USA", location_type="country"
     )
-    Claim.objects.assert_claim(
+    make_claim(
         loc,
         "divisions",
         {"exists": False, "note": "free-form scalar JSON"},
@@ -170,18 +171,14 @@ def test_member_no_op_check_reads_present_tombstone_and_absent(source: Source) -
     assert _source_claims_member_present(source, ct_id, mfr.pk, claim_key) is False
 
     # exists=true membership → present.
-    Claim.objects.assert_claim(
-        mfr, _ALIAS_NS, present, source=source, claim_key=claim_key
-    )
+    make_claim(mfr, _ALIAS_NS, present, source=source, claim_key=claim_key)
     assert _source_claims_member_present(source, ct_id, mfr.pk, claim_key) is True
 
     # Tombstone (exists=false) supersedes it → absent again.
     _, tombstone = build_relationship_claim(
         _ALIAS_NS, {"alias_value": "bally corp"}, exists=False
     )
-    Claim.objects.assert_claim(
-        mfr, _ALIAS_NS, tombstone, source=source, claim_key=claim_key
-    )
+    make_claim(mfr, _ALIAS_NS, tombstone, source=source, claim_key=claim_key)
     assert _source_claims_member_present(source, ct_id, mfr.pk, claim_key) is False
 
 
@@ -193,9 +190,7 @@ def test_member_owned_by_another_source_is_a_no_op_for_ours(source: Source) -> N
     claim_key, present = build_relationship_claim(
         _ALIAS_NS, {"alias_value": "wms", "alias_display": "WMS"}
     )
-    Claim.objects.assert_claim(
-        mfr, _ALIAS_NS, present, source=other, claim_key=claim_key
-    )
+    make_claim(mfr, _ALIAS_NS, present, source=other, claim_key=claim_key)
     # Our source holds nothing here → no-op (source-scoped, not resolved).
     assert _source_claims_member_present(source, ct_id, mfr.pk, claim_key) is False
 
@@ -231,9 +226,7 @@ def test_source_scoped_diverges_when_other_source_owns_member(source: Source) ->
     claim_key, present = build_relationship_claim(
         _ALIAS_NS, {"alias_value": "stern pinball", "alias_display": "Stern Pinball"}
     )
-    Claim.objects.assert_claim(
-        mfr, _ALIAS_NS, present, source=other, claim_key=claim_key
-    )
+    make_claim(mfr, _ALIAS_NS, present, source=other, claim_key=claim_key)
 
     resolved = _resolved_member_presence(mfr, claim_key)
     source_scoped = _source_claims_member_present(source, ct_id, mfr.pk, claim_key)
@@ -260,12 +253,8 @@ def test_source_scoped_diverges_when_other_source_wins_tombstone(
         _ALIAS_NS, {"alias_value": "de"}, exists=False
     )
     # Our (lower-priority) source asserts presence; the winner tombstones it.
-    Claim.objects.assert_claim(
-        mfr, _ALIAS_NS, present, source=source, claim_key=claim_key
-    )
-    Claim.objects.assert_claim(
-        mfr, _ALIAS_NS, tombstone, source=winner, claim_key=claim_key
-    )
+    make_claim(mfr, _ALIAS_NS, present, source=source, claim_key=claim_key)
+    make_claim(mfr, _ALIAS_NS, tombstone, source=winner, claim_key=claim_key)
 
     resolved = _resolved_member_presence(mfr, claim_key)
     source_scoped = _source_claims_member_present(source, ct_id, mfr.pk, claim_key)

--- a/backend/apps/catalog/tests/conftest.py
+++ b/backend/apps/catalog/tests/conftest.py
@@ -13,7 +13,8 @@ from apps.catalog.models import (
     Title,
 )
 from apps.citation.models import CitationSource
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 
 def make_machine_model(
@@ -46,14 +47,14 @@ def make_machine_model(
             slug=t_slug, defaults={"name": name}
         )
         if created:
-            Claim.objects.assert_claim(title, "name", name, source=src)
+            make_claim(title, "name", name, source=src)
     mm = MachineModel.objects.create(
         title=title,
         name=name,
         slug=resolved_slug,
         **kwargs,
     )
-    Claim.objects.assert_claim(mm, "name", name, source=src)
+    make_claim(mm, "name", name, source=src)
     return mm
 
 
@@ -136,14 +137,14 @@ def flipcommons_catalog(db):
 @pytest.fixture
 def manufacturer(db, _bootstrap_source):
     mfr = Manufacturer.objects.create(name="Williams", slug="williams")
-    Claim.objects.assert_claim(mfr, "name", "Williams", source=_bootstrap_source)
+    make_claim(mfr, "name", "Williams", source=_bootstrap_source)
     return mfr
 
 
 @pytest.fixture
 def stern(db, _bootstrap_source):
     mfr = Manufacturer.objects.create(name="Stern", slug="stern")
-    Claim.objects.assert_claim(mfr, "name", "Stern", source=_bootstrap_source)
+    make_claim(mfr, "name", "Stern", source=_bootstrap_source)
     return mfr
 
 
@@ -175,7 +176,7 @@ def credit_roles(db):
 @pytest.fixture
 def person(db, _bootstrap_source):
     p = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
-    Claim.objects.assert_claim(p, "name", "Pat Lawlor", source=_bootstrap_source)
+    make_claim(p, "name", "Pat Lawlor", source=_bootstrap_source)
     return p
 
 
@@ -191,9 +192,7 @@ def williams_entity(db, manufacturer, _bootstrap_source):
         slug="williams-electronics",
         manufacturer=manufacturer,
     )
-    Claim.objects.assert_claim(
-        ce, "name", "Williams Electronics", source=_bootstrap_source
-    )
+    make_claim(ce, "name", "Williams Electronics", source=_bootstrap_source)
     return ce
 
 
@@ -204,18 +203,14 @@ def stern_entity(db, stern, _bootstrap_source):
         slug="stern-pinball-inc",
         manufacturer=stern,
     )
-    Claim.objects.assert_claim(
-        ce, "name", "Stern Pinball, Inc.", source=_bootstrap_source
-    )
+    make_claim(ce, "name", "Stern Pinball, Inc.", source=_bootstrap_source)
     return ce
 
 
 @pytest.fixture
 def machine_model(db, williams_entity, solid_state, _bootstrap_source):
     title = Title.objects.create(name="Medieval Madness", slug="medieval-madness-title")
-    Claim.objects.assert_claim(
-        title, "name", "Medieval Madness", source=_bootstrap_source
-    )
+    make_claim(title, "name", "Medieval Madness", source=_bootstrap_source)
     pm = MachineModel.objects.create(
         name="Medieval Madness",
         slug="medieval-madness",
@@ -224,7 +219,7 @@ def machine_model(db, williams_entity, solid_state, _bootstrap_source):
         year=1997,
         technology_generation=solid_state,
     )
-    Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
     t = Theme.objects.create(name="Medieval", slug="medieval")
     pm.themes.add(t)
     return pm
@@ -233,9 +228,7 @@ def machine_model(db, williams_entity, solid_state, _bootstrap_source):
 @pytest.fixture
 def another_model(db, stern_entity, solid_state, _bootstrap_source):
     title = Title.objects.create(name="The Mandalorian", slug="the-mandalorian-title")
-    Claim.objects.assert_claim(
-        title, "name", "The Mandalorian", source=_bootstrap_source
-    )
+    make_claim(title, "name", "The Mandalorian", source=_bootstrap_source)
     pm = MachineModel.objects.create(
         name="The Mandalorian",
         slug="the-mandalorian",
@@ -244,5 +237,5 @@ def another_model(db, stern_entity, solid_state, _bootstrap_source):
         year=2021,
         technology_generation=solid_state,
     )
-    Claim.objects.assert_claim(pm, "name", "The Mandalorian", source=_bootstrap_source)
+    make_claim(pm, "name", "The Mandalorian", source=_bootstrap_source)
     return pm

--- a/backend/apps/catalog/tests/conftest.py
+++ b/backend/apps/catalog/tests/conftest.py
@@ -77,18 +77,6 @@ def client():
 
 
 @pytest.fixture
-def _bootstrap_source(db):
-    """Low-priority source for seeding name claims in shared fixtures.
-
-    Priority 1 ensures bootstrap claims never outrank real source or user
-    claims in tests that set up competing claims.
-    """
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
-
-
-@pytest.fixture
 def source(db):
     return Source.objects.create(name="IPDB", source_type="database", priority=10)
 
@@ -135,16 +123,16 @@ def flipcommons_catalog(db):
 
 
 @pytest.fixture
-def manufacturer(db, _bootstrap_source):
+def manufacturer(db, bootstrap_source):
     mfr = Manufacturer.objects.create(name="Williams", slug="williams")
-    make_claim(mfr, "name", "Williams", source=_bootstrap_source)
+    make_claim(mfr, "name", "Williams", source=bootstrap_source)
     return mfr
 
 
 @pytest.fixture
-def stern(db, _bootstrap_source):
+def stern(db, bootstrap_source):
     mfr = Manufacturer.objects.create(name="Stern", slug="stern")
-    make_claim(mfr, "name", "Stern", source=_bootstrap_source)
+    make_claim(mfr, "name", "Stern", source=bootstrap_source)
     return mfr
 
 
@@ -174,9 +162,9 @@ def credit_roles(db):
 
 
 @pytest.fixture
-def person(db, _bootstrap_source):
+def person(db, bootstrap_source):
     p = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
-    make_claim(p, "name", "Pat Lawlor", source=_bootstrap_source)
+    make_claim(p, "name", "Pat Lawlor", source=bootstrap_source)
     return p
 
 
@@ -186,31 +174,31 @@ def solid_state(db):
 
 
 @pytest.fixture
-def williams_entity(db, manufacturer, _bootstrap_source):
+def williams_entity(db, manufacturer, bootstrap_source):
     ce = CorporateEntity.objects.create(
         name="Williams Electronics",
         slug="williams-electronics",
         manufacturer=manufacturer,
     )
-    make_claim(ce, "name", "Williams Electronics", source=_bootstrap_source)
+    make_claim(ce, "name", "Williams Electronics", source=bootstrap_source)
     return ce
 
 
 @pytest.fixture
-def stern_entity(db, stern, _bootstrap_source):
+def stern_entity(db, stern, bootstrap_source):
     ce = CorporateEntity.objects.create(
         name="Stern Pinball, Inc.",
         slug="stern-pinball-inc",
         manufacturer=stern,
     )
-    make_claim(ce, "name", "Stern Pinball, Inc.", source=_bootstrap_source)
+    make_claim(ce, "name", "Stern Pinball, Inc.", source=bootstrap_source)
     return ce
 
 
 @pytest.fixture
-def machine_model(db, williams_entity, solid_state, _bootstrap_source):
+def machine_model(db, williams_entity, solid_state, bootstrap_source):
     title = Title.objects.create(name="Medieval Madness", slug="medieval-madness-title")
-    make_claim(title, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(title, "name", "Medieval Madness", source=bootstrap_source)
     pm = MachineModel.objects.create(
         name="Medieval Madness",
         slug="medieval-madness",
@@ -219,16 +207,16 @@ def machine_model(db, williams_entity, solid_state, _bootstrap_source):
         year=1997,
         technology_generation=solid_state,
     )
-    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
     t = Theme.objects.create(name="Medieval", slug="medieval")
     pm.themes.add(t)
     return pm
 
 
 @pytest.fixture
-def another_model(db, stern_entity, solid_state, _bootstrap_source):
+def another_model(db, stern_entity, solid_state, bootstrap_source):
     title = Title.objects.create(name="The Mandalorian", slug="the-mandalorian-title")
-    make_claim(title, "name", "The Mandalorian", source=_bootstrap_source)
+    make_claim(title, "name", "The Mandalorian", source=bootstrap_source)
     pm = MachineModel.objects.create(
         name="The Mandalorian",
         slug="the-mandalorian",
@@ -237,5 +225,5 @@ def another_model(db, stern_entity, solid_state, _bootstrap_source):
         year=2021,
         technology_generation=solid_state,
     )
-    make_claim(pm, "name", "The Mandalorian", source=_bootstrap_source)
+    make_claim(pm, "name", "The Mandalorian", source=bootstrap_source)
     return pm

--- a/backend/apps/catalog/tests/test_api_claims.py
+++ b/backend/apps/catalog/tests/test_api_claims.py
@@ -5,8 +5,8 @@ from django.contrib.auth import get_user_model
 
 from apps.catalog.resolve import resolve_model
 from apps.catalog.tests.conftest import make_machine_model
-from apps.provenance.models import Claim, Source
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -19,7 +19,7 @@ def low_priority_source(db):
 @pytest.fixture
 def pm(db, _bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
     return pm
 
 
@@ -170,10 +170,8 @@ class TestPatchClaimsPersistence:
     def test_user_claim_beats_lower_priority_source(
         self, client, user, pm, low_priority_source
     ):
-        Claim.objects.assert_claim(
-            pm, "name", "Medieval Madness", source=low_priority_source
-        )
-        Claim.objects.assert_claim(pm, "year", 1997, source=low_priority_source)
+        make_claim(pm, "name", "Medieval Madness", source=low_priority_source)
+        make_claim(pm, "year", 1997, source=low_priority_source)
         resolve_model(pm)
         pm.refresh_from_db()
         assert pm.year == 1997
@@ -198,11 +196,9 @@ class TestUserClaimResolution:
     def test_user_claim_wins_over_lower_priority_source(
         self, user, pm, low_priority_source
     ):
-        Claim.objects.assert_claim(
-            pm, "name", "Medieval Madness", source=low_priority_source
-        )
-        Claim.objects.assert_claim(pm, "year", 1990, source=low_priority_source)
-        Claim.objects.assert_claim(
+        make_claim(pm, "name", "Medieval Madness", source=low_priority_source)
+        make_claim(pm, "year", 1990, source=low_priority_source)
+        make_claim(
             pm, "year", 2000, user=user, changeset=user_changeset(user)
         )  # priority 10000 > 10
 
@@ -213,9 +209,9 @@ class TestUserClaimResolution:
         high_source = Source.objects.create(
             name="HighPri", source_type="editorial", priority=50000
         )
-        Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=high_source)
-        Claim.objects.assert_claim(pm, "year", 1990, source=high_source)
-        Claim.objects.assert_claim(
+        make_claim(pm, "name", "Medieval Madness", source=high_source)
+        make_claim(pm, "year", 1990, source=high_source)
+        make_claim(
             pm, "year", 2000, user=user, changeset=user_changeset(user)
         )  # priority 10000 < 50000
 

--- a/backend/apps/catalog/tests/test_api_claims.py
+++ b/backend/apps/catalog/tests/test_api_claims.py
@@ -17,9 +17,9 @@ def low_priority_source(db):
 
 
 @pytest.fixture
-def pm(db, _bootstrap_source):
+def pm(db, bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
     return pm
 
 

--- a/backend/apps/catalog/tests/test_api_claims_additional_entities.py
+++ b/backend/apps/catalog/tests/test_api_claims_additional_entities.py
@@ -30,8 +30,8 @@ from apps.catalog.models import (
 from apps.catalog.tests.conftest import make_machine_model
 from apps.citation.models import CitationSource
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, CitationInstance, Claim, Source
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.models import ChangeSet, CitationInstance, Source
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -65,9 +65,7 @@ def _get_bootstrap_source():
 
 def _assert_name_claim(entity):
     """Assert a bootstrap name claim for entities with non-unique name fields."""
-    Claim.objects.assert_claim(
-        entity, "name", entity.name, source=_get_bootstrap_source()
-    )
+    make_claim(entity, "name", entity.name, source=_get_bootstrap_source())
     return entity
 
 
@@ -497,12 +495,8 @@ class TestPatchSystemResponseShape:
         )
         # Manufacturer is now claim-controlled on System — assert claims so
         # resolution preserves the FK when description is PATCHed.
-        Claim.objects.assert_claim(
-            system, "manufacturer", manufacturer.slug, source=source
-        )
-        Claim.objects.assert_claim(
-            sibling, "manufacturer", manufacturer.slug, source=source
-        )
+        make_claim(system, "manufacturer", manufacturer.slug, source=source)
+        make_claim(sibling, "manufacturer", manufacturer.slug, source=source)
         title = Title.objects.create(name="Medieval Madness", slug="medieval-madness")
         make_machine_model(
             name="Medieval Madness",
@@ -583,7 +577,7 @@ class TestPatchRewardTypeResponseShape:
         self, client, user, citation_source
     ):
         reward_type = RewardType.objects.create(name="Replay", slug="replay")
-        template_claim = Claim.objects.assert_claim(
+        template_claim = make_claim(
             reward_type,
             field_name="description",
             value="Template citation",

--- a/backend/apps/catalog/tests/test_api_claims_additional_entities.py
+++ b/backend/apps/catalog/tests/test_api_claims_additional_entities.py
@@ -363,8 +363,10 @@ class TestAdditionalPatchClaimEndpoints:
         claim = entity.claims.get(user=user, field_name=field_name, is_active=True)
         assert claim.value == field_value
 
-        assert ChangeSet.objects.count() == 1
-        changeset = ChangeSet.objects.get()
+        # Some factories assert a seed (ingest) name claim, so filter to the
+        # user's changeset rather than assuming it's the only row.
+        assert ChangeSet.objects.filter(user=user).count() == 1
+        changeset = ChangeSet.objects.get(user=user)
         assert changeset.user == user
         assert changeset.claims.count() == 1
 

--- a/backend/apps/catalog/tests/test_api_claims_corporate_entity.py
+++ b/backend/apps/catalog/tests/test_api_claims_corporate_entity.py
@@ -13,7 +13,8 @@ from apps.catalog.models import (
     Title,
 )
 from apps.catalog.tests.conftest import make_machine_model
-from apps.provenance.models import ChangeSet, Claim
+from apps.provenance.models import ChangeSet
+from apps.provenance.test_factories import make_claim
 
 User = get_user_model()
 
@@ -21,7 +22,7 @@ User = get_user_model()
 @pytest.fixture
 def mfr(db, _bootstrap_source):
     m = Manufacturer.objects.create(name="Gottlieb", slug="gottlieb")
-    Claim.objects.assert_claim(m, "name", "Gottlieb", source=_bootstrap_source)
+    make_claim(m, "name", "Gottlieb", source=_bootstrap_source)
     return m
 
 
@@ -34,9 +35,7 @@ def entity(db, mfr, _bootstrap_source):
         year_start=1927,
         year_end=1983,
     )
-    Claim.objects.assert_claim(
-        ce, "name", "D. Gottlieb & Company", source=_bootstrap_source
-    )
+    make_claim(ce, "name", "D. Gottlieb & Company", source=_bootstrap_source)
     return ce
 
 
@@ -49,9 +48,7 @@ def other_entity(db, mfr, _bootstrap_source):
         year_start=1983,
         year_end=1984,
     )
-    Claim.objects.assert_claim(
-        ce, "name", "Mylstar Electronics", source=_bootstrap_source
-    )
+    make_claim(ce, "name", "Mylstar Electronics", source=_bootstrap_source)
     return ce
 
 

--- a/backend/apps/catalog/tests/test_api_claims_corporate_entity.py
+++ b/backend/apps/catalog/tests/test_api_claims_corporate_entity.py
@@ -20,14 +20,14 @@ User = get_user_model()
 
 
 @pytest.fixture
-def mfr(db, _bootstrap_source):
+def mfr(db, bootstrap_source):
     m = Manufacturer.objects.create(name="Gottlieb", slug="gottlieb")
-    make_claim(m, "name", "Gottlieb", source=_bootstrap_source)
+    make_claim(m, "name", "Gottlieb", source=bootstrap_source)
     return m
 
 
 @pytest.fixture
-def entity(db, mfr, _bootstrap_source):
+def entity(db, mfr, bootstrap_source):
     ce = CorporateEntity.objects.create(
         name="D. Gottlieb & Company",
         slug="d-gottlieb-company",
@@ -35,12 +35,12 @@ def entity(db, mfr, _bootstrap_source):
         year_start=1927,
         year_end=1983,
     )
-    make_claim(ce, "name", "D. Gottlieb & Company", source=_bootstrap_source)
+    make_claim(ce, "name", "D. Gottlieb & Company", source=bootstrap_source)
     return ce
 
 
 @pytest.fixture
-def other_entity(db, mfr, _bootstrap_source):
+def other_entity(db, mfr, bootstrap_source):
     ce = CorporateEntity.objects.create(
         name="Mylstar Electronics",
         slug="mylstar-electronics",
@@ -48,7 +48,7 @@ def other_entity(db, mfr, _bootstrap_source):
         year_start=1983,
         year_end=1984,
     )
-    make_claim(ce, "name", "Mylstar Electronics", source=_bootstrap_source)
+    make_claim(ce, "name", "Mylstar Electronics", source=bootstrap_source)
     return ce
 
 

--- a/backend/apps/catalog/tests/test_api_claims_corporate_entity.py
+++ b/backend/apps/catalog/tests/test_api_claims_corporate_entity.py
@@ -279,9 +279,10 @@ class TestPatchCorporateEntityScalars:
             entity.slug,
             {"fields": {"description": "Updated"}, "note": "Test note"},
         )
-        assert ChangeSet.objects.count() == 1
-        cs = ChangeSet.objects.first()
-        assert cs is not None
+        # Fixtures assert seed (ingest) name claims, so filter to the user's
+        # changeset rather than assuming it's the only row.
+        assert ChangeSet.objects.filter(user=user).count() == 1
+        cs = ChangeSet.objects.get(user=user)
         assert cs.note == "Test note"
         assert cs.claims.count() == 1
 
@@ -334,7 +335,11 @@ class TestCorporateEntityEditHistory:
     def test_edit_history_empty(self, client, entity):
         resp = client.get(f"/api/pages/edit-history/corporate-entity/{entity.slug}/")
         assert resp.status_code == 200
-        assert resp.json() == []
+        # Seed name claims surface as ingest changesets; only user edits count here.
+        user_entries = [
+            cs for cs in resp.json() if cs["attribution"]["author"]["kind"] == "user"
+        ]
+        assert user_entries == []
 
     def test_edit_history_after_edit(self, client, user, entity):
         client.force_login(user)
@@ -343,7 +348,10 @@ class TestCorporateEntityEditHistory:
         )
         resp = client.get(f"/api/pages/edit-history/corporate-entity/{entity.slug}/")
         assert resp.status_code == 200
-        data = resp.json()
-        assert len(data) == 1
-        assert data[0]["note"] == "Fix"
-        assert any(c["field_name"] == "description" for c in data[0]["changes"])
+        # Filter out fixture seed (ingest) changesets; assert only the user edit.
+        user_entries = [
+            cs for cs in resp.json() if cs["attribution"]["author"]["kind"] == "user"
+        ]
+        assert len(user_entries) == 1
+        assert user_entries[0]["note"] == "Fix"
+        assert any(c["field_name"] == "description" for c in user_entries[0]["changes"])

--- a/backend/apps/catalog/tests/test_api_claims_manufacturer_person.py
+++ b/backend/apps/catalog/tests/test_api_claims_manufacturer_person.py
@@ -4,7 +4,8 @@ import pytest
 from django.contrib.auth import get_user_model
 
 from apps.catalog.models import Manufacturer, Person
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 User = get_user_model()
 
@@ -12,14 +13,14 @@ User = get_user_model()
 @pytest.fixture
 def mfr(db, _bootstrap_source):
     m = Manufacturer.objects.create(name="Williams", slug="williams")
-    Claim.objects.assert_claim(m, "name", "Williams", source=_bootstrap_source)
+    make_claim(m, "name", "Williams", source=_bootstrap_source)
     return m
 
 
 @pytest.fixture
 def person(db, _bootstrap_source):
     p = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
-    Claim.objects.assert_claim(p, "name", "Pat Lawlor", source=_bootstrap_source)
+    make_claim(p, "name", "Pat Lawlor", source=_bootstrap_source)
     return p
 
 
@@ -164,7 +165,7 @@ class TestPatchManufacturerClaimsPersistence:
         source = Source.objects.create(
             name="LowPri", source_type="database", priority=10
         )
-        Claim.objects.assert_claim(mfr, "description", "Source Name", source=source)
+        make_claim(mfr, "description", "Source Name", source=source)
         from apps.catalog.resolve import resolve_entity
 
         resolve_entity(mfr)

--- a/backend/apps/catalog/tests/test_api_claims_manufacturer_person.py
+++ b/backend/apps/catalog/tests/test_api_claims_manufacturer_person.py
@@ -11,16 +11,16 @@ User = get_user_model()
 
 
 @pytest.fixture
-def mfr(db, _bootstrap_source):
+def mfr(db, bootstrap_source):
     m = Manufacturer.objects.create(name="Williams", slug="williams")
-    make_claim(m, "name", "Williams", source=_bootstrap_source)
+    make_claim(m, "name", "Williams", source=bootstrap_source)
     return m
 
 
 @pytest.fixture
-def person(db, _bootstrap_source):
+def person(db, bootstrap_source):
     p = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
-    make_claim(p, "name", "Pat Lawlor", source=_bootstrap_source)
+    make_claim(p, "name", "Pat Lawlor", source=bootstrap_source)
     return p
 
 

--- a/backend/apps/catalog/tests/test_api_claims_model_relationships.py
+++ b/backend/apps/catalog/tests/test_api_claims_model_relationships.py
@@ -16,8 +16,8 @@ from apps.catalog.models import (
 )
 from apps.catalog.tests.conftest import make_machine_model
 from apps.citation.models import CitationSource
-from apps.provenance.models import ChangeSet, Claim
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.models import ChangeSet
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -31,7 +31,7 @@ def _only_changeset() -> ChangeSet:
 @pytest.fixture
 def pm(db, _bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
     return pm
 
 
@@ -308,7 +308,7 @@ class TestCombinedEdits:
         credit_roles,
         citation_source,
     ):
-        seed_claim = Claim.objects.assert_claim(
+        seed_claim = make_claim(
             pm,
             "description",
             "Template citation seed",

--- a/backend/apps/catalog/tests/test_api_claims_model_relationships.py
+++ b/backend/apps/catalog/tests/test_api_claims_model_relationships.py
@@ -28,9 +28,9 @@ def _only_user_changeset(user) -> ChangeSet:
 
 
 @pytest.fixture
-def pm(db, _bootstrap_source):
+def pm(db, bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
     return pm
 
 

--- a/backend/apps/catalog/tests/test_api_claims_model_relationships.py
+++ b/backend/apps/catalog/tests/test_api_claims_model_relationships.py
@@ -22,10 +22,9 @@ from apps.provenance.test_factories import make_claim, user_changeset
 User = get_user_model()
 
 
-def _only_changeset() -> ChangeSet:
-    cs = ChangeSet.objects.first()
-    assert cs is not None
-    return cs
+def _only_user_changeset(user) -> ChangeSet:
+    """The sole user-authored changeset (fixture seed claims are ingest)."""
+    return ChangeSet.objects.get(user=user)
 
 
 @pytest.fixture
@@ -287,8 +286,10 @@ class TestCombinedEdits:
         )
         assert resp.status_code == 200
 
-        assert ChangeSet.objects.count() == 1
-        cs = _only_changeset()
+        # The pm fixture asserts a seed (ingest) name claim, so filter to the
+        # user's changeset rather than assuming it's the only row.
+        assert ChangeSet.objects.filter(user=user).count() == 1
+        cs = _only_user_changeset(user)
         assert cs.note == "Full edit"
         field_names = set(cs.claims.values_list("field_name", flat=True))
         assert "year" in field_names
@@ -336,7 +337,13 @@ class TestCombinedEdits:
         assert resp.status_code == 200, resp.json()
 
         assert seed_claim.changeset_id is not None
-        changeset = ChangeSet.objects.exclude(pk=seed_claim.changeset_id).get()
+        # Restrict to the editing user's changesets (the pm fixture's seed name
+        # claim is ingest) and exclude the citation-template seed changeset.
+        changeset = (
+            ChangeSet.objects.filter(user=user)
+            .exclude(pk=seed_claim.changeset_id)
+            .get()
+        )
         claims = list(changeset.claims.order_by("pk"))
         assert claims
         for claim in claims:

--- a/backend/apps/catalog/tests/test_api_claims_title.py
+++ b/backend/apps/catalog/tests/test_api_claims_title.py
@@ -20,11 +20,11 @@ User = get_user_model()
 
 
 @pytest.fixture
-def title(db, _bootstrap_source):
+def title(db, bootstrap_source):
     t = Title.objects.create(
         name="Medieval Madness", slug="medieval-madness", opdb_id="G5pe4"
     )
-    make_claim(t, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(t, "name", "Medieval Madness", source=bootstrap_source)
     return t
 
 

--- a/backend/apps/catalog/tests/test_api_claims_title.py
+++ b/backend/apps/catalog/tests/test_api_claims_title.py
@@ -14,7 +14,7 @@ from apps.citation.models import CitationSource
 from apps.core.types import JsonBody
 from apps.provenance.claims import build_relationship_claim
 from apps.provenance.models import ChangeSet, Claim, Source
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -24,7 +24,7 @@ def title(db, _bootstrap_source):
     t = Title.objects.create(
         name="Medieval Madness", slug="medieval-madness", opdb_id="G5pe4"
     )
-    Claim.objects.assert_claim(t, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(t, "name", "Medieval Madness", source=_bootstrap_source)
     return t
 
 
@@ -65,7 +65,7 @@ def _assert_title_abbreviations(
         claim_key, claim_value = build_relationship_claim(
             "abbreviation", {"value": value}
         )
-        Claim.objects.assert_claim(
+        make_claim(
             title,
             "abbreviation",
             claim_value,
@@ -249,7 +249,7 @@ class TestPatchTitleClaims:
         self, client, user, title, citation_source
     ):
         client.force_login(user)
-        template_claim = Claim.objects.assert_claim(
+        template_claim = make_claim(
             title,
             "description",
             "Template citation seed",

--- a/backend/apps/catalog/tests/test_api_claims_title.py
+++ b/backend/apps/catalog/tests/test_api_claims_title.py
@@ -218,8 +218,10 @@ class TestPatchTitleClaims:
         )
         assert resp.status_code == 200
 
-        assert ChangeSet.objects.count() == 1
-        changeset = ChangeSet.objects.get()
+        # The title fixture asserts a seed (ingest) name claim, so filter to the
+        # user's changeset rather than assuming it's the only row.
+        assert ChangeSet.objects.filter(user=user).count() == 1
+        changeset = ChangeSet.objects.get(user=user)
         assert changeset.note == "Grouped title edit"
         assert changeset.claims.count() == 3
         assert {claim.field_name for claim in changeset.claims.all()} == {
@@ -272,7 +274,13 @@ class TestPatchTitleClaims:
 
         assert resp.status_code == 200, resp.json()
         assert template_claim.changeset_id is not None
-        changeset = ChangeSet.objects.exclude(pk=template_claim.changeset_id).get()
+        # Restrict to the editing user's changesets (the title fixture's seed name
+        # claim is ingest) and exclude the citation-template seed changeset.
+        changeset = (
+            ChangeSet.objects.filter(user=user)
+            .exclude(pk=template_claim.changeset_id)
+            .get()
+        )
         created_claim = changeset.claims.get(field_name="description")
         claim_citations = list(created_claim.citation_instances.all())
         assert len(claim_citations) == 1
@@ -295,7 +303,9 @@ class TestPatchTitleClaims:
         )
 
         assert resp.status_code == 422
-        assert ChangeSet.objects.count() == 0
+        # The title fixture's seed name claim is an ingest changeset; the rolled-
+        # back edit must leave no user changeset behind.
+        assert ChangeSet.objects.filter(user=user).count() == 0
         assert not Claim.objects.filter(
             user=user, field_name="description", value="Updated"
         ).exists()

--- a/backend/apps/catalog/tests/test_api_corporate_entity_delete.py
+++ b/backend/apps/catalog/tests/test_api_corporate_entity_delete.py
@@ -23,7 +23,8 @@ from apps.catalog.models import (
     Title,
 )
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.test_factories import make_claim
 
 User = get_user_model()
 
@@ -38,7 +39,7 @@ def bootstrap_source(db):
 @pytest.fixture
 def mfr(db, bootstrap_source):
     m = Manufacturer.objects.create(name="Stern", slug="stern", status="active")
-    Claim.objects.assert_claim(m, "name", "Stern", source=bootstrap_source)
+    make_claim(m, "name", "Stern", source=bootstrap_source)
     return m
 
 
@@ -50,8 +51,8 @@ def ce(db, bootstrap_source, mfr):
         manufacturer=mfr,
         status="active",
     )
-    Claim.objects.assert_claim(c, "name", c.name, source=bootstrap_source)
-    Claim.objects.assert_claim(c, "status", "active", source=bootstrap_source)
+    make_claim(c, "name", c.name, source=bootstrap_source)
+    make_claim(c, "status", "active", source=bootstrap_source)
     return c
 
 
@@ -63,7 +64,7 @@ def _make_model(
         slug=f"{slug}-title",
         status="active",
     )
-    Claim.objects.assert_claim(title, "name", title.name, source=bootstrap_source)
+    make_claim(title, "name", title.name, source=bootstrap_source)
     m = MachineModel.objects.create(
         title=title,
         name=slug.replace("-", " ").title(),
@@ -71,7 +72,7 @@ def _make_model(
         corporate_entity=ce,
         status=status,
     )
-    Claim.objects.assert_claim(m, "name", m.name, source=bootstrap_source)
+    make_claim(m, "name", m.name, source=bootstrap_source)
     return m
 
 

--- a/backend/apps/catalog/tests/test_api_corporate_entity_delete.py
+++ b/backend/apps/catalog/tests/test_api_corporate_entity_delete.py
@@ -23,17 +23,10 @@ from apps.catalog.models import (
     Title,
 )
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction
 from apps.provenance.test_factories import make_claim
 
 User = get_user_model()
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_api_export.py
+++ b/backend/apps/catalog/tests/test_api_export.py
@@ -14,6 +14,7 @@ from apps.catalog.api.export import (
 from apps.catalog.cache import invalidate_all
 from apps.catalog.engine.aliases import discover_alias_types
 from apps.catalog.models import MachineModel
+from apps.provenance.test_factories import make_claim
 
 from .conftest import SAMPLE_IMAGES
 
@@ -237,11 +238,8 @@ class TestExportDerivedFields:
         self, client, machine_model, williams_entity, source
     ):
         from apps.catalog.resolve import resolve_entity
-        from apps.provenance.models import Claim
 
-        Claim.objects.assert_claim(
-            williams_entity, "operating_status", "ongoing", source=source
-        )
+        make_claim(williams_entity, "operating_status", "ongoing", source=source)
         resolve_entity(williams_entity)
         invalidate_all()
         row = _row(client, "manufacturers", "williams")

--- a/backend/apps/catalog/tests/test_api_manufacturer_delete.py
+++ b/backend/apps/catalog/tests/test_api_manufacturer_delete.py
@@ -15,17 +15,10 @@ from django.core.cache import cache
 
 from apps.catalog.models import CorporateEntity, Manufacturer, System
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction
 from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_api_manufacturer_delete.py
+++ b/backend/apps/catalog/tests/test_api_manufacturer_delete.py
@@ -16,7 +16,7 @@ from django.core.cache import cache
 from apps.catalog.models import CorporateEntity, Manufacturer, System
 from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Source
-from apps.provenance.test_factories import make_claim
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -174,10 +174,9 @@ class TestDeleteIdempotence:
 @pytest.mark.django_db
 class TestDeletePreview:
     def test_preview_returns_counts(self, client, user, bootstrap_source, mfr):
-        cs = ChangeSet.objects.create(
-            user=user, action=ChangeSetAction.EDIT, note="seed"
-        )
-        make_claim(mfr, "description", "hi", user=user, changeset=cs)
+        # Route through the factory so the seed changeset carries an actor.
+        cs = user_changeset(user, note="seed")
+        make_claim(mfr, "description", "hi", changeset=cs)
         client.force_login(user)
         resp = _get_preview(client, "stern")
         assert resp.status_code == 200

--- a/backend/apps/catalog/tests/test_api_manufacturer_delete.py
+++ b/backend/apps/catalog/tests/test_api_manufacturer_delete.py
@@ -15,7 +15,8 @@ from django.core.cache import cache
 
 from apps.catalog.models import CorporateEntity, Manufacturer, System
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.test_factories import make_claim
 
 User = get_user_model()
 
@@ -30,8 +31,8 @@ def bootstrap_source(db):
 @pytest.fixture
 def mfr(db, bootstrap_source):
     m = Manufacturer.objects.create(name="Stern", slug="stern", status="active")
-    Claim.objects.assert_claim(m, "name", "Stern", source=bootstrap_source)
-    Claim.objects.assert_claim(m, "status", "active", source=bootstrap_source)
+    make_claim(m, "name", "Stern", source=bootstrap_source)
+    make_claim(m, "status", "active", source=bootstrap_source)
     return m
 
 
@@ -44,7 +45,7 @@ def _make_ce(
         manufacturer=mfr,
         status=status,
     )
-    Claim.objects.assert_claim(ce, "name", ce.name, source=bootstrap_source)
+    make_claim(ce, "name", ce.name, source=bootstrap_source)
     return ce
 
 
@@ -55,7 +56,7 @@ def _make_system(bootstrap_source, mfr, slug: str, *, status: str = "active") ->
         manufacturer=mfr,
         status=status,
     )
-    Claim.objects.assert_claim(s, "name", s.name, source=bootstrap_source)
+    make_claim(s, "name", s.name, source=bootstrap_source)
     return s
 
 
@@ -176,7 +177,7 @@ class TestDeletePreview:
         cs = ChangeSet.objects.create(
             user=user, action=ChangeSetAction.EDIT, note="seed"
         )
-        Claim.objects.assert_claim(mfr, "description", "hi", user=user, changeset=cs)
+        make_claim(mfr, "description", "hi", user=user, changeset=cs)
         client.force_login(user)
         resp = _get_preview(client, "stern")
         assert resp.status_code == 200

--- a/backend/apps/catalog/tests/test_api_manufacturers.py
+++ b/backend/apps/catalog/tests/test_api_manufacturers.py
@@ -3,6 +3,7 @@ from apps.catalog.models import (
     Title,
 )
 from apps.catalog.tests.conftest import make_machine_model
+from apps.provenance.test_factories import make_claim
 
 
 class TestManufacturersAPI:
@@ -153,11 +154,8 @@ class TestManufacturersAPI:
         self, client, manufacturer, williams_entity, source
     ):
         from apps.catalog.resolve import resolve_entity
-        from apps.provenance.models import Claim
 
-        Claim.objects.assert_claim(
-            williams_entity, "operating_status", "ongoing", source=source
-        )
+        make_claim(williams_entity, "operating_status", "ongoing", source=source)
         resolve_entity(williams_entity)
         resp = client.get(f"/api/pages/manufacturer/{manufacturer.slug}")
         data = resp.json()

--- a/backend/apps/catalog/tests/test_api_model_delete.py
+++ b/backend/apps/catalog/tests/test_api_model_delete.py
@@ -16,7 +16,7 @@ from apps.accounts.test_factories import make_user
 from apps.catalog.models import MachineModel, Title
 from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Source
-from apps.provenance.test_factories import make_claim
+from apps.provenance.test_factories import make_claim, user_changeset
 
 
 @pytest.fixture
@@ -286,10 +286,9 @@ class TestDeletePreview:
     def test_returns_counts_and_title(self, client, user, bootstrap_source):
         t = _make_title(bootstrap_source, "mm", name="Medieval Madness")
         m = _make_model(bootstrap_source, t, "mm-pro")
-        cs = ChangeSet.objects.create(
-            user=user, action=ChangeSetAction.EDIT, note="seed"
-        )
-        make_claim(m, "name", "MM Pro", user=user, changeset=cs)
+        # Route through the factory so the seed changeset carries an actor.
+        cs = user_changeset(user, note="seed")
+        make_claim(m, "name", "MM Pro", changeset=cs)
         client.force_login(user)
 
         resp = _get_preview(client, "mm-pro")

--- a/backend/apps/catalog/tests/test_api_model_delete.py
+++ b/backend/apps/catalog/tests/test_api_model_delete.py
@@ -15,17 +15,8 @@ from django.core.cache import cache
 from apps.accounts.test_factories import make_user
 from apps.catalog.models import MachineModel, Title
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction
 from apps.provenance.test_factories import make_claim, user_changeset
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    """Low-priority source so the resolver has something to fall back to
-    after the user's status=deleted claim is undone."""
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
 
 
 @pytest.fixture(autouse=True)

--- a/backend/apps/catalog/tests/test_api_model_delete.py
+++ b/backend/apps/catalog/tests/test_api_model_delete.py
@@ -15,7 +15,8 @@ from django.core.cache import cache
 from apps.accounts.test_factories import make_user
 from apps.catalog.models import MachineModel, Title
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -37,8 +38,8 @@ def _clear_cache():
 def _make_title(bootstrap_source, slug: str, name: str | None = None) -> Title:
     label = name or slug.replace("-", " ").title()
     t = Title.objects.create(name=label, slug=slug, status="active")
-    Claim.objects.assert_claim(t, "name", label, source=bootstrap_source)
-    Claim.objects.assert_claim(t, "status", "active", source=bootstrap_source)
+    make_claim(t, "name", label, source=bootstrap_source)
+    make_claim(t, "status", "active", source=bootstrap_source)
     return t
 
 
@@ -61,8 +62,8 @@ def _make_model(
         converted_from=converted_from,
         remake_of=remake_of,
     )
-    Claim.objects.assert_claim(m, "name", label, source=bootstrap_source)
-    Claim.objects.assert_claim(m, "status", "active", source=bootstrap_source)
+    make_claim(m, "name", label, source=bootstrap_source)
+    make_claim(m, "status", "active", source=bootstrap_source)
     return m
 
 
@@ -288,7 +289,7 @@ class TestDeletePreview:
         cs = ChangeSet.objects.create(
             user=user, action=ChangeSetAction.EDIT, note="seed"
         )
-        Claim.objects.assert_claim(m, "name", "MM Pro", user=user, changeset=cs)
+        make_claim(m, "name", "MM Pro", user=user, changeset=cs)
         client.force_login(user)
 
         resp = _get_preview(client, "mm-pro")

--- a/backend/apps/catalog/tests/test_api_models.py
+++ b/backend/apps/catalog/tests/test_api_models.py
@@ -6,7 +6,7 @@ from apps.catalog.models import (
     Title,
 )
 from apps.catalog.tests.conftest import make_machine_model
-from apps.provenance.models import Claim
+from apps.provenance.test_factories import make_claim
 
 from .conftest import SAMPLE_IMAGES
 
@@ -99,9 +99,7 @@ class TestModelsAPI:
     ):
         role = CreditRole.objects.get(slug="design")
         Credit.objects.create(model=machine_model, person=person, role=role)
-        Claim.objects.assert_claim(
-            machine_model, "year", 1997, "IPDB entry", source=source
-        )
+        make_claim(machine_model, "year", 1997, "IPDB entry", source=source)
 
         resp = client.get(f"/api/pages/model/{machine_model.slug}")
         assert resp.status_code == 200

--- a/backend/apps/catalog/tests/test_api_patch_claims_rate_limit.py
+++ b/backend/apps/catalog/tests/test_api_patch_claims_rate_limit.py
@@ -54,9 +54,9 @@ def _assert_429_edit(resp) -> None:
 
 
 @pytest.fixture
-def title(db, _bootstrap_source):
+def title(db, bootstrap_source):
     t = Title.objects.create(name="Medieval Madness", slug="medieval-madness")
-    make_claim(t, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(t, "name", "Medieval Madness", source=bootstrap_source)
     return t
 
 

--- a/backend/apps/catalog/tests/test_api_patch_claims_rate_limit.py
+++ b/backend/apps/catalog/tests/test_api_patch_claims_rate_limit.py
@@ -31,8 +31,8 @@ import pytest
 from apps.catalog.models import Tag, Title
 from apps.core.types import JsonBody
 from apps.provenance.constants import EDIT_RATE_LIMIT
-from apps.provenance.models import Claim
 from apps.provenance.rate_limits import EDIT_RATE_LIMIT_SPEC, check_and_record
+from apps.provenance.test_factories import make_claim
 
 
 def _fill_edit_bucket(user) -> None:
@@ -56,7 +56,7 @@ def _assert_429_edit(resp) -> None:
 @pytest.fixture
 def title(db, _bootstrap_source):
     t = Title.objects.create(name="Medieval Madness", slug="medieval-madness")
-    Claim.objects.assert_claim(t, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(t, "name", "Medieval Madness", source=_bootstrap_source)
     return t
 
 

--- a/backend/apps/catalog/tests/test_api_person_delete.py
+++ b/backend/apps/catalog/tests/test_api_person_delete.py
@@ -15,7 +15,8 @@ from django.core.cache import cache
 
 from apps.catalog.models import Credit, CreditRole, MachineModel, Person, Series, Title
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -40,15 +41,15 @@ def _clear_cache():
 def _make_person(bootstrap_source, slug: str, name: str | None = None) -> Person:
     label = name or slug.replace("-", " ").title()
     p = Person.objects.create(name=label, slug=slug, status="active")
-    Claim.objects.assert_claim(p, "name", label, source=bootstrap_source)
-    Claim.objects.assert_claim(p, "status", "active", source=bootstrap_source)
+    make_claim(p, "name", label, source=bootstrap_source)
+    make_claim(p, "status", "active", source=bootstrap_source)
     return p
 
 
 def _make_title(bootstrap_source, slug: str) -> Title:
     label = slug.replace("-", " ").title()
     t = Title.objects.create(name=label, slug=slug, status="active")
-    Claim.objects.assert_claim(t, "name", label, source=bootstrap_source)
+    make_claim(t, "name", label, source=bootstrap_source)
     return t
 
 
@@ -57,7 +58,7 @@ def _make_model(
 ) -> MachineModel:
     label = slug.replace("-", " ").title()
     m = MachineModel.objects.create(title=title, name=label, slug=slug, status=status)
-    Claim.objects.assert_claim(m, "name", label, source=bootstrap_source)
+    make_claim(m, "name", label, source=bootstrap_source)
     return m
 
 
@@ -200,9 +201,7 @@ class TestDeleteCreditBlocker:
         series = Series.objects.create(
             name="Star Wars Series", slug="star-wars-series", status="active"
         )
-        Claim.objects.assert_claim(
-            series, "name", "Star Wars Series", source=bootstrap_source
-        )
+        make_claim(series, "name", "Star Wars Series", source=bootstrap_source)
         Credit.objects.create(person=p, series=series, role=design_role)
         client.force_login(user)
 
@@ -277,7 +276,7 @@ class TestDeletePreview:
         cs = ChangeSet.objects.create(
             user=user, action=ChangeSetAction.EDIT, note="seed"
         )
-        Claim.objects.assert_claim(p, "birth_place", "Chicago", user=user, changeset=cs)
+        make_claim(p, "birth_place", "Chicago", user=user, changeset=cs)
         client.force_login(user)
 
         resp = _get_preview(client, "pat-lawlor")

--- a/backend/apps/catalog/tests/test_api_person_delete.py
+++ b/backend/apps/catalog/tests/test_api_person_delete.py
@@ -16,7 +16,7 @@ from django.core.cache import cache
 from apps.catalog.models import Credit, CreditRole, MachineModel, Person, Series, Title
 from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Source
-from apps.provenance.test_factories import make_claim
+from apps.provenance.test_factories import make_claim, user_changeset
 
 
 @pytest.fixture
@@ -273,10 +273,9 @@ class TestDeleteRateLimit:
 class TestDeletePreview:
     def test_returns_counts_without_blockers(self, client, user, bootstrap_source):
         p = _make_person(bootstrap_source, "pat-lawlor")
-        cs = ChangeSet.objects.create(
-            user=user, action=ChangeSetAction.EDIT, note="seed"
-        )
-        make_claim(p, "birth_place", "Chicago", user=user, changeset=cs)
+        # Route through the factory so the seed changeset carries an actor.
+        cs = user_changeset(user, note="seed")
+        make_claim(p, "birth_place", "Chicago", changeset=cs)
         client.force_login(user)
 
         resp = _get_preview(client, "pat-lawlor")

--- a/backend/apps/catalog/tests/test_api_person_delete.py
+++ b/backend/apps/catalog/tests/test_api_person_delete.py
@@ -15,15 +15,8 @@ from django.core.cache import cache
 
 from apps.catalog.models import Credit, CreditRole, MachineModel, Person, Series, Title
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction
 from apps.provenance.test_factories import make_claim, user_changeset
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_api_search.py
+++ b/backend/apps/catalog/tests/test_api_search.py
@@ -36,11 +36,11 @@ def _make_person(name: str, slug: str, source: Source) -> Person:
 
 
 @pytest.fixture
-def nova_in_each_section(_bootstrap_source):
+def nova_in_each_section(bootstrap_source):
     """One matching row per section for the term ``nova``."""
     Title.objects.create(name="Nova Madness", slug="nova-madness")
-    _make_manufacturer("Nova Games", "nova-games", _bootstrap_source)
-    _make_person("Nova Lawlor", "nova-lawlor", _bootstrap_source)
+    _make_manufacturer("Nova Games", "nova-games", bootstrap_source)
+    _make_person("Nova Lawlor", "nova-lawlor", bootstrap_source)
 
 
 def test_short_q_returns_empty_sections_and_does_no_db_work(
@@ -74,10 +74,10 @@ def test_basic_q_matches_each_section_with_card_shape(client, nova_in_each_secti
         assert data[section]["has_more"] is False
 
 
-def test_section_caps_at_ten_and_sets_has_more(client, db, _bootstrap_source):
+def test_section_caps_at_ten_and_sets_has_more(client, db, bootstrap_source):
     """11 matches → 10 cards + ``has_more``; the other sections stay empty."""
     for i in range(11):
-        _make_manufacturer(f"Capco {i:02d}", f"capco-{i:02d}", _bootstrap_source)
+        _make_manufacturer(f"Capco {i:02d}", f"capco-{i:02d}", bootstrap_source)
     data = client.get("/api/pages/search?q=capco").json()
     assert len(data["manufacturers"]["items"]) == 10
     assert data["manufacturers"]["has_more"] is True
@@ -85,9 +85,9 @@ def test_section_caps_at_ten_and_sets_has_more(client, db, _bootstrap_source):
     assert data["people"] == {"items": [], "has_more": False}
 
 
-def test_exactly_ten_matches_does_not_set_has_more(client, db, _bootstrap_source):
+def test_exactly_ten_matches_does_not_set_has_more(client, db, bootstrap_source):
     for i in range(10):
-        _make_manufacturer(f"Tenco {i:02d}", f"tenco-{i:02d}", _bootstrap_source)
+        _make_manufacturer(f"Tenco {i:02d}", f"tenco-{i:02d}", bootstrap_source)
     data = client.get("/api/pages/search?q=tenco").json()
     assert len(data["manufacturers"]["items"]) == 10
     assert data["manufacturers"]["has_more"] is False
@@ -118,7 +118,7 @@ def test_no_match_returns_all_empty_sections(client, nova_in_each_section):
 
 
 def test_people_section_preserves_listing_order(
-    client, db, _bootstrap_source, credit_roles, williams_entity
+    client, db, bootstrap_source, credit_roles, williams_entity
 ):
     """A section's rows are a prefix of its listing — so the People section must keep
     the ``-credit_count, name, pk`` order. This guards the explicit ``order_by`` the
@@ -133,9 +133,9 @@ def test_people_section_preserves_listing_order(
     art = CreditRole.objects.get(slug="art")
 
     # Names sort the OPPOSITE way to credit count, so a by-name regression fails.
-    two = _make_person("Order Zzz", "order-zzz", _bootstrap_source)  # 2 credits
-    one = _make_person("Order Mmm", "order-mmm", _bootstrap_source)  # 1 credit
-    _make_person("Order Aaa", "order-aaa", _bootstrap_source)  # 0 credits
+    two = _make_person("Order Zzz", "order-zzz", bootstrap_source)  # 2 credits
+    one = _make_person("Order Mmm", "order-mmm", bootstrap_source)  # 1 credit
+    _make_person("Order Aaa", "order-aaa", bootstrap_source)  # 0 credits
     Credit.objects.create(model=mm, person=two, role=design)
     Credit.objects.create(model=mm, person=two, role=art)
     Credit.objects.create(model=mm, person=one, role=design)
@@ -148,7 +148,7 @@ def test_people_section_preserves_listing_order(
 
 
 def test_query_count_is_constant_across_result_size(
-    client, db, _bootstrap_source, credit_roles, williams_entity
+    client, db, bootstrap_source, credit_roles, williams_entity
 ):
     """N+1 guard: each section batches its rows, related cards and thumbnails, so the
     query count must not grow with the number of matching rows. Rows carry real models,
@@ -166,9 +166,9 @@ def test_query_count_is_constant_across_result_size(
             year=1990 + i,
             extra_data={"opdb.images": SAMPLE_IMAGES},
         )
-        _make_manufacturer(f"Scale Mfr {i}", f"scale-mfr-{i}", _bootstrap_source)
+        _make_manufacturer(f"Scale Mfr {i}", f"scale-mfr-{i}", bootstrap_source)
         person = _make_person(
-            f"Scale Person {i}", f"scale-person-{i}", _bootstrap_source
+            f"Scale Person {i}", f"scale-person-{i}", bootstrap_source
         )
         Credit.objects.create(model=model, person=person, role=design)
 

--- a/backend/apps/catalog/tests/test_api_search.py
+++ b/backend/apps/catalog/tests/test_api_search.py
@@ -13,7 +13,8 @@ from django.test.utils import CaptureQueriesContext
 
 from apps.catalog.models import Credit, CreditRole, Manufacturer, Person, Title
 from apps.catalog.tests.conftest import SAMPLE_IMAGES, make_machine_model
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 CARD_KEYS = {
     "titles": {"name", "slug", "year", "model_count", "manufacturer", "thumbnail_url"},
@@ -24,13 +25,13 @@ CARD_KEYS = {
 
 def _make_manufacturer(name: str, slug: str, source: Source) -> Manufacturer:
     mfr = Manufacturer.objects.create(name=name, slug=slug)
-    Claim.objects.assert_claim(mfr, "name", name, source=source)
+    make_claim(mfr, "name", name, source=source)
     return mfr
 
 
 def _make_person(name: str, slug: str, source: Source) -> Person:
     p = Person.objects.create(name=name, slug=slug)
-    Claim.objects.assert_claim(p, "name", name, source=source)
+    make_claim(p, "name", name, source=source)
     return p
 
 

--- a/backend/apps/catalog/tests/test_api_system_delete.py
+++ b/backend/apps/catalog/tests/test_api_system_delete.py
@@ -14,15 +14,8 @@ from django.core.cache import cache
 
 from apps.catalog.models import MachineModel, Manufacturer, System, Title
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction
 from apps.provenance.test_factories import make_claim, user_changeset
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
 
 
 @pytest.fixture

--- a/backend/apps/catalog/tests/test_api_system_delete.py
+++ b/backend/apps/catalog/tests/test_api_system_delete.py
@@ -14,7 +14,8 @@ from django.core.cache import cache
 
 from apps.catalog.models import MachineModel, Manufacturer, System, Title
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -27,15 +28,15 @@ def bootstrap_source(db):
 @pytest.fixture
 def mfr(db, bootstrap_source):
     m = Manufacturer.objects.create(name="Stern", slug="stern", status="active")
-    Claim.objects.assert_claim(m, "name", "Stern", source=bootstrap_source)
+    make_claim(m, "name", "Stern", source=bootstrap_source)
     return m
 
 
 def _make_system(bootstrap_source, mfr, slug: str, name: str | None = None) -> System:
     label = name or slug.replace("-", " ").title()
     s = System.objects.create(name=label, slug=slug, manufacturer=mfr, status="active")
-    Claim.objects.assert_claim(s, "name", label, source=bootstrap_source)
-    Claim.objects.assert_claim(s, "status", "active", source=bootstrap_source)
+    make_claim(s, "name", label, source=bootstrap_source)
+    make_claim(s, "status", "active", source=bootstrap_source)
     return s
 
 
@@ -45,7 +46,7 @@ def _make_model(
     title = Title.objects.create(
         name=slug.replace("-", " ").title(), slug=f"{slug}-title", status="active"
     )
-    Claim.objects.assert_claim(title, "name", title.name, source=bootstrap_source)
+    make_claim(title, "name", title.name, source=bootstrap_source)
     m = MachineModel.objects.create(
         title=title,
         name=slug.replace("-", " ").title(),
@@ -53,7 +54,7 @@ def _make_model(
         system=system,
         status=status,
     )
-    Claim.objects.assert_claim(m, "name", m.name, source=bootstrap_source)
+    make_claim(m, "name", m.name, source=bootstrap_source)
     return m
 
 
@@ -204,7 +205,7 @@ class TestDeletePreview:
         cs = ChangeSet.objects.create(
             user=user, action=ChangeSetAction.EDIT, note="seed"
         )
-        Claim.objects.assert_claim(s, "description", "hi", user=user, changeset=cs)
+        make_claim(s, "description", "hi", user=user, changeset=cs)
         client.force_login(user)
 
         resp = _get_preview(client, "spike")

--- a/backend/apps/catalog/tests/test_api_system_delete.py
+++ b/backend/apps/catalog/tests/test_api_system_delete.py
@@ -15,7 +15,7 @@ from django.core.cache import cache
 from apps.catalog.models import MachineModel, Manufacturer, System, Title
 from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Source
-from apps.provenance.test_factories import make_claim
+from apps.provenance.test_factories import make_claim, user_changeset
 
 
 @pytest.fixture
@@ -202,10 +202,9 @@ class TestDeleteRateLimit:
 class TestDeletePreview:
     def test_returns_counts_without_blockers(self, client, user, bootstrap_source, mfr):
         s = _make_system(bootstrap_source, mfr, "spike")
-        cs = ChangeSet.objects.create(
-            user=user, action=ChangeSetAction.EDIT, note="seed"
-        )
-        make_claim(s, "description", "hi", user=user, changeset=cs)
+        # Route through the factory so the seed changeset carries an actor.
+        cs = user_changeset(user, note="seed")
+        make_claim(s, "description", "hi", changeset=cs)
         client.force_login(user)
 
         resp = _get_preview(client, "spike")

--- a/backend/apps/catalog/tests/test_api_title_delete.py
+++ b/backend/apps/catalog/tests/test_api_title_delete.py
@@ -11,6 +11,7 @@ from apps.accounts.test_factories import make_user
 from apps.catalog.models import MachineModel, Title
 from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -35,8 +36,8 @@ def _make_title(bootstrap_source, slug: str, name: str | None = None) -> Title:
     # Seed name + status claims from a low-priority source so the resolver
     # has something to fall back to after an undo deactivates the user's
     # status claim. Mirrors what ingest would provide in production.
-    Claim.objects.assert_claim(t, "name", label, source=bootstrap_source)
-    Claim.objects.assert_claim(t, "status", "active", source=bootstrap_source)
+    make_claim(t, "name", label, source=bootstrap_source)
+    make_claim(t, "status", "active", source=bootstrap_source)
     return t
 
 
@@ -48,8 +49,8 @@ def _make_model(bootstrap_source, title: Title, slug: str) -> MachineModel:
         slug=slug,
         status="active",
     )
-    Claim.objects.assert_claim(m, "name", label, source=bootstrap_source)
-    Claim.objects.assert_claim(m, "status", "active", source=bootstrap_source)
+    make_claim(m, "name", label, source=bootstrap_source)
+    make_claim(m, "status", "active", source=bootstrap_source)
     return m
 
 
@@ -237,9 +238,7 @@ class TestDeletePreview:
         cs = ChangeSet.objects.create(
             user=user, action=ChangeSetAction.EDIT, note="seed"
         )
-        Claim.objects.assert_claim(
-            t, "name", "Medieval Madness", user=user, changeset=cs
-        )
+        make_claim(t, "name", "Medieval Madness", user=user, changeset=cs)
         client.force_login(user)
         resp = _get_preview(client, "mm")
         assert resp.status_code == 200

--- a/backend/apps/catalog/tests/test_api_title_delete.py
+++ b/backend/apps/catalog/tests/test_api_title_delete.py
@@ -11,7 +11,7 @@ from apps.accounts.test_factories import make_user
 from apps.catalog.models import MachineModel, Title
 from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
-from apps.provenance.test_factories import make_claim
+from apps.provenance.test_factories import make_claim, user_changeset
 
 
 @pytest.fixture
@@ -234,11 +234,10 @@ class TestDeletePreview:
         t = _make_title(bootstrap_source, "mm")
         _make_model(bootstrap_source, t, "mm-pro")
         _make_model(bootstrap_source, t, "mm-le")
-        # Stamp a user changeset touching the title so changeset_count > 0.
-        cs = ChangeSet.objects.create(
-            user=user, action=ChangeSetAction.EDIT, note="seed"
-        )
-        make_claim(t, "name", "Medieval Madness", user=user, changeset=cs)
+        # Stamp a user changeset (via the factory so it carries an actor)
+        # touching the title so changeset_count > 0.
+        cs = user_changeset(user, note="seed")
+        make_claim(t, "name", "Medieval Madness", changeset=cs)
         client.force_login(user)
         resp = _get_preview(client, "mm")
         assert resp.status_code == 200

--- a/backend/apps/catalog/tests/test_api_title_delete.py
+++ b/backend/apps/catalog/tests/test_api_title_delete.py
@@ -10,17 +10,8 @@ from django.core.cache import cache
 from apps.accounts.test_factories import make_user
 from apps.catalog.models import MachineModel, Title
 from apps.core.types import JsonBody
-from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 from apps.provenance.test_factories import make_claim, user_changeset
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    """Low-priority source; seeds name claims so the resolver doesn't blank
-    ``name`` when a status claim is written during the delete path."""
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
 
 
 @pytest.fixture(autouse=True)

--- a/backend/apps/catalog/tests/test_db_constraints.py
+++ b/backend/apps/catalog/tests/test_db_constraints.py
@@ -24,7 +24,7 @@ from apps.catalog.models import (
 )
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.models import Claim, IngestRun, Source
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.test_factories import make_claim, user_changeset
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -441,7 +441,7 @@ class TestProvenanceConstraints:
     def test_claim_retracted_while_active_rejected(self, user):
         source = Source.objects.create(name="Test", source_type="database")
         mfr = Manufacturer.objects.create(name="Test", slug="test-mfr")
-        claim = Claim.objects.assert_claim(mfr, "name", "Test", source=source)
+        claim = make_claim(mfr, "name", "Test", source=source)
 
         cs = user_changeset(user)
         with pytest.raises(IntegrityError):
@@ -502,8 +502,8 @@ class TestValidateCheckConstraints:
         mm = make_machine_model(
             name="Test Machine", slug="test-mm", corporate_entity=ce, year=1992
         )
-        Claim.objects.assert_claim(mm, "name", "Test Machine", source=source)
-        Claim.objects.assert_claim(mm, "month", 6, source=source)
+        make_claim(mm, "name", "Test Machine", source=source)
+        make_claim(mm, "month", 6, source=source)
         # No year claim — resolver will reset year to None, month stays 6.
         # validate_check_constraints should catch this before save().
         from apps.catalog.resolve import resolve_model
@@ -526,9 +526,9 @@ class TestValidateCheckConstraints:
             year_start=1985,
             year_end=2000,
         )
-        Claim.objects.assert_claim(ce, "name", "Williams Corp", source=source)
-        Claim.objects.assert_claim(ce, "year_start", 1985, source=source)
-        Claim.objects.assert_claim(ce, "year_end", 2000, source=source)
+        make_claim(ce, "name", "Williams Corp", source=source)
+        make_claim(ce, "year_start", 1985, source=source)
+        make_claim(ce, "year_end", 2000, source=source)
 
         client = Client()
         client.force_login(user)

--- a/backend/apps/catalog/tests/test_description_html.py
+++ b/backend/apps/catalog/tests/test_description_html.py
@@ -4,6 +4,7 @@ import pytest
 
 from apps.catalog.models import Location, Manufacturer, System
 from apps.core.models import RecordReference
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -250,12 +251,12 @@ class TestReferenceSync:
         from django.contrib.contenttypes.models import ContentType
 
         from apps.catalog.resolve import resolve_entity
-        from apps.provenance.models import Claim, Source
+        from apps.provenance.models import Source
 
         mfr = Manufacturer.objects.create(name="Williams", slug="williams")
         system = System.objects.create(name="WPC-95", slug="wpc-95", manufacturer=mfr)
         source = Source.objects.create(name="test", priority=100)
-        Claim.objects.assert_claim(
+        make_claim(
             mfr,
             "description",
             f"Uses [[system:id:{system.pk}]].",
@@ -284,7 +285,7 @@ class TestReferenceSync:
         source = Source.objects.create(name="test", priority=100)
 
         # Create a reference via description with a link
-        Claim.objects.assert_claim(
+        make_claim(
             mfr,
             "description",
             f"Uses [[system:id:{system.pk}]].",

--- a/backend/apps/catalog/tests/test_dump_patch_entry.py
+++ b/backend/apps/catalog/tests/test_dump_patch_entry.py
@@ -23,8 +23,8 @@ from apps.citation.models import CitationSource
 from apps.claim_ingest.apply import apply_plan
 from apps.claim_ingest.patches import EditEntry, build_plan, load_patch
 from apps.core.markdown import convert_authoring_to_storage
-from apps.provenance.models import CitationInstance, Claim, Source
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.models import CitationInstance, Source
+from apps.provenance.test_factories import make_claim, user_changeset
 
 pytestmark = pytest.mark.django_db
 
@@ -92,7 +92,7 @@ def test_round_trip_byte_identity_with_adversarial_text(flipcommons_catalog):
         f"End with no trailing newline.[[cite:id:{ci2.pk}]]"
     )
     pm = make_machine_model(name="Adversarial", slug="adversarial", description=stored)
-    Claim.objects.assert_claim(pm, "description", stored, source=flipcommons_catalog)
+    make_claim(pm, "description", stored, source=flipcommons_catalog)
 
     dumped = _dump("model.adversarial")
     authoring = _description_of(dumped)
@@ -134,9 +134,7 @@ claims:
 
 def test_attribution_defaults_to_owning_source(flipcommons_catalog):
     pm = make_machine_model(name="Attar", slug="attar", description="Just text.")
-    Claim.objects.assert_claim(
-        pm, "description", "Just text.", source=flipcommons_catalog
-    )
+    make_claim(pm, "description", "Just text.", source=flipcommons_catalog)
 
     doc = yaml.safe_load(_dump("model.attar"))
     assert doc["attribution"] == "flipcommons-catalog"
@@ -147,7 +145,7 @@ def test_attribution_override(flipcommons_catalog):
         slug="flipcommons-ai-desc-model", name="AI Desc", source_type="editorial"
     )
     pm = make_machine_model(name="Override", slug="override", description="Text.")
-    Claim.objects.assert_claim(pm, "description", "Text.", source=flipcommons_catalog)
+    make_claim(pm, "description", "Text.", source=flipcommons_catalog)
 
     doc = yaml.safe_load(_dump("model.override", attribution=other.slug))
     assert doc["attribution"] == "flipcommons-ai-desc-model"
@@ -156,7 +154,7 @@ def test_attribution_override(flipcommons_catalog):
 def test_user_owned_winning_claim_requires_attribution(flipcommons_catalog):
     user = User.objects.create_user(username="editor", email="ed@example.com")
     pm = make_machine_model(name="UserEd", slug="user-ed", description="Hand edited.")
-    Claim.objects.assert_claim(
+    make_claim(
         pm,
         "description",
         "Hand edited.",

--- a/backend/apps/catalog/tests/test_extra_data_excludes_relationships.py
+++ b/backend/apps/catalog/tests/test_extra_data_excludes_relationships.py
@@ -1,0 +1,69 @@
+"""The generic scalar resolver must not spill relationship claims into extra_data.
+
+``extra_data`` is the overflow bucket for *scalar* claims whose field has no
+column on the model, so the API can still filter by them. Relationship-namespace
+claims (``media_attachment``, ``credit``, …) resolve into their own tables
+(``EntityMedia``, through-tables) and must never land in ``extra_data``.
+
+``resolve_model`` (the MachineModel resolver) already skips relationship
+namespaces; the generic ``_resolve_single`` / ``_resolve_bulk`` used for every
+other catalog entity did not, so a Manufacturer/Person/GameplayFeature that
+carried a media claim leaked it into ``extra_data`` on any scalar re-resolution.
+Regression test for that leak.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.catalog.claims import build_media_attachment_claim
+from apps.catalog.models import Manufacturer
+from apps.catalog.resolve._entities import resolve_all_entities, resolve_entity
+from apps.media.models import MediaAsset
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def source(db):
+    return Source.objects.create(
+        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
+    )
+
+
+@pytest.fixture
+def manufacturer_with_media(db, source, user) -> Manufacturer:
+    """A Manufacturer whose only relationship claim is a media attachment."""
+    mfr = Manufacturer.objects.create(name="Acme", slug="acme", status="active")
+    make_claim(mfr, "name", "Acme", source=source)
+    make_claim(mfr, "slug", "acme", source=source)
+    make_claim(mfr, "status", "active", source=source)
+    asset = MediaAsset.objects.create(
+        kind=MediaAsset.Kind.IMAGE,
+        status=MediaAsset.Status.READY,
+        original_filename="logo.jpg",
+        mime_type="image/jpeg",
+        byte_size=1,
+        width=1,
+        height=1,
+        uploaded_by=user,
+    )
+    claim_key, value = build_media_attachment_claim(
+        mfr, asset.pk, category="logo", is_primary=True
+    )
+    make_claim(mfr, "media_attachment", value, source=source, claim_key=claim_key)
+    return mfr
+
+
+def test_single_resolve_excludes_media_attachment(manufacturer_with_media):
+    resolve_entity(manufacturer_with_media)
+    manufacturer_with_media.refresh_from_db()
+    assert "media_attachment" not in manufacturer_with_media.extra_data
+
+
+def test_bulk_resolve_excludes_media_attachment(manufacturer_with_media):
+    resolve_all_entities(Manufacturer, object_ids={manufacturer_with_media.pk})
+    manufacturer_with_media.refresh_from_db()
+    assert "media_attachment" not in manufacturer_with_media.extra_data

--- a/backend/apps/catalog/tests/test_image_licensing.py
+++ b/backend/apps/catalog/tests/test_image_licensing.py
@@ -8,7 +8,8 @@ from apps.catalog.resolve import resolve_model
 from apps.catalog.tests.conftest import make_machine_model
 from apps.core.models import License
 from apps.provenance.licensing import resolve_effective_license
-from apps.provenance.models import Claim, Source, SourceFieldLicense
+from apps.provenance.models import Source, SourceFieldLicense
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -60,7 +61,7 @@ class TestEffectiveLicenseResolution:
     def test_claim_license_overrides_all(self, opdb, cc_by_sa):
         """Per-claim license takes precedence over source defaults."""
         title = Title.objects.create(name="Test Title", slug="t1")
-        claim = Claim.objects.assert_claim(title, "description", "text", source=opdb)
+        claim = make_claim(title, "description", "text", source=opdb)
         claim.license = cc_by_sa
         claim.save()
         claim.refresh_from_db()
@@ -76,7 +77,7 @@ class TestEffectiveLicenseResolution:
             source=opdb, field_name="description", license=cc_by_sa
         )
         title = Title.objects.create(name="Test Title", slug="t1")
-        claim = Claim.objects.assert_claim(title, "description", "text", source=opdb)
+        claim = make_claim(title, "description", "text", source=opdb)
         claim.source = opdb
 
         from apps.provenance.licensing import build_source_field_license_map
@@ -88,7 +89,7 @@ class TestEffectiveLicenseResolution:
     def test_source_default_license_fallback(self, ipdb, not_allowed):
         """Falls back to source.default_license when no overrides exist."""
         title = Title.objects.create(name="Test Title", slug="t1")
-        claim = Claim.objects.assert_claim(title, "description", "text", source=ipdb)
+        claim = make_claim(title, "description", "text", source=ipdb)
         claim.source = ipdb
 
         lic = resolve_effective_license(claim)
@@ -97,7 +98,7 @@ class TestEffectiveLicenseResolution:
     def test_all_null_returns_none(self, opdb):
         """Returns None when no license is set anywhere."""
         title = Title.objects.create(name="Test Title", slug="t1")
-        claim = Claim.objects.assert_claim(title, "description", "text", source=opdb)
+        claim = make_claim(title, "description", "text", source=opdb)
         claim.source = opdb
 
         lic = resolve_effective_license(claim)
@@ -112,8 +113,8 @@ class TestImageLicenseDenormalization:
         opdb.save()
 
         pm = make_machine_model(name="Test", slug="test-pm")
-        Claim.objects.assert_claim(pm, "name", "Test", source=opdb)
-        Claim.objects.assert_claim(
+        make_claim(pm, "name", "Test", source=opdb)
+        make_claim(
             pm,
             "opdb.images",
             [
@@ -138,8 +139,8 @@ class TestImageLicenseDenormalization:
     def test_null_license_stores_null_rank(self, opdb):
         """Null license should store null rank in extra_data."""
         pm = make_machine_model(name="Test", slug="test-pm")
-        Claim.objects.assert_claim(pm, "name", "Test", source=opdb)
-        Claim.objects.assert_claim(
+        make_claim(pm, "name", "Test", source=opdb)
+        make_claim(
             pm,
             "opdb.images",
             [

--- a/backend/apps/catalog/tests/test_models.py
+++ b/backend/apps/catalog/tests/test_models.py
@@ -14,6 +14,7 @@ from apps.catalog.models import (
 from apps.catalog.tests.conftest import make_machine_model
 from apps.core.validators import validate_no_mojibake
 from apps.provenance.models import Claim, Source, get_claim_fields
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -211,15 +212,13 @@ class TestCredit:
 
 class TestClaim:
     def test_assert_claim_creates(self, machine_model, source):
-        claim = Claim.objects.assert_claim(
-            machine_model, "name", "Medieval Madness", source=source
-        )
+        claim = make_claim(machine_model, "name", "Medieval Madness", source=source)
         assert claim.is_active is True
         assert claim.value == "Medieval Madness"
 
     def test_assert_claim_supersedes(self, machine_model, source):
-        c1 = Claim.objects.assert_claim(machine_model, "year", 1997, source=source)
-        c2 = Claim.objects.assert_claim(machine_model, "year", 1998, source=source)
+        c1 = make_claim(machine_model, "year", 1997, source=source)
+        c2 = make_claim(machine_model, "year", 1998, source=source)
         c1.refresh_from_db()
         assert c1.is_active is False
         assert c2.is_active is True
@@ -227,10 +226,8 @@ class TestClaim:
     def test_assert_claim_different_sources_coexist(
         self, machine_model, source, editorial_source
     ):
-        c1 = Claim.objects.assert_claim(machine_model, "year", 1997, source=source)
-        c2 = Claim.objects.assert_claim(
-            machine_model, "year", 1997, source=editorial_source
-        )
+        c1 = make_claim(machine_model, "year", 1997, source=source)
+        c2 = make_claim(machine_model, "year", 1997, source=editorial_source)
         c1.refresh_from_db()
         assert c1.is_active is True
         assert c2.is_active is True
@@ -238,7 +235,7 @@ class TestClaim:
     def test_unique_active_constraint(self, machine_model, source):
         from django.contrib.contenttypes.models import ContentType
 
-        Claim.objects.assert_claim(machine_model, "name", "V1", source=source)
+        make_claim(machine_model, "name", "V1", source=source)
         ct = ContentType.objects.get_for_model(machine_model)
         # Direct create (bypassing manager) should violate the constraint
         # (keyed on claim_key, which equals field_name for scalar claims).
@@ -254,7 +251,7 @@ class TestClaim:
             )
 
     def test_str(self, machine_model, source):
-        claim = Claim.objects.assert_claim(machine_model, "year", 1997, source=source)
+        claim = make_claim(machine_model, "year", 1997, source=source)
         assert "IPDB" in str(claim)
         assert "year" in str(claim)
 

--- a/backend/apps/catalog/tests/test_operating_status.py
+++ b/backend/apps/catalog/tests/test_operating_status.py
@@ -13,7 +13,8 @@ from django.db import IntegrityError, connection
 
 from apps.catalog.models import CorporateEntity, Manufacturer, OperatingStatus
 from apps.catalog.resolve import resolve_entity
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 from apps.provenance.validation import validate_claim_value
 
 pytestmark = pytest.mark.django_db
@@ -39,7 +40,7 @@ def entity(db, test_source):
     )
     # Name is non-unique, so resolution resets it to blank unless a claim
     # backs it. Seed one so resolve_entity() in these tests keeps the name.
-    Claim.objects.assert_claim(ce, "name", "D. Gottlieb & Company", source=test_source)
+    make_claim(ce, "name", "D. Gottlieb & Company", source=test_source)
     return ce
 
 
@@ -103,9 +104,7 @@ class TestChoicesValidation:
 class TestResolution:
     def test_resolved_from_claim(self, entity, test_source):
         """The field resolves from a claim like any other scalar."""
-        Claim.objects.assert_claim(
-            entity, "operating_status", "ongoing", source=test_source
-        )
+        make_claim(entity, "operating_status", "ongoing", source=test_source)
         resolve_entity(entity)
         entity.refresh_from_db()
         assert entity.operating_status == OperatingStatus.ONGOING

--- a/backend/apps/catalog/tests/test_patch_provenance.py
+++ b/backend/apps/catalog/tests/test_patch_provenance.py
@@ -274,7 +274,9 @@ claims:
 def test_note_sets_changeset_note(flipcommons_catalog, pm):
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: corrected per the flyer\n      year: 1998\n"
     _apply(text)
-    cs = ChangeSet.objects.get(ingest_run__isnull=False)
+    # Filter to this patch's changeset; seed name claims now ride their own
+    # (patch_id-less) ingest changesets.
+    cs = ChangeSet.objects.get(ingest_run__patch_id="0001-test")
     assert cs.note == "corrected per the flyer"
 
 
@@ -572,7 +574,9 @@ def test_note_on_unchanged_value_rejected(flipcommons_catalog, pm):
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: confirmed correct\n      year: 2000\n"
     with pytest.raises(ValidationError, match="changes nothing"):
         _apply(text)
-    assert not ChangeSet.objects.filter(ingest_run__isnull=False).exists()
+    # The no-op apply must mint no changeset; scope to this patch since seed
+    # name/year claims now ride their own ingest changesets.
+    assert not ChangeSet.objects.filter(ingest_run__patch_id="0001-test").exists()
 
 
 def test_empty_diff_rejected_at_dry_run(flipcommons_catalog, pm):
@@ -1011,7 +1015,11 @@ def test_url_cite_surfaced_in_edit_history(
 
     resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
     assert resp.status_code == 200
-    (cs,) = resp.json()
+    # Seed name claim now rides its own ingest changeset, so pick the one
+    # carrying the year change rather than assuming a single entry.
+    cs = next(
+        c for c in resp.json() if any(ch["field_name"] == "year" for ch in c["changes"])
+    )
     year_change = next(c for c in cs["changes"] if c["field_name"] == "year")
     (citation,) = year_change["citations"]
     assert citation["source_name"] == url
@@ -1038,7 +1046,11 @@ def test_url_cite_with_archive_surfaces_live_link_in_edit_history(
 
     resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
     assert resp.status_code == 200
-    (cs,) = resp.json()
+    # Seed name claim now rides its own ingest changeset, so pick the one
+    # carrying the year change rather than assuming a single entry.
+    cs = next(
+        c for c in resp.json() if any(ch["field_name"] == "year" for ch in c["changes"])
+    )
     year_change = next(c for c in cs["changes"] if c["field_name"] == "year")
     (citation,) = year_change["citations"]
     assert citation["url"] == url  # the live page, not the archive snapshot
@@ -1054,7 +1066,9 @@ def test_edit_history_exposes_citation(client, flipcommons_catalog, ipdb_root, p
     resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
     assert resp.status_code == 200
     body = resp.json()
-    (cs,) = body
+    # Seed name claim now rides its own ingest changeset, so pick the one
+    # carrying the year change rather than assuming a single entry.
+    cs = next(c for c in body if any(ch["field_name"] == "year" for ch in c["changes"]))
     assert cs["note"] == "per ipdb"
     year_change = next(c for c in cs["changes"] if c["field_name"] == "year")
     (citation,) = year_change["citations"]
@@ -1067,7 +1081,9 @@ def test_changeset_detail_exposes_citation(client, flipcommons_catalog, ipdb_roo
     # its claims prefetch must also load citation instances.
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 1998\n"
     _apply(text)
-    cs = ChangeSet.objects.get(ingest_run__isnull=False)
+    # Filter to this patch's changeset; seed name claims now ride their own
+    # (patch_id-less) ingest changesets.
+    cs = ChangeSet.objects.get(ingest_run__patch_id="0001-test")
 
     resp = client.get(f"/api/pages/changesets/{cs.pk}/")
     assert resp.status_code == 200

--- a/backend/apps/catalog/tests/test_patch_provenance.py
+++ b/backend/apps/catalog/tests/test_patch_provenance.py
@@ -30,10 +30,10 @@ from apps.claim_ingest.plan import (
 from apps.provenance.models import (
     ChangeSet,
     CitationInstance,
-    Claim,
     IngestRun,
     Source,
 )
+from apps.provenance.test_factories import make_claim
 
 pytestmark = pytest.mark.django_db
 
@@ -186,7 +186,7 @@ claims:
 def test_same_field_retracted_twice_rejected(flipcommons_catalog, pm):
     # Decision 2 (retractions): two entries retracting the same field collapse to
     # one deactivation, dropping one entry's note — rejected.
-    Claim.objects.assert_claim(pm, "year", 1998, source=flipcommons_catalog)
+    make_claim(pm, "year", 1998, source=flipcommons_catalog)
     text = """
 attribution: flipcommons-catalog
 claims:
@@ -222,7 +222,7 @@ claims:
 
 def test_cite_on_retraction_only_entry_rejected(flipcommons_catalog, pm):
     # A cite has nothing to attach to when the entry only retracts.
-    Claim.objects.assert_claim(pm, "year", 1998, source=flipcommons_catalog)
+    make_claim(pm, "year", 1998, source=flipcommons_catalog)
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      retract: [year]\n"
     with pytest.raises(PatchError, match="cite has no field to attach to"):
         _apply(text)
@@ -281,7 +281,7 @@ def test_note_sets_changeset_note(flipcommons_catalog, pm):
 def test_retract_only_entry_lands_note(flipcommons_catalog, pm):
     # Seed a flipcommons-catalog year claim, then retract it with a note. A retraction
     # emits no assertion, so its note must still reach the changeset.
-    Claim.objects.assert_claim(pm, "year", 1998, source=flipcommons_catalog)
+    make_claim(pm, "year", 1998, source=flipcommons_catalog)
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: removing our bad year\n      retract: [year]\n"
     report = _apply(text, patch_id="0002-retract")
     assert report.retracted == 1
@@ -556,7 +556,7 @@ def test_cite_on_unchanged_value_rejected(flipcommons_catalog, ipdb_root, pm):
     # cite: would attach to nothing and silently vanish — now a hard error. The
     # empty-diff guard runs in the apply layer (ValidationError; the command
     # converts it to a PatchError for the author).
-    Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
+    make_claim(pm, "year", 2000, source=flipcommons_catalog)
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 2000\n"
     with pytest.raises(ValidationError, match="changes nothing"):
         _apply(text)
@@ -568,7 +568,7 @@ def test_note_on_unchanged_value_rejected(flipcommons_catalog, pm):
     # diffs as unchanged, which would drop the note — now a hard error. Build time
     # can't catch this (it depends on the post-diff result), so the apply-layer
     # empty-diff guard does.
-    Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
+    make_claim(pm, "year", 2000, source=flipcommons_catalog)
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: confirmed correct\n      year: 2000\n"
     with pytest.raises(ValidationError, match="changes nothing"):
         _apply(text)
@@ -578,7 +578,7 @@ def test_note_on_unchanged_value_rejected(flipcommons_catalog, pm):
 def test_empty_diff_rejected_at_dry_run(flipcommons_catalog, pm):
     # The empty-diff guard must fire at --dry-run too, so an author's pre-flight
     # check catches the no-op note before apply — not only at apply time.
-    Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
+    make_claim(pm, "year", 2000, source=flipcommons_catalog)
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: confirmed correct\n      year: 2000\n"
     with pytest.raises(ValidationError, match="changes nothing"):
         _apply(text, dry_run=True)
@@ -586,7 +586,7 @@ def test_empty_diff_rejected_at_dry_run(flipcommons_catalog, pm):
 
 def test_changing_note_entry_passes_dry_run(flipcommons_catalog, pm):
     # A real change carrying a note validates clean at --dry-run (no false reject).
-    Claim.objects.assert_claim(pm, "year", 2000, source=flipcommons_catalog)
+    make_claim(pm, "year", 2000, source=flipcommons_catalog)
     text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      note: corrected per the flyer\n      year: 1999\n"
     report = _apply(text, dry_run=True)
     assert report.asserted == 1

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -55,6 +55,7 @@ from apps.provenance.claims import (
     normalize_alias_identity,
 )
 from apps.provenance.models import ChangeSet, CitationInstance, Claim, IngestRun, Source
+from apps.provenance.test_factories import make_claim
 from apps.provenance.validation import (
     FkTarget,
     RelationshipSchema,
@@ -977,9 +978,9 @@ def test_retract_fk_falls_through_to_remaining_source(
         slug="western-products-incorporated",
         manufacturer=stern,
     )
-    Claim.objects.assert_claim(ce, "name", "Western Products, Inc.", source=catalog)
-    Claim.objects.assert_claim(ce, "manufacturer", "williams", source=catalog)
-    Claim.objects.assert_claim(ce, "manufacturer", "stern", source=ipdb)
+    make_claim(ce, "name", "Western Products, Inc.", source=catalog)
+    make_claim(ce, "manufacturer", "williams", source=catalog)
+    make_claim(ce, "manufacturer", "stern", source=ipdb)
 
     text = """
 attribution: flipcommons-catalog
@@ -1014,8 +1015,8 @@ def test_retract_sole_required_fk_claim_preserves_value(stern):
         slug="western-products-incorporated",
         manufacturer=stern,
     )
-    Claim.objects.assert_claim(ce, "name", "Western Products, Inc.", source=ipdb)
-    Claim.objects.assert_claim(ce, "manufacturer", "stern", source=ipdb)
+    make_claim(ce, "name", "Western Products, Inc.", source=ipdb)
+    make_claim(ce, "manufacturer", "stern", source=ipdb)
 
     text = """
 attribution: ipdb
@@ -1042,7 +1043,7 @@ def test_retract_idempotent_when_claim_absent(stern):
         slug="western-products-incorporated",
         manufacturer=stern,
     )
-    Claim.objects.assert_claim(ce, "name", "Western Products, Inc.", source=ipdb)
+    make_claim(ce, "name", "Western Products, Inc.", source=ipdb)
 
     text = """
 attribution: ipdb
@@ -1070,7 +1071,7 @@ def test_retract_noop_with_note_rejected(stern):
     )
     # ipdb claims `name` but not `manufacturer`, so retracting manufacturer is a
     # no-op for this source.
-    Claim.objects.assert_claim(ce, "name", "Western Products, Inc.", source=ipdb)
+    make_claim(ce, "name", "Western Products, Inc.", source=ipdb)
 
     text = """
 attribution: ipdb
@@ -1094,8 +1095,8 @@ def test_retract_real_with_note_records_changeset(stern):
         slug="western-products-incorporated",
         manufacturer=stern,
     )
-    Claim.objects.assert_claim(ce, "name", "Western Products, Inc.", source=ipdb)
-    Claim.objects.assert_claim(ce, "manufacturer", "stern", source=ipdb)
+    make_claim(ce, "name", "Western Products, Inc.", source=ipdb)
+    make_claim(ce, "manufacturer", "stern", source=ipdb)
 
     text = """
 attribution: ipdb
@@ -1164,9 +1165,9 @@ def test_retract_one_field_assert_another_in_same_entry(stern, flipcommons_catal
         slug="western-products-incorporated",
         manufacturer=stern,
     )
-    Claim.objects.assert_claim(ce, "name", "Western Products, Inc.", source=ipdb)
-    Claim.objects.assert_claim(ce, "manufacturer", "stern", source=ipdb)
-    Claim.objects.assert_claim(ce, "manufacturer", "stern", source=catalog)
+    make_claim(ce, "name", "Western Products, Inc.", source=ipdb)
+    make_claim(ce, "manufacturer", "stern", source=ipdb)
+    make_claim(ce, "manufacturer", "stern", source=catalog)
 
     text = """
 attribution: ipdb
@@ -1196,7 +1197,7 @@ def test_retract_and_assert_same_field_rejected(stern):
         slug="western-products-incorporated",
         manufacturer=stern,
     )
-    Claim.objects.assert_claim(ce, "name", "Western Products, Inc.", source=ipdb)
+    make_claim(ce, "name", "Western Products, Inc.", source=ipdb)
     text = """
 attribution: ipdb
 claims:
@@ -1220,7 +1221,7 @@ def test_retract_and_assert_same_field_across_entries_rejected(stern):
         slug="western-products-incorporated",
         manufacturer=stern,
     )
-    Claim.objects.assert_claim(ce, "name", "Western Products, Inc.", source=ipdb)
+    make_claim(ce, "name", "Western Products, Inc.", source=ipdb)
     text = """
 attribution: ipdb
 claims:
@@ -1450,11 +1451,9 @@ def bally_wulff(db, flipcommons_catalog):
     ce = CorporateEntity.objects.create(
         name="Bally Wulff", slug="bally-wulff", manufacturer=mfr
     )
-    Claim.objects.assert_claim(ce, "name", "Bally Wulff", source=catalog)
+    make_claim(ce, "name", "Bally Wulff", source=catalog)
     claim_key, value = build_relationship_claim("location", {"location": germany.pk})
-    Claim.objects.assert_claim(
-        ce, "location", value, source=catalog, claim_key=claim_key
-    )
+    make_claim(ce, "location", value, source=catalog, claim_key=claim_key)
     resolve_all_corporate_entity_locations(subject_ids={ce.pk})
     return ce
 
@@ -1844,7 +1843,7 @@ def test_losing_fk_reassign_onto_deleted_still_rejected(machine_model, stern_ent
     authority = Source.objects.create(
         name="Authority", slug="authority", source_type="editorial", priority=900
     )
-    Claim.objects.assert_claim(
+    make_claim(
         machine_model, "corporate_entity", "williams-electronics", source=authority
     )
     text = f"""
@@ -1886,7 +1885,7 @@ def test_reassign_fk_onto_deleted_normalizes_numeric(machine_model, manufacturer
     doomed = CorporateEntity.objects.create(
         name="Numbered", slug="1234", manufacturer=manufacturer
     )
-    Claim.objects.assert_claim(
+    make_claim(
         doomed,
         "name",
         "Numbered",

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -467,7 +467,7 @@ claims:
 # ── Same-patch backward references (create-first) ──────────────────
 
 
-def test_backward_fk_on_create(_bootstrap_source):
+def test_backward_fk_on_create(bootstrap_source):
     # Create a manufacturer, then create a corporate-entity whose `manufacturer`
     # FK points at it — both in one patch, the dependency declared first.
     text = """
@@ -491,7 +491,7 @@ claims:
     assert ce.claims.filter(field_name="manufacturer", is_active=True).exists()
 
 
-def test_backward_fk_on_create_dry_run(_bootstrap_source):
+def test_backward_fk_on_create_dry_run(bootstrap_source):
     # Dry-run must not reject the FK-to-planned-target just because the target
     # doesn't exist yet, and must write nothing (guards the apply.py P1 carve-out).
     text = """
@@ -606,7 +606,7 @@ claims:
     assert _location_claim("munich").value["location"] == munich.pk
 
 
-def test_backward_member_on_created_subject(_bootstrap_source):
+def test_backward_member_on_created_subject(bootstrap_source):
     # Both the relationship subject (a CE) and its member (a Location) are
     # created in this same patch — the deferred member targets the subject's
     # *handle*, not an existing row, plus a backward FK to a created manufacturer.
@@ -905,7 +905,7 @@ claims:
         _apply(text)
 
 
-def test_backward_unresolvable_ref_errors(_bootstrap_source):
+def test_backward_unresolvable_ref_errors(bootstrap_source):
     # A reference in neither the DB nor this patch → PatchError, updated message.
     text = """
 attribution: flipcommons-catalog

--- a/backend/apps/catalog/tests/test_production_status.py
+++ b/backend/apps/catalog/tests/test_production_status.py
@@ -21,6 +21,7 @@ from apps.catalog.resolve import resolve_machine_models
 from apps.catalog.tests.conftest import make_machine_model
 from apps.core.types import JsonBody
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.test_factories import make_claim
 
 
 def _post(client, path: str, body: JsonBody):
@@ -150,7 +151,7 @@ class TestProductionStatusClaimResolution:
         model = make_machine_model(name="Cancelled Project")
         src = Source.objects.get(slug="bootstrap")
 
-        Claim.objects.assert_claim(model, "production_status", "unreleased", source=src)
+        make_claim(model, "production_status", "unreleased", source=src)
         resolve_machine_models()
 
         model.refresh_from_db()

--- a/backend/apps/catalog/tests/test_resolve.py
+++ b/backend/apps/catalog/tests/test_resolve.py
@@ -19,7 +19,8 @@ from apps.catalog.resolve import (
 from apps.catalog.resolve._relationships import resolve_all_corporate_entity_locations
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.claims import build_relationship_claim
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -47,11 +48,9 @@ def pm(db):
 class TestResolveModel:
     def test_basic_resolution(self, pm, ipdb):
         ss = TechnologyGeneration.objects.create(name="Solid State", slug="solid-state")
-        Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=ipdb)
-        Claim.objects.assert_claim(pm, "year", 1997, source=ipdb)
-        Claim.objects.assert_claim(
-            pm, "technology_generation", "solid-state", source=ipdb
-        )
+        make_claim(pm, "name", "Medieval Madness", source=ipdb)
+        make_claim(pm, "year", 1997, source=ipdb)
+        make_claim(pm, "technology_generation", "solid-state", source=ipdb)
 
         resolved = resolve_model(pm)
         assert resolved.name == "Medieval Madness"
@@ -59,23 +58,23 @@ class TestResolveModel:
         assert resolved.technology_generation == ss
 
     def test_higher_priority_wins(self, pm, ipdb, editorial):
-        Claim.objects.assert_claim(pm, "name", "Test Game", source=ipdb)
-        Claim.objects.assert_claim(pm, "year", 1996, source=ipdb)
-        Claim.objects.assert_claim(pm, "year", 1997, source=editorial)
+        make_claim(pm, "name", "Test Game", source=ipdb)
+        make_claim(pm, "year", 1996, source=ipdb)
+        make_claim(pm, "year", 1997, source=editorial)
 
         resolved = resolve_model(pm)
         assert resolved.year == 1997  # editorial has higher priority
 
     def test_same_priority_latest_wins(self, pm, ipdb, opdb):
-        Claim.objects.assert_claim(pm, "name", "IPDB Name", source=ipdb)
-        Claim.objects.assert_claim(pm, "name", "OPDB Name", source=opdb)
+        make_claim(pm, "name", "IPDB Name", source=ipdb)
+        make_claim(pm, "name", "OPDB Name", source=opdb)
 
         resolved = resolve_model(pm)
         assert resolved.name == "OPDB Name"
 
     def test_extra_data_catchall(self, pm, ipdb):
-        Claim.objects.assert_claim(pm, "name", "Test Game", source=ipdb)
-        Claim.objects.assert_claim(pm, "model_number", "20021", source=ipdb)
+        make_claim(pm, "name", "Test Game", source=ipdb)
+        make_claim(pm, "model_number", "20021", source=ipdb)
 
         resolved = resolve_model(pm)
         assert resolved.extra_data["model_number"] == "20021"
@@ -83,19 +82,17 @@ class TestResolveModel:
     def test_abbreviation_relationship_claim(self, pm, ipdb):
         from apps.provenance.claims import build_relationship_claim
 
-        Claim.objects.assert_claim(pm, "name", "Test Game", source=ipdb)
+        make_claim(pm, "name", "Test Game", source=ipdb)
         claim_key, value = build_relationship_claim("abbreviation", {"value": "MM"})
-        Claim.objects.assert_claim(
-            pm, "abbreviation", value, source=ipdb, claim_key=claim_key
-        )
+        make_claim(pm, "abbreviation", value, source=ipdb, claim_key=claim_key)
 
         resolved = resolve_model(pm)
         assert list(resolved.abbreviations.values_list("value", flat=True)) == ["MM"]
 
     def test_int_coercion(self, pm, ipdb):
-        Claim.objects.assert_claim(pm, "name", "Test Game", source=ipdb)
-        Claim.objects.assert_claim(pm, "year", "1997", source=ipdb)
-        Claim.objects.assert_claim(pm, "player_count", "4", source=ipdb)
+        make_claim(pm, "name", "Test Game", source=ipdb)
+        make_claim(pm, "year", "1997", source=ipdb)
+        make_claim(pm, "player_count", "4", source=ipdb)
 
         resolved = resolve_model(pm)
         assert resolved.year == 1997
@@ -104,15 +101,15 @@ class TestResolveModel:
     def test_decimal_coercion(self, pm, ipdb):
         from decimal import Decimal
 
-        Claim.objects.assert_claim(pm, "name", "Test Game", source=ipdb)
-        Claim.objects.assert_claim(pm, "ipdb_rating", "8.75", source=ipdb)
+        make_claim(pm, "name", "Test Game", source=ipdb)
+        make_claim(pm, "ipdb_rating", "8.75", source=ipdb)
 
         resolved = resolve_model(pm)
         assert resolved.ipdb_rating == Decimal("8.75")
 
     def test_empty_string_coercion(self, pm, ipdb):
-        Claim.objects.assert_claim(pm, "name", "Test Game", source=ipdb)
-        Claim.objects.assert_claim(pm, "year", "", source=ipdb)
+        make_claim(pm, "name", "Test Game", source=ipdb)
+        make_claim(pm, "year", "", source=ipdb)
         resolved = resolve_model(pm)
         assert resolved.year is None
 
@@ -121,12 +118,12 @@ class TestResolveModel:
         from django.core.exceptions import ValidationError
 
         with pytest.raises(ValidationError, match="must be an integer"):
-            Claim.objects.assert_claim(pm, "year", "not-a-number", source=ipdb)
+            make_claim(pm, "year", "not-a-number", source=ipdb)
 
     def test_stale_values_cleared_on_re_resolve(self, pm, ipdb):
-        Claim.objects.assert_claim(pm, "name", "Test Game", source=ipdb)
-        Claim.objects.assert_claim(pm, "year", 1997, source=ipdb)
-        Claim.objects.assert_claim(pm, "player_count", 4, source=ipdb)
+        make_claim(pm, "name", "Test Game", source=ipdb)
+        make_claim(pm, "year", 1997, source=ipdb)
+        make_claim(pm, "player_count", 4, source=ipdb)
         resolve_model(pm)
         assert pm.year == 1997
         assert pm.player_count == 4
@@ -142,10 +139,10 @@ class TestResolveModel:
         assert pm.extra_data == {}
 
     def test_mixed_fields_and_extra_data(self, pm, ipdb, editorial):
-        Claim.objects.assert_claim(pm, "name", "The Addams Family", source=ipdb)
-        Claim.objects.assert_claim(pm, "year", 1992, source=ipdb)
-        Claim.objects.assert_claim(pm, "toys", "Thing hand, bookcase", source=ipdb)
-        Claim.objects.assert_claim(pm, "fun_facts", "A seminal game.", source=editorial)
+        make_claim(pm, "name", "The Addams Family", source=ipdb)
+        make_claim(pm, "year", 1992, source=ipdb)
+        make_claim(pm, "toys", "Thing hand, bookcase", source=ipdb)
+        make_claim(pm, "fun_facts", "A seminal game.", source=editorial)
 
         resolved = resolve_model(pm)
         assert resolved.name == "The Addams Family"
@@ -165,13 +162,11 @@ class TestResolveAll:
         pm2 = make_machine_model(name="P2", slug="p2")
         pm3 = make_machine_model(name="P3", slug="p3")
 
-        Claim.objects.assert_claim(pm1, "name", "Medieval Madness", source=ipdb)
-        Claim.objects.assert_claim(pm1, "year", 1997, source=ipdb)
-        Claim.objects.assert_claim(pm2, "name", "The Addams Family", source=ipdb)
-        Claim.objects.assert_claim(pm3, "name", "Twilight Zone", source=ipdb)
-        Claim.objects.assert_claim(
-            pm3, "technology_generation", "solid-state", source=ipdb
-        )
+        make_claim(pm1, "name", "Medieval Madness", source=ipdb)
+        make_claim(pm1, "year", 1997, source=ipdb)
+        make_claim(pm2, "name", "The Addams Family", source=ipdb)
+        make_claim(pm3, "name", "Twilight Zone", source=ipdb)
+        make_claim(pm3, "technology_generation", "solid-state", source=ipdb)
 
         before = timezone.now()
         count = resolve_machine_models()
@@ -200,7 +195,7 @@ class TestResolveAll:
         title = Title.objects.create(
             opdb_id="G1111", name="Medieval Madness", slug="mm"
         )
-        Claim.objects.assert_claim(title, "name", "Medieval Madness", source=ipdb)
+        make_claim(title, "name", "Medieval Madness", source=ipdb)
         TechnologyGeneration.objects.create(name="Solid State", slug="solid-state")
 
         pm_bulk = make_machine_model(name="P1", slug="p1", title=title)
@@ -211,15 +206,11 @@ class TestResolveAll:
         abbr_key, abbr_val = build_relationship_claim("abbreviation", {"value": "MM"})
 
         for pm in (pm_bulk, pm_single):
-            Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=ipdb)
-            Claim.objects.assert_claim(pm, "year", 1997, source=opdb)
-            Claim.objects.assert_claim(pm, "title", title.slug, source=opdb)
-            Claim.objects.assert_claim(
-                pm, "abbreviation", abbr_val, source=ipdb, claim_key=abbr_key
-            )
-            Claim.objects.assert_claim(
-                pm, "technology_generation", "solid-state", source=ipdb
-            )
+            make_claim(pm, "name", "Medieval Madness", source=ipdb)
+            make_claim(pm, "year", 1997, source=opdb)
+            make_claim(pm, "title", title.slug, source=opdb)
+            make_claim(pm, "abbreviation", abbr_val, source=ipdb, claim_key=abbr_key)
+            make_claim(pm, "technology_generation", "solid-state", source=ipdb)
 
         resolve_model(pm_single)
         pm_single.refresh_from_db()
@@ -240,10 +231,10 @@ class TestResolveAll:
         pm_a = make_machine_model(name="Alpha", slug="alpha")
         pm_b = make_machine_model(name="Beta", slug="beta")
 
-        Claim.objects.assert_claim(pm_a, "name", "Alpha", source=ipdb)
-        Claim.objects.assert_claim(pm_b, "name", "Beta", source=ipdb)
-        Claim.objects.assert_claim(pm_a, "opdb_id", "GCONFLICT-M1", source=ipdb)
-        Claim.objects.assert_claim(pm_b, "opdb_id", "GCONFLICT-M1", source=ipdb)
+        make_claim(pm_a, "name", "Alpha", source=ipdb)
+        make_claim(pm_b, "name", "Beta", source=ipdb)
+        make_claim(pm_a, "opdb_id", "GCONFLICT-M1", source=ipdb)
+        make_claim(pm_b, "opdb_id", "GCONFLICT-M1", source=ipdb)
 
         resolve_machine_models()
         pm_a.refresh_from_db()
@@ -258,9 +249,9 @@ class TestResolveAll:
         )
         pm = make_machine_model(name="P1", slug="p1")
 
-        Claim.objects.assert_claim(pm, "name", "P1", source=ipdb)
-        Claim.objects.assert_claim(pm, "year", 1997, source=ipdb)
-        Claim.objects.assert_claim(pm, "player_count", 4, source=ipdb)
+        make_claim(pm, "name", "P1", source=ipdb)
+        make_claim(pm, "year", 1997, source=ipdb)
+        make_claim(pm, "player_count", 4, source=ipdb)
         resolve_machine_models()
         pm.refresh_from_db()
         assert pm.year == 1997
@@ -282,8 +273,8 @@ class TestResolveAll:
         )
         for i in range(5):
             pm = make_machine_model(name=f"Model {i}", slug=f"model-{i}")
-            Claim.objects.assert_claim(pm, "name", f"Resolved {i}", source=ipdb)
-            Claim.objects.assert_claim(pm, "year", 2000 + i, source=ipdb)
+            make_claim(pm, "name", f"Resolved {i}", source=ipdb)
+            make_claim(pm, "year", 2000 + i, source=ipdb)
 
         with django_assert_max_num_queries(185):
             resolve_machine_models()
@@ -301,9 +292,7 @@ class TestResolveThemes:
 
         for theme in (horror, licensed):
             claim_key, value = build_relationship_claim("theme", {"theme": theme.pk})
-            Claim.objects.assert_claim(
-                pm, "theme", value, source=ipdb, claim_key=claim_key
-            )
+            make_claim(pm, "theme", value, source=ipdb, claim_key=claim_key)
 
         resolve_all_themes(subject_ids={pm.pk})
         assert set(pm.themes.values_list("slug", flat=True)) == {
@@ -323,13 +312,11 @@ class TestResolveThemes:
 
         # IPDB says horror, editorial disputes it.
         claim_key, value = build_relationship_claim("theme", {"theme": horror.pk})
-        Claim.objects.assert_claim(pm, "theme", value, source=ipdb, claim_key=claim_key)
+        make_claim(pm, "theme", value, source=ipdb, claim_key=claim_key)
         _, dispute_value = build_relationship_claim(
             "theme", {"theme": horror.pk}, exists=False
         )
-        Claim.objects.assert_claim(
-            pm, "theme", dispute_value, source=editorial, claim_key=claim_key
-        )
+        make_claim(pm, "theme", dispute_value, source=editorial, claim_key=claim_key)
 
         resolve_all_themes(subject_ids={pm.pk})
         assert pm.themes.count() == 0
@@ -342,7 +329,7 @@ class TestResolveThemes:
         horror = Theme.objects.create(name="Horror", slug="horror")
 
         claim_key, value = build_relationship_claim("theme", {"theme": horror.pk})
-        Claim.objects.assert_claim(pm, "theme", value, source=ipdb, claim_key=claim_key)
+        make_claim(pm, "theme", value, source=ipdb, claim_key=claim_key)
         resolve_all_themes(subject_ids={pm.pk})
         assert pm.themes.count() == 1
 
@@ -360,17 +347,15 @@ class TestResolveThemes:
         sports = Theme.objects.create(name="Sports", slug="sports")
         baseball = Theme.objects.create(name="Baseball", slug="baseball")
 
-        Claim.objects.assert_claim(pm1, "name", "P1", source=ipdb)
-        Claim.objects.assert_claim(pm2, "name", "P2", source=ipdb)
+        make_claim(pm1, "name", "P1", source=ipdb)
+        make_claim(pm2, "name", "P2", source=ipdb)
 
         for pm, themes in [(pm1, [sports, baseball]), (pm2, [sports])]:
             for theme in themes:
                 claim_key, value = build_relationship_claim(
                     "theme", {"theme": theme.pk}
                 )
-                Claim.objects.assert_claim(
-                    pm, "theme", value, source=ipdb, claim_key=claim_key
-                )
+                make_claim(pm, "theme", value, source=ipdb, claim_key=claim_key)
 
         resolve_machine_models()
         assert set(pm1.themes.values_list("slug", flat=True)) == {
@@ -393,8 +378,8 @@ class TestResolveSystem:
             name="Williams WPC-95", slug="wpc-95", manufacturer=mfr
         )
         pm = make_machine_model(name="Medieval Madness", slug="medieval-madness")
-        Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=ipdb)
-        Claim.objects.assert_claim(pm, "system", "wpc-95", source=ipdb)
+        make_claim(pm, "name", "Medieval Madness", source=ipdb)
+        make_claim(pm, "system", "wpc-95", source=ipdb)
 
         resolve_model(pm)
         pm.refresh_from_db()
@@ -405,8 +390,8 @@ class TestResolveSystem:
             name="IPDB", slug="ipdb", source_type="database", priority=10
         )
         pm = make_machine_model(name="Mystery Machine", slug="mystery-machine")
-        Claim.objects.assert_claim(pm, "name", "Mystery Machine", source=ipdb)
-        Claim.objects.assert_claim(pm, "system", "nonexistent-slug", source=ipdb)
+        make_claim(pm, "name", "Mystery Machine", source=ipdb)
+        make_claim(pm, "system", "nonexistent-slug", source=ipdb)
 
         resolve_model(pm)
         pm.refresh_from_db()
@@ -426,7 +411,7 @@ class TestResolveSystem:
             name="Medieval Madness", slug="medieval-madness", system=system
         )
         # Name claim but no system claim — system should be cleared after resolve.
-        Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=ipdb)
+        make_claim(pm, "name", "Medieval Madness", source=ipdb)
         resolve_model(pm)
         pm.refresh_from_db()
         assert pm.system is None
@@ -448,9 +433,7 @@ class TestResolveCorporateEntityLocations:
 
     def _assert_location(self, source, ce, loc):
         claim_key, value = build_relationship_claim("location", {"location": loc.pk})
-        Claim.objects.assert_claim(
-            ce, "location", value, source=source, claim_key=claim_key
-        )
+        make_claim(ce, "location", value, source=source, claim_key=claim_key)
 
     def test_creates_cel_from_active_claim(self, db):
         source = Source.objects.create(name="PB", source_type="editorial", priority=300)
@@ -484,9 +467,7 @@ class TestResolveCorporateEntityLocations:
         claim_key, value = build_relationship_claim(
             "location", {"location": loc.pk}, exists=False
         )
-        Claim.objects.assert_claim(
-            ce, "location", value, source=source, claim_key=claim_key
-        )
+        make_claim(ce, "location", value, source=source, claim_key=claim_key)
 
         resolve_all_corporate_entity_locations()
 
@@ -505,9 +486,7 @@ class TestResolveCorporateEntityLocations:
         claim_key, value = build_relationship_claim(
             "location", {"location": loc.pk}, exists=False
         )
-        Claim.objects.assert_claim(
-            ce, "location", value, source=source, claim_key=claim_key
-        )
+        make_claim(ce, "location", value, source=source, claim_key=claim_key)
         resolve_all_corporate_entity_locations()
 
         assert not CorporateEntityLocation.objects.filter(corporate_entity=ce).exists()
@@ -544,9 +523,7 @@ class TestResolveCorporateEntityLocations:
         claim_key, value = build_relationship_claim(
             "location", {"location": loc.pk}, exists=False
         )
-        Claim.objects.assert_claim(
-            ce, "location", value, source=editorial, claim_key=claim_key
-        )
+        make_claim(ce, "location", value, source=editorial, claim_key=claim_key)
 
         resolve_all_corporate_entity_locations()
 
@@ -585,8 +562,8 @@ class TestResolveEntitySlugConflictGuard:
             parent=oh,
         )
 
-        Claim.objects.assert_claim(target, "slug", "springfield", source=editorial)
-        Claim.objects.assert_claim(target, "name", "Springfield", source=editorial)
+        make_claim(target, "slug", "springfield", source=editorial)
+        make_claim(target, "name", "Springfield", source=editorial)
 
         # Bypass the dispatcher so the bug is reachable directly.
         resolve_entity(target)

--- a/backend/apps/catalog/tests/test_resolve_bulk.py
+++ b/backend/apps/catalog/tests/test_resolve_bulk.py
@@ -21,6 +21,7 @@ from apps.catalog.resolve import (
 from apps.catalog.tests.conftest import make_machine_model
 from apps.core.models import RecordReference
 from apps.provenance.models import Claim, Source, get_claim_fields
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -43,8 +44,8 @@ class TestResolveBulkTitle:
         t1 = Title.objects.create(opdb_id="G1", name="Title One", slug="t1")
         t2 = Title.objects.create(opdb_id="G2", name="Title Two", slug="t2")
 
-        Claim.objects.assert_claim(t1, "name", "Godzilla", source=opdb)
-        Claim.objects.assert_claim(t2, "name", "Blackout", source=opdb)
+        make_claim(t1, "name", "Godzilla", source=opdb)
+        make_claim(t2, "name", "Blackout", source=opdb)
 
         _resolve_bulk(Title, get_claim_fields(Title))
 
@@ -56,8 +57,8 @@ class TestResolveBulkTitle:
     def test_winner_by_priority(self, opdb, editorial):
         t = Title.objects.create(opdb_id="G1", name="Placeholder", slug="t1")
 
-        Claim.objects.assert_claim(t, "name", "Low Priority", source=opdb)
-        Claim.objects.assert_claim(t, "name", "High Priority", source=editorial)
+        make_claim(t, "name", "Low Priority", source=opdb)
+        make_claim(t, "name", "High Priority", source=editorial)
 
         _resolve_bulk(Title, get_claim_fields(Title))
 
@@ -70,7 +71,7 @@ class TestResolveBulkTitle:
         )
 
         # Name claim to satisfy the NOT-blank constraint; no description claim.
-        Claim.objects.assert_claim(t, "name", "Stale Name", source=opdb)
+        make_claim(t, "name", "Stale Name", source=opdb)
         _resolve_bulk(Title, get_claim_fields(Title))
 
         t.refresh_from_db()
@@ -82,8 +83,8 @@ class TestResolveBulkTitle:
         franchise = Franchise.objects.create(name="Godzilla", slug="godzilla")
         t = Title.objects.create(opdb_id="G1", name="Placeholder", slug="t1")
 
-        Claim.objects.assert_claim(t, "name", "Godzilla", source=opdb)
-        Claim.objects.assert_claim(t, "franchise", "godzilla", source=opdb)
+        make_claim(t, "name", "Godzilla", source=opdb)
+        make_claim(t, "franchise", "godzilla", source=opdb)
 
         resolve_all_entities(Title)
 
@@ -96,8 +97,8 @@ class TestResolveBulkTitle:
         series = Series.objects.create(name="Godzilla Line", slug="godzilla-line")
         t = Title.objects.create(opdb_id="G1", name="Placeholder", slug="t1")
 
-        Claim.objects.assert_claim(t, "name", "Godzilla", source=opdb)
-        Claim.objects.assert_claim(t, "series", "godzilla-line", source=opdb)
+        make_claim(t, "name", "Godzilla", source=opdb)
+        make_claim(t, "series", "godzilla-line", source=opdb)
 
         resolve_all_entities(Title)
 
@@ -113,7 +114,7 @@ class TestResolveBulkTitle:
         )
 
         # Name claim but no franchise claim — franchise should reset to None.
-        Claim.objects.assert_claim(t, "name", "Godzilla", source=opdb)
+        make_claim(t, "name", "Godzilla", source=opdb)
         resolve_all_entities(Title)
 
         t.refresh_from_db()
@@ -128,7 +129,7 @@ class TestResolveBulkTitle:
         )
 
         # Name claim but no series claim — series should reset to None.
-        Claim.objects.assert_claim(t, "name", "Godzilla", source=opdb)
+        make_claim(t, "name", "Godzilla", source=opdb)
         resolve_all_entities(Title)
 
         t.refresh_from_db()
@@ -138,7 +139,7 @@ class TestResolveBulkTitle:
         t1 = Title.objects.create(opdb_id="G1", name="Untouched", slug="t1")
         t2 = Title.objects.create(opdb_id="G2", name="Placeholder", slug="t2")
 
-        Claim.objects.assert_claim(t2, "name", "Resolved", source=opdb)
+        make_claim(t2, "name", "Resolved", source=opdb)
 
         # Only resolve t2.
         _resolve_bulk(Title, get_claim_fields(Title), object_ids={t2.pk})
@@ -152,7 +153,7 @@ class TestResolveBulkTitle:
         t = Title.objects.create(opdb_id="G1", name="Placeholder", slug="t1")
         old_updated_at = t.updated_at
 
-        Claim.objects.assert_claim(t, "name", "New Name", source=opdb)
+        make_claim(t, "name", "New Name", source=opdb)
         _resolve_bulk(Title, get_claim_fields(Title))
 
         t.refresh_from_db()
@@ -169,8 +170,8 @@ class TestResolveBulkManufacturer:
             manufacturer=m, name="Stern Pinball, Inc.", slug="stern-pinball-inc"
         )
 
-        Claim.objects.assert_claim(ce, "name", "Stern Pinball, Inc.", source=opdb)
-        Claim.objects.assert_claim(ce, "year_start", "1999", source=opdb)
+        make_claim(ce, "name", "Stern Pinball, Inc.", source=opdb)
+        make_claim(ce, "year_start", "1999", source=opdb)
 
         _resolve_bulk(
             CorporateEntity,
@@ -189,8 +190,8 @@ class TestResolveBulkMarkdownReferences:
         mfr = Manufacturer.objects.create(name="Williams", slug="williams")
         system = System.objects.create(name="WPC-95", slug="wpc-95", manufacturer=mfr)
 
-        Claim.objects.assert_claim(mfr, "name", "Williams", source=opdb)
-        Claim.objects.assert_claim(
+        make_claim(mfr, "name", "Williams", source=opdb)
+        make_claim(
             mfr,
             "description",
             f"Uses [[system:id:{system.pk}]].",
@@ -214,7 +215,7 @@ class TestResolveBulkMarkdownReferences:
         system = System.objects.create(name="WPC-95", slug="wpc-95", manufacturer=mfr)
 
         # First resolve with a link
-        Claim.objects.assert_claim(
+        make_claim(
             mfr,
             "description",
             f"Uses [[system:id:{system.pk}]].",
@@ -253,7 +254,7 @@ class TestResolveBulkUniqueFieldSafety:
         t2 = Theme.objects.create(name="Sports", slug="sports")
 
         # Only t1 gets a name claim; t2 has none.
-        Claim.objects.assert_claim(t1, "name", "Horror Movies", source=opdb)
+        make_claim(t1, "name", "Horror Movies", source=opdb)
 
         _resolve_bulk(Theme, get_claim_fields(Theme))
 
@@ -269,7 +270,7 @@ class TestResolveBulkUniqueFieldSafety:
         t = Theme.objects.create(name="Horror", slug="horror", description="Old desc")
 
         # Name claim but no description claim.
-        Claim.objects.assert_claim(t, "name", "Horror", source=opdb)
+        make_claim(t, "name", "Horror", source=opdb)
 
         _resolve_bulk(Theme, get_claim_fields(Theme))
 
@@ -283,7 +284,7 @@ class TestResolveBulkUniqueFieldSafety:
         t = Theme.objects.create(name="Horror", slug="horror", description="Old desc")
 
         # Description claim but no name claim.
-        Claim.objects.assert_claim(t, "description", "Scary stuff", source=opdb)
+        make_claim(t, "description", "Scary stuff", source=opdb)
 
         _resolve_single(t, get_claim_fields(Theme))
 
@@ -303,8 +304,8 @@ class TestResolveBulkUniqueFieldSafety:
         )
 
         # Both get only a description claim, no name claim.
-        Claim.objects.assert_claim(t_single, "description", "Scary stuff", source=opdb)
-        Claim.objects.assert_claim(t_bulk, "description", "Scary stuff", source=opdb)
+        make_claim(t_single, "description", "Scary stuff", source=opdb)
+        make_claim(t_bulk, "description", "Scary stuff", source=opdb)
 
         _resolve_single(t_single, get_claim_fields(Theme))
         t_single.save()
@@ -348,7 +349,7 @@ class TestPreserveNotNullFK:
         )
 
         # Name claim but no technology_generation claim.
-        Claim.objects.assert_claim(subgen, "name", "Discrete Logic", source=opdb)
+        make_claim(subgen, "name", "Discrete Logic", source=opdb)
 
         _resolve_bulk(
             TechnologySubgeneration,
@@ -373,7 +374,7 @@ class TestPreserveNotNullFK:
             name="Discrete Logic", slug="discrete-logic", technology_generation=gen
         )
 
-        Claim.objects.assert_claim(subgen, "name", "Discrete Logic", source=opdb)
+        make_claim(subgen, "name", "Discrete Logic", source=opdb)
 
         _resolve_single(subgen, subgen_fields)
         subgen.save()
@@ -395,8 +396,8 @@ class TestPreserveNotNullFK:
             name="Discrete Logic", slug="discrete-logic", technology_generation=gen1
         )
 
-        Claim.objects.assert_claim(subgen, "name", "Discrete Logic", source=opdb)
-        Claim.objects.assert_claim(subgen, "technology_generation", "em", source=opdb)
+        make_claim(subgen, "name", "Discrete Logic", source=opdb)
+        make_claim(subgen, "technology_generation", "em", source=opdb)
 
         _resolve_bulk(
             TechnologySubgeneration,
@@ -416,9 +417,9 @@ class TestResolveBulkTaxonomy:
 
         tag = Tag.objects.create(name="Test Tag", slug="test-tag")
 
-        Claim.objects.assert_claim(tag, "name", "Test Tag", source=opdb)
+        make_claim(tag, "name", "Test Tag", source=opdb)
         with pytest.raises(ValidationError, match="must be an integer"):
-            Claim.objects.assert_claim(tag, "display_order", "abc", source=opdb)
+            make_claim(tag, "display_order", "abc", source=opdb)
 
 
 @pytest.mark.django_db
@@ -427,9 +428,9 @@ class TestResolveTitle:
         franchise = Franchise.objects.create(name="Godzilla", slug="godzilla")
         t = Title.objects.create(opdb_id="G1", name="Placeholder", slug="t1")
 
-        Claim.objects.assert_claim(t, "name", "Godzilla", source=opdb)
-        Claim.objects.assert_claim(t, "description", "A monster game.", source=opdb)
-        Claim.objects.assert_claim(t, "franchise", "godzilla", source=opdb)
+        make_claim(t, "name", "Godzilla", source=opdb)
+        make_claim(t, "description", "A monster game.", source=opdb)
+        make_claim(t, "franchise", "godzilla", source=opdb)
 
         result = resolve_entity(t)
 
@@ -441,9 +442,9 @@ class TestResolveTitle:
         series = Series.objects.create(name="Godzilla Line", slug="godzilla-line")
         t = Title.objects.create(opdb_id="G1", name="Placeholder", slug="t1")
 
-        Claim.objects.assert_claim(t, "name", "Godzilla", source=opdb)
-        Claim.objects.assert_claim(t, "description", "A monster game.", source=opdb)
-        Claim.objects.assert_claim(t, "series", "godzilla-line", source=opdb)
+        make_claim(t, "name", "Godzilla", source=opdb)
+        make_claim(t, "description", "A monster game.", source=opdb)
+        make_claim(t, "series", "godzilla-line", source=opdb)
 
         result = resolve_entity(t)
 
@@ -458,7 +459,7 @@ class TestResolveTitle:
         )
 
         # Only a name claim, no franchise.
-        Claim.objects.assert_claim(t, "name", "Godzilla", source=opdb)
+        make_claim(t, "name", "Godzilla", source=opdb)
         result = resolve_entity(t)
 
         assert result.franchise is None
@@ -470,7 +471,7 @@ class TestResolveTitle:
         )
 
         # Only a name claim, no series.
-        Claim.objects.assert_claim(t, "name", "Godzilla", source=opdb)
+        make_claim(t, "name", "Godzilla", source=opdb)
         result = resolve_entity(t)
 
         assert result.series is None
@@ -491,11 +492,11 @@ class TestSlugConflictDetection:
         t1 = Title.objects.create(name="First", slug="target-slug")
         t2 = Title.objects.create(name="Second", slug="original-slug")
 
-        Claim.objects.assert_claim(t1, "name", "First", source=opdb)
-        Claim.objects.assert_claim(t1, "slug", "target-slug", source=opdb)
-        Claim.objects.assert_claim(t2, "name", "Second", source=opdb)
+        make_claim(t1, "name", "First", source=opdb)
+        make_claim(t1, "slug", "target-slug", source=opdb)
+        make_claim(t2, "name", "Second", source=opdb)
         # t2 claims the same slug as t1.
-        Claim.objects.assert_claim(t2, "slug", "target-slug", source=opdb)
+        make_claim(t2, "slug", "target-slug", source=opdb)
 
         _resolve_bulk(Title, title_fields_with_slug)
 
@@ -509,10 +510,10 @@ class TestSlugConflictDetection:
         t1 = Title.objects.create(name="Changer", slug="alpha")
         t2 = Title.objects.create(name="Preserver", slug="beta")
 
-        Claim.objects.assert_claim(t1, "name", "Changer", source=opdb)
+        make_claim(t1, "name", "Changer", source=opdb)
         # t1 claims t2's slug — t1 is the changer.
-        Claim.objects.assert_claim(t1, "slug", "beta", source=opdb)
-        Claim.objects.assert_claim(t2, "name", "Preserver", source=opdb)
+        make_claim(t1, "slug", "beta", source=opdb)
+        make_claim(t2, "name", "Preserver", source=opdb)
         # t2 has no slug claim — preserved by preserve_when_unclaimed.
 
         _resolve_bulk(Title, title_fields_with_slug)
@@ -526,10 +527,10 @@ class TestSlugConflictDetection:
         t1 = Title.objects.create(name="First", slug="slug-a")
         t2 = Title.objects.create(name="Second", slug="slug-b")
 
-        Claim.objects.assert_claim(t1, "name", "First", source=opdb)
-        Claim.objects.assert_claim(t1, "slug", "slug-a", source=opdb)
-        Claim.objects.assert_claim(t2, "name", "Second", source=opdb)
-        Claim.objects.assert_claim(t2, "slug", "slug-b", source=opdb)
+        make_claim(t1, "name", "First", source=opdb)
+        make_claim(t1, "slug", "slug-a", source=opdb)
+        make_claim(t2, "name", "Second", source=opdb)
+        make_claim(t2, "slug", "slug-b", source=opdb)
 
         _resolve_bulk(Title, title_fields_with_slug)
 
@@ -543,8 +544,8 @@ class TestSlugConflictDetection:
         Title.objects.create(name="Owner", slug="taken-slug")
         t2 = Title.objects.create(name="Challenger", slug="original-slug")
 
-        Claim.objects.assert_claim(t2, "name", "Challenger", source=opdb)
-        Claim.objects.assert_claim(t2, "slug", "taken-slug", source=opdb)
+        make_claim(t2, "name", "Challenger", source=opdb)
+        make_claim(t2, "slug", "taken-slug", source=opdb)
 
         # Use explicit fields so this test is independent of claim-field discovery.
         fields = get_claim_fields(Title)
@@ -556,8 +557,8 @@ class TestSlugConflictDetection:
         # resolve_entity handles this; _resolve_single doesn't check DB.
         # So test via resolve_entity instead.
         t2 = Title.objects.get(pk=t2.pk)  # re-fetch clean
-        Claim.objects.assert_claim(t2, "name", "Challenger", source=opdb)
-        Claim.objects.assert_claim(t2, "slug", "taken-slug", source=opdb)
+        make_claim(t2, "name", "Challenger", source=opdb)
+        make_claim(t2, "slug", "taken-slug", source=opdb)
 
         # resolve_entity checks DB for slug conflict and reverts.
         result = resolve_entity(t2)
@@ -570,7 +571,7 @@ class TestApplyResolutionPreserve:
 
     def test_preserves_slug_without_claim(self, opdb):
         mm = make_machine_model(name="Test", slug="test-slug")
-        Claim.objects.assert_claim(mm, "name", "Test Model", source=opdb)
+        make_claim(mm, "name", "Test Model", source=opdb)
         # No slug claim — slug should be preserved after resolution.
 
         resolve_model(mm)
@@ -581,7 +582,7 @@ class TestApplyResolutionPreserve:
 
     def test_preserves_opdb_id_without_claim(self, opdb):
         mm = make_machine_model(name="Test", slug="test-slug", opdb_id="O123")
-        Claim.objects.assert_claim(mm, "name", "Test Model", source=opdb)
+        make_claim(mm, "name", "Test Model", source=opdb)
         # No opdb_id claim.
 
         resolve_model(mm)
@@ -592,8 +593,8 @@ class TestApplyResolutionPreserve:
     def test_bulk_preserves_slug_without_claim(self, opdb):
         mm1 = make_machine_model(name="A", slug="a-slug")
         mm2 = make_machine_model(name="B", slug="b-slug")
-        Claim.objects.assert_claim(mm1, "name", "Model A", source=opdb)
-        Claim.objects.assert_claim(mm2, "name", "Model B", source=opdb)
+        make_claim(mm1, "name", "Model A", source=opdb)
+        make_claim(mm2, "name", "Model B", source=opdb)
         # No slug claims — both should preserve their slugs.
 
         resolve_machine_models()

--- a/backend/apps/catalog/tests/test_resolve_credits.py
+++ b/backend/apps/catalog/tests/test_resolve_credits.py
@@ -8,6 +8,7 @@ from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.claims import build_relationship_claim
 from apps.provenance.models import Claim, Source
 from apps.provenance.resolution import resolve_after_mutation, resolve_entities_bulk
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -50,9 +51,7 @@ def _assert_credit_claim(subject, person_pk, role_slug, source, *, exists=True):
     claim_key, value = build_relationship_claim(
         "credit", {"person": person_pk, "role": role.pk}, exists=exists
     )
-    Claim.objects.assert_claim(
-        subject, "credit", value, source=source, claim_key=claim_key
-    )
+    make_claim(subject, "credit", value, source=source, claim_key=claim_key)
 
 
 class TestResolveCredits:
@@ -115,9 +114,7 @@ class TestResolveCredits:
         claim_key, value = build_relationship_claim(
             "credit", {"person": person.pk, "role": design_role.pk}, exists=False
         )
-        Claim.objects.assert_claim(
-            machine, "credit", value, source=high_source, claim_key=claim_key
-        )
+        make_claim(machine, "credit", value, source=high_source, claim_key=claim_key)
         resolve_all_credits(subject_ids={machine.pk})
 
         assert Credit.objects.filter(model=machine).count() == 0
@@ -131,9 +128,7 @@ class TestResolveCredits:
         claim_key, value = build_relationship_claim(
             "credit", {"person": person2.pk, "role": art_role.pk}
         )
-        Claim.objects.assert_claim(
-            machine, "credit", value, source=high_source, claim_key=claim_key
-        )
+        make_claim(machine, "credit", value, source=high_source, claim_key=claim_key)
         resolve_all_credits(subject_ids={machine.pk})
 
         assert Credit.objects.filter(model=machine).count() == 2
@@ -144,9 +139,7 @@ class TestResolveCredits:
         claim_key, value = build_relationship_claim(
             "credit", {"person": 99999, "role": design_role.pk}
         )
-        Claim.objects.assert_claim(
-            machine, "credit", value, source=source, claim_key=claim_key
-        )
+        make_claim(machine, "credit", value, source=source, claim_key=claim_key)
         resolve_all_credits(subject_ids={machine.pk})
 
         assert Credit.objects.filter(model=machine).count() == 0

--- a/backend/apps/catalog/tests/test_resolve_dispatch.py
+++ b/backend/apps/catalog/tests/test_resolve_dispatch.py
@@ -16,8 +16,9 @@ from apps.catalog.models import (
 )
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.claims import build_relationship_claim
-from apps.provenance.models import Claim, ClaimControlledModel, Source
+from apps.provenance.models import ClaimControlledModel, Source
 from apps.provenance.resolution import resolve_after_mutation
+from apps.provenance.test_factories import make_claim
 from apps.provenance.validation import get_relationship_schema
 
 # ---------------------------------------------------------------------------
@@ -131,10 +132,8 @@ class TestLiteralSchemasAutoPopulated:
 class TestMachineModelRouting:
     def test_scalars_resolved(self, pm, source):
         ss = TechnologyGeneration.objects.create(name="Solid State", slug="solid-state")
-        Claim.objects.assert_claim(pm, "name", "Test Machine", source=source)
-        Claim.objects.assert_claim(
-            pm, "technology_generation", "solid-state", source=source
-        )
+        make_claim(pm, "name", "Test Machine", source=source)
+        make_claim(pm, "technology_generation", "solid-state", source=source)
 
         resolve_after_mutation(pm, field_names=["name", "technology_generation"])
 
@@ -143,10 +142,10 @@ class TestMachineModelRouting:
         assert pm.technology_generation == ss
 
     def test_m2m_resolved(self, pm, source):
-        Claim.objects.assert_claim(pm, "name", "Test Machine", source=source)
+        make_claim(pm, "name", "Test Machine", source=source)
         theme = Theme.objects.create(name="Adventure", slug="adventure")
         ck, val = build_relationship_claim("theme", {"theme": theme.pk})
-        Claim.objects.assert_claim(pm, "theme", val, source=source, claim_key=ck)
+        make_claim(pm, "theme", val, source=source, claim_key=ck)
 
         resolve_after_mutation(pm, field_names=["name", "theme"])
 
@@ -156,7 +155,7 @@ class TestMachineModelRouting:
 @pytest.mark.django_db
 class TestScalarResolution:
     def test_non_machine_model_scalars(self, theme, source):
-        Claim.objects.assert_claim(theme, "name", "Updated Theme", source=source)
+        make_claim(theme, "name", "Updated Theme", source=source)
 
         resolve_after_mutation(theme, field_names=["name"])
 
@@ -168,9 +167,7 @@ class TestScalarResolution:
 class TestAliasDispatch:
     def test_theme_alias(self, theme, source):
         ck, val = build_relationship_claim("theme_alias", {"alias_value": "test-alias"})
-        Claim.objects.assert_claim(
-            theme, "theme_alias", val, source=source, claim_key=ck
-        )
+        make_claim(theme, "theme_alias", val, source=source, claim_key=ck)
 
         resolve_after_mutation(theme, field_names=["theme_alias"])
 
@@ -180,9 +177,7 @@ class TestAliasDispatch:
         ck, val = build_relationship_claim(
             "manufacturer_alias", {"alias_value": "mfr-alias"}
         )
-        Claim.objects.assert_claim(
-            manufacturer, "manufacturer_alias", val, source=source, claim_key=ck
-        )
+        make_claim(manufacturer, "manufacturer_alias", val, source=source, claim_key=ck)
 
         resolve_after_mutation(manufacturer, field_names=["manufacturer_alias"])
 
@@ -196,9 +191,7 @@ class TestParentDispatch:
         child_theme = Theme.objects.create(name="Child", slug="child")
 
         ck, val = build_relationship_claim("theme_parent", {"parent": parent_theme.pk})
-        Claim.objects.assert_claim(
-            child_theme, "theme_parent", val, source=source, claim_key=ck
-        )
+        make_claim(child_theme, "theme_parent", val, source=source, claim_key=ck)
 
         resolve_after_mutation(child_theme, field_names=["theme_parent"])
 
@@ -208,11 +201,9 @@ class TestParentDispatch:
 @pytest.mark.django_db
 class TestCustomDispatch:
     def test_abbreviation(self, title, source):
-        Claim.objects.assert_claim(title, "name", title.name, source=source)
+        make_claim(title, "name", title.name, source=source)
         ck, val = build_relationship_claim("abbreviation", {"value": "TST"})
-        Claim.objects.assert_claim(
-            title, "abbreviation", val, source=source, claim_key=ck
-        )
+        make_claim(title, "abbreviation", val, source=source, claim_key=ck)
 
         resolve_after_mutation(title, field_names=["abbreviation"])
 
@@ -234,7 +225,7 @@ class TestEntityTypeGuard:
 @pytest.mark.django_db
 class TestFieldNamesNone:
     def test_resolves_scalars(self, theme, source):
-        Claim.objects.assert_claim(theme, "name", "Fallback Theme", source=source)
+        make_claim(theme, "name", "Fallback Theme", source=source)
 
         resolve_after_mutation(theme, field_names=None)
 
@@ -245,9 +236,7 @@ class TestFieldNamesNone:
         ck, val = build_relationship_claim(
             "theme_alias", {"alias_value": "fallback-alias"}
         )
-        Claim.objects.assert_claim(
-            theme, "theme_alias", val, source=source, claim_key=ck
-        )
+        make_claim(theme, "theme_alias", val, source=source, claim_key=ck)
 
         resolve_after_mutation(theme, field_names=None)
 

--- a/backend/apps/catalog/tests/test_resolve_manufacturer_person.py
+++ b/backend/apps/catalog/tests/test_resolve_manufacturer_person.py
@@ -4,7 +4,8 @@ import pytest
 
 from apps.catalog.models import Manufacturer, Person
 from apps.catalog.resolve import resolve_entity
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -31,22 +32,22 @@ def person(db):
 
 class TestResolveManufacturer:
     def test_basic_resolution(self, mfr, ipdb):
-        Claim.objects.assert_claim(mfr, "name", "Williams", source=ipdb)
+        make_claim(mfr, "name", "Williams", source=ipdb)
 
         resolved = resolve_entity(mfr)
         assert resolved.name == "Williams"
 
     def test_higher_priority_wins(self, mfr, ipdb, editorial):
-        Claim.objects.assert_claim(mfr, "name", "Williams Low", source=ipdb)
-        Claim.objects.assert_claim(mfr, "name", "Williams High", source=editorial)
+        make_claim(mfr, "name", "Williams Low", source=ipdb)
+        make_claim(mfr, "name", "Williams High", source=editorial)
 
         resolved = resolve_entity(mfr)
         assert resolved.name == "Williams High"
 
     def test_deactivated_claim_is_not_applied(self, mfr, ipdb):
-        Claim.objects.assert_claim(mfr, "description", "Old desc", source=ipdb)
+        make_claim(mfr, "description", "Old desc", source=ipdb)
         # Supersede it.
-        Claim.objects.assert_claim(mfr, "description", "New desc", source=ipdb)
+        make_claim(mfr, "description", "New desc", source=ipdb)
 
         resolved = resolve_entity(mfr)
         assert resolved.description == "New desc"
@@ -62,7 +63,7 @@ class TestResolveManufacturer:
 
     def test_all_claims_removed_field_blanked(self, mfr, ipdb):
         """Deactivating all claims for a field blanks it on the next resolve."""
-        Claim.objects.assert_claim(mfr, "description", "Old bio", source=ipdb)
+        make_claim(mfr, "description", "Old bio", source=ipdb)
         resolve_entity(mfr)
         assert mfr.description == "Old bio"
 
@@ -73,7 +74,7 @@ class TestResolveManufacturer:
         assert mfr.description == ""  # blanked — no active claims remain
 
     def test_saves_to_db(self, mfr, ipdb):
-        Claim.objects.assert_claim(mfr, "name", "Bally", source=ipdb)
+        make_claim(mfr, "name", "Bally", source=ipdb)
         resolve_entity(mfr)
         mfr.refresh_from_db()
         assert mfr.name == "Bally"
@@ -81,21 +82,17 @@ class TestResolveManufacturer:
 
 class TestResolvePerson:
     def test_basic_resolution(self, person, ipdb):
-        Claim.objects.assert_claim(person, "name", "Pat Lawlor", source=ipdb)
-        Claim.objects.assert_claim(
-            person, "description", "Designer of TAF.", source=ipdb
-        )
+        make_claim(person, "name", "Pat Lawlor", source=ipdb)
+        make_claim(person, "description", "Designer of TAF.", source=ipdb)
 
         resolved = resolve_entity(person)
         assert resolved.name == "Pat Lawlor"
         assert resolved.description == "Designer of TAF."
 
     def test_higher_priority_wins(self, person, ipdb, editorial):
-        Claim.objects.assert_claim(person, "name", "Pat Lawlor", source=ipdb)
-        Claim.objects.assert_claim(person, "description", "Short bio.", source=ipdb)
-        Claim.objects.assert_claim(
-            person, "description", "Better bio.", source=editorial
-        )
+        make_claim(person, "name", "Pat Lawlor", source=ipdb)
+        make_claim(person, "description", "Short bio.", source=ipdb)
+        make_claim(person, "description", "Better bio.", source=editorial)
 
         resolved = resolve_entity(person)
         assert resolved.description == "Better bio."
@@ -106,12 +103,12 @@ class TestResolvePerson:
         person.save()
 
         # Name claim required to satisfy the non-blank constraint.
-        Claim.objects.assert_claim(person, "name", "Placeholder Person", source=ipdb)
+        make_claim(person, "name", "Placeholder Person", source=ipdb)
         resolved = resolve_entity(person)
         assert resolved.description == ""
 
     def test_saves_to_db(self, person, ipdb):
-        Claim.objects.assert_claim(person, "name", "Steve Ritchie", source=ipdb)
+        make_claim(person, "name", "Steve Ritchie", source=ipdb)
         resolve_entity(person)
         person.refresh_from_db()
         assert person.name == "Steve Ritchie"

--- a/backend/apps/catalog/tests/test_resolve_parents.py
+++ b/backend/apps/catalog/tests/test_resolve_parents.py
@@ -3,7 +3,8 @@ import pytest
 from apps.catalog.models import GameplayFeature
 from apps.catalog.resolve._relationships import resolve_gameplay_feature_parents
 from apps.provenance.claims import build_relationship_claim
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -28,7 +29,7 @@ class TestResolveGameplayFeatureParents:
         claim_key, value = build_relationship_claim(
             "gameplay_feature_parent", {"parent": parent.pk}
         )
-        Claim.objects.assert_claim(
+        make_claim(
             child,
             "gameplay_feature_parent",
             value,

--- a/backend/apps/catalog/tests/test_soft_delete_walker.py
+++ b/backend/apps/catalog/tests/test_soft_delete_walker.py
@@ -25,7 +25,8 @@ from apps.catalog.models import (
     Theme,
     Title,
 )
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 pytestmark = pytest.mark.django_db
 
@@ -45,7 +46,7 @@ def _title(
     label = name or slug.replace("-", " ").title()
     t = Title.objects.create(name=label, slug=slug, status=status)
     if source is not None:
-        Claim.objects.assert_claim(t, "name", label, source=source)
+        make_claim(t, "name", label, source=source)
     return t
 
 
@@ -66,7 +67,7 @@ def _model(
         variant_of=variant_of,
     )
     if source is not None:
-        Claim.objects.assert_claim(m, "name", label, source=source)
+        make_claim(m, "name", label, source=source)
     return m
 
 

--- a/backend/apps/catalog/tests/test_soft_delete_walker.py
+++ b/backend/apps/catalog/tests/test_soft_delete_walker.py
@@ -25,19 +25,9 @@ from apps.catalog.models import (
     Theme,
     Title,
 )
-from apps.provenance.models import Source
 from apps.provenance.test_factories import make_claim
 
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    """Low-priority source used to seed name claims so the resolver doesn't
-    blank the ``name`` column when a status claim is written during delete."""
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
 
 
 def _title(

--- a/backend/apps/catalog/tests/test_source_enabled.py
+++ b/backend/apps/catalog/tests/test_source_enabled.py
@@ -18,8 +18,8 @@ from apps.catalog.resolve._relationships import resolve_all_credits
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.claims import build_relationship_claim
 from apps.provenance.helpers import active_claims
-from apps.provenance.models import Claim, Source, get_claim_fields
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.models import Source, get_claim_fields
+from apps.provenance.test_factories import make_claim, user_changeset
 
 
 @pytest.fixture
@@ -41,7 +41,7 @@ class TestIsEnabledResolveSingle:
     def test_disabled_source_excluded_from_resolution(self, source_a):
         """Claims from a disabled source should not participate in resolution."""
         mfr = Manufacturer.objects.create(name="Test Mfr", slug="test-mfr")
-        Claim.objects.assert_claim(mfr, "name", "From Disabled", source=source_a)
+        make_claim(mfr, "name", "From Disabled", source=source_a)
 
         source_a.is_enabled = False
         source_a.save()
@@ -53,8 +53,8 @@ class TestIsEnabledResolveSingle:
     def test_disabled_source_fallback_to_enabled(self, source_a, source_b):
         """When the higher-priority source is disabled, the lower-priority one wins."""
         mfr = Manufacturer.objects.create(name="Test Mfr", slug="test-mfr")
-        Claim.objects.assert_claim(mfr, "name", "Low Priority", source=source_a)
-        Claim.objects.assert_claim(mfr, "name", "High Priority", source=source_b)
+        make_claim(mfr, "name", "Low Priority", source=source_a)
+        make_claim(mfr, "name", "High Priority", source=source_b)
 
         # With both enabled, source_b wins (priority 200 > 100).
         resolve_entity(mfr)
@@ -76,8 +76,8 @@ class TestIsEnabledResolveBulk:
         """Bulk resolution should skip claims from disabled sources."""
         t = Title.objects.create(opdb_id="G1", name="Test Title", slug="t1")
         # Name claim from source_b (stays enabled) so name satisfies constraint.
-        Claim.objects.assert_claim(t, "name", "Test Title", source=source_b)
-        Claim.objects.assert_claim(t, "description", "From Disabled", source=source_a)
+        make_claim(t, "name", "Test Title", source=source_b)
+        make_claim(t, "description", "From Disabled", source=source_a)
 
         source_a.is_enabled = False
         source_a.save()
@@ -90,8 +90,8 @@ class TestIsEnabledResolveBulk:
     def test_bulk_fallback_when_winner_disabled(self, source_a, source_b):
         """Bulk resolution falls back to enabled source when winner is disabled."""
         t = Title.objects.create(opdb_id="G1", name="Test Title", slug="t1")
-        Claim.objects.assert_claim(t, "name", "Low Priority", source=source_a)
-        Claim.objects.assert_claim(t, "name", "High Priority", source=source_b)
+        make_claim(t, "name", "Low Priority", source=source_a)
+        make_claim(t, "name", "High Priority", source=source_b)
 
         source_b.is_enabled = False
         source_b.save()
@@ -107,9 +107,7 @@ class TestIsEnabledUserClaims:
     def test_user_claims_unaffected_by_source_enabled(self, source_a, user):
         """User claims (source=None) should not be filtered by is_enabled."""
         mfr = Manufacturer.objects.create(name="Test Mfr", slug="test-mfr")
-        Claim.objects.assert_claim(
-            mfr, "name", "User Claim", user=user, changeset=user_changeset(user)
-        )
+        make_claim(mfr, "name", "User Claim", user=user, changeset=user_changeset(user))
 
         # Disable source_a (irrelevant — the claim is user-owned, not source-owned).
         source_a.is_enabled = False
@@ -128,7 +126,7 @@ class TestIsEnabledRelationshipResolution:
         pm = make_machine_model(name="Test", slug="test-pm")
 
         claim_key, value = build_relationship_claim("theme", {"theme": theme.pk})
-        Claim.objects.assert_claim(
+        make_claim(
             pm,
             "theme",
             value,
@@ -156,7 +154,7 @@ class TestIsEnabledRelationshipResolution:
         claim_key, value = build_relationship_claim(
             "credit", {"person": person.pk, "role": role.pk}
         )
-        Claim.objects.assert_claim(
+        make_claim(
             pm,
             "credit",
             value,
@@ -183,8 +181,8 @@ class TestIsEnabledSourcesPrefetch:
         from apps.provenance.helpers import claims_prefetch
 
         mfr = Manufacturer.objects.create(name="Test Mfr", slug="test-mfr")
-        Claim.objects.assert_claim(mfr, "name", "From A", source=source_a)
-        Claim.objects.assert_claim(mfr, "description", "From B", source=source_b)
+        make_claim(mfr, "name", "From A", source=source_a)
+        make_claim(mfr, "description", "From B", source=source_b)
 
         source_a.is_enabled = False
         source_a.save()

--- a/backend/apps/catalog/tests/test_status.py
+++ b/backend/apps/catalog/tests/test_status.py
@@ -13,7 +13,8 @@ from apps.claim_ingest.plan import (
     PlannedClaimAssert,
     PlannedEntityCreate,
 )
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 from apps.provenance.validation import validate_claim_value
 
 pytestmark = pytest.mark.django_db
@@ -181,7 +182,7 @@ class TestStatusResolution:
     def test_status_resolved_from_claim(self, test_source):
         """Status field is resolved from claims like any other scalar."""
         mfr = Manufacturer.objects.create(name="Bally", slug="bally")
-        Claim.objects.assert_claim(mfr, "status", "active", source=test_source)
+        make_claim(mfr, "status", "active", source=test_source)
 
         from apps.catalog.resolve._entities import resolve_all_entities
 

--- a/backend/apps/claim_edit/claim_write.py
+++ b/backend/apps/claim_edit/claim_write.py
@@ -25,6 +25,7 @@ from django.db import IntegrityError, transaction
 
 from apps.accounts.models import User
 from apps.core.exceptions import StructuredValidationError
+from apps.provenance.changeset_writer import record_changeset
 from apps.provenance.claim_writer import _assert_claim
 from apps.provenance.models import (
     ChangeSet,
@@ -214,7 +215,6 @@ def _write_claims_in_changeset(
     entity: ClaimControlledModel,
     specs: list[ClaimSpec],
     *,
-    user: User,
     changeset: ChangeSet,
 ) -> list[Claim]:
     """Assert claims on *entity* inside an already-open *changeset*.
@@ -222,6 +222,7 @@ def _write_claims_in_changeset(
     Does not open a transaction, create a ChangeSet, attach citations, or
     resolve. The caller is responsible for all of that. Returns the list of
     newly-created active Claim rows so the caller can attach citations.
+    Attribution rides on ``changeset.actor``.
     """
     created_claims: list[Claim] = []
     for spec in specs:
@@ -230,7 +231,6 @@ def _write_claims_in_changeset(
                 entity,
                 spec.field_name,
                 spec.value,
-                user=user,
                 claim_key=spec.claim_key,
                 changeset=changeset,
             )
@@ -284,10 +284,8 @@ def execute_claims(
     auth_user = _narrow_to_user(user)
     try:
         with transaction.atomic():
-            cs = ChangeSet.objects.create(user=auth_user, action=action, note=note)
-            created_claims = _write_claims_in_changeset(
-                entity, specs, user=auth_user, changeset=cs
-            )
+            cs = record_changeset(actor=auth_user.actor, action=action, note=note)
+            created_claims = _write_claims_in_changeset(entity, specs, changeset=cs)
             _attach_citation(created_claims, citation)
             field_names = list({s.field_name for s in specs})
             resolve_after_mutation(entity, field_names=field_names)
@@ -322,15 +320,13 @@ def execute_multi_entity_claims(
     auth_user = _narrow_to_user(user)
     try:
         with transaction.atomic():
-            cs = ChangeSet.objects.create(user=auth_user, action=action, note=note)
+            cs = record_changeset(actor=auth_user.actor, action=action, note=note)
             all_created: list[Claim] = []
             per_entity_fields: list[tuple[ClaimControlledModel, list[str]]] = []
             for entity, specs in entries:
                 if not specs:
                     continue
-                created = _write_claims_in_changeset(
-                    entity, specs, user=auth_user, changeset=cs
-                )
+                created = _write_claims_in_changeset(entity, specs, changeset=cs)
                 all_created.extend(created)
                 per_entity_fields.append((entity, list({s.field_name for s in specs})))
             _attach_citation(all_created, citation)

--- a/backend/apps/claim_edit/claim_write.py
+++ b/backend/apps/claim_edit/claim_write.py
@@ -25,6 +25,7 @@ from django.db import IntegrityError, transaction
 
 from apps.accounts.models import User
 from apps.core.exceptions import StructuredValidationError
+from apps.provenance.claim_writer import _assert_claim
 from apps.provenance.models import (
     ChangeSet,
     ChangeSetAction,
@@ -225,7 +226,7 @@ def _write_claims_in_changeset(
     created_claims: list[Claim] = []
     for spec in specs:
         created_claims.append(
-            Claim.objects.assert_claim(
+            _assert_claim(
                 entity,
                 spec.field_name,
                 spec.value,

--- a/backend/apps/claim_ingest/apply/persist.py
+++ b/backend/apps/claim_ingest/apply/persist.py
@@ -414,7 +414,12 @@ def _link_to_changesets[K](
     ChangeSet, stamped ``retracted_by_changeset``.
     """
     for claim in to_create:
-        claim.changeset_id = group_to_cs[claim_group(claim)].pk
+        cs = group_to_cs[claim_group(claim)]
+        claim.changeset_id = cs.pk
+        # Denormalized copy of the ChangeSet's actor (the source of truth), so
+        # each bulk Claim's actor matches its ChangeSet's — same invariant the
+        # interactive path gets from ``changeset.actor``.
+        claim.actor_id = cs.actor_id
     if to_create:
         Claim.objects.bulk_create(to_create, batch_size=2000)
 
@@ -459,7 +464,8 @@ def _persist_per_entry(
         {claim_idx(c) for c in to_create} | {retract_idx(e) for e in retract_entries}
     )
     changesets = [
-        ChangeSet(ingest_run=run, note=entry_notes.get(idx, "")) for idx in ordered
+        ChangeSet(ingest_run=run, actor=run.source.actor, note=entry_notes.get(idx, ""))
+        for idx in ordered
     ]
     ChangeSet.objects.bulk_create(changesets)
     idx_to_cs = dict(zip(ordered, changesets, strict=True))

--- a/backend/apps/core/tests/test_admin_dashboard_page.py
+++ b/backend/apps/core/tests/test_admin_dashboard_page.py
@@ -15,8 +15,12 @@ from django.utils import timezone
 from apps.accounts.models import User
 from apps.accounts.test_factories import make_user
 from apps.media.models import MediaAsset
-from apps.provenance.models import ChangeSet, IngestRun, Source
-from apps.provenance.test_factories import ingest_changeset, user_changeset
+from apps.provenance.models import ChangeSet, Source
+from apps.provenance.test_factories import (
+    ingest_changeset,
+    ingest_run,
+    user_changeset,
+)
 
 DASHBOARD_URL = "/api/pages/admin/dashboard/"
 
@@ -130,7 +134,7 @@ class TestEditsMetric:
         source = Source.objects.create(
             name="TestSource", slug="test-source", priority=10
         )
-        run = IngestRun.objects.create(source=source, input_fingerprint="fp-1")
+        run = ingest_run(source)
         ingest_changeset(run)
         ingest_changeset(run)
 

--- a/backend/apps/media/api.py
+++ b/backend/apps/media/api.py
@@ -19,7 +19,7 @@ from ninja.security import django_auth
 
 from apps.accounts.models import User
 from apps.catalog.claims import build_media_attachment_claim
-from apps.catalog.resolve import resolve_media_attachments
+from apps.claim_edit.claim_write import ClaimSpec, execute_claims
 from apps.core.api_helpers import authed_user
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -58,37 +58,39 @@ from apps.media.storage import (
     delete_from_storage,
     upload_to_storage,
 )
-from apps.provenance.claim_writer import _assert_claim
-from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
+from apps.provenance.models import ChangeSetAction
 
 logger = logging.getLogger(__name__)
 
 media_router = Router(tags=["media", "private"])
 
 
-def _assert_media_claim(
+def _write_media_claim(
     entity: MediaSupportedModel,
     *,
     claim_key: str,
     claim_value: object,
     user: User,
-) -> Claim:
-    """Assert a ``media_attachment`` claim inside a fresh user ChangeSet.
+) -> None:
+    """Write a ``media_attachment`` claim for *entity* through the single path.
 
-    Every media mutation is one user action, so it gets its own
-    ``action=EDIT`` ChangeSet — the single attribution path through
-    provenance. Callers must already hold a ``transaction.atomic()`` block so
-    the ChangeSet and claim commit together. See docs/plans/auth/Actors.md
-    ("Fix Media Claims").
+    Every media mutation is one user action, so it gets its own ``action=EDIT``
+    ChangeSet. ``execute_claims`` is the single non-ingest mint caller: it opens
+    that ChangeSet, mints the claim and resolves the entity. Resolution needs no
+    media-specific call — the generic ``resolve_after_mutation`` dispatch already
+    routes ``media_attachment`` to the media resolver. Callers stay inside their
+    own ``transaction.atomic()`` block for asset/storage orchestration;
+    ``execute_claims`` nests a savepoint within it. See docs/plans/auth/Actors.md.
     """
-    changeset = ChangeSet.objects.create(user=user, action=ChangeSetAction.EDIT)
-    return _assert_claim(
+    execute_claims(
         entity,
-        "media_attachment",
-        claim_value,
+        [
+            ClaimSpec(
+                field_name="media_attachment", value=claim_value, claim_key=claim_key
+            )
+        ],
         user=user,
-        claim_key=claim_key,
-        changeset=changeset,
+        action=ChangeSetAction.EDIT,
     )
 
 
@@ -204,7 +206,9 @@ def upload_media(
         raise HttpError(400, f"File exceeds maximum size of {size_mb} MB.")
 
     # --- Resolve entity and validate category ---
-    ct, entity = _resolve_entity(entity_type, public_id)
+    # ``_ct``: upload resolves via execute_claims, so the ContentType the other
+    # endpoints use for their EntityMedia lookup is unused here.
+    _ct, entity = _resolve_entity(entity_type, public_id)
     try:
         # Validate category early (asset_pk=0 is a placeholder — only category
         # validation runs here; the real claim is built after asset creation).
@@ -292,12 +296,8 @@ def upload_media(
                 category=category,
                 is_primary=False,
             )
-            _assert_media_claim(
+            _write_media_claim(
                 entity, claim_key=claim_key, claim_value=claim_value, user=user
-            )
-            resolve_media_attachments(
-                content_type_id=ct.id,
-                subject_ids={entity.pk},
             )
     except Exception:
         logger.exception("DB transaction failed, cleaning up storage keys")
@@ -360,12 +360,8 @@ def detach_media(request: HttpRequest, body: MediaAssetInputSchema) -> Status[No
             asset.pk,
             exists=False,
         )
-        _assert_media_claim(
+        _write_media_claim(
             entity, claim_key=claim_key, claim_value=claim_value, user=user
-        )
-        resolve_media_attachments(
-            content_type_id=ct.id,
-            subject_ids={entity.pk},
         )
         asset.delete()
         if storage_keys:
@@ -407,12 +403,8 @@ def set_primary(request: HttpRequest, body: MediaAssetInputSchema) -> Status[Non
             category=em.category,
             is_primary=True,
         )
-        _assert_media_claim(
+        _write_media_claim(
             entity, claim_key=claim_key, claim_value=claim_value, user=user
-        )
-        resolve_media_attachments(
-            content_type_id=ct.id,
-            subject_ids={entity.pk},
         )
 
     return Status(204, None)
@@ -463,12 +455,8 @@ def set_category(
         except ValueError as exc:
             raise HttpError(400, str(exc)) from exc
 
-        _assert_media_claim(
+        _write_media_claim(
             entity, claim_key=claim_key, claim_value=claim_value, user=user
-        )
-        resolve_media_attachments(
-            content_type_id=ct.id,
-            subject_ids={entity.pk},
         )
 
     return Status(204, None)

--- a/backend/apps/media/api.py
+++ b/backend/apps/media/api.py
@@ -24,6 +24,7 @@ from apps.core.api_helpers import authed_user
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
 from apps.core.entity_types import get_linkable_model
+from apps.core.exceptions import StructuredValidationError
 from apps.core.schemas import ErrorDetailSchema, ValidationErrorSchema
 from apps.media.constants import (
     ALLOWED_IMAGE_EXTENSIONS,
@@ -167,7 +168,11 @@ def _resolve_entity(
 
 @media_router.post(
     "/upload/",
-    response={200: UploadSchema, 429: ErrorDetailSchema},
+    response={
+        200: UploadSchema,
+        422: ValidationErrorSchema,
+        429: ErrorDetailSchema,
+    },
     auth=django_auth,
 )
 @requires(Activity.MEDIA_EDIT)
@@ -299,6 +304,12 @@ def upload_media(
             _write_media_claim(
                 entity, claim_key=claim_key, claim_value=claim_value, user=user
             )
+    except StructuredValidationError:
+        # A client-fault claim failure (constraint/validation) — clean up the
+        # blobs uploaded before the atomic block, then re-raise so Ninja's
+        # handler maps it to a 422, matching the other media endpoints.
+        delete_from_storage(uploaded_keys)
+        raise
     except Exception:
         logger.exception("DB transaction failed, cleaning up storage keys")
         delete_from_storage(uploaded_keys)

--- a/backend/apps/media/api.py
+++ b/backend/apps/media/api.py
@@ -58,6 +58,7 @@ from apps.media.storage import (
     delete_from_storage,
     upload_to_storage,
 )
+from apps.provenance.claim_writer import _assert_claim
 from apps.provenance.models import ChangeSet, ChangeSetAction, Claim
 
 logger = logging.getLogger(__name__)
@@ -81,7 +82,7 @@ def _assert_media_claim(
     ("Fix Media Claims").
     """
     changeset = ChangeSet.objects.create(user=user, action=ChangeSetAction.EDIT)
-    return Claim.objects.assert_claim(
+    return _assert_claim(
         entity,
         "media_attachment",
         claim_value,

--- a/backend/apps/media/tests/test_detach.py
+++ b/backend/apps/media/tests/test_detach.py
@@ -13,7 +13,7 @@ from apps.catalog.tests.conftest import make_machine_model
 from apps.media.models import EntityMedia, MediaAsset, MediaRendition
 from apps.media.storage import build_storage_key
 from apps.provenance.models import Claim
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -64,7 +64,7 @@ def _attach_via_claims(entity, asset, user, category="backglass", is_primary=Tru
     claim_key, claim_value = build_media_attachment_claim(
         entity, asset.pk, category=category, is_primary=is_primary
     )
-    Claim.objects.assert_claim(
+    make_claim(
         entity,
         "media_attachment",
         claim_value,

--- a/backend/apps/media/tests/test_media_claims.py
+++ b/backend/apps/media/tests/test_media_claims.py
@@ -14,8 +14,8 @@ from apps.catalog.claims import build_media_attachment_claim
 from apps.catalog.models import MachineModel
 from apps.catalog.tests.conftest import make_machine_model
 from apps.media.models import EntityMedia, MediaAsset
-from apps.provenance.models import Claim, Source
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -30,7 +30,7 @@ def _assert_claim(subject, field_name, value, *, user=None, source=None, claim_k
     calls pass through unchanged.
     """
     changeset = user_changeset(user) if user is not None else None
-    return Claim.objects.assert_claim(
+    return make_claim(
         subject,
         field_name,
         value,

--- a/backend/apps/media/tests/test_media_single_path_characterization.py
+++ b/backend/apps/media/tests/test_media_single_path_characterization.py
@@ -1,0 +1,239 @@
+"""Characterization of media mutations across the single-write-path reroute.
+
+Pins the observable behavior of the four media endpoints (upload / detach /
+set-primary / set-category) before and after they are rerouted through
+``execute_claims`` (Actors v1, "Save actor FKs" PR, commit 2). The reroute drops
+media's bespoke ``resolve_media_attachments`` call in favor of the generic
+``resolve_after_mutation`` dispatch; this suite must stay green across the change,
+proving the materialized result (``EntityMedia`` rows, primary flag, category)
+and the entity's own scalar columns are unperturbed.
+
+Both resolve-dispatch branches are exercised: a MachineModel target (the
+full-re-resolution ``resolve_model`` path) and a Manufacturer target (the
+``_resolve_non_machine_model`` path). Entities are seeded so every scalar field
+is claim-backed — modeling production, where re-resolution is a no-op — so the
+scalar-snapshot assertion isolates "the wider re-resolution perturbs nothing".
+
+The error path is pinned separately (per-endpoint status) in
+``test_media_single_path_errors`` once the reroute lands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Model
+from django.test import Client
+
+from apps.catalog.models import Manufacturer
+from apps.catalog.tests.conftest import make_machine_model
+from apps.media.models import EntityMedia, MediaAsset
+from apps.provenance.models import CitationInstance, Source
+from apps.provenance.test_factories import make_claim
+
+_TEST_STORAGE = {
+    "default": {"BACKEND": "django.core.files.storage.InMemoryStorage"},
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    },
+}
+
+UPLOAD_URL = "/api/media/upload/"
+DETACH_URL = "/api/media/detach/"
+SET_PRIMARY_URL = "/api/media/set-primary/"
+SET_CATEGORY_URL = "/api/media/set-category/"
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _media_settings(settings):
+    settings.STORAGES = _TEST_STORAGE
+    settings.MEDIA_PUBLIC_BASE_URL = "https://test-media.example.com/"
+    from django.core.cache import cache
+
+    cache.clear()
+
+
+@pytest.fixture
+def client(user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+@dataclass(frozen=True)
+class MediaTarget:
+    """A media-supported entity plus the two categories its tests use."""
+
+    entity: Model
+    entity_type: str
+    public_id: str
+    cat1: str
+    cat2: str
+
+
+def _bootstrap_source() -> Source:
+    src, _ = Source.objects.get_or_create(
+        slug="bootstrap",
+        defaults={"name": "Bootstrap", "source_type": "editorial", "priority": 1},
+    )
+    return src
+
+
+@pytest.fixture(params=["model", "manufacturer"])
+def target(request, db) -> MediaTarget:
+    """A resolution-stable media target, parametrized over both dispatch branches.
+
+    ``model`` exercises ``resolve_model`` (ignores field_names, full re-resolve);
+    ``manufacturer`` exercises ``_resolve_non_machine_model`` (always re-resolves
+    scalars). Both are seeded so every scalar claim field is backed, so the
+    post-reroute scalar re-resolution is a no-op and the snapshot assertion
+    measures only "media mutation didn't perturb the row".
+    """
+    if request.param == "model":
+        mm = make_machine_model(name="Char Machine", slug="char-machine")
+        return MediaTarget(mm, "model", mm.public_id, "backglass", "playfield")
+
+    src = _bootstrap_source()
+    mfr = Manufacturer.objects.create(name="Char Mfr", slug="char-mfr", status="active")
+    # Back every scalar that re-resolution would otherwise normalize away.
+    make_claim(mfr, "name", "Char Mfr", source=src)
+    make_claim(mfr, "slug", "char-mfr", source=src)
+    make_claim(mfr, "status", "active", source=src)
+    return MediaTarget(mfr, "manufacturer", mfr.public_id, "logo", "other")
+
+
+def _image(name: str = "test.jpg") -> BytesIO:
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (100, 100), color="red").save(buf, format="JPEG")
+    buf.seek(0)
+    buf.name = name
+    return buf
+
+
+def _scalar_snapshot(entity: Model) -> dict[str, object]:
+    """Semantic column values of the entity row (FKs as ``*_id``), reloaded.
+
+    Excludes auto-timestamps: routing media through the unified resolver now
+    re-saves the entity row (bumping ``updated_at``), which is a benign
+    consequence of full re-resolution, not a semantic change. The snapshot
+    isolates claim-resolved state so it can assert the media mutation perturbs
+    nothing else.
+    """
+    entity.refresh_from_db()
+    return {
+        f.attname: getattr(entity, f.attname)
+        for f in entity._meta.local_concrete_fields
+        if not getattr(f, "auto_now", False) and not getattr(f, "auto_now_add", False)
+    }
+
+
+def _upload(client: Client, target: MediaTarget, category: str) -> MediaAsset:
+    resp = client.post(
+        UPLOAD_URL,
+        data={
+            "file": _image(),
+            "entity_type": target.entity_type,
+            "public_id": target.public_id,
+            "category": category,
+        },
+    )
+    assert resp.status_code == 200, resp.content
+    return MediaAsset.objects.latest("pk")
+
+
+def _entity_media(target: MediaTarget) -> EntityMedia:
+    ct = ContentType.objects.get_for_model(type(target.entity))
+    return EntityMedia.objects.get(content_type=ct, object_id=target.entity.pk)
+
+
+def _entity_media_for(target: MediaTarget, asset: MediaAsset) -> EntityMedia:
+    ct = ContentType.objects.get_for_model(type(target.entity))
+    return EntityMedia.objects.get(
+        content_type=ct, object_id=target.entity.pk, asset=asset
+    )
+
+
+class TestMediaSinglePathCharacterization:
+    def test_upload_materializes_entity_media(self, client, target):
+        before = _scalar_snapshot(target.entity)
+
+        asset = _upload(client, target, target.cat1)
+
+        em = _entity_media(target)
+        assert em.asset_id == asset.pk
+        assert em.category == target.cat1
+        assert em.is_primary is True  # sole attachment in its category
+        # A media mutation never attaches a citation.
+        assert (
+            CitationInstance.objects.filter(
+                claim__field_name="media_attachment"
+            ).count()
+            == 0
+        )
+        assert _scalar_snapshot(target.entity) == before
+
+    def test_set_primary_promotes_second_asset(self, client, target):
+        _upload(client, target, target.cat1)
+        asset2 = _upload(client, target, target.cat1)
+        before = _scalar_snapshot(target.entity)
+
+        resp = client.post(
+            SET_PRIMARY_URL,
+            data={
+                "entity_type": target.entity_type,
+                "public_id": target.public_id,
+                "asset_uuid": str(asset2.uuid),
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 204, resp.content
+
+        assert _entity_media_for(target, asset2).is_primary is True
+        assert _scalar_snapshot(target.entity) == before
+
+    def test_set_category_moves_asset(self, client, target):
+        asset = _upload(client, target, target.cat1)
+        before = _scalar_snapshot(target.entity)
+
+        resp = client.post(
+            SET_CATEGORY_URL,
+            data={
+                "entity_type": target.entity_type,
+                "public_id": target.public_id,
+                "asset_uuid": str(asset.uuid),
+                "category": target.cat2,
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 204, resp.content
+
+        assert _entity_media_for(target, asset).category == target.cat2
+        assert _scalar_snapshot(target.entity) == before
+
+    def test_detach_removes_entity_media(self, client, target):
+        asset = _upload(client, target, target.cat1)
+        before = _scalar_snapshot(target.entity)
+
+        resp = client.post(
+            DETACH_URL,
+            data={
+                "entity_type": target.entity_type,
+                "public_id": target.public_id,
+                "asset_uuid": str(asset.uuid),
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 204, resp.content
+
+        ct = ContentType.objects.get_for_model(type(target.entity))
+        assert not EntityMedia.objects.filter(
+            content_type=ct, object_id=target.entity.pk, asset=asset
+        ).exists()
+        assert _scalar_snapshot(target.entity) == before

--- a/backend/apps/media/tests/test_media_single_path_errors.py
+++ b/backend/apps/media/tests/test_media_single_path_errors.py
@@ -1,16 +1,15 @@
-"""Per-endpoint error contract after media is rerouted through execute_claims.
+"""Uniform per-endpoint error contract for media writes through execute_claims.
 
-Routing media writes through ``execute_claims`` changes how a claim-write failure
-surfaces, and it differs by endpoint:
+All four media endpoints surface a client-fault claim-write failure
+(``execute_claims``'s ``StructuredValidationError``, raised on ``IntegrityError``
+/ ``ValidationError``) as a 422:
 
 - ``detach`` / ``set-primary`` / ``set-category`` have no try/except around their
-  atomic block, so ``execute_claims``'s ``StructuredValidationError`` (raised on
-  ``IntegrityError`` / ``ValidationError``) propagates to Ninja as a 422. Before
-  the reroute these raised an unhandled 500.
-- ``upload`` wraps its DB work in ``try/except Exception`` so it can delete the
-  storage blobs it already uploaded; that broad ``except`` catches the
-  ``StructuredValidationError`` and re-wraps it as a 500. (Surfacing 422 from
-  upload while keeping storage cleanup is a later commit.)
+  atomic block, so it propagates straight to Ninja's 422 handler.
+- ``upload`` wraps its DB work so it can delete the storage blobs it already
+  uploaded; a dedicated ``except StructuredValidationError`` cleans up and
+  re-raises (→ 422), while the broad ``except Exception`` still maps an
+  unexpected failure to a 500 (also cleaning up).
 
 A forced mint failure pins both behaviors.
 """
@@ -147,10 +146,16 @@ class TestMutationEndpointsReturn422:
         assert resp.status_code == 422, resp.content
 
 
-class TestUploadReWrapsTo500:
-    def test_upload_returns_500_and_cleans_up_storage(
+class TestUploadSurfaces422:
+    def test_upload_returns_422_and_cleans_up_storage(
         self, client, machine_model, monkeypatch
     ):
+        """A client-fault claim failure surfaces as 422, blobs still cleaned up.
+
+        Upload's storage-cleanup ``except`` no longer masks the
+        ``StructuredValidationError`` as a 500 — it cleans up and re-raises, so
+        the error contract matches the other three endpoints.
+        """
         deleted: list[list[str]] = []
 
         def record_delete(keys):
@@ -169,7 +174,7 @@ class TestUploadReWrapsTo500:
             },
         )
 
-        assert resp.status_code == 500, resp.content
-        # The broad except cleaned up the blobs uploaded before the failure.
+        assert resp.status_code == 422, resp.content
+        # The dedicated except still cleaned up the blobs uploaded before the failure.
         assert deleted, "delete_from_storage was not called on failure"
         assert deleted[-1], "uploaded storage keys were not cleaned up"

--- a/backend/apps/media/tests/test_media_single_path_errors.py
+++ b/backend/apps/media/tests/test_media_single_path_errors.py
@@ -1,0 +1,175 @@
+"""Per-endpoint error contract after media is rerouted through execute_claims.
+
+Routing media writes through ``execute_claims`` changes how a claim-write failure
+surfaces, and it differs by endpoint:
+
+- ``detach`` / ``set-primary`` / ``set-category`` have no try/except around their
+  atomic block, so ``execute_claims``'s ``StructuredValidationError`` (raised on
+  ``IntegrityError`` / ``ValidationError``) propagates to Ninja as a 422. Before
+  the reroute these raised an unhandled 500.
+- ``upload`` wraps its DB work in ``try/except Exception`` so it can delete the
+  storage blobs it already uploaded; that broad ``except`` catches the
+  ``StructuredValidationError`` and re-wraps it as a 500. (Surfacing 422 from
+  upload while keeping storage cleanup is a later commit.)
+
+A forced mint failure pins both behaviors.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+from django.db import IntegrityError
+from django.test import Client
+
+from apps.catalog.tests.conftest import make_machine_model
+from apps.media.models import MediaAsset
+
+_TEST_STORAGE = {
+    "default": {"BACKEND": "django.core.files.storage.InMemoryStorage"},
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    },
+}
+
+UPLOAD_URL = "/api/media/upload/"
+DETACH_URL = "/api/media/detach/"
+SET_PRIMARY_URL = "/api/media/set-primary/"
+SET_CATEGORY_URL = "/api/media/set-category/"
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _media_settings(settings):
+    settings.STORAGES = _TEST_STORAGE
+    settings.MEDIA_PUBLIC_BASE_URL = "https://test-media.example.com/"
+    from django.core.cache import cache
+
+    cache.clear()
+
+
+@pytest.fixture
+def client(user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+@pytest.fixture
+def machine_model(db):
+    return make_machine_model(name="Err Machine", slug="err-machine")
+
+
+def _image() -> BytesIO:
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (100, 100), color="red").save(buf, format="JPEG")
+    buf.seek(0)
+    buf.name = "test.jpg"
+    return buf
+
+
+def _upload(client: Client, machine_model, category: str = "backglass") -> MediaAsset:
+    resp = client.post(
+        UPLOAD_URL,
+        data={
+            "file": _image(),
+            "entity_type": "model",
+            "public_id": machine_model.public_id,
+            "category": category,
+        },
+    )
+    assert resp.status_code == 200, resp.content
+    return MediaAsset.objects.latest("pk")
+
+
+def _break_mint(monkeypatch) -> None:
+    """Force the claim-mint primitive execute_claims uses to raise IntegrityError.
+
+    Patches the name as bound into ``claim_write`` (where execute_claims looks it
+    up), so execute_claims's IntegrityError→StructuredValidationError translation
+    runs.
+    """
+
+    def boom(*args, **kwargs):
+        raise IntegrityError("forced mint failure")
+
+    monkeypatch.setattr("apps.claim_edit.claim_write._assert_claim", boom)
+
+
+class TestMutationEndpointsReturn422:
+    """The three endpoints with no storage-cleanup wrapper surface a 422."""
+
+    def test_detach_returns_422(self, client, machine_model, monkeypatch):
+        asset = _upload(client, machine_model)
+        _break_mint(monkeypatch)
+        resp = client.post(
+            DETACH_URL,
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 422, resp.content
+
+    def test_set_primary_returns_422(self, client, machine_model, monkeypatch):
+        asset = _upload(client, machine_model)
+        _break_mint(monkeypatch)
+        resp = client.post(
+            SET_PRIMARY_URL,
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 422, resp.content
+
+    def test_set_category_returns_422(self, client, machine_model, monkeypatch):
+        asset = _upload(client, machine_model, category="backglass")
+        _break_mint(monkeypatch)
+        resp = client.post(
+            SET_CATEGORY_URL,
+            data={
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "asset_uuid": str(asset.uuid),
+                "category": "playfield",
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 422, resp.content
+
+
+class TestUploadReWrapsTo500:
+    def test_upload_returns_500_and_cleans_up_storage(
+        self, client, machine_model, monkeypatch
+    ):
+        deleted: list[list[str]] = []
+
+        def record_delete(keys):
+            deleted.append(list(keys))
+
+        monkeypatch.setattr("apps.media.api.delete_from_storage", record_delete)
+        _break_mint(monkeypatch)
+
+        resp = client.post(
+            UPLOAD_URL,
+            data={
+                "file": _image(),
+                "entity_type": "model",
+                "public_id": machine_model.public_id,
+                "category": "backglass",
+            },
+        )
+
+        assert resp.status_code == 500, resp.content
+        # The broad except cleaned up the blobs uploaded before the failure.
+        assert deleted, "delete_from_storage was not called on failure"
+        assert deleted[-1], "uploaded storage keys were not cleaned up"

--- a/backend/apps/media/tests/test_set_category.py
+++ b/backend/apps/media/tests/test_set_category.py
@@ -11,8 +11,7 @@ from apps.catalog.claims import build_media_attachment_claim
 from apps.catalog.resolve import resolve_media_attachments
 from apps.catalog.tests.conftest import make_machine_model
 from apps.media.models import EntityMedia, MediaAsset
-from apps.provenance.models import Claim
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -41,7 +40,7 @@ def _attach_via_claims(entity, asset, user, category="backglass", is_primary=Fal
     claim_key, claim_value = build_media_attachment_claim(
         entity, asset.pk, category=category, is_primary=is_primary
     )
-    Claim.objects.assert_claim(
+    make_claim(
         entity,
         "media_attachment",
         claim_value,

--- a/backend/apps/media/tests/test_set_primary.py
+++ b/backend/apps/media/tests/test_set_primary.py
@@ -10,8 +10,7 @@ from apps.catalog.claims import build_media_attachment_claim
 from apps.catalog.resolve import resolve_media_attachments
 from apps.catalog.tests.conftest import make_machine_model
 from apps.media.models import EntityMedia, MediaAsset
-from apps.provenance.models import Claim
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -48,7 +47,7 @@ def _attach_via_claims(entity, asset, user, category="backglass", is_primary=Fal
     claim_key, claim_value = build_media_attachment_claim(
         entity, asset.pk, category=category, is_primary=is_primary
     )
-    Claim.objects.assert_claim(
+    make_claim(
         entity,
         "media_attachment",
         claim_value,

--- a/backend/apps/provenance/changeset_writer.py
+++ b/backend/apps/provenance/changeset_writer.py
@@ -1,0 +1,72 @@
+"""The actor-first ChangeSet funnel, ``record_changeset``.
+
+Every interactive (user) ChangeSet is minted here, so attribution is set in
+exactly one place: ``actor`` is always populated, and the legacy ``user``
+column is filled from ``actor.user`` as the single transitional bridge (it
+retires at "Drop dead schema", where ``action IFF user`` becomes
+``action IFF ingest_run IS NULL``).
+
+Production ingest does **not** funnel through here — it bulk-creates ChangeSets
+directly in ``claim_ingest/apply/persist.py`` (a sanctioned bulk path). The
+ingest branch below exists only so the test factories (``ingest_changeset`` /
+``source_changeset``) can encode the same actor invariant through one seam. The
+bulk path's actor guarantee comes from that module plus the AST persistence
+guard and the cross-table invariant test, not from this funnel.
+
+Sits at the ``validation`` tier of the provenance internal stack: it imports
+only ``models.ChangeSet`` at runtime, so its importers — ``revert``, the
+``claim_edit`` engine and the test factories — all reach it as a clean downward
+edge.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from apps.provenance.models import ChangeSet
+
+if TYPE_CHECKING:
+    from apps.actors.models import Actor
+    from apps.provenance.models import ChangeSetAction, IngestRun
+
+
+def record_changeset(
+    *,
+    actor: Actor,
+    action: ChangeSetAction | None = None,
+    ingest_run: IngestRun | None = None,
+    note: str = "",
+) -> ChangeSet:
+    """Create an attributed ChangeSet, always stamping ``actor``.
+
+    Two shapes, discriminated by ``ingest_run``:
+
+    * **interactive** (``ingest_run is None``): an ``action`` is required and the
+      ``actor`` must be user-backed. The legacy ``user`` column is set from
+      ``actor.user`` — the single point that bridges to the pre-actor schema.
+    * **ingest** (``ingest_run`` given): ``action`` must be ``None`` (ingest
+      ChangeSets never carry one) and ``actor`` must be the run's source actor.
+
+    ``actor`` is a required keyword arg; callers convert at the boundary
+    (``user.actor`` / ``run.source.actor``) so this layer speaks ``actor`` only.
+    """
+    if ingest_run is None:
+        if action is None:
+            raise ValueError("An interactive ChangeSet requires an action.")
+        # Reverse one-to-one: ``RelatedObjectDoesNotExist`` subclasses
+        # AttributeError, so getattr returns None for a non-user actor.
+        user = getattr(actor, "user", None)
+        if user is None:
+            raise ValueError(
+                "An interactive ChangeSet requires a user-backed actor; "
+                f"got a {actor.backing_model!r} actor."
+            )
+        return ChangeSet.objects.create(
+            actor=actor, user=user, action=action, note=note
+        )
+
+    if action is not None:
+        raise ValueError("Ingest ChangeSets never carry an action.")
+    if actor.pk != ingest_run.source.actor_id:
+        raise ValueError("Ingest ChangeSet actor must be the run's source actor.")
+    return ChangeSet.objects.create(actor=actor, ingest_run=ingest_run, note=note)

--- a/backend/apps/provenance/claim_writer.py
+++ b/backend/apps/provenance/claim_writer.py
@@ -1,0 +1,123 @@
+"""The single claim-mint primitive, ``_assert_claim``.
+
+It's one of two sanctioned places a ``Claim`` is persisted (the other being
+the bulk ingest path in ``claim_ingest/apply/persist.py``).
+
+Why here instead of on a custom manager?  Because in the provenance app's internal
+stack, this function lives above ``models`` and ``validation``; a module-level function keeps
+the chokepoint nameable by the import graph, and lets ``validation`` import at
+module scope (a clean downward edge) instead of the lazy import a manager method
+on ``models.claim`` would be forced into.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+
+from apps.provenance.models import ChangeSet, Claim, ClaimControlledModel, Source
+from apps.provenance.validation import (
+    DIRECT,
+    RELATIONSHIP,
+    UNRECOGNIZED,
+    classify_claim,
+    validate_claim_value,
+    validate_single_relationship_claim,
+)
+
+if TYPE_CHECKING:
+    from apps.accounts.models import User
+    from apps.core.models import License
+
+
+def _assert_claim(
+    subject: ClaimControlledModel,
+    field_name: str,
+    value: object,
+    citation: str = "",
+    *,
+    source: Source | None = None,
+    user: User | None = None,
+    claim_key: str = "",
+    license: License | None = None,
+    changeset: ChangeSet | None = None,
+) -> Claim:
+    """Create a claim, deactivating any existing active claim for the same claim_key+author.
+
+    ``subject`` can be any model instance (MachineModel, Manufacturer, Person, …).
+    Exactly one of ``source`` or ``user`` must be provided.
+    ``claim_key`` defaults to ``field_name`` for scalar claims.
+    ``license`` is an optional per-claim License override (null inherits from source).
+    ``changeset`` groups this claim with others; it is **required** for
+    user-attributed claims (every user write is an attributed ChangeSet)
+    and optional for source-attributed (ingest) claims.
+    Runs in a transaction to ensure the old claim is deactivated atomically.
+    """
+    if (source is None) == (user is None):
+        raise ValueError("Exactly one of source or user must be provided.")
+    if user is not None and changeset is None:
+        raise ValueError(
+            "A user-attributed claim requires a changeset "
+            "(every user write must be an attributed ChangeSet)."
+        )
+    if changeset is not None:
+        if (
+            user is not None
+            and changeset.user is not None
+            and changeset.user.pk != user.pk
+        ):
+            raise ValueError("ChangeSet user must match the claim user.")
+        ingest_run = changeset.ingest_run
+        if source is not None and (
+            ingest_run is None or ingest_run.source.pk != source.pk
+        ):
+            raise ValueError(
+                "ChangeSet must belong to an IngestRun from the same source."
+            )
+    if not claim_key:
+        claim_key = field_name
+
+    # Classify and validate. DIRECT claims get scalar/FK validation.
+    # RELATIONSHIP claims get shape validation. EXTRA claims pass through.
+    # UNRECOGNIZED claims are rejected outright.
+    model_class = type(subject)
+    ct_result = classify_claim(model_class, field_name, claim_key, value)
+    if ct_result == UNRECOGNIZED:
+        raise ValueError(
+            f"Unrecognized claim field_name {field_name!r} on {model_class.__name__}"
+        )
+    if ct_result == DIRECT:
+        value = validate_claim_value(field_name, value, model_class)
+    elif ct_result == RELATIONSHIP:
+        validate_single_relationship_claim(
+            subject_model=model_class,
+            field_name=field_name,
+            claim_key=claim_key,
+            value=value,
+        )
+
+    ct = ContentType.objects.get_for_model(subject)
+    with transaction.atomic():
+        Claim.objects.filter(
+            content_type=ct,
+            object_id=subject.pk,
+            source=source,
+            user=user,
+            claim_key=claim_key,
+            is_active=True,
+        ).update(is_active=False)
+
+        return Claim.objects.create(
+            content_type=ct,
+            object_id=subject.pk,
+            source=source,
+            user=user,
+            field_name=field_name,
+            claim_key=claim_key,
+            value=value,
+            citation=citation,
+            license=license,
+            changeset=changeset,
+        )

--- a/backend/apps/provenance/claim_writer.py
+++ b/backend/apps/provenance/claim_writer.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
-from apps.provenance.models import ChangeSet, Claim, ClaimControlledModel, Source
+from apps.provenance.models import Claim, ClaimControlledModel
 from apps.provenance.validation import (
     DIRECT,
     RELATIONSHIP,
@@ -28,8 +28,8 @@ from apps.provenance.validation import (
 )
 
 if TYPE_CHECKING:
-    from apps.accounts.models import User
     from apps.core.models import License
+    from apps.provenance.models import ChangeSet
 
 
 def _assert_claim(
@@ -38,44 +38,20 @@ def _assert_claim(
     value: object,
     citation: str = "",
     *,
-    source: Source | None = None,
-    user: User | None = None,
+    changeset: ChangeSet,
     claim_key: str = "",
     license: License | None = None,
-    changeset: ChangeSet | None = None,
 ) -> Claim:
     """Create a claim, deactivating any existing active claim for the same claim_key+author.
 
     ``subject`` can be any model instance (MachineModel, Manufacturer, Person, …).
-    Exactly one of ``source`` or ``user`` must be provided.
+    Attribution comes from the (required) ``changeset``: ``changeset.actor`` is
+    the source of truth, and the matching legacy author column
+    (``Claim.user`` / ``Claim.source``) is stamped from it.
     ``claim_key`` defaults to ``field_name`` for scalar claims.
     ``license`` is an optional per-claim License override (null inherits from source).
-    ``changeset`` groups this claim with others; it is **required** for
-    user-attributed claims (every user write is an attributed ChangeSet)
-    and optional for source-attributed (ingest) claims.
     Runs in a transaction to ensure the old claim is deactivated atomically.
     """
-    if (source is None) == (user is None):
-        raise ValueError("Exactly one of source or user must be provided.")
-    if user is not None and changeset is None:
-        raise ValueError(
-            "A user-attributed claim requires a changeset "
-            "(every user write must be an attributed ChangeSet)."
-        )
-    if changeset is not None:
-        if (
-            user is not None
-            and changeset.user is not None
-            and changeset.user.pk != user.pk
-        ):
-            raise ValueError("ChangeSet user must match the claim user.")
-        ingest_run = changeset.ingest_run
-        if source is not None and (
-            ingest_run is None or ingest_run.source.pk != source.pk
-        ):
-            raise ValueError(
-                "ChangeSet must belong to an IngestRun from the same source."
-            )
     if not claim_key:
         claim_key = field_name
 
@@ -98,26 +74,43 @@ def _assert_claim(
             value=value,
         )
 
+    # Model-driven legacy stamp: ``actor.backing_model`` ("user" / "source") is
+    # both the reverse accessor on Actor and the legacy Claim FK field name (the
+    # FKs are named after the lowercased model, so they coincide with
+    # ``_meta.model_name`` by construction). ``getattr`` / ``setattr`` on a
+    # model-declared relation name is sanctioned here. This stamp and the legacy
+    # dedupe key below retire together: dedupe flips to ``actor`` at "Tighten
+    # schema", the stamp at "Drop dead schema".
+    actor = changeset.actor
+    if actor is None:
+        raise ValueError(
+            "ChangeSet must carry an actor (mint it via record_changeset)."
+        )
+    legacy_field = actor.backing_model
+    backing = getattr(actor, legacy_field)
+
     ct = ContentType.objects.get_for_model(subject)
     with transaction.atomic():
+        # Dedupe on the legacy author column — the live per-user / per-source
+        # unique index. Correct while historical active rows still carry
+        # ``actor = NULL``; moves to the ``actor`` key at "Tighten schema".
         Claim.objects.filter(
             content_type=ct,
             object_id=subject.pk,
-            source=source,
-            user=user,
             claim_key=claim_key,
             is_active=True,
+            **{legacy_field: backing},
         ).update(is_active=False)
 
         return Claim.objects.create(
             content_type=ct,
             object_id=subject.pk,
-            source=source,
-            user=user,
+            actor=actor,
             field_name=field_name,
             claim_key=claim_key,
             value=value,
             citation=citation,
             license=license,
             changeset=changeset,
+            **{legacy_field: backing},
         )

--- a/backend/apps/provenance/models/__init__.py
+++ b/backend/apps/provenance/models/__init__.py
@@ -13,7 +13,6 @@ from .changeset import CHANGESET_NOTE_MAX_LENGTH, ChangeSet, ChangeSetAction
 from .citation_instance import CITATION_INSTANCE_LOCATOR_MAX_LENGTH, CitationInstance
 from .claim import (
     Claim,
-    ClaimManager,
     ExistingClaimRow,
     IdentityPart,
     make_claim_key,

--- a/backend/apps/provenance/models/changeset.py
+++ b/backend/apps/provenance/models/changeset.py
@@ -35,7 +35,7 @@ class ChangeSet(models.Model):
     All claims in a ChangeSet must share the same actor (same user or same
     source). A CheckConstraint enforces that exactly one of user or
     ingest_run is set; same-actor consistency within those groups is
-    enforced by assert_claim().
+    enforced by ``claim_writer._assert_claim``.
     """
 
     claims: models.Manager[Claim]

--- a/backend/apps/provenance/models/claim.py
+++ b/backend/apps/provenance/models/claim.py
@@ -1,13 +1,18 @@
-"""Claim model and manager: atomic fact assertions about catalog entities."""
+"""Claim model: atomic fact assertions about catalog entities.
+
+The mint primitive that writes ``Claim`` rows lives in
+``apps.provenance.claim_writer`` (``_assert_claim``), not on a custom manager —
+see that module and ``tests/test_single_claim_write_path.py``.
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.db import models, transaction
+from django.db import models
 from django.db.models.functions import Now
 
 from apps.core.models import BoundedTextField, field_not_blank
@@ -20,9 +25,6 @@ CLAIM_CITATION_MAX_LENGTH = 2_000
 CLAIM_NEEDS_REVIEW_NOTES_MAX_LENGTH = 2_000
 
 if TYPE_CHECKING:
-    from apps.accounts.models import User
-    from apps.core.models import License
-
     from .citation_instance import CitationInstance
 
 type IdentityPart = str | int | None
@@ -68,108 +70,6 @@ def make_claim_key(field_name: str, **identity_parts: IdentityPart) -> str:
     return "|".join(parts)
 
 
-class ClaimManager(models.Manager["Claim"]):
-    def assert_claim(
-        self,
-        subject: ClaimControlledModel,
-        field_name: str,
-        value: object,
-        citation: str = "",
-        *,
-        source: Source | None = None,
-        user: User | None = None,
-        claim_key: str = "",
-        license: License | None = None,
-        changeset: ChangeSet | None = None,
-    ) -> Claim:
-        """Create a claim, deactivating any existing active claim for the same claim_key+author.
-
-        ``subject`` can be any model instance (MachineModel, Manufacturer, Person, …).
-        Exactly one of ``source`` or ``user`` must be provided.
-        ``claim_key`` defaults to ``field_name`` for scalar claims.
-        ``license`` is an optional per-claim License override (null inherits from source).
-        ``changeset`` groups this claim with others; it is **required** for
-        user-attributed claims (every user write is an attributed ChangeSet)
-        and optional for source-attributed (ingest) claims.
-        Runs in a transaction to ensure the old claim is deactivated atomically.
-        """
-        if (source is None) == (user is None):
-            raise ValueError("Exactly one of source or user must be provided.")
-        if user is not None and changeset is None:
-            raise ValueError(
-                "A user-attributed claim requires a changeset "
-                "(every user write must be an attributed ChangeSet)."
-            )
-        if changeset is not None:
-            if (
-                user is not None
-                and changeset.user is not None
-                and changeset.user.pk != user.pk
-            ):
-                raise ValueError("ChangeSet user must match the claim user.")
-            ingest_run = changeset.ingest_run
-            if source is not None and (
-                ingest_run is None or ingest_run.source.pk != source.pk
-            ):
-                raise ValueError(
-                    "ChangeSet must belong to an IngestRun from the same source."
-                )
-        if not claim_key:
-            claim_key = field_name
-
-        # Classify and validate. DIRECT claims get scalar/FK validation.
-        # RELATIONSHIP claims get shape validation. EXTRA claims pass through.
-        # UNRECOGNIZED claims are rejected outright.
-        from apps.provenance.validation import (
-            DIRECT,
-            RELATIONSHIP,
-            UNRECOGNIZED,
-            classify_claim,
-            validate_claim_value,
-            validate_single_relationship_claim,
-        )
-
-        model_class = type(subject)
-        ct_result = classify_claim(model_class, field_name, claim_key, value)
-        if ct_result == UNRECOGNIZED:
-            raise ValueError(
-                f"Unrecognized claim field_name {field_name!r} on {model_class.__name__}"
-            )
-        if ct_result == DIRECT:
-            value = validate_claim_value(field_name, value, model_class)
-        elif ct_result == RELATIONSHIP:
-            validate_single_relationship_claim(
-                subject_model=model_class,
-                field_name=field_name,
-                claim_key=claim_key,
-                value=value,
-            )
-
-        ct = ContentType.objects.get_for_model(subject)
-        with transaction.atomic():
-            self.filter(
-                content_type=ct,
-                object_id=subject.pk,
-                source=source,
-                user=user,
-                claim_key=claim_key,
-                is_active=True,
-            ).update(is_active=False)
-
-            return self.create(
-                content_type=ct,
-                object_id=subject.pk,
-                source=source,
-                user=user,
-                field_name=field_name,
-                claim_key=claim_key,
-                value=value,
-                citation=citation,
-                license=license,
-                changeset=changeset,
-            )
-
-
 class Claim(models.Model):
     """A single fact asserted by a Source or User about any catalog entity.
 
@@ -177,7 +77,7 @@ class Claim(models.Model):
     MachineModel, Manufacturer, Person, etc.
 
     Exactly one of ``source`` or ``user`` must be set — enforced by a
-    CheckConstraint and by ClaimManager.assert_claim().
+    CheckConstraint and by ``claim_writer._assert_claim``.
     """
 
     content_type_id: int
@@ -276,8 +176,6 @@ class Claim(models.Model):
         help_text="Context for reviewers about why this claim needs attention.",
     )
     created_at = models.DateTimeField(auto_now_add=True, db_default=Now())
-
-    objects: ClassVar[ClaimManager] = ClaimManager()
 
     class Meta:
         indexes = [

--- a/backend/apps/provenance/revert.py
+++ b/backend/apps/provenance/revert.py
@@ -106,7 +106,7 @@ def execute_revert(
             # Re-activate the most recent superseded (not retracted) claim
             # from the same user for the same claim_key.  Without this,
             # reverting a user's latest edit would leave ALL their previous
-            # edits for the field inactive (because assert_claim deactivates
+            # edits for the field inactive (because _assert_claim deactivates
             # the predecessor when creating a new claim).
             predecessor = (
                 Claim.objects.filter(

--- a/backend/apps/provenance/revert.py
+++ b/backend/apps/provenance/revert.py
@@ -26,6 +26,7 @@ from apps.core.authz.exceptions import PolicyDeniedError
 from apps.core.authz.types import DenialCode, Deny
 from apps.core.types import EntityKey
 
+from .changeset_writer import record_changeset
 from .constants import REVERT_OTHERS_MIN_EDITS
 from .models import ChangeSet, ChangeSetAction, Claim, ClaimControlledModel
 from .resolution import resolve_after_mutation
@@ -96,8 +97,8 @@ def execute_revert(
 
     try:
         with transaction.atomic():
-            cs = ChangeSet.objects.create(
-                user=user, action=ChangeSetAction.REVERT, note=note
+            cs = record_changeset(
+                actor=user.actor, action=ChangeSetAction.REVERT, note=note
             )
             target.is_active = False
             target.retracted_by_changeset = cs
@@ -191,8 +192,8 @@ def execute_undo_changeset(
     affected_fields: dict[EntityKey, set[str]] = defaultdict(set)
     try:
         with transaction.atomic():
-            new_cs = ChangeSet.objects.create(
-                user=user, action=ChangeSetAction.REVERT, note=note
+            new_cs = record_changeset(
+                actor=user.actor, action=ChangeSetAction.REVERT, note=note
             )
             for claim in claims:
                 claim.is_active = False

--- a/backend/apps/provenance/test_factories.py
+++ b/backend/apps/provenance/test_factories.py
@@ -62,6 +62,22 @@ def make_claim(
     )
 
 
+def ingest_run(
+    source: Source,
+    *,
+    input_fingerprint: str = "sha256:test",
+    patch_id: str | None = None,
+) -> IngestRun:
+    """Create an ``IngestRun`` for tests that need one as incidental scaffolding.
+
+    Tests asserting ``IngestRun``'s own constraints/lifecycle should construct
+    it directly with the specific fields under test instead of using this.
+    """
+    return IngestRun.objects.create(
+        source=source, input_fingerprint=input_fingerprint, patch_id=patch_id
+    )
+
+
 def user_changeset(
     user: User,
     *,
@@ -99,7 +115,5 @@ def source_changeset(source: Source, *, note: str = "") -> ChangeSet:
     Use it when a test needs a source-attributed claim minted through
     ``make_claim`` without hand-building the run.
     """
-    run = IngestRun.objects.create(
-        source=source, input_fingerprint="test-source-changeset"
-    )
+    run = ingest_run(source, input_fingerprint="test-source-changeset")
     return ingest_changeset(run, note=note)

--- a/backend/apps/provenance/test_factories.py
+++ b/backend/apps/provenance/test_factories.py
@@ -51,6 +51,17 @@ def make_claim(
             changeset = source_changeset(source)
         else:
             raise ValueError("Provide exactly one of source or user (or a changeset).")
+    else:
+        # A user=/source= passed alongside an explicit changeset is redundant —
+        # attribution rides on changeset.actor, not these args. Guard that they
+        # agree so a mismatched pair fails loudly here (the cross-check the old
+        # assert_claim enforced) instead of silently attributing to the
+        # changeset's actor.
+        attributed = user if user is not None else source
+        if attributed is not None and changeset.actor_id != attributed.actor_id:
+            raise ValueError(
+                "make_claim: changeset.actor does not match the given user=/source=."
+            )
     return _assert_claim(
         subject,
         field_name,

--- a/backend/apps/provenance/test_factories.py
+++ b/backend/apps/provenance/test_factories.py
@@ -10,9 +10,51 @@ user) so mistakes fail at call time rather than at constraint time.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from apps.accounts.models import User
 
+from .claim_writer import _assert_claim
 from .models import ChangeSet, ChangeSetAction, IngestRun
+
+if TYPE_CHECKING:
+    from apps.core.models import License
+
+    from .models import Claim, ClaimControlledModel, Source
+
+
+def make_claim(
+    subject: ClaimControlledModel,
+    field_name: str,
+    value: object,
+    citation: str = "",
+    *,
+    source: Source | None = None,
+    user: User | None = None,
+    claim_key: str = "",
+    license: License | None = None,
+    changeset: ChangeSet | None = None,
+) -> Claim:
+    """Mint a claim through the single write primitive, for tests.
+
+    A behavior-identical drop-in for the old ``Claim.objects.assert_claim``: same
+    arguments, same semantics (user claims still require a ``changeset``; source
+    claims may omit one). The factory exists so tests target a single seam — when
+    the primitive goes actor-first, only this function changes, not the call
+    sites. ``source_changeset`` / ``user_changeset`` remain available for callers
+    that want to mint the attributing ChangeSet explicitly.
+    """
+    return _assert_claim(
+        subject,
+        field_name,
+        value,
+        citation,
+        source=source,
+        user=user,
+        claim_key=claim_key,
+        license=license,
+        changeset=changeset,
+    )
 
 
 def user_changeset(
@@ -37,3 +79,18 @@ def ingest_changeset(ingest_run: IngestRun, *, note: str = "") -> ChangeSet:
     user-driven changes (see ``ChangeSet`` check constraints).
     """
     return ChangeSet.objects.create(ingest_run=ingest_run, note=note)
+
+
+def source_changeset(source: Source, *, note: str = "") -> ChangeSet:
+    """Create a source-attributed ChangeSet for tests.
+
+    A source can only attribute a ChangeSet through an ``IngestRun`` (the
+    ChangeSet user-XOR-ingest_run constraint), so this mints a throwaway
+    ``IngestRun`` for the source and returns an ingest ChangeSet linked to it.
+    Use it when a test needs a source-attributed claim minted through
+    ``make_claim`` without hand-building the run.
+    """
+    run = IngestRun.objects.create(
+        source=source, input_fingerprint="test-source-changeset"
+    )
+    return ingest_changeset(run, note=note)

--- a/backend/apps/provenance/test_factories.py
+++ b/backend/apps/provenance/test_factories.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 from apps.accounts.models import User
 
+from .changeset_writer import record_changeset
 from .claim_writer import _assert_claim
 from .models import ChangeSet, ChangeSetAction, IngestRun
 
@@ -37,23 +38,27 @@ def make_claim(
 ) -> Claim:
     """Mint a claim through the single write primitive, for tests.
 
-    A behavior-identical drop-in for the old ``Claim.objects.assert_claim``: same
-    arguments, same semantics (user claims still require a ``changeset``; source
-    claims may omit one). The factory exists so tests target a single seam — when
-    the primitive goes actor-first, only this function changes, not the call
-    sites. ``source_changeset`` / ``user_changeset`` remain available for callers
-    that want to mint the attributing ChangeSet explicitly.
+    A drop-in for the old ``Claim.objects.assert_claim``: same ``user=`` /
+    ``source=`` signature. Attribution now rides on a ChangeSet's actor, so when
+    no ``changeset`` is supplied this auto-creates the attributing one (user →
+    ``user_changeset``; source → ``source_changeset``) and threads it into the
+    actor-first primitive. The factory is the single seam the call sites target.
     """
+    if changeset is None:
+        if user is not None and source is None:
+            changeset = user_changeset(user)
+        elif source is not None and user is None:
+            changeset = source_changeset(source)
+        else:
+            raise ValueError("Provide exactly one of source or user (or a changeset).")
     return _assert_claim(
         subject,
         field_name,
         value,
         citation,
-        source=source,
-        user=user,
+        changeset=changeset,
         claim_key=claim_key,
         license=license,
-        changeset=changeset,
     )
 
 
@@ -67,18 +72,22 @@ def user_changeset(
 
     Defaults to ``action=EDIT`` since that's what every pre-create test
     fixture was implicitly asserting. Callers testing create/delete/revert
-    paths pass the matching action explicitly.
+    paths pass the matching action explicitly. Routed through
+    ``record_changeset`` so every fixture ChangeSet carries an actor.
     """
-    return ChangeSet.objects.create(user=user, action=action, note=note)
+    return record_changeset(actor=user.actor, action=ChangeSetAction(action), note=note)
 
 
 def ingest_changeset(ingest_run: IngestRun, *, note: str = "") -> ChangeSet:
     """Create an ingest-attributed ChangeSet for tests.
 
     Ingest ChangeSets never carry an action — that column is reserved for
-    user-driven changes (see ``ChangeSet`` check constraints).
+    user-driven changes (see ``ChangeSet`` check constraints). Routed through
+    ``record_changeset`` so the actor invariant is encoded in one place.
     """
-    return ChangeSet.objects.create(ingest_run=ingest_run, note=note)
+    return record_changeset(
+        actor=ingest_run.source.actor, ingest_run=ingest_run, note=note
+    )
 
 
 def source_changeset(source: Source, *, note: str = "") -> ChangeSet:

--- a/backend/apps/provenance/tests/test_actor_attribution_invariants.py
+++ b/backend/apps/provenance/tests/test_actor_attribution_invariants.py
@@ -1,0 +1,177 @@
+"""Cross-table actor-attribution invariants across every write path.
+
+Commit "Save actor FKs" makes the interactive primitives actor-first and stamps
+``actor`` on bulk ingest rows. Two rules must hold table-wide after any write.
+Each is guarded on the row's own ``actor`` being non-NULL, so it is safe during
+the transition (rows still awaiting backfill are exempt; once ``actor`` is NOT
+NULL at "Tighten schema" the guard is vacuous and the full invariant holds):
+
+* ``claim.actor IS NULL OR claim.actor == claim.changeset.actor``
+* ``changeset.actor IS NULL OR (ingest_run IS NULL OR actor == ingest_run.source.actor)``
+  ``and changeset.actor IS NULL OR (user IS NULL OR actor == user.actor)``
+
+The transition-dedupe test pins the legacy-author-keyed dedupe for the window
+where historical active rows still carry ``actor = NULL``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+from apps.catalog.models import Manufacturer
+from apps.catalog.tests.conftest import make_machine_model
+from apps.claim_edit.claim_write import (
+    ClaimSpec,
+    EntityClaims,
+    execute_claims,
+    execute_multi_entity_claims,
+)
+from apps.claim_ingest.apply import apply_plan
+from apps.claim_ingest.plan import IngestPlan, PlannedClaimAssert, PlannedEntityCreate
+from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.revert import execute_revert, execute_undo_changeset
+from apps.provenance.test_factories import make_claim
+
+pytestmark = pytest.mark.django_db
+
+
+def assert_attribution_invariants() -> None:
+    """Assert both NULL-guarded cross-table rules over every row in the DB."""
+    for claim in Claim.objects.select_related("changeset").all():
+        if claim.actor_id is None:
+            continue
+        cs = claim.changeset
+        assert cs is not None, f"Claim {claim.pk} carries an actor but no changeset"
+        assert claim.actor_id == cs.actor_id, (
+            f"Claim {claim.pk}.actor != its changeset.actor"
+        )
+
+    for cs in ChangeSet.objects.select_related("user", "ingest_run__source").all():
+        if cs.actor_id is None:
+            continue
+        ingest_run = cs.ingest_run
+        if ingest_run is not None:
+            assert cs.actor_id == ingest_run.source.actor_id, (
+                f"ChangeSet {cs.pk}.actor != ingest_run.source.actor"
+            )
+        cs_user = cs.user
+        if cs_user is not None:
+            assert cs.actor_id == cs_user.actor_id, (
+                f"ChangeSet {cs.pk}.actor != user.actor"
+            )
+
+
+@pytest.fixture
+def _bootstrap_source(db):
+    return Source.objects.create(
+        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
+    )
+
+
+@pytest.fixture
+def pm(db, _bootstrap_source):
+    return make_machine_model(
+        name="Medieval Madness", slug="medieval-madness", year=1997
+    )
+
+
+def _active_user_claim(entity, field_name, user) -> Claim:
+    ct = ContentType.objects.get_for_model(entity)
+    return Claim.objects.get(
+        content_type=ct,
+        object_id=entity.pk,
+        field_name=field_name,
+        user=user,
+        is_active=True,
+    )
+
+
+class TestWritePathSetsActor:
+    def test_interactive(self, user, pm):
+        execute_claims(pm, [ClaimSpec(field_name="year", value=1998)], user=user)
+        claim = _active_user_claim(pm, "year", user)
+        assert claim.actor_id == user.actor_id
+        assert claim.user == user
+        assert_attribution_invariants()
+
+    def test_multi_entity(self, user, pm):
+        mfr = Manufacturer.objects.create(name="Williams", slug="williams")
+        execute_multi_entity_claims(
+            [
+                EntityClaims(pm, [ClaimSpec(field_name="year", value=1999)]),
+                EntityClaims(mfr, [ClaimSpec(field_name="description", value="x")]),
+            ],
+            user=user,
+            action=ChangeSetAction.EDIT,
+        )
+        for entity, field in ((pm, "year"), (mfr, "description")):
+            assert _active_user_claim(entity, field, user).actor_id == user.actor_id
+        assert_attribution_invariants()
+
+    def test_revert(self, user, pm):
+        execute_claims(pm, [ClaimSpec(field_name="year", value=1998)], user=user)
+        claim = _active_user_claim(pm, "year", user)
+        execute_revert(pm, claim_id=claim.pk, user=user, note="undo it")
+        assert_attribution_invariants()
+
+    def test_undo_changeset(self, user, pm):
+        cs = execute_multi_entity_claims(
+            [EntityClaims(pm, [ClaimSpec(field_name="year", value=1998)])],
+            user=user,
+            action=ChangeSetAction.DELETE,
+        )
+        execute_undo_changeset(cs, user=user, note="undo delete")
+        assert_attribution_invariants()
+
+    def test_ingest_bulk(self, _bootstrap_source):
+        source = Source.objects.create(
+            name="TestSource", slug="test-source", source_type="database", priority=50
+        )
+        plan = IngestPlan(
+            source=source,
+            input_fingerprint="fp-actor",
+            patch_id="fp-actor",
+            entities=[
+                PlannedEntityCreate(
+                    model_class=Manufacturer,
+                    kwargs={"name": "Bally", "slug": "bally", "status": "active"},
+                    handle="bally",
+                )
+            ],
+            assertions=[
+                PlannedClaimAssert(
+                    field_name="name", value="Bally", handle="bally", entry_index=0
+                ),
+                PlannedClaimAssert(
+                    field_name="slug", value="bally", handle="bally", entry_index=0
+                ),
+                PlannedClaimAssert(
+                    field_name="status", value="active", handle="bally", entry_index=0
+                ),
+            ],
+        )
+        apply_plan(plan)
+        claim = Claim.objects.get(source=source, field_name="name")
+        assert claim.actor_id == source.actor_id
+        assert claim.changeset is not None
+        assert claim.changeset.actor_id == source.actor_id
+        assert_attribution_invariants()
+
+
+class TestTransitionDedupe:
+    def test_legacy_keyed_dedupe_with_null_actor_predecessor(self, user, pm):
+        """A historical active claim with ``actor = NULL`` is still deactivated
+        when the same user re-edits the field through the actor-first funnel."""
+        # Seed a prior active user claim, then strip its actor to mimic a
+        # not-yet-backfilled historical row (legacy author column intact).
+        seed = make_claim(pm, "year", 1990, user=user)
+        Claim.objects.filter(pk=seed.pk).update(actor=None, changeset=None)
+
+        execute_claims(pm, [ClaimSpec(field_name="year", value=1998)], user=user)
+
+        seed.refresh_from_db()
+        assert seed.is_active is False
+        new_claim = _active_user_claim(pm, "year", user)
+        assert new_claim.value == 1998
+        assert new_claim.actor_id == user.actor_id

--- a/backend/apps/provenance/tests/test_actor_attribution_invariants.py
+++ b/backend/apps/provenance/tests/test_actor_attribution_invariants.py
@@ -63,14 +63,7 @@ def assert_attribution_invariants() -> None:
 
 
 @pytest.fixture
-def _bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
-
-
-@pytest.fixture
-def pm(db, _bootstrap_source):
+def pm(db, bootstrap_source):
     return make_machine_model(
         name="Medieval Madness", slug="medieval-madness", year=1997
     )
@@ -124,7 +117,7 @@ class TestWritePathSetsActor:
         execute_undo_changeset(cs, user=user, note="undo delete")
         assert_attribution_invariants()
 
-    def test_ingest_bulk(self, _bootstrap_source):
+    def test_ingest_bulk(self, bootstrap_source):
         source = Source.objects.create(
             name="TestSource", slug="test-source", source_type="database", priority=50
         )

--- a/backend/apps/provenance/tests/test_api_citation_instances.py
+++ b/backend/apps/provenance/tests/test_api_citation_instances.py
@@ -8,6 +8,7 @@ from django.test import Client
 
 from apps.citation.models import CitationSource
 from apps.provenance.models import CitationInstance
+from apps.provenance.test_factories import make_claim
 
 User = get_user_model()
 
@@ -59,7 +60,7 @@ class TestListCitationInstances:
             name="IPDB", slug="ipdb-test", source_type="database", priority=10
         )
         mfr = Manufacturer.objects.create(name="Williams", slug="williams")
-        Claim.objects.assert_claim(mfr, "name", "Williams", source=src)
+        make_claim(mfr, "name", "Williams", source=src)
         claim = Claim.objects.filter(is_active=True).first()
         assert claim is not None
 

--- a/backend/apps/provenance/tests/test_api_edit_history.py
+++ b/backend/apps/provenance/tests/test_api_edit_history.py
@@ -1,11 +1,23 @@
 """Tests for GET /api/pages/edit-history/{entity_type}/{public_id}/ endpoint."""
 
+from typing import Any
+
 import pytest
 
 from apps.accounts.test_factories import make_user
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.models import Source
 from apps.provenance.test_factories import make_claim
+
+
+def _user_changesets(resp) -> list[dict[str, Any]]:
+    """User-authored entries from an edit-history response.
+
+    Seed/ingest claims now carry (ingest) ChangeSets — realistic, and visible in
+    the full history just as ingested catalog data is in production. These tests
+    are about *user* edit history, so they filter to it.
+    """
+    return [cs for cs in resp.json() if cs["attribution"]["author"]["kind"] == "user"]
 
 
 @pytest.fixture
@@ -33,18 +45,18 @@ class TestEditHistoryEmpty:
     def test_no_changesets_returns_empty_list(self, client, pm):
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert _user_changesets(resp) == []
 
     def test_nonexistent_slug_returns_404(self, client):
         resp = client.get("/api/pages/edit-history/model/does-not-exist/")
         assert resp.status_code == 404
 
     def test_source_claims_not_included(self, client, pm, source):
-        """Source-attributed claims (no changeset) should not appear."""
+        """Source-attributed claims should not appear in *user* edit history."""
         make_claim(pm, "year", 1998, source=source)
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert _user_changesets(resp) == []
 
 
 @pytest.mark.django_db
@@ -60,7 +72,7 @@ class TestEditHistoryBasic:
 
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
         assert resp.status_code == 200
-        data = resp.json()
+        data = _user_changesets(resp)
         assert len(data) == 1
 
         cs = data[0]
@@ -90,7 +102,7 @@ class TestEditHistoryBasic:
         )
 
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
-        data = resp.json()
+        data = _user_changesets(resp)
         assert len(data) == 2
 
         # Most recent first
@@ -116,7 +128,7 @@ class TestEditHistoryMultipleFields:
         )
 
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
-        data = resp.json()
+        data = _user_changesets(resp)
         assert len(data) == 1
 
         field_names = {c["field_name"] for c in data[0]["changes"]}
@@ -143,7 +155,7 @@ class TestEditHistoryMultiUser:
         )
 
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
-        data = resp.json()
+        data = _user_changesets(resp)
         assert len(data) == 2
 
         # User B's edit is newest — old value is User A's prior claim
@@ -174,7 +186,7 @@ class TestEditHistoryMultiUser:
         )
 
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
-        data = resp.json()
+        data = _user_changesets(resp)
         assert len(data) == 1
         assert data[0]["changes"][0]["old_value"]["raw"] == 1997
         assert data[0]["changes"][0]["new_value"]["raw"] == 1999
@@ -197,7 +209,7 @@ class TestEditHistoryOrdering:
         )
 
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
-        data = resp.json()
+        data = _user_changesets(resp)
         assert len(data) == 2
         # Newest changeset (player_count) first
         assert data[0]["changes"][0]["field_name"] == "player_count"
@@ -224,7 +236,7 @@ class TestEditHistorySoftDeleted:
 
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
         assert resp.status_code == 200
-        data = resp.json()
+        data = _user_changesets(resp)
         assert len(data) == 1
         assert data[0]["changes"][0]["new_value"]["raw"] == 1998
 

--- a/backend/apps/provenance/tests/test_api_edit_history.py
+++ b/backend/apps/provenance/tests/test_api_edit_history.py
@@ -4,7 +4,8 @@ import pytest
 
 from apps.accounts.test_factories import make_user
 from apps.catalog.tests.conftest import make_machine_model
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -23,7 +24,7 @@ def source(db):
 @pytest.fixture
 def pm(db, _bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
     return pm
 
 
@@ -40,7 +41,7 @@ class TestEditHistoryEmpty:
 
     def test_source_claims_not_included(self, client, pm, source):
         """Source-attributed claims (no changeset) should not appear."""
-        Claim.objects.assert_claim(pm, "year", 1998, source=source)
+        make_claim(pm, "year", 1998, source=source)
         resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
         assert resp.status_code == 200
         assert resp.json() == []
@@ -163,7 +164,7 @@ class TestEditHistoryMultiUser:
 
     def test_old_value_uses_source_claim(self, client, user, pm, source):
         """A user edit shows the prior source/ingest claim's value as old."""
-        Claim.objects.assert_claim(pm, "year", 1997, source=source)
+        make_claim(pm, "year", 1997, source=source)
 
         client.force_login(user)
         client.patch(

--- a/backend/apps/provenance/tests/test_api_edit_history.py
+++ b/backend/apps/provenance/tests/test_api_edit_history.py
@@ -21,22 +21,14 @@ def _user_changesets(resp) -> list[dict[str, Any]]:
 
 
 @pytest.fixture
-def _bootstrap_source(db):
-    """Low-priority source for seeding name claims."""
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
-
-
-@pytest.fixture
 def source(db):
     return Source.objects.create(name="IPDB", source_type="database", priority=10)
 
 
 @pytest.fixture
-def pm(db, _bootstrap_source):
+def pm(db, bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
     return pm
 
 

--- a/backend/apps/provenance/tests/test_api_evidence.py
+++ b/backend/apps/provenance/tests/test_api_evidence.py
@@ -7,17 +7,10 @@ from django.contrib.auth import get_user_model
 
 from apps.catalog.models import Title
 from apps.citation.models import CitationSource, CitationSourceLink
-from apps.provenance.models import CitationInstance, Source
+from apps.provenance.models import CitationInstance
 from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=100
-    )
 
 
 @pytest.fixture

--- a/backend/apps/provenance/tests/test_api_evidence.py
+++ b/backend/apps/provenance/tests/test_api_evidence.py
@@ -7,8 +7,8 @@ from django.contrib.auth import get_user_model
 
 from apps.catalog.models import Title
 from apps.citation.models import CitationSource, CitationSourceLink
-from apps.provenance.models import CitationInstance, Claim, Source
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.models import CitationInstance, Source
+from apps.provenance.test_factories import make_claim, user_changeset
 
 User = get_user_model()
 
@@ -23,9 +23,7 @@ def bootstrap_source(db):
 @pytest.fixture
 def title(db, bootstrap_source):
     title = Title.objects.create(name="Medieval Madness", slug="medieval-madness")
-    Claim.objects.assert_claim(
-        title, "name", "Medieval Madness", source=bootstrap_source
-    )
+    make_claim(title, "name", "Medieval Madness", source=bootstrap_source)
     return title
 
 
@@ -55,10 +53,10 @@ class TestCitedEditEvidence:
         self, client, user, title, citation_source
     ):
         changeset = user_changeset(user, note="Documented the flyer")
-        year_claim = Claim.objects.assert_claim(
+        year_claim = make_claim(
             title, "name", "Medieval Madness (1997)", user=user, changeset=changeset
         )
-        desc_claim = Claim.objects.assert_claim(
+        desc_claim = make_claim(
             title, "description", "Updated copy", user=user, changeset=changeset
         )
         _attach_citation(year_claim, citation_source)
@@ -82,10 +80,10 @@ class TestCitedEditEvidence:
         self, client, user, title, citation_source
     ):
         changeset = user_changeset(user, note="Grouped edit")
-        first_claim = Claim.objects.assert_claim(
+        first_claim = make_claim(
             title, "name", "Medieval Madness (1997)", user=user, changeset=changeset
         )
-        second_claim = Claim.objects.assert_claim(
+        second_claim = make_claim(
             title, "description", "Updated copy", user=user, changeset=changeset
         )
         _attach_citation(first_claim, citation_source, locator="p. 3")
@@ -99,10 +97,8 @@ class TestCitedEditEvidence:
     def test_omits_uncited_changesets(self, client, user, title, citation_source):
         uncited = user_changeset(user, note="Uncited cleanup")
         cited = user_changeset(user, note="Cited update")
-        Claim.objects.assert_claim(
-            title, "description", "Cleanup", user=user, changeset=uncited
-        )
-        cited_claim = Claim.objects.assert_claim(
+        make_claim(title, "description", "Cleanup", user=user, changeset=uncited)
+        cited_claim = make_claim(
             title, "name", "Medieval Madness (1997)", user=user, changeset=cited
         )
         _attach_citation(cited_claim, citation_source)
@@ -123,7 +119,7 @@ class TestCitedEditEvidence:
         docstring.
         """
         changeset = user_changeset(user, note="Documented the flyer")
-        cited_claim = Claim.objects.assert_claim(
+        cited_claim = make_claim(
             title, "name", "Medieval Madness (1997)", user=user, changeset=changeset
         )
         _attach_citation(cited_claim, citation_source)

--- a/backend/apps/provenance/tests/test_api_review.py
+++ b/backend/apps/provenance/tests/test_api_review.py
@@ -9,6 +9,7 @@ from django.test.utils import CaptureQueriesContext
 from apps.catalog.models import CreditRole, Person, Series, Title
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.models import Claim, Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -32,7 +33,7 @@ class TestReviewClaimsDisplay:
         pm = make_machine_model(name="MM", slug="mm-review", year=1997)
         person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
         role = CreditRole.objects.create(name="Art", slug="art")
-        claim = Claim.objects.assert_claim(
+        claim = make_claim(
             pm,
             "credit",
             {"person": person.pk, "role": role.pk, "exists": True},
@@ -58,7 +59,7 @@ class TestReviewClaimsDisplay:
         title = Title.objects.create(name="Whirlwind", slug="whirlwind")
         Title.objects.create(name="Whirlwind", slug="whirlwind-opdb", opdb_id="G5pe4")
         pm = make_machine_model(name="Whirlwind", slug="whirlwind-mm")
-        claim = Claim.objects.assert_claim(pm, "title", title.public_id, source=source)
+        claim = make_claim(pm, "title", title.public_id, source=source)
         _flag(claim)
 
         resp = client.get("/api/review/claims/")
@@ -70,7 +71,7 @@ class TestReviewClaimsDisplay:
 
     def test_scalar_claim_value_has_null_display(self, client, source):
         series = Series.objects.create(slug="s", name="S")
-        claim = Claim.objects.assert_claim(series, "name", "Some Name", source=source)
+        claim = make_claim(series, "name", "Some Name", source=source)
         _flag(claim)
 
         resp = client.get("/api/review/claims/")
@@ -88,9 +89,7 @@ def test_review_claims_query_count_does_not_scale_with_rows(client, source):
     def _seed(start: int, count: int) -> None:
         for i in range(start, start + count):
             series = Series.objects.create(slug=f"s-{i}", name=f"S {i}")
-            claim = Claim.objects.assert_claim(
-                series, "name", f"Name {i}", source=source
-            )
+            claim = make_claim(series, "name", f"Name {i}", source=source)
             _flag(claim)
 
     _seed(start=0, count=2)

--- a/backend/apps/provenance/tests/test_capabilities_embed.py
+++ b/backend/apps/provenance/tests/test_capabilities_embed.py
@@ -22,17 +22,10 @@ from apps.accounts.test_factories import make_user
 from apps.catalog.models import Title
 from apps.catalog.tests.conftest import make_machine_model
 from apps.citation.models import CitationSource
-from apps.provenance.models import CitationInstance, Source
+from apps.provenance.models import CitationInstance
 from apps.provenance.test_factories import make_claim, user_changeset
 
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
 
 
 def _seed_changesets(client, user, pm, n: int) -> None:

--- a/backend/apps/provenance/tests/test_capabilities_embed.py
+++ b/backend/apps/provenance/tests/test_capabilities_embed.py
@@ -22,8 +22,8 @@ from apps.accounts.test_factories import make_user
 from apps.catalog.models import Title
 from apps.catalog.tests.conftest import make_machine_model
 from apps.citation.models import CitationSource
-from apps.provenance.models import CitationInstance, Claim, Source
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.models import CitationInstance, Source
+from apps.provenance.test_factories import make_claim, user_changeset
 
 pytestmark = pytest.mark.django_db
 
@@ -63,7 +63,7 @@ def test_edit_history_capabilities_does_not_scale_queries(client, bootstrap_sour
     """GET /api/pages/edit-history/... query count must not grow with N rows."""
     user = make_user()
     pm = make_machine_model(name="MM", slug="mm-x", year=1997)
-    Claim.objects.assert_claim(pm, "name", "MM", source=bootstrap_source)
+    make_claim(pm, "name", "MM", source=bootstrap_source)
 
     _seed_changesets(client, user, pm, 2)
     # Fetch anonymously so we don't tangle with session refresh side-effects.
@@ -89,7 +89,7 @@ def test_global_changes_feed_capabilities_does_not_scale_queries(
     """GET /api/pages/changesets/ query count must not grow with N rows."""
     user = make_user()
     pm = make_machine_model(name="MM2", slug="mm-y", year=1997)
-    Claim.objects.assert_claim(pm, "name", "MM2", source=bootstrap_source)
+    make_claim(pm, "name", "MM2", source=bootstrap_source)
 
     _seed_changesets(client, user, pm, 2)
     client.logout()
@@ -108,7 +108,7 @@ def _seed_cited_changesets(user, title: Title, citation_source, n: int) -> None:
     """Create ``n`` cited user changesets on ``title``, each with one claim."""
     for i in range(n):
         cs = user_changeset(user, note=f"Edit {i}")
-        claim = Claim.objects.assert_claim(
+        claim = make_claim(
             title, "description", f"Updated copy {i}", user=user, changeset=cs
         )
         CitationInstance.objects.create(
@@ -126,7 +126,7 @@ def test_sources_page_capabilities_does_not_scale_queries(client, bootstrap_sour
     """
     user = make_user()
     title = Title.objects.create(name="MM3", slug="mm-z")
-    Claim.objects.assert_claim(title, "name", "MM3", source=bootstrap_source)
+    make_claim(title, "name", "MM3", source=bootstrap_source)
     citation_source = CitationSource.objects.create(name="Flyer", source_type="web")
 
     _seed_cited_changesets(user, title, citation_source, 2)
@@ -146,7 +146,7 @@ def test_user_profile_recent_edits_capabilities_does_not_scale_queries(
     """GET /api/pages/user/{username}/ recent_edits embed must not scale queries."""
     user = make_user()
     pm = make_machine_model(name="MM4", slug="mm-w", year=1997)
-    Claim.objects.assert_claim(pm, "name", "MM4", source=bootstrap_source)
+    make_claim(pm, "name", "MM4", source=bootstrap_source)
 
     _seed_changesets(client, user, pm, 2)
     client.logout()

--- a/backend/apps/provenance/tests/test_changes.py
+++ b/backend/apps/provenance/tests/test_changes.py
@@ -9,9 +9,9 @@ from django.utils import timezone
 from apps.accounts.test_factories import make_user
 from apps.catalog.models import Manufacturer
 from apps.catalog.tests.conftest import make_machine_model
-from apps.provenance.models import ChangeSet, Claim, IngestRun, Source
+from apps.provenance.models import ChangeSet, IngestRun, Source
 from apps.provenance.pagination import cursor_paginate
-from apps.provenance.test_factories import ingest_changeset, user_changeset
+from apps.provenance.test_factories import ingest_changeset, make_claim, user_changeset
 
 
 @pytest.fixture
@@ -39,14 +39,14 @@ def source(db):
 @pytest.fixture
 def pm(db, bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
     return pm
 
 
 @pytest.fixture
 def mfr(db, bootstrap_source):
     mfr = Manufacturer.objects.create(name="Williams", slug="williams")
-    Claim.objects.assert_claim(mfr, "name", "Williams", source=bootstrap_source)
+    make_claim(mfr, "name", "Williams", source=bootstrap_source)
     return mfr
 
 
@@ -58,7 +58,7 @@ class TestCursorPaginate:
     def test_first_page(self, user, pm):
         for i in range(5):
             cs = user_changeset(user)
-            Claim.objects.assert_claim(pm, "year", 1990 + i, user=user, changeset=cs)
+            make_claim(pm, "year", 1990 + i, user=user, changeset=cs)
 
         items, next_cursor = cursor_paginate(ChangeSet.objects.all(), "", 3)
         assert len(items) == 3
@@ -67,7 +67,7 @@ class TestCursorPaginate:
     def test_second_page_via_cursor(self, user, pm):
         for i in range(5):
             cs = user_changeset(user)
-            Claim.objects.assert_claim(pm, "year", 1990 + i, user=user, changeset=cs)
+            make_claim(pm, "year", 1990 + i, user=user, changeset=cs)
 
         items1, cursor = cursor_paginate(ChangeSet.objects.all(), "", 3)
         assert cursor is not None
@@ -85,7 +85,7 @@ class TestCursorPaginate:
         cs_ids = []
         for i in range(3):
             cs = user_changeset(user)
-            Claim.objects.assert_claim(pm, "year", 1990 + i, user=user, changeset=cs)
+            make_claim(pm, "year", 1990 + i, user=user, changeset=cs)
             ChangeSet.objects.filter(pk=cs.pk).update(created_at=now)
             cs_ids.append(cs.pk)
 
@@ -136,7 +136,7 @@ class TestChangesList:
             finished_at=timezone.now(),
         )
         cs = ingest_changeset(run)
-        Claim.objects.assert_claim(pm, "year", 1999, source=source, changeset=cs)
+        make_claim(pm, "year", 1999, source=source, changeset=cs)
 
         resp = client.get("/api/pages/changesets/")
         assert resp.status_code == 200
@@ -298,9 +298,7 @@ class TestChangesDetail:
         """A changeset with only retracted claims shows retractions, no changes."""
         # Create a claim, then retract it via a separate changeset.
         original_cs = user_changeset(user)
-        claim = Claim.objects.assert_claim(
-            pm, "year", 2000, user=user, changeset=original_cs
-        )
+        claim = make_claim(pm, "year", 2000, user=user, changeset=original_cs)
 
         retract_cs = user_changeset(user)
         claim.retracted_by_changeset = retract_cs

--- a/backend/apps/provenance/tests/test_changes.py
+++ b/backend/apps/provenance/tests/test_changes.py
@@ -69,9 +69,11 @@ class TestCursorPaginate:
             cs = user_changeset(user)
             make_claim(pm, "year", 1990 + i, user=user, changeset=cs)
 
-        items1, cursor = cursor_paginate(ChangeSet.objects.all(), "", 3)
+        # Scope to this user's changesets; the pm fixture seeds ingest changesets.
+        qs = ChangeSet.objects.filter(user=user)
+        items1, cursor = cursor_paginate(qs, "", 3)
         assert cursor is not None
-        items2, cursor2 = cursor_paginate(ChangeSet.objects.all(), cursor, 3)
+        items2, cursor2 = cursor_paginate(qs, cursor, 3)
         assert len(items2) == 2
         assert cursor2 is None
         # No overlapping IDs
@@ -89,10 +91,12 @@ class TestCursorPaginate:
             ChangeSet.objects.filter(pk=cs.pk).update(created_at=now)
             cs_ids.append(cs.pk)
 
-        items, cursor = cursor_paginate(ChangeSet.objects.all(), "", 2)
+        # Scope to this user's changesets; the pm fixture seeds ingest changesets.
+        qs = ChangeSet.objects.filter(user=user)
+        items, cursor = cursor_paginate(qs, "", 2)
         assert len(items) == 2
         assert cursor is not None
-        items2, _ = cursor_paginate(ChangeSet.objects.all(), cursor, 2)
+        items2, _ = cursor_paginate(qs, cursor, 2)
         assert len(items2) == 1
         all_ids = [i.pk for i in items] + [i.pk for i in items2]
         assert len(set(all_ids)) == 3
@@ -106,6 +110,15 @@ class TestCursorPaginate:
 # ── List endpoint ─────────────────────────────────────────────────
 
 
+def _user_items(resp):
+    """Feed entries authored by users; the pm/mfr fixtures seed ingest changesets."""
+    return [
+        it
+        for it in resp.json()["items"]
+        if it["attribution"]["author"]["kind"] == "user"
+    ]
+
+
 @pytest.mark.django_db
 class TestChangesList:
     def test_returns_user_edits(self, client, user, pm):
@@ -117,9 +130,9 @@ class TestChangesList:
         )
         resp = client.get("/api/pages/changesets/")
         assert resp.status_code == 200
-        data = resp.json()
-        assert len(data["items"]) == 1
-        item = data["items"][0]
+        items = _user_items(resp)
+        assert len(items) == 1
+        item = items[0]
         assert item["attribution"]["author"] == {
             "kind": "user",
             "username": user.username,
@@ -141,8 +154,14 @@ class TestChangesList:
         resp = client.get("/api/pages/changesets/")
         assert resp.status_code == 200
         items = resp.json()["items"]
-        assert len(items) == 1
-        assert items[0]["attribution"]["author"] == {"kind": "source", "name": "IPDB"}
+        # The pm fixture seeds its own (Bootstrap) ingest changesets; assert the
+        # IPDB ingest changeset created here is present in the feed.
+        ipdb = [
+            it
+            for it in items
+            if it["attribution"]["author"] == {"kind": "source", "name": "IPDB"}
+        ]
+        assert len(ipdb) == 1
 
     def test_entity_type_filter(self, client, user, pm, mfr):
         client.force_login(user)
@@ -159,7 +178,9 @@ class TestChangesList:
 
         resp = client.get("/api/pages/changesets/?entity_type=manufacturer")
         assert resp.status_code == 200
-        items = resp.json()["items"]
+        # mfr fixture seeds an ingest changeset on the manufacturer; assert on the
+        # user edit (which must be a manufacturer, confirming the filter works).
+        items = _user_items(resp)
         assert len(items) == 1
         assert items[0]["entity"]["type_label"] == "Manufacturer"
 
@@ -177,20 +198,23 @@ class TestChangesList:
                 content_type="application/json",
             )
 
+        # The feed also carries the pm fixture's seed ingest changesets, which are
+        # older than these user edits and so sort after them; assert on the user
+        # edits surfaced per page (3 newest, then the remaining 2).
         resp1 = client.get("/api/pages/changesets/?limit=3")
         data1 = resp1.json()
-        assert len(data1["items"]) == 3
+        user1 = _user_items(resp1)
+        assert len(user1) == 3
         assert data1["next_cursor"] is not None
 
         resp2 = client.get(
             f"/api/pages/changesets/?limit=3&cursor={data1['next_cursor']}"
         )
-        data2 = resp2.json()
-        assert len(data2["items"]) == 2
-        assert data2["next_cursor"] is None
+        user2 = _user_items(resp2)
+        assert len(user2) == 2
 
-        ids1 = {i["id"] for i in data1["items"]}
-        ids2 = {i["id"] for i in data2["items"]}
+        ids1 = {i["id"] for i in user1}
+        ids2 = {i["id"] for i in user2}
         assert ids1.isdisjoint(ids2)
 
     def test_after_filter(self, client, user, pm):
@@ -206,11 +230,12 @@ class TestChangesList:
         assert resp.status_code == 200
         assert len(resp.json()["items"]) == 0
 
-        # Use a past timestamp so the edit falls after it.
+        # Use a past timestamp so the edit falls after it. Filter to the user edit;
+        # the pm fixture's seed ingest changesets also fall after the past boundary.
         past = "2000-01-01T00:00:00"
         resp = client.get(f"/api/pages/changesets/?after={past}")
         assert resp.status_code == 200
-        assert len(resp.json()["items"]) == 1
+        assert len(_user_items(resp)) == 1
 
     def test_deleted_entity_excluded(self, client, user, pm):
         client.force_login(user)
@@ -223,7 +248,12 @@ class TestChangesList:
 
         resp = client.get("/api/pages/changesets/")
         assert resp.status_code == 200
-        assert len(resp.json()["items"]) == 0
+        # The deleted model's changesets (including the user edit) are excluded.
+        # The auto-Title survives, so its seed ingest changeset may remain; assert
+        # no feed entry references the deleted Model.
+        items = resp.json()["items"]
+        assert all(it["entity"]["type_label"] != "Model" for it in items)
+        assert _user_items(resp) == []
 
 
 # ── Detail endpoint ───────────────────────────────────────────────
@@ -329,8 +359,9 @@ class TestChangesListBeforeFilter:
         assert resp.status_code == 200
         assert len(resp.json()["items"]) == 0
 
-        # Use a future timestamp so the edit falls before it.
+        # Use a future timestamp so the edit falls before it. Filter to the user
+        # edit; the pm fixture's seed ingest changesets also fall before the future.
         future = "2099-01-01T00:00:00"
         resp = client.get(f"/api/pages/changesets/?before={future}")
         assert resp.status_code == 200
-        assert len(resp.json()["items"]) == 1
+        assert len(_user_items(resp)) == 1

--- a/backend/apps/provenance/tests/test_changes.py
+++ b/backend/apps/provenance/tests/test_changes.py
@@ -20,13 +20,6 @@ def client():
 
 
 @pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
-
-
-@pytest.fixture
 def user_b(db):
     return make_user()
 

--- a/backend/apps/provenance/tests/test_changeset.py
+++ b/backend/apps/provenance/tests/test_changeset.py
@@ -3,6 +3,7 @@
 import pytest
 from django.db import IntegrityError
 
+from apps.accounts.test_factories import make_user
 from apps.catalog.models import Manufacturer
 from apps.core.models import License
 from apps.provenance.changeset_writer import record_changeset
@@ -67,6 +68,13 @@ class TestChangeSetClaimGrouping:
         assert claim.changeset.actor_id == user.actor_id
         assert claim.actor_id == user.actor_id
         assert claim.user == user
+
+    def test_changeset_actor_mismatch_with_user_rejected(self, user, mfr):
+        """A changeset whose actor differs from user= fails loudly, rather than
+        silently attributing to the changeset's actor."""
+        cs = user_changeset(make_user())
+        with pytest.raises(ValueError, match="does not match"):
+            make_claim(mfr, "name", "Williams", user=user, changeset=cs)
 
     def test_source_claim_with_changeset_accepted(self, source, mfr):
         """A source claim rides on an ingest ChangeSet's actor."""

--- a/backend/apps/provenance/tests/test_changeset.py
+++ b/backend/apps/provenance/tests/test_changeset.py
@@ -6,8 +6,13 @@ from django.db import IntegrityError
 from apps.catalog.models import Manufacturer
 from apps.core.models import License
 from apps.provenance.changeset_writer import record_changeset
-from apps.provenance.models import ChangeSet, ChangeSetAction, IngestRun, Source
-from apps.provenance.test_factories import ingest_changeset, make_claim, user_changeset
+from apps.provenance.models import ChangeSet, ChangeSetAction, Source
+from apps.provenance.test_factories import (
+    ingest_changeset,
+    ingest_run,
+    make_claim,
+    user_changeset,
+)
 
 
 @pytest.fixture
@@ -37,7 +42,7 @@ class TestChangeSetModel:
 
     def test_changeset_with_ingest_run(self, source):
         """ChangeSet with ingest_run (no user) is allowed."""
-        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        run = ingest_run(source)
         cs = ChangeSet.objects.create(ingest_run=run)
         assert cs.user is None
         assert cs.ingest_run == run
@@ -65,7 +70,7 @@ class TestChangeSetClaimGrouping:
 
     def test_source_claim_with_changeset_accepted(self, source, mfr):
         """A source claim rides on an ingest ChangeSet's actor."""
-        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        run = ingest_run(source)
         cs = ingest_changeset(run)
         claim = make_claim(mfr, "name", "Williams", source=source, changeset=cs)
         assert claim.changeset == cs
@@ -106,7 +111,7 @@ class TestRecordChangeset:
         assert cs.actor_id == user.actor_id
 
     def test_ingest_rejects_action(self, source):
-        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        run = ingest_run(source)
         with pytest.raises(ValueError, match="never carry an action"):
             record_changeset(
                 actor=source.actor, ingest_run=run, action=ChangeSetAction.EDIT
@@ -114,12 +119,12 @@ class TestRecordChangeset:
 
     def test_ingest_actor_must_match_run_source(self, source):
         other = Source.objects.create(name="Other", slug="other", priority=5)
-        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        run = ingest_run(source)
         with pytest.raises(ValueError, match="source actor"):
             record_changeset(actor=other.actor, ingest_run=run)
 
     def test_ingest_sets_run_and_actor(self, source):
-        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        run = ingest_run(source)
         cs = record_changeset(actor=source.actor, ingest_run=run)
         assert cs.ingest_run == run
         assert cs.actor_id == source.actor_id
@@ -132,7 +137,7 @@ class TestChangeSetConstraints:
         assert cs.pk is not None
 
     def test_ingest_run_only(self, source):
-        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        run = ingest_run(source)
         cs = ChangeSet.objects.create(ingest_run=run)
         assert cs.pk is not None
 
@@ -141,7 +146,7 @@ class TestChangeSetConstraints:
             ChangeSet.objects.create()
 
     def test_both_user_and_ingest_run_rejected(self, user, source):
-        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        run = ingest_run(source)
         with pytest.raises(IntegrityError):
             ChangeSet.objects.create(user=user, ingest_run=run)
 
@@ -152,7 +157,7 @@ class TestChangeSetConstraints:
 
     def test_ingest_run_with_action_rejected(self, source):
         """Ingest ChangeSets must not carry an action value."""
-        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        run = ingest_run(source)
         with pytest.raises(IntegrityError):
             ChangeSet.objects.create(ingest_run=run, action="edit")
 

--- a/backend/apps/provenance/tests/test_changeset.py
+++ b/backend/apps/provenance/tests/test_changeset.py
@@ -6,7 +6,8 @@ from django.db import IntegrityError
 from apps.accounts.test_factories import make_user
 from apps.catalog.models import Manufacturer
 from apps.core.models import License
-from apps.provenance.models import ChangeSet, Claim, IngestRun, Source
+from apps.provenance.models import ChangeSet, IngestRun, Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -46,10 +47,8 @@ class TestChangeSetModel:
 class TestChangeSetClaimGrouping:
     def test_claims_linked_to_changeset(self, user, mfr):
         cs = ChangeSet.objects.create(user=user, action="edit", note="Updated fields")
-        c1 = Claim.objects.assert_claim(
-            mfr, "name", "Williams Electronics", user=user, changeset=cs
-        )
-        c2 = Claim.objects.assert_claim(
+        c1 = make_claim(mfr, "name", "Williams Electronics", user=user, changeset=cs)
+        c2 = make_claim(
             mfr, "description", "Pinball manufacturer", user=user, changeset=cs
         )
         assert c1.changeset == cs
@@ -59,15 +58,13 @@ class TestChangeSetClaimGrouping:
     def test_user_claim_without_changeset_rejected(self, user, mfr):
         """A user-attributed claim must carry a ChangeSet — no unattributed user writes."""
         with pytest.raises(ValueError, match="requires a changeset"):
-            Claim.objects.assert_claim(mfr, "name", "Williams", user=user)
+            make_claim(mfr, "name", "Williams", user=user)
 
     def test_source_claim_with_changeset_accepted(self, source, mfr):
         """Source-attributed claims can use ChangeSets linked to matching ingest run."""
         run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
         cs = ChangeSet.objects.create(ingest_run=run)
-        claim = Claim.objects.assert_claim(
-            mfr, "name", "Williams", source=source, changeset=cs
-        )
+        claim = make_claim(mfr, "name", "Williams", source=source, changeset=cs)
         assert claim.changeset == cs
 
     def test_source_claim_changeset_source_mismatch_rejected(self, source, mfr):
@@ -80,28 +77,22 @@ class TestChangeSetClaimGrouping:
         )
         cs = ChangeSet.objects.create(ingest_run=run)
         with pytest.raises(ValueError, match="same source"):
-            Claim.objects.assert_claim(
-                mfr, "name", "Williams", source=source, changeset=cs
-            )
+            make_claim(mfr, "name", "Williams", source=source, changeset=cs)
 
     def test_changeset_user_mismatch_rejected(self, user, mfr):
         """ChangeSet user must match the claim user."""
         other_user = make_user()
         cs = ChangeSet.objects.create(user=other_user, action="edit")
         with pytest.raises(ValueError, match="must match"):
-            Claim.objects.assert_claim(mfr, "name", "Williams", user=user, changeset=cs)
+            make_claim(mfr, "name", "Williams", user=user, changeset=cs)
 
     def test_changeset_survives_claim_superseding(self, user, mfr):
         """When a claim is superseded, the old claim keeps its changeset link."""
         cs1 = ChangeSet.objects.create(user=user, action="edit", note="First edit")
-        c1 = Claim.objects.assert_claim(
-            mfr, "description", "First", user=user, changeset=cs1
-        )
+        c1 = make_claim(mfr, "description", "First", user=user, changeset=cs1)
 
         cs2 = ChangeSet.objects.create(user=user, action="edit", note="Second edit")
-        c2 = Claim.objects.assert_claim(
-            mfr, "description", "Second", user=user, changeset=cs2
-        )
+        c2 = make_claim(mfr, "description", "Second", user=user, changeset=cs2)
 
         c1.refresh_from_db()
         assert c1.is_active is False
@@ -148,7 +139,7 @@ class TestClaimConstraints:
         """DB-level CHECK constraint rejects empty claim_key."""
         from django.db import IntegrityError, connection
 
-        claim = Claim.objects.assert_claim(mfr, "name", "Williams", source=source)
+        claim = make_claim(mfr, "name", "Williams", source=source)
         with connection.cursor() as cursor, pytest.raises(IntegrityError):
             cursor.execute(
                 "UPDATE provenance_claim SET claim_key = '' WHERE id = %s",
@@ -163,7 +154,7 @@ class TestClaimProtect:
         from django.db.models import ProtectedError
 
         cs = ChangeSet.objects.create(user=user, action="edit")
-        Claim.objects.assert_claim(mfr, "name", "Williams", user=user, changeset=cs)
+        make_claim(mfr, "name", "Williams", user=user, changeset=cs)
         with pytest.raises(ProtectedError):
             user.delete()
 
@@ -172,7 +163,7 @@ class TestClaimProtect:
         from django.db.models import ProtectedError
 
         cs = ChangeSet.objects.create(user=user, action="edit")
-        Claim.objects.assert_claim(mfr, "name", "Williams", user=user, changeset=cs)
+        make_claim(mfr, "name", "Williams", user=user, changeset=cs)
         with pytest.raises(ProtectedError):
             cs.delete()
 
@@ -181,6 +172,6 @@ class TestClaimProtect:
         from django.db.models import ProtectedError
 
         lic = License.objects.create(name="Test License", short_name="test-lic")
-        Claim.objects.assert_claim(mfr, "name", "Williams", source=source, license=lic)
+        make_claim(mfr, "name", "Williams", source=source, license=lic)
         with pytest.raises(ProtectedError):
             lic.delete()

--- a/backend/apps/provenance/tests/test_changeset.py
+++ b/backend/apps/provenance/tests/test_changeset.py
@@ -3,11 +3,11 @@
 import pytest
 from django.db import IntegrityError
 
-from apps.accounts.test_factories import make_user
 from apps.catalog.models import Manufacturer
 from apps.core.models import License
-from apps.provenance.models import ChangeSet, IngestRun, Source
-from apps.provenance.test_factories import make_claim
+from apps.provenance.changeset_writer import record_changeset
+from apps.provenance.models import ChangeSet, ChangeSetAction, IngestRun, Source
+from apps.provenance.test_factories import ingest_changeset, make_claim, user_changeset
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ class TestChangeSetModel:
 @pytest.mark.django_db
 class TestChangeSetClaimGrouping:
     def test_claims_linked_to_changeset(self, user, mfr):
-        cs = ChangeSet.objects.create(user=user, action="edit", note="Updated fields")
+        cs = user_changeset(user, note="Updated fields")
         c1 = make_claim(mfr, "name", "Williams Electronics", user=user, changeset=cs)
         c2 = make_claim(
             mfr, "description", "Pinball manufacturer", user=user, changeset=cs
@@ -55,43 +55,29 @@ class TestChangeSetClaimGrouping:
         assert c2.changeset == cs
         assert set(cs.claims.values_list("pk", flat=True)) == {c1.pk, c2.pk}
 
-    def test_user_claim_without_changeset_rejected(self, user, mfr):
-        """A user-attributed claim must carry a ChangeSet — no unattributed user writes."""
-        with pytest.raises(ValueError, match="requires a changeset"):
-            make_claim(mfr, "name", "Williams", user=user)
+    def test_user_claim_auto_creates_attributed_changeset(self, user, mfr):
+        """make_claim with no changeset mints one carrying the user's actor."""
+        claim = make_claim(mfr, "name", "Williams", user=user)
+        assert claim.changeset is not None
+        assert claim.changeset.actor_id == user.actor_id
+        assert claim.actor_id == user.actor_id
+        assert claim.user == user
 
     def test_source_claim_with_changeset_accepted(self, source, mfr):
-        """Source-attributed claims can use ChangeSets linked to matching ingest run."""
+        """A source claim rides on an ingest ChangeSet's actor."""
         run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
-        cs = ChangeSet.objects.create(ingest_run=run)
+        cs = ingest_changeset(run)
         claim = make_claim(mfr, "name", "Williams", source=source, changeset=cs)
         assert claim.changeset == cs
-
-    def test_source_claim_changeset_source_mismatch_rejected(self, source, mfr):
-        """ChangeSet's ingest run source must match the claim source."""
-        other_source = Source.objects.create(
-            name="OtherSource", slug="other-source", priority=5
-        )
-        run = IngestRun.objects.create(
-            source=other_source, input_fingerprint="sha256:abc"
-        )
-        cs = ChangeSet.objects.create(ingest_run=run)
-        with pytest.raises(ValueError, match="same source"):
-            make_claim(mfr, "name", "Williams", source=source, changeset=cs)
-
-    def test_changeset_user_mismatch_rejected(self, user, mfr):
-        """ChangeSet user must match the claim user."""
-        other_user = make_user()
-        cs = ChangeSet.objects.create(user=other_user, action="edit")
-        with pytest.raises(ValueError, match="must match"):
-            make_claim(mfr, "name", "Williams", user=user, changeset=cs)
+        assert claim.actor_id == source.actor_id
+        assert claim.source == source
 
     def test_changeset_survives_claim_superseding(self, user, mfr):
         """When a claim is superseded, the old claim keeps its changeset link."""
-        cs1 = ChangeSet.objects.create(user=user, action="edit", note="First edit")
+        cs1 = user_changeset(user, note="First edit")
         c1 = make_claim(mfr, "description", "First", user=user, changeset=cs1)
 
-        cs2 = ChangeSet.objects.create(user=user, action="edit", note="Second edit")
+        cs2 = user_changeset(user, note="Second edit")
         c2 = make_claim(mfr, "description", "Second", user=user, changeset=cs2)
 
         c1.refresh_from_db()
@@ -99,6 +85,44 @@ class TestChangeSetClaimGrouping:
         assert c1.changeset == cs1
         assert c2.is_active is True
         assert c2.changeset == cs2
+
+
+@pytest.mark.django_db
+class TestRecordChangeset:
+    """The actor-first funnel's contract (the validations that used to live on
+    ``_assert_claim``'s source/user/changeset args)."""
+
+    def test_interactive_requires_action(self, user):
+        with pytest.raises(ValueError, match="requires an action"):
+            record_changeset(actor=user.actor)
+
+    def test_interactive_requires_user_backed_actor(self, source):
+        with pytest.raises(ValueError, match="user-backed actor"):
+            record_changeset(actor=source.actor, action=ChangeSetAction.EDIT)
+
+    def test_interactive_sets_user_and_actor(self, user):
+        cs = record_changeset(actor=user.actor, action=ChangeSetAction.EDIT)
+        assert cs.user == user
+        assert cs.actor_id == user.actor_id
+
+    def test_ingest_rejects_action(self, source):
+        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        with pytest.raises(ValueError, match="never carry an action"):
+            record_changeset(
+                actor=source.actor, ingest_run=run, action=ChangeSetAction.EDIT
+            )
+
+    def test_ingest_actor_must_match_run_source(self, source):
+        other = Source.objects.create(name="Other", slug="other", priority=5)
+        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        with pytest.raises(ValueError, match="source actor"):
+            record_changeset(actor=other.actor, ingest_run=run)
+
+    def test_ingest_sets_run_and_actor(self, source):
+        run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
+        cs = record_changeset(actor=source.actor, ingest_run=run)
+        assert cs.ingest_run == run
+        assert cs.actor_id == source.actor_id
 
 
 @pytest.mark.django_db
@@ -153,7 +177,7 @@ class TestClaimProtect:
         """PROTECT prevents deleting a user who has claims."""
         from django.db.models import ProtectedError
 
-        cs = ChangeSet.objects.create(user=user, action="edit")
+        cs = user_changeset(user)
         make_claim(mfr, "name", "Williams", user=user, changeset=cs)
         with pytest.raises(ProtectedError):
             user.delete()
@@ -162,7 +186,7 @@ class TestClaimProtect:
         """PROTECT prevents deleting a ChangeSet that has claims."""
         from django.db.models import ProtectedError
 
-        cs = ChangeSet.objects.create(user=user, action="edit")
+        cs = user_changeset(user)
         make_claim(mfr, "name", "Williams", user=user, changeset=cs)
         with pytest.raises(ProtectedError):
             cs.delete()

--- a/backend/apps/provenance/tests/test_claim_license_write.py
+++ b/backend/apps/provenance/tests/test_claim_license_write.py
@@ -7,6 +7,7 @@ from apps.claim_ingest.apply import apply_plan
 from apps.claim_ingest.plan import IngestPlan, PlannedClaimAssert
 from apps.core.models import License
 from apps.provenance.models import Claim, Source
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -42,16 +43,14 @@ class TestAssertClaimLicense:
         from apps.catalog.models import Manufacturer
 
         mfr = Manufacturer.objects.create(name="Test", slug="test")
-        claim = Claim.objects.assert_claim(
-            mfr, "description", "text", source=source, license=cc_by_sa
-        )
+        claim = make_claim(mfr, "description", "text", source=source, license=cc_by_sa)
         assert claim.license == cc_by_sa
 
     def test_assert_claim_without_license(self, source):
         from apps.catalog.models import Manufacturer
 
         mfr = Manufacturer.objects.create(name="Test", slug="test")
-        claim = Claim.objects.assert_claim(mfr, "description", "text", source=source)
+        claim = make_claim(mfr, "description", "text", source=source)
         assert claim.license is None
 
 

--- a/backend/apps/provenance/tests/test_display.py
+++ b/backend/apps/provenance/tests/test_display.py
@@ -28,7 +28,6 @@ from apps.provenance.display import (
     resolve_display_context,
     resolve_labels,
 )
-from apps.provenance.models import Source
 from apps.provenance.schemas import (
     ClaimDisplayIdentityPartSchema,
     ClaimDisplayQualifierPartSchema,
@@ -504,13 +503,6 @@ class TestClaimValue:
 # would scale with the number of distinct FK targets in history — this
 # test pins it.
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
 
 
 def _q(fn: Callable[[], object]) -> int:

--- a/backend/apps/provenance/tests/test_display.py
+++ b/backend/apps/provenance/tests/test_display.py
@@ -28,13 +28,14 @@ from apps.provenance.display import (
     resolve_display_context,
     resolve_labels,
 )
-from apps.provenance.models import Claim, Source
+from apps.provenance.models import Source
 from apps.provenance.schemas import (
     ClaimDisplayIdentityPartSchema,
     ClaimDisplayQualifierPartSchema,
     ClaimDisplayValueSchema,
     MarkdownClaimDisplaySchema,
 )
+from apps.provenance.test_factories import make_claim
 
 # Any ClaimControlledModel works for relationship/scalar dispatch: the display
 # kind is derived from field_name + value, not from this model. Markdown tests
@@ -529,7 +530,7 @@ class TestQueryCountDoesNotScale:
         """
         user = make_user()
         pm = make_machine_model(name="MM", slug="mm-credits", year=1997)
-        Claim.objects.assert_claim(pm, "name", "MM", source=bootstrap_source)
+        make_claim(pm, "name", "MM", source=bootstrap_source)
         CreditRole.objects.create(name="Design", slug="design")
 
         counter = 0

--- a/backend/apps/provenance/tests/test_helpers.py
+++ b/backend/apps/provenance/tests/test_helpers.py
@@ -12,6 +12,7 @@ from apps.provenance.helpers import (
 )
 from apps.provenance.models import Claim, Source
 from apps.provenance.schemas import ClaimDisplayValueSchema
+from apps.provenance.test_factories import make_claim
 
 
 @pytest.fixture
@@ -25,7 +26,7 @@ def source():
 class TestActiveClaims:
     def test_returns_list_when_prefetched(self, source):
         series = Series.objects.create(slug="s", name="S")
-        Claim.objects.assert_claim(series, "name", "S", source=source)
+        make_claim(series, "name", "S", source=source)
 
         loaded = Series.objects.prefetch_related(claims_prefetch()).get(pk=series.pk)
 
@@ -44,7 +45,7 @@ class TestActiveClaims:
 class TestCitationInstances:
     def test_returns_list_when_prefetched(self, source):
         series = Series.objects.create(slug="s", name="S")
-        Claim.objects.assert_claim(series, "name", "S", source=source)
+        make_claim(series, "name", "S", source=source)
 
         loaded = Series.objects.prefetch_related(claims_prefetch()).get(pk=series.pk)
         claim = active_claims(loaded)[0]
@@ -54,7 +55,7 @@ class TestCitationInstances:
 
     def test_raises_when_claim_not_prefetched(self, source):
         series = Series.objects.create(slug="s", name="S")
-        Claim.objects.assert_claim(series, "name", "S", source=source)
+        make_claim(series, "name", "S", source=source)
         bare_claim = Claim.objects.get(object_id=series.pk, field_name="name")
 
         with pytest.raises(AssertionError, match="claims_prefetch"):
@@ -71,7 +72,7 @@ class TestBuildSources:
         pm = make_machine_model(name="MM", slug="mm", year=1997)
         person = Person.objects.create(name="Pat Lawlor", slug="pat-lawlor")
         role = CreditRole.objects.create(name="Art", slug="art")
-        Claim.objects.assert_claim(
+        make_claim(
             pm,
             "credit",
             {"person": person.pk, "role": role.pk, "exists": True},
@@ -91,7 +92,7 @@ class TestBuildSources:
 
     def test_scalar_claim_value_has_null_display(self, source):
         series = Series.objects.create(slug="s", name="S")
-        Claim.objects.assert_claim(series, "name", "S", source=source)
+        make_claim(series, "name", "S", source=source)
 
         loaded = Series.objects.prefetch_related(claims_prefetch()).get(pk=series.pk)
         sources = build_sources(type(loaded), active_claims(loaded))

--- a/backend/apps/provenance/tests/test_ingest_run.py
+++ b/backend/apps/provenance/tests/test_ingest_run.py
@@ -4,8 +4,8 @@ import pytest
 from django.utils import timezone
 
 from apps.catalog.models import Manufacturer
-from apps.provenance.models import ChangeSet, Claim, IngestRun, Source
-from apps.provenance.test_factories import ingest_changeset, user_changeset
+from apps.provenance.models import ChangeSet, IngestRun, Source
+from apps.provenance.test_factories import ingest_changeset, make_claim, user_changeset
 
 
 @pytest.fixture
@@ -147,7 +147,7 @@ class TestChangeSetIngestRunFK:
 class TestClaimRetractedByChangeset:
     def test_retracted_by_changeset_set(self, source, mfr):
         run = IngestRun.objects.create(source=source, input_fingerprint="sha256:abc")
-        claim = Claim.objects.assert_claim(mfr, "name", "Williams", source=source)
+        claim = make_claim(mfr, "name", "Williams", source=source)
         cs = ingest_changeset(run)
         claim.retracted_by_changeset = cs
         claim.is_active = False
@@ -159,7 +159,7 @@ class TestClaimRetractedByChangeset:
         assert cs.retracted_claims.count() == 1
 
     def test_retracted_by_changeset_null_by_default(self, source, mfr):
-        claim = Claim.objects.assert_claim(mfr, "name", "Williams", source=source)
+        claim = make_claim(mfr, "name", "Williams", source=source)
         assert claim.retracted_by_changeset is None
 
     def test_delete_changeset_blocked_by_retracted_claims(self, source, mfr):
@@ -167,7 +167,7 @@ class TestClaimRetractedByChangeset:
         from django.db.models import ProtectedError
 
         run = IngestRun.objects.create(source=source, input_fingerprint="sha256:ret")
-        claim = Claim.objects.assert_claim(mfr, "name", "Williams", source=source)
+        claim = make_claim(mfr, "name", "Williams", source=source)
         cs = ingest_changeset(run)
         claim.retracted_by_changeset = cs
         claim.is_active = False

--- a/backend/apps/provenance/tests/test_revert.py
+++ b/backend/apps/provenance/tests/test_revert.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from apps.accounts.test_factories import make_user
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.models import ChangeSetAction, Claim, Source
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.test_factories import make_claim, user_changeset
 
 REVERT_URL = "/api/claims/{claim_id}/revert/"
 
@@ -28,7 +28,7 @@ def source(db):
 @pytest.fixture
 def pm(db, _bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    Claim.objects.assert_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
     return pm
 
 
@@ -72,7 +72,7 @@ def _revert(client, claim_id, note):
 class TestRevertScalar:
     def test_revert_deactivates_claim_and_re_resolves(self, client, user, pm, source):
         """Reverting a user's scalar claim deactivates it; source value surfaces."""
-        Claim.objects.assert_claim(pm, "year", 1998, source=source)
+        make_claim(pm, "year", 1998, source=source)
         _make_user_edit(client, user, pm, {"year": 2002})
 
         claim = _get_active_claim(pm, "year", user)
@@ -181,7 +181,7 @@ class TestRevertNonWinning:
         hi_source = Source.objects.create(
             name="HiPri", slug="hipri", source_type="database", priority=20000
         )
-        Claim.objects.assert_claim(pm, "year", 1998, source=hi_source)
+        make_claim(pm, "year", 1998, source=hi_source)
         from apps.provenance.resolution import resolve_after_mutation
 
         resolve_after_mutation(pm, field_names=["year"])
@@ -297,7 +297,7 @@ class TestRevertValidation:
 
     def test_source_claim_returns_422(self, client, user, pm, source):
         """Source-attributed claims cannot be reverted."""
-        Claim.objects.assert_claim(pm, "year", 1998, source=source)
+        make_claim(pm, "year", 1998, source=source)
         ct = ContentType.objects.get_for_model(pm)
         src_claim = Claim.objects.get(
             content_type=ct,
@@ -356,7 +356,7 @@ class TestRevertValidation:
 class TestRevertMultiUser:
     def test_revert_surfaces_next_winner(self, client, user, pm, source, db):
         """A:1998, C:2001, A:2002 → revert A:2002 → surfaces C:2001."""
-        Claim.objects.assert_claim(pm, "year", 1998, source=source)
+        make_claim(pm, "year", 1998, source=source)
 
         user_c = make_user()
         _make_user_edit(client, user_c, pm, {"year": 2001})

--- a/backend/apps/provenance/tests/test_revert.py
+++ b/backend/apps/provenance/tests/test_revert.py
@@ -12,13 +12,6 @@ REVERT_URL = "/api/claims/{claim_id}/revert/"
 
 
 @pytest.fixture
-def _bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
-
-
-@pytest.fixture
 def source(db):
     return Source.objects.create(
         name="IPDB", slug="ipdb", source_type="database", priority=10
@@ -26,9 +19,9 @@ def source(db):
 
 
 @pytest.fixture
-def pm(db, _bootstrap_source):
+def pm(db, bootstrap_source):
     pm = make_machine_model(name="Medieval Madness", slug="medieval-madness", year=1997)
-    make_claim(pm, "name", "Medieval Madness", source=_bootstrap_source)
+    make_claim(pm, "name", "Medieval Madness", source=bootstrap_source)
     return pm
 
 

--- a/backend/apps/provenance/tests/test_single_claim_write_path.py
+++ b/backend/apps/provenance/tests/test_single_claim_write_path.py
@@ -1,0 +1,75 @@
+"""Guard: the single ``Claim`` persistence chokepoint.
+
+import-linter (``pyproject.toml``) enforces that only the interactive write
+surfaces may *import* the mint primitive — but it sees imports, not call sites,
+and ``Claim`` is imported everywhere for reads, so an import contract cannot tell
+a read from a write. This AST guard holds the *persistence* line: no production
+module may call ``Claim.objects.{create,bulk_create,get_or_create,update_or_create}``
+except the two sanctioned mint sites — ``claim_writer`` (the interactive
+primitive ``_assert_claim``) and the ingest bulk path. Bare ``Claim(...)``
+construction is fine: ingest builds unsaved instances that persist only through
+the sanctioned ``bulk_create``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from apps.core.tests._source_guard import production_sources
+
+# Persisting manager methods. Reads (filter/get/...) and bare ``Claim(...)``
+# construction are not mints and are left alone.
+_MINT_METHODS = frozenset(
+    {"create", "bulk_create", "get_or_create", "update_or_create"}
+)
+
+# The only two modules allowed to persist Claim rows, relative to ``apps/``.
+_SANCTIONED = frozenset(
+    {
+        "provenance/claim_writer.py",
+        "claim_ingest/apply/persist.py",
+    }
+)
+
+_APPS_DIR = Path(__file__).resolve().parents[2]  # .../backend/apps
+
+
+def _claim_mint_methods(tree: ast.AST) -> list[str]:
+    """Method names of every ``Claim.objects.<mint>(...)`` call in ``tree``."""
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        func = node.func if isinstance(node, ast.Call) else None
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr in _MINT_METHODS
+            and isinstance(func.value, ast.Attribute)
+            and func.value.attr == "objects"
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "Claim"
+        ):
+            hits.append(func.attr)
+    return hits
+
+
+def test_no_unsanctioned_claim_persistence() -> None:
+    offenders = [
+        rel
+        for path in production_sources()
+        if (rel := path.relative_to(_APPS_DIR).as_posix()) not in _SANCTIONED
+        and _claim_mint_methods(ast.parse(path.read_text()))
+    ]
+    assert not offenders, (
+        "Claim rows must be minted only through claim_writer._assert_claim or the "
+        "sanctioned ingest bulk path. Unsanctioned Claim.objects mint call(s) in: "
+        + ", ".join(sorted(offenders))
+    )
+
+
+def test_sanctioned_paths_actually_mint() -> None:
+    """Canary: the guard isn't passing vacuously — both sanctioned files mint."""
+    for rel in sorted(_SANCTIONED):
+        tree = ast.parse((_APPS_DIR / rel).read_text())
+        assert _claim_mint_methods(tree), (
+            f"{rel} no longer mints a Claim — the guard would pass vacuously"
+        )

--- a/backend/apps/provenance/tests/test_single_claim_write_path.py
+++ b/backend/apps/provenance/tests/test_single_claim_write_path.py
@@ -1,42 +1,46 @@
-"""Guard: the single ``Claim`` persistence chokepoint.
+"""Guard: the single ``Claim`` / ``ChangeSet`` persistence chokepoints.
 
 import-linter (``pyproject.toml``) enforces that only the interactive write
-surfaces may *import* the mint primitive — but it sees imports, not call sites,
-and ``Claim`` is imported everywhere for reads, so an import contract cannot tell
-a read from a write. This AST guard holds the *persistence* line: no production
-module may call ``Claim.objects.{create,bulk_create,get_or_create,update_or_create}``
-except the two sanctioned mint sites — ``claim_writer`` (the interactive
-primitive ``_assert_claim``) and the ingest bulk path. Bare ``Claim(...)``
-construction is fine: ingest builds unsaved instances that persist only through
-the sanctioned ``bulk_create``.
+surfaces may *import* the writer modules — but it sees imports, not call sites,
+and these models are imported everywhere for reads, so an import contract cannot
+tell a read from a write. This AST guard holds the *persistence* line in two
+tiers, applied to both ``Claim`` and ``ChangeSet``:
+
+* **Tier 1 — mint methods**: ``X.objects.{create,bulk_create,get_or_create,
+  update_or_create}`` only in the writer module (``claim_writer`` /
+  ``changeset_writer``) and the ingest bulk path (``claim_ingest/apply/persist.py``).
+* **Tier 2 — construction**: a bare ``X(...)`` call only in the ingest planning /
+  bulk modules that legitimately build unsaved instances. AST can't attribute an
+  ``instance.save()`` to a model without type inference, so *construction* is the
+  detectable proxy — you can't ``.save()`` what you don't construct. This closes
+  the bare-construction hole the mint-method tier alone would leave open.
+
+The writer modules mint via ``.objects.create`` (Tier 1), not bare construction,
+so they appear in the Tier-1 allowlist only; ``persist.py`` constructs *and*
+bulk-creates ``ChangeSet``, so it appears in both ChangeSet tiers.
 """
 
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
 from pathlib import Path
+from typing import NamedTuple
+
+import pytest
 
 from apps.core.tests._source_guard import production_sources
 
-# Persisting manager methods. Reads (filter/get/...) and bare ``Claim(...)``
-# construction are not mints and are left alone.
+# Persisting manager methods. Reads (filter/get/...) are not mints.
 _MINT_METHODS = frozenset(
     {"create", "bulk_create", "get_or_create", "update_or_create"}
-)
-
-# The only two modules allowed to persist Claim rows, relative to ``apps/``.
-_SANCTIONED = frozenset(
-    {
-        "provenance/claim_writer.py",
-        "claim_ingest/apply/persist.py",
-    }
 )
 
 _APPS_DIR = Path(__file__).resolve().parents[2]  # .../backend/apps
 
 
-def _claim_mint_methods(tree: ast.AST) -> list[str]:
-    """Method names of every ``Claim.objects.<mint>(...)`` call in ``tree``."""
+def _mint_method_calls(tree: ast.AST, model: str) -> list[str]:
+    """Method names of every ``<model>.objects.<mint>(...)`` call in ``tree``."""
     hits: list[str] = []
     for node in ast.walk(tree):
         func = node.func if isinstance(node, ast.Call) else None
@@ -46,30 +50,80 @@ def _claim_mint_methods(tree: ast.AST) -> list[str]:
             and isinstance(func.value, ast.Attribute)
             and func.value.attr == "objects"
             and isinstance(func.value.value, ast.Name)
-            and func.value.value.id == "Claim"
+            and func.value.value.id == model
         ):
             hits.append(func.attr)
     return hits
 
 
-def test_no_unsanctioned_claim_persistence() -> None:
+def _construction_calls(tree: ast.AST, model: str) -> list[str]:
+    """Every bare ``<model>(...)`` Name-call in ``tree`` (instance construction)."""
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        func = node.func if isinstance(node, ast.Call) else None
+        if isinstance(func, ast.Name) and func.id == model:
+            hits.append(model)
+    return hits
+
+
+class GuardSpec(NamedTuple):
+    """One (model, tier) persistence rule: a detector + its sanctioned files."""
+
+    label: str
+    model: str
+    detector: Callable[[ast.AST, str], list[str]]
+    sanctioned: frozenset[str]  # paths relative to ``apps/``
+
+
+_SPECS = [
+    GuardSpec(
+        "Claim mint methods",
+        "Claim",
+        _mint_method_calls,
+        frozenset({"provenance/claim_writer.py", "claim_ingest/apply/persist.py"}),
+    ),
+    GuardSpec(
+        "ChangeSet mint methods",
+        "ChangeSet",
+        _mint_method_calls,
+        frozenset({"provenance/changeset_writer.py", "claim_ingest/apply/persist.py"}),
+    ),
+    GuardSpec(
+        "Claim construction",
+        "Claim",
+        _construction_calls,
+        frozenset({"claim_ingest/apply/claims.py", "claim_ingest/apply/dry_run.py"}),
+    ),
+    GuardSpec(
+        "ChangeSet construction",
+        "ChangeSet",
+        _construction_calls,
+        frozenset({"claim_ingest/apply/persist.py"}),
+    ),
+]
+
+
+@pytest.mark.parametrize("spec", _SPECS, ids=lambda s: s.label)
+def test_no_unsanctioned_persistence(spec: GuardSpec) -> None:
     offenders = [
         rel
         for path in production_sources()
-        if (rel := path.relative_to(_APPS_DIR).as_posix()) not in _SANCTIONED
-        and _claim_mint_methods(ast.parse(path.read_text()))
+        if (rel := path.relative_to(_APPS_DIR).as_posix()) not in spec.sanctioned
+        and spec.detector(ast.parse(path.read_text()), spec.model)
     ]
     assert not offenders, (
-        "Claim rows must be minted only through claim_writer._assert_claim or the "
-        "sanctioned ingest bulk path. Unsanctioned Claim.objects mint call(s) in: "
-        + ", ".join(sorted(offenders))
+        f"{spec.model} rows must be persisted only through the sanctioned "
+        f"modules ({', '.join(sorted(spec.sanctioned))}). "
+        f"Unsanctioned {spec.label.lower()} in: " + ", ".join(sorted(offenders))
     )
 
 
-def test_sanctioned_paths_actually_mint() -> None:
-    """Canary: the guard isn't passing vacuously — both sanctioned files mint."""
-    for rel in sorted(_SANCTIONED):
+@pytest.mark.parametrize("spec", _SPECS, ids=lambda s: s.label)
+def test_sanctioned_paths_not_vacuous(spec: GuardSpec) -> None:
+    """Canary: each tier's allowlisted files actually exhibit the pattern."""
+    for rel in sorted(spec.sanctioned):
         tree = ast.parse((_APPS_DIR / rel).read_text())
-        assert _claim_mint_methods(tree), (
-            f"{rel} no longer mints a Claim — the guard would pass vacuously"
+        assert spec.detector(tree, spec.model), (
+            f"{rel} no longer matches '{spec.label}' — the guard would pass "
+            "vacuously; update the allowlist."
         )

--- a/backend/apps/provenance/tests/test_undo_changeset.py
+++ b/backend/apps/provenance/tests/test_undo_changeset.py
@@ -30,13 +30,6 @@ def author(db):
     return make_user()
 
 
-@pytest.fixture
-def bootstrap_source(db):
-    return Source.objects.create(
-        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
-    )
-
-
 def _title(slug: str, source: Source) -> Title:
     label = slug.replace("-", " ").title()
     t = Title.objects.create(name=label, slug=slug, status="active")

--- a/backend/apps/provenance/tests/test_undo_changeset.py
+++ b/backend/apps/provenance/tests/test_undo_changeset.py
@@ -13,9 +13,9 @@ import pytest
 from apps.accounts.test_factories import make_user
 from apps.catalog.engine.entity_api.delete import execute_soft_delete
 from apps.catalog.models import Title
-from apps.provenance.models import ChangeSet, ChangeSetAction, Claim, Source
+from apps.provenance.models import ChangeSet, ChangeSetAction, Source
 from apps.provenance.revert import UndoError, execute_undo_changeset
-from apps.provenance.test_factories import user_changeset
+from apps.provenance.test_factories import make_claim, user_changeset
 
 pytestmark = pytest.mark.django_db
 
@@ -42,8 +42,8 @@ def _title(slug: str, source: Source) -> Title:
     t = Title.objects.create(name=label, slug=slug, status="active")
     # Seed name + status claims so the resolver has something to fall
     # back to after an undo deactivates the user's claim.
-    Claim.objects.assert_claim(t, "name", label, source=source)
-    Claim.objects.assert_claim(t, "status", "active", source=source)
+    make_claim(t, "name", label, source=source)
+    make_claim(t, "status", "active", source=source)
     return t
 
 
@@ -57,11 +57,8 @@ class TestEligibility:
         t = _title("g", bootstrap_source)
         cs, _ = execute_soft_delete(t, user=author)
         # Supersede the status=deleted claim with a status=active claim.
-        from apps.provenance.models import Claim
 
-        Claim.objects.assert_claim(
-            t, "status", "active", user=author, changeset=user_changeset(author)
-        )
+        make_claim(t, "status", "active", user=author, changeset=user_changeset(author))
         with pytest.raises(UndoError):
             execute_undo_changeset(_require_changeset(cs), user=author)
 
@@ -74,8 +71,8 @@ class TestInverseBehavior:
         m = MachineModel.objects.create(
             title=t, name="MM Pro", slug="mm-pro", status="active"
         )
-        Claim.objects.assert_claim(m, "name", "MM Pro", source=bootstrap_source)
-        Claim.objects.assert_claim(m, "status", "active", source=bootstrap_source)
+        make_claim(m, "name", "MM Pro", source=bootstrap_source)
+        make_claim(m, "status", "active", source=bootstrap_source)
         delete_cs, _ = execute_soft_delete(t, user=author)
 
         t.refresh_from_db()
@@ -103,7 +100,7 @@ class TestInverseBehavior:
     def test_reactivates_prior_user_claim_if_any(self, author, bootstrap_source):
         t = _title("g", bootstrap_source)
         # User first asserts status=active (their own prior claim).
-        prior = Claim.objects.assert_claim(
+        prior = make_claim(
             t, "status", "active", user=author, changeset=user_changeset(author)
         )
         # Then deletes.

--- a/backend/apps/provenance/tests/test_validation.py
+++ b/backend/apps/provenance/tests/test_validation.py
@@ -17,6 +17,7 @@ from apps.catalog.models import (
 )
 from apps.catalog.tests.conftest import make_machine_model
 from apps.provenance.models import Claim, Source
+from apps.provenance.test_factories import make_claim
 from apps.provenance.validation import (
     DIRECT,
     EXTRA,
@@ -396,17 +397,17 @@ class TestAssertClaimValidation:
         """assert_claim should reject invalid scalar values."""
         model = make_machine_model(name="Test", slug="test")
         with pytest.raises(ValidationError, match="must be an integer"):
-            Claim.objects.assert_claim(model, "ipdb_id", "not-a-number", source=source)
+            make_claim(model, "ipdb_id", "not-a-number", source=source)
 
     def test_allows_valid_direct_claim(self, source):
         model = make_machine_model(name="Test", slug="test")
-        claim = Claim.objects.assert_claim(model, "ipdb_id", 42, source=source)
+        claim = make_claim(model, "ipdb_id", 42, source=source)
         assert claim.value == 42
 
     def test_allows_relationship_claim(self, source):
         """assert_claim accepts relationship claims (batch target validation is separate)."""
         model = make_machine_model(name="Test", slug="test")
-        claim = Claim.objects.assert_claim(
+        claim = make_claim(
             model,
             "credit",
             {"person": 1, "role": 2, "exists": True},
@@ -418,18 +419,14 @@ class TestAssertClaimValidation:
     def test_allows_extra_data_claim(self, source):
         """Extra-data claims should pass through without validation."""
         model = make_machine_model(name="Test", slug="test")
-        claim = Claim.objects.assert_claim(
-            model, "opdb.description", "A great game", source=source
-        )
+        claim = make_claim(model, "opdb.description", "A great game", source=source)
         assert claim.value == "A great game"
 
     def test_rejects_unrecognized_claim(self, source):
         """Unrecognized field on a model without extra_data is rejected."""
         theme = Theme.objects.create(name="Medieval", slug="medieval")
         with pytest.raises(ValueError, match="Unrecognized claim field_name"):
-            Claim.objects.assert_claim(
-                theme, "nonexistent_field", "whatever", source=source
-            )
+            make_claim(theme, "nonexistent_field", "whatever", source=source)
 
 
 # ---------------------------------------------------------------------------
@@ -982,7 +979,7 @@ class TestAssertClaimRelationshipShape:
         # model with extra_data would fall through to EXTRA and silently land.
         # Now it routes to RELATIONSHIP and the validator rejects it.
         with pytest.raises(ValidationError, match="missing required 'exists'"):
-            Claim.objects.assert_claim(
+            make_claim(
                 model,
                 "credit",
                 {"person": 1, "role": 1},  # no "exists"
@@ -995,7 +992,7 @@ class TestAssertClaimRelationshipShape:
         design_pk = credit_targets["roles"]["design"].pk
         with pytest.raises(ValidationError, match="not canonical"):
             # No claim_key= → assert_claim defaults it to field_name.
-            Claim.objects.assert_claim(
+            make_claim(
                 model,
                 "credit",
                 {"person": pat_pk, "role": design_pk, "exists": True},
@@ -1005,7 +1002,7 @@ class TestAssertClaimRelationshipShape:
     def test_wrong_subject_rejected(self, source):
         title = Title.objects.create(name="T", slug="t")
         with pytest.raises(ValidationError, match="not valid on Title"):
-            Claim.objects.assert_claim(
+            make_claim(
                 title,
                 "credit",
                 {"person": 1, "role": 1, "exists": True},

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -358,7 +358,7 @@ def classify_claim(
 
     Pass ``claim_fields`` to avoid repeated ``get_claim_fields()`` calls in
     batch contexts. When omitted, it is computed on each call (fine for
-    single-claim use in ``assert_claim``).
+    single-claim use in ``_assert_claim``).
     """
     if claim_fields is None:
         claim_fields = get_claim_fields(model_class)
@@ -384,7 +384,7 @@ def validate_single_relationship_claim(
 ) -> None:
     """Validate one relationship claim's shape. Raises ``ValidationError``.
 
-    Shared by ``assert_claim`` and ``validate_claims_batch``. Rules are
+    Shared by ``_assert_claim`` and ``validate_claims_batch``. Rules are
     applied in a fixed order (see implementation) — each rule assumes its
     predecessors have passed; reordering trades a clean ``ValidationError``
     for a ``TypeError``/``KeyError`` that masks the real problem.

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -9,6 +9,7 @@ from sentry_sdk.transport import Transport
 from apps.accounts.models import User
 from apps.accounts.test_factories import make_user
 from apps.catalog.models import CreditRole, Person
+from apps.provenance.models import Source
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Event
@@ -37,6 +38,21 @@ def staff(db: None) -> User:
 def superuser(db: None) -> User:
     """Default superuser test user (also staff)."""
     return make_user(is_staff=True, is_superuser=True)
+
+
+@pytest.fixture
+def bootstrap_source(db: None) -> Source:
+    """Low-priority editorial Source for seeding baseline name/scalar claims.
+
+    Priority 1 ensures bootstrap claims never outrank real source or user
+    claims in tests that set up competing claims. Project-root fixture so test
+    files don't each define their own; a local fixture of the same name shadows
+    it (and tests needing a different priority/slug should call
+    ``Source.objects.create`` directly).
+    """
+    return Source.objects.create(
+        name="Bootstrap", slug="bootstrap", source_type="editorial", priority=1
+    )
 
 
 @pytest.fixture

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -513,6 +513,7 @@ layers = [
     "evidence | history",
     "helpers",
     "claims | claim_writer | display | revert",
+    "changeset_writer",
     "validation | schemas | claim_ranking_in_db | licensing | resolution | rate_limits",
     "models | claim_presence | constants | entity_resolution | pagination | authz | typing",
     # The abstract claim-control bases every claim-controlled model inherits.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -247,6 +247,29 @@ allow_indirect_imports = "true"
 source_modules = ["apps.claim_ingest"]
 forbidden_modules = ["apps.claim_edit"]
 
+# The single claim-mint chokepoint. ``apps.provenance.claim_writer._assert_claim``
+# is the one sanctioned non-ingest place a Claim is minted; only the two
+# interactive write surfaces may reach it — claim_edit (the generic engine) and
+# media (its own attach/detach mutations). Every other app is forbidden, so a new
+# write path can't quietly grow a second mint primitive. Commit 2 drops media
+# from this allow-set once media routes through claim_edit's execute_claims.
+# (provenance itself is not a source — intra-app imports of claim_writer are
+# governed by the internal-stack layers contract instead.)
+[[tool.importlinter.contracts]]
+name = "Only the interactive write surfaces import the claim-mint primitive"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "apps.core",
+    "apps.accounts",
+    "apps.actors",
+    "apps.citation",
+    "apps.catalog",
+    "apps.claim_ingest",
+    "apps.kiosk",
+]
+forbidden_modules = ["apps.provenance.claim_writer"]
+
 # --- Media peer-isolation ---
 
 # Media internals are peer-isolated from the citation/provenance data apps.
@@ -359,7 +382,10 @@ source_modules = [
     "apps.kiosk",
 ]
 forbidden_modules = ["apps.provenance.test_factories"]
-ignore_imports = ["apps.*.tests.** -> apps.provenance.test_factories"]
+# apps.**.tests.** (not apps.*.tests.**) so nested test packages like
+# apps.catalog.resolve.tests are covered — the commit that routed tests through
+# make_claim means deeply-nested test packages now import this factory too.
+ignore_imports = ["apps.**.tests.** -> apps.provenance.test_factories"]
 
 # ===========================================================================
 # Per-app internal structure (dependency order: consumers first, core last)
@@ -485,7 +511,7 @@ layers = [
     "page_endpoints",
     "evidence | history",
     "helpers",
-    "claims | display | revert",
+    "claims | claim_writer | display | revert",
     "validation | schemas | claim_ranking_in_db | licensing | resolution | rate_limits",
     "models | claim_presence | constants | entity_resolution | pagination | authz | typing",
     # The abstract claim-control bases every claim-controlled model inherits.
@@ -495,11 +521,6 @@ layers = [
     # since the global tiers would otherwise let it import down into citation /
     # accounts. Together they keep the package lift-out-ready (below citation).
     "model_bases",
-]
-ignore_imports = [
-    # validation imports models, so ClaimManager (models/claim.py) calls it lazily
-    # at write time; hoisting that out would weaken self-validation.
-    "apps.provenance.models.claim -> apps.provenance.validation",
 ]
 
 [[tool.importlinter.contracts]]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -248,13 +248,13 @@ source_modules = ["apps.claim_ingest"]
 forbidden_modules = ["apps.claim_edit"]
 
 # The single claim-mint chokepoint. ``apps.provenance.claim_writer._assert_claim``
-# is the one sanctioned non-ingest place a Claim is minted; only the two
-# interactive write surfaces may reach it — claim_edit (the generic engine) and
-# media (its own attach/detach mutations). Every other app is forbidden, so a new
-# write path can't quietly grow a second mint primitive. Commit 2 drops media
-# from this allow-set once media routes through claim_edit's execute_claims.
-# (provenance itself is not a source — intra-app imports of claim_writer are
-# governed by the internal-stack layers contract instead.)
+# is the one sanctioned non-ingest place a Claim is minted; only claim_edit (the
+# generic interactive write engine) may reach it. Every other app is forbidden,
+# so a new write path can't quietly grow a second mint primitive. Media routes
+# its attach/detach mutations through claim_edit's execute_claims, so it is
+# forbidden here too — leaving execute_claims as the single non-ingest mint
+# caller. (provenance itself is not a source — intra-app imports of claim_writer
+# are governed by the internal-stack layers contract instead.)
 [[tool.importlinter.contracts]]
 name = "Only the interactive write surfaces import the claim-mint primitive"
 type = "forbidden"
@@ -267,6 +267,7 @@ source_modules = [
     "apps.catalog",
     "apps.claim_ingest",
     "apps.kiosk",
+    "apps.media",
 ]
 forbidden_modules = ["apps.provenance.claim_writer"]
 

--- a/docs/Provenance.md
+++ b/docs/Provenance.md
@@ -56,6 +56,7 @@ NOT claims-based: **System-generated fields** like `id`/`uuid`, timestamps, deri
 
 ## Key Code
 
-- `backend/apps/provenance/models.py` — Source, Claim, ClaimManager
+- `backend/apps/provenance/models/` — Source, Claim, ChangeSet, IngestRun
+- `backend/apps/provenance/claim_writer.py` — `_assert_claim`, the single claim-mint primitive (the one non-ingest place a Claim is persisted)
 - `backend/apps/catalog/claims.py` — Relationship schemas and claim key helpers
 - `backend/apps/catalog/resolve/` — Resolution logic

--- a/docs/plans/auth/Actors.md
+++ b/docs/plans/auth/Actors.md
@@ -386,7 +386,7 @@ Write paths save `ChangeSet.actor` and `Claim.actor` going forward, so the backf
 
 Write-path invariants (held by the funnel plus a NULL-guarded data-integrity test, so they're safe to run pre-backfill): `Claim.actor == changeset.actor`; `changeset.actor == ingest_run.source.actor` / `changeset.user.actor`.
 
-**One PR, three commits** (reviewed on commit boundaries): (1) relocate the mint primitive — behavior-neutral; (2) route media through `execute_claims` — behavioral, characterization-tested; (3) save actor FKs — the actor-first funnel + stamp + invariants.
+**One PR, four commits** (reviewed on commit boundaries): (1) relocate the mint primitive — behavior-neutral; (2) route media through `execute_claims` — behavioral, characterization-tested; (3) upload's error contract — surface 422 from `upload_media` while preserving storage cleanup; (4) save actor FKs — the actor-first funnel + stamp + invariants.
 
 #### Backfill actor FKs
 

--- a/docs/plans/auth/Actors.md
+++ b/docs/plans/auth/Actors.md
@@ -365,13 +365,13 @@ This will be its own PR.
 
 This will be its own PR.
 
-#### Enforce single claims write path
+#### ✅ DONE: Enforce single claims write path
 
 Make the claim-mint primitive the single, enforced chokepoint before layering actor attribution on it. Relocate the primitive off `Claim.objects` into a module-level `_assert_claim` (new `apps/provenance/claim_writer.py`) and **delete `ClaimManager`** (its only method). Validation moves up with it, retiring the `models.claim → validation` import-linter exception. Lock the chokepoint two ways: an import-linter forbidden contract (only `claim_edit` may import `claim_writer`) and an AST mint-guard test (no `Claim` _persistence_ — `objects.create`/`bulk_create`/etc. — outside `claim_writer` + ingest's `persist.py`). Route media through `execute_claims` so there's one non-ingest mint caller. Sweep tests onto a `make_claim` factory.
 
 Ships together with "Save actor FKs" as one PR — see the commit breakdown there.
 
-#### Save actor FKs
+#### ✅ DONE: Save actor FKs
 
 Write paths save `ChangeSet.actor` and `Claim.actor` going forward, so the backfill (next step) runs **once** with no fresh gaps appearing behind it.
 

--- a/docs/plans/auth/Actors.md
+++ b/docs/plans/auth/Actors.md
@@ -365,6 +365,29 @@ This will be its own PR.
 
 This will be its own PR.
 
+#### Enforce single claims write path
+
+Make the claim-mint primitive the single, enforced chokepoint before layering actor attribution on it. Relocate the primitive off `Claim.objects` into a module-level `_assert_claim` (new `apps/provenance/claim_writer.py`) and **delete `ClaimManager`** (its only method). Validation moves up with it, retiring the `models.claim → validation` import-linter exception. Lock the chokepoint two ways: an import-linter forbidden contract (only `claim_edit` may import `claim_writer`) and an AST mint-guard test (no `Claim` _persistence_ — `objects.create`/`bulk_create`/etc. — outside `claim_writer` + ingest's `persist.py`). Route media through `execute_claims` so there's one non-ingest mint caller. Sweep tests onto a `make_claim` factory.
+
+Ships together with "Save actor FKs" as one PR — see the commit breakdown there.
+
+#### Save actor FKs
+
+Write paths save `ChangeSet.actor` and `Claim.actor` going forward, so the backfill (next step) runs **once** with no fresh gaps appearing behind it.
+
+- **Build**
+  - A `record_changeset(*, actor, action=None, ingest_run=None, …)` funnel (new `changeset_writer.py`) and the relocated `_assert_claim` go **actor-first**: callers pass an `Actor`, never user/source.
+  - `Claim.actor = changeset.actor`. The legacy `user`/`source` column is still populated this PR (its CHECK + unique constraints stay live until later steps) via a **model-driven stamp** — `setattr(claim, actor.backing_model, backing)`, no `if actor_type` branch and no hand-declared per-type field name (`backing_model` already names the legacy Claim FK) — deletion-scheduled for "Drop dead schema".
+  - **Dedupe stays keyed on the legacy author column** this PR: historical active claims have `actor = NULL`, so an actor-keyed filter would miss them and trip the live per-user/per-source unique index on any re-edit. Actor-keyed dedupe moves to "Tighten schema" (with the unified index).
+  - Ingest sets `actor` on its bulk ChangeSets/Claims (`= ingest_run.source.actor`).
+  - Extend the AST guard to also lock `ChangeSet` creation to the funnel + ingest.
+- **Migrate**
+  - None — the `actor` columns already exist nullable.
+
+Write-path invariants (held by the funnel plus a NULL-guarded data-integrity test, so they're safe to run pre-backfill): `Claim.actor == changeset.actor`; `changeset.actor == ingest_run.source.actor` / `changeset.user.actor`.
+
+**One PR, three commits** (reviewed on commit boundaries): (1) relocate the mint primitive — behavior-neutral; (2) route media through `execute_claims` — behavioral, characterization-tested; (3) save actor FKs — the actor-first funnel + stamp + invariants.
+
 #### Backfill actor FKs
 
 All ~222K changesets (original + backfilled) need `ChangeSet.actor` populated:
@@ -407,13 +430,25 @@ These migrations don't move data; they only change validation.
 
 This will be its own PR.
 
-#### Drop dead schema
+#### Drop dead stuff
+
+Drop dead schema:
 
 - **Migrate**
   - DELETE priority from User
   - DELETE priority, is_enabled from Source
   - DELETE `Claim.user` / `Claim.source`, the per-source/per-user unique indexes and the `source`-XOR-`user` check (all replaced by `Claim.actor` + the unified index)
   - DELETE `ChangeSet.user` and the `user`-XOR-`ingest_run` check (replaced by `ChangeSet.actor`); re-express `action IFF user` as `action IFF ingest_run IS NULL` (interactive edits carry an action; batch/ingest ones don't). `ingest_run` itself stays — it's batch metadata now, not attribution.
+
+Drop dead reads:
+
+The load-bearing reads — resolution, license, author/display, history, revert and undo authz — were already repointed onto `actor` in "Cut over consumers" (that PR carries the byte-identical acceptance bar). What's left here is the dead scaffolding that only existed to service the legacy columns, removed in lockstep with deleting them:
+
+- **The transitional legacy-author stamp** from "Save actor FKs" — the `setattr(claim, actor.backing_model, backing)` stamp helper and `record_changeset`'s `cs.user = actor.user` line. With `Claim.user`/`source` and `ChangeSet.user` gone there's nothing left to stamp, so the write funnel becomes purely actor (its end state).
+- **The model field declarations + annotations** they leave behind: the `user` / `source` FKs on `Claim`, `user` on `ChangeSet`, and the `user_id` / `ingest_run_id` / `source_id` typing shims. The per-user `ChangeSet` indexes (`provenance_cs_user_created`, `provenance_cs_user_action`) go too — their actor-keyed replacement (for revert's experience gate, `ChangeSet.filter(actor=…)`) lands in "Tighten schema".
+- **Cosmetic readers** that "Cut over consumers" left alone because they don't touch resolution: `ChangeSet.__str__`, provenance/catalog admin `list_display` / `search_fields`, and any `select_related("…user")` / `("source")` prefetch hints that survive — repoint to `actor` or drop.
+
+Acceptance: a grep gate proving no non-migration code names `claim.user` / `claim.source` / `changeset.user` / `ingest_run.source` for attribution — `actor` is the only attribution read left.
 
 This will be its own PR.
 

--- a/docs/plans/model_driven_metadata/ClaimResolutionRefactor.md
+++ b/docs/plans/model_driven_metadata/ClaimResolutionRefactor.md
@@ -1,0 +1,209 @@
+# Claim Resolution: Pick and Reconcile
+
+## Context
+
+Claims are the source of truth. A claim is a provenance-bearing assertion about one field of one entity ("this MachineModel's `name` is X, per source Y, at priority P"). The queryable catalog — the denormalized columns on each entity row, plus the through-tables for relationships (themes, credits, gameplay features, aliases, abbreviations, parents) — is **not** truth. It is a **materialized view** computed by a deterministic reduction over the active claims. **Resolution** is the function that maintains that view: given an entity whose claims just changed, recompute the affected part of the view so it agrees with the claims.
+
+This document is about the machinery that drives that reduction across entities, fields, cardinalities and caches. That machinery grew one relationship at a time, by copy-pasting the nearest existing resolver and changing the keying, and it is now the hardest part of the system to reason about. Sessions stumble on it because there is no canonical resolver to reason _from_ — there are ~25 near-identical variations, one of which (MachineModel) is silently different from the rest.
+
+The merge policy itself is **not** the problem and is **not** what this document changes. It is already single-sourced. Per `claim_key`, rank by effective priority then recency and take the winner (`ranked_claims` in `apps/provenance/claim_ranking_in_db.py`). Per relationship member, rank independently and let an `exists=false` tombstone win to remove the member (`member_is_present`). The rule "anything that needs a resolved value reuses these primitives and never reimplements the merge" holds and stays. The problem is the **loop around** the merge — group, pick, project to a desired set, diff against what's stored, write the delta — which lives nowhere and is therefore re-implemented everywhere.
+
+A structural goal shapes the end state: the resolution _mechanism_ should live in provenance beside the claim store it operates on, leaving only pinball-specific schema and config in catalog. Flipcommons is also meant to prove out reusable collaborative-encyclopedia software, so a future domain (baseball, medicine) could replace the pinball catalog without rewriting the claim machinery. Keep two horizons distinct. **Relocating the already-domain-agnostic mechanism to provenance is a concrete goal of this effort** (it is what makes the boundary real) and the plan is structured to make it a cheap, mechanical follow-on — see [step 7](#plan-of-record). **Building a declaration DSL so a second domain needs no code at all is speculative generality** and is deferred until a real second domain forces its shape. The pain today is duplication and a privileged entity type, not "can't reuse for medicine" — so the mechanism is extracted and moved, but no DSL is built over it.
+
+## Open Questions
+
+- **Can the scalar column projection share the literal `reconcile()` body, or only its winner-picking?** A scalar field is conceptually the degenerate reconcile where the "table" is the entity row and the member set has cardinality ≤1 keyed by `field_name`. Elegant — but the write sides genuinely differ (`bulk_update` of columns vs `bulk_create`/`delete` of through-rows). Unify the _winner-picking_ for certain; treat one-literal-`reconcile`-over-both as a judgment call at implementation time, not a goal.
+- **Ordering as data, or just control flow?** "Ordering" decomposes into two things that want opposite representations: (a) the **batch from-scratch rebuild** needs a global order across entity types (FK targets before dependents — because FK lookups read the target's _resolved_ natural key, [\_helpers.py:120](../../../backend/apps/catalog/resolve/_helpers.py#L120)) plus intra-type DAGs (Location tree, Theme/GameplayFeature parents); this is a ~15-line explicit sequence that runs offline once and should stay plain control flow, not a topological-sort engine. (b) The **incremental path** needs no cross-entity order — targets are already resolved — except for genuine cross-projection _cascade_ edges (projection A reads projection B's materialized output, so a change to B must re-run A). The audit found exactly one such edge (model*abbreviations ← title_abbreviations), and [the decision below](#decision-collapse-the-model-abbreviation-cross-entity-edge) removes it — so after step 0 the incremental-cascade count is **zero** and no cascade-trigger mechanism is warranted. The one residual output-read anywhere is the FK natural-key lookup, and it is a \_batch-order* concern (target resolved before dependent in the rebuild), not an incremental cascade — the target's pk is stable, so a dependent never needs re-resolving when its target changes. Keep it as control flow. If a future projection ever reads another projection's _output_ incrementally, that violates [Purity](#invariants-to-preserve) and should be redesigned to read claims, not patched with a cascade edge.
+
+## The root cause, stated precisely
+
+**The subsystem is indexed along the wrong axis, so two primitives that should exist once were instead inlined everywhere.**
+
+The code is organized by _(entity type × relationship name)_ — 25 named `resolve_*` functions. But the actual variation is _(projection shape × subject set)_, and there are only about four shapes:
+
+| Shape                    | Target                                              | Examples                                                        |
+| ------------------------ | --------------------------------------------------- | --------------------------------------------------------------- |
+| Scalar / FK column       | a column on the entity row                          | name, slug, manufacturer FK, status                             |
+| Plain through-row        | `(subject, target)` rows                            | themes, tags, reward_types, parents, corporate-entity locations |
+| Payload through-row      | `(subject, target, …columns)` rows, supports update | gameplay features (`count`), aliases (display case), media      |
+| Compound-key through-row | `(subject, tuplekey)` rows                          | credits `(person, role)`                                        |
+
+String-sets (abbreviations) are plain through-rows whose target _is_ the string. Aliases are payload-rows. There are ~4 shapes instantiated ~25 times because every new relationship was added by copy-paste, since there was no primitive to call instead. That is the whole story of how a four-shape problem became a twenty-five-function one.
+
+Underneath the wrong axis sit two un-extracted primitives. Resolution is really three layers, and only the innermost is shared:
+
+1. **rank** — order claims by (priority, recency). Extracted: `ranked_claims`, a SQL window. ✓
+2. **pick winners** — walk the ranked rows and take the first per key into a dict. Copy-pasted **13 times** across `_entities.py`, `_relationships.py` and `__init__.py`. ✗
+3. **reconcile** — build the desired set, read the existing rows, diff, write create/delete/update. Copy-pasted **9 times** across `_relationships.py` (8) and `_media.py` (1). ✗
+
+The team extracted ranking and treated that as "the merge is single-sourced." It is — but the merge people struggle with is layers 2 and 3, and those live nowhere. Because they live nowhere, there is no single place to put field-scoping, cardinality, incrementality or cache scope, so each becomes a separately hand-maintained concern and each copy drifts. The most-edited entity drifted furthest (see below).
+
+This is the load-bearing diagnosis: **`pick_winners` and `reconcile` are two missing functions, and `pick_winners` — a ~3-line function with 13 call sites — is the cheapest, highest-leverage extraction in the subsystem.**
+
+### The second root cause: `resolve_model` should not exist
+
+`resolve_model` ([**init**.py:88](../../../backend/apps/catalog/resolve/__init__.py#L88)) is a hand-tuned full-entity mega-resolver for MachineModel, the single most-edited entity. It is a parallel implementation of everything the generic path already does:
+
+- its own winner-pick loop ([**init**.py:99-105](../../../backend/apps/catalog/resolve/__init__.py#L99)),
+- its own scalar apply (`_apply_resolution`, a third near-clone of `_resolve_single` / `_resolve_bulk`),
+- slug/opdb_id conflict guards folded in as save-time **side effects** ([**init**.py:127-156](../../../backend/apps/catalog/resolve/__init__.py#L127)) that re-fire on edits to fields that never touched a guarded column,
+- six hardcoded relationship calls ([**init**.py:160-170](../../../backend/apps/catalog/resolve/__init__.py#L160)),
+- and it ignores `field_names` entirely.
+
+It is reached through the only `isinstance(entity, MachineModel)` branch left in the dispatch ([\_dispatch.py:132](../../../backend/apps/catalog/resolve/_dispatch.py#L132)). It is why MachineModel runs a different code path from every other entity — which is most of why sessions can't form a single mental model of resolution — and it is nearly the entire content of issue #558 (per-entity resolution ignoring `field_names`).
+
+Everything `resolve_model` does is already available generically. `resolve_all_entities` resolves its scalars and FKs; `resolve_unique_conflicts` already implements the slug/opdb_id guard for the bulk path; the six relationship resolvers already take `subject_ids`. `resolve_model` is not load-bearing — it is un-deleted history.
+
+### Current dispatch state — accurate as of this writing
+
+The owner-registered dispatch inversion **already shipped at the provenance seam**. `apps/provenance/resolution/_dispatch.py` holds the registry keyed by concrete model, `register_resolve_handlers`, fail-fast `ImproperlyConfigured` and the two entry points (`resolve_after_mutation`, `resolve_entities_bulk`); catalog registers a handler pair for every model at `CatalogConfig.ready()`. That part is done and correct — it is the right boundary and should be left alone.
+
+But the inversion landed at the outer boundary and stopped. The `isinstance(MachineModel)` switch still sits _inside_ catalog's single registered per-entity handler ([\_dispatch.py:132](../../../backend/apps/catalog/resolve/_dispatch.py#L132)), because `resolve_model` is still a parallel implementation. The boundary that mattered least was inverted; the type-switch that mattered most remains. Any plan must start from this actual state.
+
+## The design patterns and data structures
+
+Naming the load-bearing constructs keeps the redesign honest — it pins which invariants to preserve and lets a reviewer check each pattern against its known failure modes.
+
+| Construct                                                         | Role here                                                                                                                                                                                                                                                                                                                        |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Event-sourced projection / CQRS**                               | Active claims are the write model (append-only, provenance-bearing). The catalog columns and through-tables are a read model. Resolution is the projection that rebuilds the read model from the claims.                                                                                                                         |
+| **Materialized view + incremental view maintenance (IVM)**        | The read model is a materialized view over the claims. The whole thesis is "do IVM with one primitive that touches only the delta," not "full-refresh-per-edit by hand across four concerns."                                                                                                                                    |
+| **CRDT — last-writer-wins register (LWW-Register)**               | The scalar / FK / status merge: one winner per `claim_key` by (priority, recency).                                                                                                                                                                                                                                               |
+| **CRDT — tombstoned LWW-Element-Set**                             | The membership merge: each member winner-picked independently, an `exists=false` tombstone able to win and remove it. Explicitly **not** an OR-Set / add-wins set — a member _can_ lose to a later removal, which add-wins forbids.                                                                                              |
+| **Fold / argmax reduction**                                       | `pick_winners` itself: a reduction over `ranked_claims` taking the first (max-ranked) row per key. The missing layer-2 primitive.                                                                                                                                                                                                |
+| **Desired-state reconciliation (the Kubernetes-controller loop)** | `reconcile`: observe desired set, observe actual set, diff, converge by create/delete/update. The missing layer-3 primitive. `_resolve_machine_model_m2m` already is one, un-extracted.                                                                                                                                          |
+| **Level-triggered (not edge-triggered)**                          | Why the system is "always correct, just wasteful": a level-triggered reconciler recomputes desired state from the current claims regardless of what changed, so scoping by changed field is an _optimization_, never a correctness fix. `field_names` is a partial, hand-rolled edge-trigger bolted onto a level-triggered core. |
+| **Set difference + idempotence**                                  | Convergence math: `to_create = desired − existing`, `to_delete = existing − desired`, `to_update = {k ∈ desired ∩ existing : payload differs}`. Re-running converges to the same state and writes nothing the second time.                                                                                                       |
+| **Strategy + registry, open/closed**                              | Dispatch: a registry of per-model handlers populated by owner registration at `ready()`, so adding a domain extends the table without editing the dispatcher. Already shipped at the provenance seam.                                                                                                                            |
+| **Degenerate case (cardinality-≤1)**                              | A scalar column is the membership reconcile with a one-element keyed set whose "table" is the entity row. Conceptually unifying; see Open Questions for the caveat on sharing the literal write body.                                                                                                                            |
+| **Inner-platform effect / Greenspun's tenth rule**                | The failure mode to avoid: a declaration DSL that grows until it badly reinvents the programming language it replaced. The reason this plan extracts _functions_, not a metadata language.                                                                                                                                       |
+
+The data structures are worth naming precisely, because every copy re-derives them untyped and the loose `dict[int, set | dict]` they amount to hides the actual design. A `Projection[K, P]` is generic over its **member key** `K` and its **payload** `P`; once parameterized, desired and existing are the _same_ shape, not a `set`-or-`dict` union:
+
+```python
+type SubjectId = int
+type RowId = int
+type ClaimKey = str
+type Winners = dict[SubjectId, dict[ClaimKey, Claim]]   # pick_winners output (layer 2)
+type MemberMap[K, P] = dict[SubjectId, dict[K, P]]      # desired AND existing share this
+
+class RowState[P](NamedTuple):       # an existing materialized row
+    pk: RowId                        # needed for delete/update; desired has no pk yet
+    payload: P
+
+class Delta[K, P](NamedTuple):       # what reconcile writes
+    create: list[tuple[SubjectId, K, P]]
+    delete: list[RowId]
+    update: list[tuple[RowId, P]]
+
+class Projection[K, P](Protocol):
+    def desired(self, winners: Winners) -> MemberMap[K, P]: ...          # ~5 lines, per-shape
+    def read(self, subjects: set[SubjectId]) -> MemberMap[K, RowState[P]]: ...
+    def write(self, delta: Delta[K, P]) -> None: ...
+```
+
+The `set | dict` smell is gone: a plain membership is `P = None`, a payload membership is `P = <a NamedTuple>`, and both are one `MemberMap[K, P]`. Each concrete shape is just a choice of `K` and `P`:
+
+| Shape                                     | `K`                                                       | `P`                                                                                                           |
+| ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| scalar / FK column                        | `str` (field name)                                        | the resolved column value                                                                                     |
+| plain through-row (themes, tags, parents) | `int` (target pk)                                         | `None`                                                                                                        |
+| payload through-row                       | `int` (target pk)                                         | a NamedTuple — `GameplayPayload(count: int \| None)`, `MediaPayload(category: str \| None, is_primary: bool)` |
+| compound-key through-row                  | a NamedTuple key — `CreditAssignment(person_id, role_id)` | `None`                                                                                                        |
+
+The redesign's job is to make `Winners`, `MemberMap[K, P]` and `Delta[K, P]` the _typed interface_ of two functions, not the incidental untyped locals of nine copies.
+
+## Clean-sheet shape
+
+One operation, not three dimensions and not a declaration engine:
+
+```python
+def reconcile[K, P](projection: Projection[K, P], subjects: set[SubjectId]) -> Delta[K, P]:
+    winners  = pick_winners(claims_for(projection, subjects))   # Winners — layer 2, shared
+    desired  = projection.desired(winners)                      # MemberMap[K, P] — per-shape, ~5 lines
+    existing = projection.read(subjects)                        # MemberMap[K, RowState[P]] — from the ORM
+    delta    = diff(desired, existing)                          # Delta[K, P]: create / delete / update
+    projection.write(delta)
+    return delta                                                # returned so the caller can scope cache (step 5)
+```
+
+There are not three reconcilers — there is one `reconcile` and ~4 `Projection` strategies (scalar column, plain through-row, payload through-row, compound-key through-row), each written **once**. Cardinality is just the size of `subject_ids`: the interactive edit passes `{pk}`, bulk ingest passes the whole affected set, both run identical code. Scope and cache fall out of "which projections a changed field touches" and "what a reconcile actually wrote" — a reconcile that wrote nothing need not invalidate, and it knows exactly which entity and dimension it touched. The `(model, field) → projection` table derives from registries that already exist (`get_claim_fields`, `get_relationship_schema`, `claim_fk_lookups`, the alias registry), so it is introspected, not declared.
+
+### Where clean-sheet is _not_ strictly better
+
+Stated plainly so the redesign does not oversell:
+
+1. **`update` is a real third operation.** Three resolvers already mutate an existing row's payload in place — gameplay-feature `count` ([\_relationships.py:271](../../../backend/apps/catalog/resolve/_relationships.py#L271)), alias display-case ([\_relationships.py:710](../../../backend/apps/catalog/resolve/_relationships.py#L710)) and media ([\_media.py:260](../../../backend/apps/catalog/resolve/_media.py#L260)). Pure set-difference (`desired - existing`) cannot express "same member, changed payload," so the primitive is `{create, delete, update}`, not the tidy `{create, delete}` a pure set-CRDT framing implies. Design `update` in from the start.
+2. **`desired` is not always a pure per-claim map — but the residue is exactly two hooks, audited.** All nine reconcile resolvers were checked. Seven build a claim-local desired set (the subject's own winning claims, optionally filtered against the target table's valid PKs — a uniform existence check that belongs as an engine _built-in_, not a per-resolver hook). Two need a bespoke `desired()`, of two distinct kinds:
+   - **Cross-entity (exactly one):** `resolve_all_model_abbreviations` subtracts the Title's resolved abbreviations ([\_relationships.py:590](../../../backend/apps/catalog/resolve/_relationships.py#L590)). This is the only _genuinely non-claim-local_ desired set — it reads another entity's resolved rows, so it forces an ordering dependency (titles before models) and a cross-entity read the `desired(winners)` signature can't express alone. This is the one real cap on engine genericness.
+   - **Sibling-coupled (exactly one):** `resolve_media_attachments` derives each attachment's `is_primary` from its _sibling_ attachments — at most one primary per category ([\_media.py:200](../../../backend/apps/catalog/resolve/_media.py#L200)), auto-promote the oldest if none ([\_media.py:221](../../../backend/apps/catalog/resolve/_media.py#L221)). Still a pure function of the entity's _own_ claims (priority and `created_at` ride on them), so it fits a `desired(winners)` hook with a group post-pass — a fat hook body, not a generality cap; it forces neither ordering nor cross-entity reads.
+
+   So the escape hatch is small and its exact shape is known: introspect the seven, make valid-PK filtering a built-in, hand-write `desired()` for the two non-trivial shapes — except the cross-entity one (`model_abbreviations`) is eliminated by [Decision: collapse the model-abbreviation cross-entity edge](#decision-collapse-the-model-abbreviation-cross-entity-edge), leaving a single bespoke `desired()` (the sibling-coupled media hook) and **zero** cross-entity reads.
+
+3. **Ordering stays explicit.** Level-triggered convergence does not remove the need to resolve FK targets before dependents and relationship rows before derived rows that read them. Make ordering declared data, do not pretend registration order handles it.
+4. **A database-side projection (SQL views / generated columns / triggers) is an ideal, not a plan.** It is the fastest expression of the two regular shapes, but it cannot host payload-update, cross-entity subtraction, alias case-folding or markdown-reference sync, and it raises the debugging floor for a volunteer team. Name it as a north star for the scalar and plain-membership shapes; do not gate this work on it.
+
+### Decision: collapse the model-abbreviation cross-entity edge
+
+The one genuinely non-claim-local `desired` (item 2 above) — `resolve_all_model_abbreviations` subtracting the Title's abbreviations — is being **removed**, not carried into the engine. That single subtraction is doing disproportionate damage: it is the engine's only cross-entity read, the only cross-projection cascade edge, and the source of a latent staleness bug — a Title abbreviation edit re-resolves `title_abbreviations` but nothing re-derives its models' abbreviations, so the materialized model set goes stale until that model is next touched or a full rebuild runs.
+
+The product semantics (per [SingleModelTitles.md](SingleModelTitles.md)): a Title owns the canonical abbreviation ("MM" for Medieval Madness); a Model carries only _edition_-specific abbreviations ("TS4LE"), and in the dominant single-model case the Model's are dormant. The subtraction exists so a Model doesn't redundantly list an abbreviation its Title already has. That is a **read-time union**, not a write-time subtraction — baking it into the projection is a CQRS smell (a cross-entity join smuggled into the write side).
+
+It is not cosmetic to remove: in the current dev corpus ~53% of Model abbreviation claims (489/928 with a Title) duplicate their Title's abbreviation, so the subtraction actively removes rows. The fix stores what's claimed and joins in the query:
+
+- **Resolver:** `model_abbreviations` becomes claim-local — the Model's own claimed abbreviations, overlaps included. It joins the seven simple resolvers; `_get_title_abbrs_for_models` and the subtraction loop are deleted.
+- **Read side:** the single place Model abbreviations are serialized — the model-detail endpoint (`_serialize_model_detail`, [machine_models.py:303](../../../backend/apps/catalog/api/machine_models.py#L303)) — subtracts the Title's _current_ abbreviations at read time. The Title is already loaded there; add a `title__abbreviations` prefetch to avoid N+1.
+
+Net: displayed output is unchanged, the staleness bug becomes structurally impossible (the dedup is always live), the engine keeps a single bespoke `desired()` hook and **zero** cross-entity reads, and no cross-projection cascade edge exists — which is most of what the "ordering as data" open question concerns. This is a cheap, self-contained simplification worth doing **before** the reconcile extraction, because it removes the single hardest case the engine would otherwise have to model. (It also grows the `ModelAbbreviation` table by ~the overlap count — claim-faithful rows the subtraction currently suppresses; storing them is the point.)
+
+## Plan of record
+
+The decisive property of this plan: **it is a behavior-preserving refactor inside `catalog/resolve/`, landed incrementally with existing tests green at every step.** No new app, no declaration DSL, no hoist, no rewrite. The strictly-better core is small and surgical.
+
+0. **Collapse the model-abbreviation cross-entity edge** (the [decision above](#decision-collapse-the-model-abbreviation-cross-entity-edge)): make `resolve_all_model_abbreviations` claim-local and move the Title dedup to `_serialize_model_detail`. Self-contained, ships on its own, and not strictly behavior-preserving on the storage side (it grows `ModelAbbreviation` and is TDD-able against the staleness bug) — so it goes first, before the mechanical refactor, removing the engine's only cross-entity read and only cascade edge up front. Do this before step 3 at the latest.
+
+1. **Kill `resolve_model`; route MachineModel through the generic per-entity path.** Register its six relationship namespaces into the _same_ `field_name → resolver` dispatch the non-MachineModel path already uses, consulted scoped by `field_names`. Move the slug/opdb_id guard from a save-time side effect into the scalar projection (applied uniformly for every subject, not just the single-object path). This deletes the `isinstance` branch, `_apply_resolution`, `_build_claims_by_model`, `_get_mm_relationship_resolvers` and the side-effecting guards in one move, and **resolves #558** with no new abstraction. Highest leverage, medium effort. First.
+
+2. **Extract `pick_winners`** and replace all 13 copies. A ~3-line function (`for row in ranked_claims(...): winners.setdefault(key, row)`), 13 call sites, behavior-preserving. The cheapest win and the one that makes the rest readable. Defines the first named type — `Winners` — as its return type.
+
+3. **Extract `reconcile`** with `{create, delete, update}` and collapse the 9 copy-pasted loops onto it. Each resolver shrinks to: build queryset → `pick_winners` → build `desired_by_subject` (the only genuinely per-shape part, ~5 lines) → `reconcile`. After step 0, exactly **one** `desired()` build needs a bespoke hook — `media_attachment` (sibling-coupled primary); every other resolver is claim-local, and valid-PK target filtering is a uniform built-in, not a hook. Deletes ~500 lines. **The typed vocabulary is born here, not in a later pass** — `Projection[K, P]`, `MemberMap[K, P]`, `RowState[P]` and `Delta[K, P]` (see [Clean-sheet shape](#clean-sheet-shape)) are `reconcile`'s signature, so the generics are what make the 9 copies collapse into one; extracting with loose types and tightening afterward would reintroduce the very drift this removes. The scalar instantiation (`Projection[str, <column value>]`) firms up in step 4.
+
+4. **Unify the scalar single/bulk split** onto `subject_ids` the way the relationship path already is — collapsing `_resolve_single` / `_resolve_bulk` (and the now-deleted `_apply_resolution`) — _if_ it falls out cheaply. Share `pick_winners` for certain; be skeptical of forcing the literal `reconcile` write body over both columns and rows (see Open Questions).
+
+   **Load-bearing constraint across steps 2–4:** write `pick_winners`, `reconcile` and the `Projection` Protocol **catalog-free from birth** — they may physically live in `catalog/resolve/` for now, but they import only provenance + core and name no concrete catalog model (they receive through-model classes as arguments). Add the import-linter contract that pins this _now_, while the code is still in catalog. This is the single decision that determines whether the hoist in step 7 is a near-`git mv` or a painful untangle; without it the mechanism silently re-grows catalog imports.
+
+5. **Scope cache invalidation to the entity and dimension a reconcile actually touched**, replacing the global `transaction.on_commit(invalidate_all)` flush that fires on every per-entity resolve today ([\_dispatch.py:137](../../../backend/apps/catalog/resolve/_dispatch.py#L137)). This is the second half of what #558 gestures at — #558 is about wasted _re-resolution_, this is the wasted _invalidation_ riding alongside it. The reconcile primitive is what makes it cheap: it returns its delta, so a reconcile that wrote nothing invalidates nothing, and a reconcile that wrote knows exactly which entity and dimension changed. Not free — it still needs the cache layer to expose per-entity / per-dimension keys to invalidate against — so treat the delta as the _enabler_, with the cache-key work as the actual task. Gated on step 3 (reconcile must exist to return the delta).
+
+6. **Defer** any general declaration-driven engine and any database-side view generation until a real second domain or a measured performance need forces them. Do not build a DSL for baseball before the pinball duplication is gone.
+
+7. **Hoist the mechanism tier into `provenance/resolution/`** (the home where the dispatch seam already lives) as a separate follow-on PR, once 1–4 land. Because step 4's constraint left the mechanism catalog-free, this is mechanical: `git mv` the catalog-free tier and flip the import-linter contract from "catalog/resolve is catalog-free" to the intra-provenance form. See [End-state homes](#end-state-homes) for what moves vs stays. This is the _goal_ of the whole effort — leave only pinball-specific logic in catalog — and steps 1–4 exist to make it cheap, not to avoid it.
+
+Steps 1–3 alone retire four of the five things that make this subsystem hard to reason about: the 25 near-clones (→ ~4 projections), the single/bulk split, the MachineModel special-case and the `field_names` contract that lies. The fifth — the two-file dispatch indirection — is the recently-shipped provenance seam, which is the correct boundary and stays.
+
+### End-state homes
+
+The extraction in steps 2–4 cleaves the code along exactly the line the hoist needs, because the primitives are domain-agnostic by construction (`pick_winners` speaks only `Claim` / `ranked_claims`; `reconcile` diffs through-model classes passed in as arguments) while the projections name concrete models. Step 6 then splits the result three ways:
+
+| Piece                                                                                                                                                                                     | Home                                             | Why                                                                                                                                                                                                                                            |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pick_winners`, `reconcile`, the `Projection` Protocol, FK/coercion helpers, read-side payload types                                                                                      | **provenance** (`resolution/`)                   | closed over the claim store; imports only provenance + core. The dispatch seam (`resolve_after_mutation`, the model-keyed registry) already lives here.                                                                                        |
+| Concrete `Projection` instances (Theme, Tag, Credit, parents…), registration at `ready()`, non-claim-local `desired()` hooks (`model_abbreviations`), `location_path`, cache invalidation | **catalog**                                      | irreducible pinball schema and config, registered into the seam at `CatalogConfig.ready()`.                                                                                                                                                    |
+| Media-attachment projection (`_media.py`)                                                                                                                                                 | **media**, registered from media's own `ready()` | the media wall forbids `provenance → media`, and `_media.py` imports `apps.media.models`. It does **not** move with the generic core — media already owns the entity-media tables and the sanctioned `media.models → provenance.models` crack. |
+
+## Invariants to preserve
+
+A naive rewrite tends to drop these; the redesign must keep them:
+
+- **Single-sourced merge.** Every projection reuses `ranked_claims` and `member_is_present`; no projection reimplements winner-picking once `pick_winners` exists.
+- **Fail-fast on an unhandled namespace.** A claim field with no projection raises (as the bulk path does today with `ValueError`); it must never be a silent no-op that leaves a derived table stale.
+- **Explicit ordering.** FK targets before dependents, relationship rows before derived rows, scalars in a defined position — a declared sequence, not an accident of registration order.
+- **The escape hatch is first-class.** Compound identity (`Credit`), non-claim-local desired sets (`model_abbreviations`) and computed fields (`Location.location_path`) register a hand-written `desired()` or a bespoke reconciler. The goal is "no per-shape boilerplate for the common case," not "no hand-written code ever."
+- **Purity — a projection is a function of claims, never of another projection's output.** A projection reads claims and writes its view, nothing else. Reading another projection's _materialized rows_ (as `model_abbreviations` did with `TitleAbbreviation`) is the violation that creates cross-entity ordering, cascade edges and staleness — the cross-projection join belongs at read time, not in the projection. The one deliberate exception is the FK natural-key lookup (the target's resolved `slug`/`location_path`), tolerated because the resolved pk is stable and the dependency is satisfied by batch _order_, not an incremental trigger. The slug/opdb_id conflict guard is likewise part of the projection's definition of the winning value, applied uniformly for every subject — never a save-time side effect that fires only on the single-object path and only for MachineModel.
+
+## Alternatives considered
+
+This plan extracts two functions and a per-shape strategy. The tempting alternatives are worth rejecting explicitly, because the mechanism it builds is exactly the kind a later session reaches for one of these to "simplify."
+
+- **Signals / pub-sub** (emit "claims changed", projections subscribe). Rejected. It destroys **fail-fast** — a missing subscriber is a silent no-op that leaves a derived table stale, the exact opposite of the raise-on-unhandled-namespace invariant above. It makes the required cross-dimension **ordering** (FK targets before dependents, relationship rows before derived rows) implicit and fragile, an emergent property of subscription order rather than a declared sequence. And it makes the bulk path's **batching** awkward, since a per-claim signal fights the whole-subject-set pass. Resolution is a correctness-critical projection that wants explicitness; signals trade away exactly that for a decoupling the call sites do not need.
+- **Polymorphism on the model (`entity.resolve()`).** The textbook fix for the `isinstance` type-switch: a virtual method per model, dynamic dispatch replacing the branch. Rejected. It scatters projection logic across every domain model, recoupling the schema to the mechanism — the precise inverse of this plan's organize-by-shape thesis and of the step-7 hoist, which depends on the mechanism naming _no_ concrete model. It optimizes for "no central dispatcher"; the goal here is "no per-entity code and a mechanism that can move to provenance." Different axis.
+- **`match`/`case` structural matching on entity type.** Rejected as cosmetic — nicer syntax for the same centralized type-switch `resolve_model` already embodies. It does not remove the privileged entity or the duplication; it reformats them.


### PR DESCRIPTION
## Summary

Route every catalog write through a single claim/changeset chokepoint and populate `ChangeSet.actor` / `Claim.actor` on every new row, clearing the way for backfilling historical rows with actor FKs and eventually moving to actor off user and source in the provenance system.

- **Single mint chokepoint**: relocate the claim-mint primitive to a module-level `_assert_claim` in `apps/provenance/claim_writer.py` (delete the old `ClaimManager`), locked by an import-linter forbidden contract plus an AST guard so no code can mint `Claim`/`ChangeSet` rows outside the sanctioned path.
- **Actor-first writes**: `record_changeset` is the single actor-first funnel (interactive requires a user-backed actor + action; ingest asserts `actor == run.source.actor`); `_assert_claim` derives actor from `changeset.actor` and stamps the legacy user/source column model-driven via `actor.backing_model`.
- **Media write-path consolidation**: route the four media endpoints through `claim_edit`'s `execute_claims` instead of their own mint path, making `execute_claims` the single non-ingest mint caller. Media write failures now surface as 422 (was 500), uniform across all four endpoints.
- **resolve fix**: stop the generic scalar resolver from spilling relationship-namespace claims (e.g. `media_attachment`) into `extra_data`.
- **Tests**: route ~57 test files onto a `make_claim` factory seam, consolidate the `bootstrap_source` fixture and `ingest_run` scaffolding, add actor-attribution invariant + single-write-path + media characterization tests.

See [docs/plans/auth/Actors.md](docs/plans/auth/Actors.md) and [docs/plans/claim_resolution_refactor/ClaimResolutionRefactor.md](docs/plans/claim_resolution_refactor/ClaimResolutionRefactor.md).

## Test plan

- [ ] `make test` (backend pytest + frontend vitest) passes
- [ ] `make mypy` passes
- [ ] `make lint` passes
