### PR TITLE
refactor(resolve): slug/opdb_id fail loudly, not silently

### DIFF
--- a/backend/apps/catalog/resolve/__init__.py
+++ b/backend/apps/catalog/resolve/__init__.py
@@ -17,7 +17,6 @@ implementation is where a derived value drifts from what apply produces.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from django.core.management.base import OutputWrapper
@@ -77,8 +76,6 @@ from ._relationships import (
     resolve_theme_parents,
 )
 
-logger = logging.getLogger(__name__)
-
 # Claim field_names whose values are images. License metadata for these
 # fields gets denormalized into extra_data so the API can filter by
 # permissiveness_rank without joining back through claims.
@@ -112,8 +109,6 @@ def resolve_model(machine_model: MachineModel) -> MachineModel:
     fk_info = build_fk_info(MachineModel, claim_fields)
     sfl_map = build_source_field_license_map()
     preserve_when_unclaimed = get_preserve_fields(MachineModel, claim_fields)
-    original_slug = machine_model.slug
-    original_opdb_id = machine_model.opdb_id
     _apply_resolution(
         machine_model,
         winners,
@@ -124,34 +119,10 @@ def resolve_model(machine_model: MachineModel) -> MachineModel:
         preserve_when_unclaimed,
     )
 
-    # Post-resolution guards for cross-reference fields only (slug, opdb_id).
-    # Other unique fields (e.g. name) rely on save() → IntegrityError which
-    # execute_claims() catches and returns as 422.
-    conflict_fields = [
-        ("slug", original_slug, original_slug),  # (attr, check_original, revert_to)
-        ("opdb_id", original_opdb_id, None),  # nullable — clear to None
-    ]
-    for attr, original, revert in conflict_fields:
-        value = getattr(machine_model, attr)
-        if not value or value == original:
-            continue
-        conflict = (
-            MachineModel.objects.filter(**{attr: value})
-            .exclude(pk=machine_model.pk)
-            .first()
-        )
-        if conflict:
-            logger.warning(
-                "Cannot resolve %s=%r onto '%s' (pk=%s): already owned by '%s' (pk=%s)",
-                attr,
-                value,
-                machine_model.name,
-                machine_model.pk,
-                conflict.name,
-                conflict.pk,
-            )
-            setattr(machine_model, attr, revert)
-
+    # Cross-reference uniqueness (slug, opdb_id, …) is not resolution's concern:
+    # the DB unique constraint is the source of truth. A collision raises
+    # IntegrityError on save(), which execute_claims() turns into a 422 on the
+    # interactive path — exactly as the non-unique ``name`` field already does.
     validate_check_constraints(machine_model)
     machine_model.save()
 

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -8,8 +8,6 @@ Also handles taxonomy model resolution.
 
 from __future__ import annotations
 
-import logging
-
 from django.utils import timezone
 
 from apps.core.types import JsonBody
@@ -26,8 +24,6 @@ from ._helpers import (
     resolve_unique_conflicts,
     validate_check_constraints,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _sync_markdown_references(obj: ClaimControlledModel) -> None:
@@ -283,39 +279,12 @@ def resolve_entity[T: ClaimControlledModel](obj: T) -> T:
 
     model_class = type(obj)
     fields = get_claim_fields(model_class)
-    original_slug = obj.slug
     _resolve_single(obj, fields)
 
-    # Single-object slug conflict guard — only slug gets silent revert.
-    # Other unique fields (e.g. name) rely on save() → IntegrityError
-    # which execute_claims() catches and returns as 422.
-    # Skip when slug isn't globally unique (e.g. Location, where slug is
-    # unique-per-location_path); mirrors the bulk path's has_unique_slug
-    # check.  django-stubs checks the ``slug=`` filter keyword against the
-    # model's declared fields; abstract ClaimControlledModel._meta lists
-    # none.  The concrete subclass always has slug.
-    slug_field = model_class._meta.get_field("slug") if "slug" in fields else None
-    slug_is_unique = slug_field is not None and bool(
-        getattr(slug_field, "unique", False)
-    )
-    if (
-        slug_is_unique
-        and obj.slug
-        and obj.slug != original_slug
-        and model_class.objects.filter(slug=obj.slug)  # type: ignore[attr-defined]
-        .exclude(pk=obj.pk)
-        .exists()
-    ):
-        logger.warning(
-            "Cannot resolve slug=%r on %s pk=%s: "
-            "already owned by another object, reverting to %r",
-            obj.slug,
-            model_class.__name__,
-            obj.pk,
-            original_slug,
-        )
-        obj.slug = original_slug
-
+    # Cross-reference uniqueness (slug, opdb_id, …) is not resolution's concern:
+    # the DB unique constraint is the source of truth. A collision raises
+    # IntegrityError on save(), which execute_claims() turns into a 422 on the
+    # interactive path — exactly as the non-unique ``name`` field already does.
     validate_check_constraints(obj)
     obj.save()
     _sync_markdown_references(obj)

--- a/backend/apps/catalog/tests/test_resolve.py
+++ b/backend/apps/catalog/tests/test_resolve.py
@@ -1,4 +1,5 @@
 import pytest
+from django.db import IntegrityError
 from django.utils import timezone
 
 from apps.catalog.models import (
@@ -531,7 +532,12 @@ class TestResolveCorporateEntityLocations:
 
 
 @pytest.mark.django_db
-class TestResolveEntitySlugConflictGuard:
+class TestSingleObjectUniqueConflict:
+    """Single-object resolution (resolve_entity, resolve_model) leaves
+    cross-reference uniqueness to the DB: a globally-unique collision fails
+    loud (IntegrityError), while a non-unique slug change is left alone.
+    """
+
     def test_slug_change_not_reverted_when_slug_field_not_unique(self):
         """resolve_entity must not silently revert a slug change when the
         model's slug field is not globally unique (e.g. Location, where
@@ -570,3 +576,30 @@ class TestResolveEntitySlugConflictGuard:
         target.refresh_from_db()
 
         assert target.slug == "springfield"
+
+    def test_machine_model_slug_conflict_raises(self, ipdb):
+        """resolve_model lets a slug collision hit the DB constraint.
+
+        Resolution leaves cross-reference uniqueness to the DB: the winning slug
+        claim is saved and the unique constraint raises IntegrityError (turned
+        into a 422 by execute_claims) rather than silently reverting.
+        """
+        make_machine_model(name="Owner", slug="taken-slug")
+        pm = make_machine_model(name="Challenger", slug="original-slug")
+        make_claim(pm, "slug", "taken-slug", source=ipdb)
+
+        with pytest.raises(IntegrityError):
+            resolve_model(pm)
+
+    def test_machine_model_opdb_conflict_raises(self, ipdb):
+        """resolve_model lets an opdb_id collision hit the DB constraint.
+
+        Previously the loser's opdb_id was silently cleared to None; now the
+        nullable unique constraint raises, surfacing the conflict.
+        """
+        make_machine_model(name="Alpha", slug="alpha", opdb_id="GCONFLICT-M1")
+        pm_b = make_machine_model(name="Beta", slug="beta")
+        make_claim(pm_b, "opdb_id", "GCONFLICT-M1", source=ipdb)
+
+        with pytest.raises(IntegrityError):
+            resolve_model(pm_b)

--- a/backend/apps/catalog/tests/test_resolve_bulk.py
+++ b/backend/apps/catalog/tests/test_resolve_bulk.py
@@ -2,6 +2,7 @@
 
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError
 
 from apps.catalog.models import (
     Franchise,
@@ -539,30 +540,23 @@ class TestSlugConflictDetection:
         assert t1.slug == "slug-a"
         assert t2.slug == "slug-b"
 
-    def test_single_object_slug_conflict_reverts(self, opdb):
-        # t1 owns "taken-slug" in the DB.
+    def test_single_object_slug_conflict_raises(self, opdb):
+        """A single-object slug collision fails loud at the DB constraint.
+
+        Resolution leaves cross-reference uniqueness to the DB rather than
+        silently reverting the loser. ``resolve_entity`` saves the winning claim
+        and the unique constraint raises IntegrityError, which ``execute_claims``
+        turns into a 422 on the interactive path.
+        """
+        # Owner holds "taken-slug" in the DB.
         Title.objects.create(name="Owner", slug="taken-slug")
         t2 = Title.objects.create(name="Challenger", slug="original-slug")
 
         make_claim(t2, "name", "Challenger", source=opdb)
         make_claim(t2, "slug", "taken-slug", source=opdb)
 
-        # Use explicit fields so this test is independent of claim-field discovery.
-        fields = get_claim_fields(Title)
-        fields["slug"] = "slug"
-        _resolve_single(t2, fields)
-
-        # resolve_entity would save — we test the in-memory state.
-        # Slug should NOT be "taken-slug" because that conflicts.
-        # resolve_entity handles this; _resolve_single doesn't check DB.
-        # So test via resolve_entity instead.
-        t2 = Title.objects.get(pk=t2.pk)  # re-fetch clean
-        make_claim(t2, "name", "Challenger", source=opdb)
-        make_claim(t2, "slug", "taken-slug", source=opdb)
-
-        # resolve_entity checks DB for slug conflict and reverts.
-        result = resolve_entity(t2)
-        assert result.slug == "original-slug"  # Reverted.
+        with pytest.raises(IntegrityError):
+            resolve_entity(t2)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What

Removes the two **single-object** resolve-time silent-revert guards so cross-reference uniqueness (`slug`, `opdb_id`) fails loudly at the DB constraint instead of silently reverting.

- `resolve_model` (MachineModel) — deleted the `original_slug`/`original_opdb_id` snapshots and the `conflict_fields` revert loop.
- `resolve_entity` (generic) — deleted the `original_slug` snapshot and the slug-revert guard.
- Removed the now-dead `logger`/`import logging` from both files.

Cross-reference uniqueness is not resolution's concern: the DB unique constraint is the source of truth, surfaced as a 422 via `execute_claims`' `IntegrityError` handler — exactly as the non-unique `name` field already is.

## Why

The silent revert was a data-loss/staleness smell — a user's claim appears to take, then quietly doesn't — and it gave resolution a uniqueness responsibility it shouldn't have. Uniqueness belongs to the DB constraint, surfaced on the write path.

## Behavior change

Narrow by design. The request-time pre-check (`validate_scalar_fields`) is **kept**, so the common interactive case still returns a friendly field-level 422 (`"This value must be unique."`). Only edge cases the pre-check can't see — resolved-winner collision, TOCTOU race between pre-check and save — change from silent-revert to a form-level `IntegrityError` → 422.

The **bulk** path is **unchanged**: `resolve_unique_conflicts` stays, because bulk ingest has no HTTP response to return and must converge deterministically rather than abort a batch.

## Tests

- Rewrote the single-object guard test → `test_single_object_slug_conflict_raises` (asserts `IntegrityError`); confirmed it went red against the old guard first.
- Added `test_machine_model_slug_conflict_raises` and `test_machine_model_opdb_conflict_raises` for the `resolve_model` path.
- Renamed `TestResolveEntitySlugConflictGuard` → `TestSingleObjectUniqueConflict` (the guard no longer exists; the class now covers both single-object paths).
- Existing bulk conflict tests and the API `test_duplicate_slug_returns_422` stay green.

## Verification

- Full catalog + provenance + claim_edit suite: 2052 passed.
- `mypy` clean (fresh, daemon stopped); ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)