### PR TITLE
refactor(resolve): extract the winner-pick fold into one primitive

### DIFF
--- a/backend/apps/catalog/resolve/_engine.py
+++ b/backend/apps/catalog/resolve/_engine.py
@@ -1,0 +1,56 @@
+"""Catalog-free resolution primitives.
+
+The shared kernel between *rank*
+(:func:`apps.provenance.claim_ranking_in_db.ranked_claims`) and the per-shape
+desired/diff/write logic — the layer-2 winner-pick.
+
+Deliberately catalog-free — it imports only provenance and names no concrete
+catalog model — so it can move wholesale to ``apps.provenance.resolution``. An
+import-linter contract pins that boundary.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Hashable, Iterable
+
+    from apps.provenance.models import Claim
+
+type Winners[Subject: Hashable, Group: Hashable] = dict[Subject, dict[Group, "Claim"]]
+"""Winning claim per ``(subject, group)`` — the first claim seen for each group
+key within each subject, which is the highest-ranked one.  Both keys are
+``Hashable`` because they index nested dicts."""
+
+
+def pick_winners[Subject: Hashable, Group: Hashable](
+    ranked: Iterable[Claim],
+    subject: Callable[[Claim], Subject],
+    group: Callable[[Claim], Group],
+) -> Winners[Subject, Group]:
+    """First (highest-ranked) claim per ``(subject, group)``.
+
+    Folds a :func:`ranked_claims` queryset — already ordered so the first row
+    per group is the winner — into a two-level map.  ``setdefault`` keeps the
+    first claim seen for each group key, so a later (lower-ranked) claim for the
+    same key is dropped.
+
+    *subject* and *group* extract the keys from each claim — group on
+    ``claim_key`` for membership sets (see :func:`pick_member_winners`) or on
+    ``field_name`` for scalar registers, subject usually ``object_id`` but
+    occasionally a composite key.
+    """
+    winners: Winners[Subject, Group] = {}
+    for claim in ranked:
+        winners.setdefault(subject(claim), {}).setdefault(group(claim), claim)
+    return winners
+
+
+def pick_member_winners(ranked: Iterable[Claim]) -> Winners[int, str]:
+    """Membership winner-pick: one winner per ``claim_key`` per entity.
+
+    Subject is the entity ``object_id``, group is the ``claim_key`` — a thin
+    partial application of :func:`pick_winners` for the common case.
+    """
+    return pick_winners(ranked, lambda c: c.object_id, lambda c: c.claim_key)

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -16,6 +16,7 @@ from apps.provenance.licensing import build_source_field_license_map
 from apps.provenance.models import Claim, ClaimControlledModel
 from apps.provenance.validation import get_relationship_namespaces
 
+from ._engine import pick_winners
 from ._helpers import (
     _coerce,
     _resolve_fk_generic,
@@ -70,10 +71,9 @@ def _resolve_single(
     if hasattr(obj, "extra_data"):
         claims = claims.select_related("actor__source__default_license")
 
-    winners: dict[str, Claim] = {}
-    for claim in claims:
-        if claim.field_name not in winners:
-            winners[claim.field_name] = claim
+    winners = pick_winners(claims, lambda c: c.object_id, lambda c: c.field_name).get(
+        obj.pk, {}
+    )
 
     # Reset resolvable fields to defaults.  Some fields must keep their
     # existing value when no winning claim exists — see _resolve_bulk().
@@ -174,11 +174,9 @@ def _resolve_bulk(
         claims_qs = claims_qs.select_related("actor__source__default_license")
 
     # Group by object_id, pick winner per field_name.
-    claims_by_obj: dict[int, dict[str, Claim]] = {}
-    for claim in claims_qs:
-        obj_winners = claims_by_obj.setdefault(claim.object_id, {})
-        if claim.field_name not in obj_winners:
-            obj_winners[claim.field_name] = claim
+    claims_by_obj = pick_winners(
+        claims_qs, lambda c: c.object_id, lambda c: c.field_name
+    )
 
     # Image fields denormalize their effective license into extra_data; build
     # the SourceFieldLicense map once iff a winning claim is an image field.

--- a/backend/apps/catalog/resolve/_media.py
+++ b/backend/apps/catalog/resolve/_media.py
@@ -8,7 +8,7 @@ from typing import NamedTuple, cast
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
-from apps.core.types import ClaimIdentity, EntityKey
+from apps.core.types import EntityKey
 from apps.media.models import EntityMedia, MediaAsset, MediaSupportedModel
 from apps.provenance.claim_presence import member_is_present
 from apps.provenance.claim_ranking_in_db import ranked_claims
@@ -16,6 +16,7 @@ from apps.provenance.models import Claim
 
 from ..cache import invalidate_all
 from ._claim_values import MediaAttachmentClaimValue
+from ._engine import pick_winners
 
 logger = logging.getLogger(__name__)
 
@@ -68,16 +69,12 @@ def resolve_media_attachments(
         claims_qs = claims_qs.filter(object_id__in=subject_ids)
     claims = ranked_claims(claims_qs, "content_type_id", "object_id", "claim_key")
 
-    # Winner per (content_type_id, object_id, claim_key).
-    # Keep priority + created_at for primary enforcement.
-    winners_by_entity: dict[EntityKey, list[Claim]] = {}
-    seen: set[ClaimIdentity] = set()
-    for claim in claims:
-        key = ClaimIdentity(claim.content_type_id, claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            entity_key = EntityKey(claim.content_type_id, claim.object_id)
-            winners_by_entity.setdefault(entity_key, []).append(claim)
+    # Winner per (content_type_id, object_id, claim_key), grouped by entity.
+    winners_by_entity = pick_winners(
+        claims,
+        lambda c: EntityKey(c.content_type_id, c.object_id),
+        lambda c: c.claim_key,
+    )
 
     # -- Validate winners & build desired state -----------------------------
 
@@ -103,7 +100,7 @@ def resolve_media_attachments(
     # Desired: {EntityKey: {asset_pk: DesiredMediaAttachment}}
     desired_by_entity: dict[EntityKey, dict[int, DesiredMediaAttachment]] = {}
 
-    for entity_key, claims_list in winners_by_entity.items():
+    for entity_key, winners in winners_by_entity.items():
         ct_info = _ct_info(entity_key.content_type_id)
 
         if not ct_info.is_media_supported:
@@ -116,7 +113,7 @@ def resolve_media_attachments(
             continue
 
         desired: dict[int, DesiredMediaAttachment] = {}
-        for claim in claims_list:
+        for claim in winners.values():
             val = cast(MediaAttachmentClaimValue, claim.value)
             if not member_is_present(claim):
                 continue

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -50,6 +50,7 @@ from ._claim_values import (
     ParentClaimValue,
 )
 from ._contracts import relationship_resolver
+from ._engine import pick_member_winners
 
 logger = logging.getLogger(__name__)
 
@@ -57,13 +58,6 @@ logger = logging.getLogger(__name__)
 # ------------------------------------------------------------------
 # Shared tuple shapes
 # ------------------------------------------------------------------
-
-
-class ClaimDedupKey(NamedTuple):
-    """Dedup key when picking first-winner-per-claim_key for an entity."""
-
-    object_id: int
-    claim_key: str
 
 
 class CreditAssignment(NamedTuple):
@@ -115,23 +109,16 @@ def _resolve_machine_model_m2m(
         claims_qs = claims_qs.filter(object_id__in=subject_ids)
     claims = ranked_claims(claims_qs, "object_id", "claim_key")
 
-    # Pick winner per (object_id, claim_key).
-    winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[ClaimDedupKey] = set()
-    for claim in claims:
-        key = ClaimDedupKey(claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_model.setdefault(claim.object_id, []).append(claim)
+    winners_by_model = pick_member_winners(claims)
 
     # Valid PKs for existence check against stale claims.
     valid_pks = set(spec.target_model._default_manager.values_list("pk", flat=True))
 
     # Desired PKs from winning claims.
     desired_by_model: dict[int, set[int]] = {}
-    for model_id, claims_list in winners_by_model.items():
+    for model_id, winners in winners_by_model.items():
         desired: set[int] = set()
-        for claim in claims_list:
+        for claim in winners.values():
             val = cast(Mapping[str, object], claim.value)
             if not member_is_present(claim):
                 continue
@@ -219,23 +206,16 @@ def resolve_all_gameplay_features(
         claims_qs = claims_qs.filter(object_id__in=subject_ids)
     claims = ranked_claims(claims_qs, "object_id", "claim_key")
 
-    # Pick winner per (object_id, claim_key).
-    winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[ClaimDedupKey] = set()
-    for claim in claims:
-        key = ClaimDedupKey(claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_model.setdefault(claim.object_id, []).append(claim)
+    winners_by_model = pick_member_winners(claims)
 
     # Valid PKs for existence check against stale claims.
     valid_pks = set(GameplayFeature.objects.values_list("pk", flat=True))
 
     # Desired (feature_pk, count) from winning claims.
     desired_by_model: dict[int, dict[int, int | None]] = {}
-    for mid, claims_list in winners_by_model.items():
+    for mid, winners in winners_by_model.items():
         desired: dict[int, int | None] = {}
-        for claim in claims_list:
+        for claim in winners.values():
             val = cast(GameplayFeatureClaimValue, claim.value)
             if not member_is_present(claim):
                 continue
@@ -376,18 +356,12 @@ def _resolve_credits(
         credit_qs = credit_qs.filter(object_id__in=subject_ids)
     credit_claims = ranked_claims(credit_qs, "object_id", "claim_key")
 
-    winners_by_subject: dict[int, list[Claim]] = {}
-    seen: set[ClaimDedupKey] = set()
-    for claim in credit_claims:
-        key = ClaimDedupKey(claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_subject.setdefault(claim.object_id, []).append(claim)
+    winners_by_subject = pick_member_winners(credit_claims)
 
     desired_by_subject: dict[int, set[CreditAssignment]] = {}
-    for subject_id, claims_list in winners_by_subject.items():
+    for subject_id, winners in winners_by_subject.items():
         desired: set[CreditAssignment] = set()
-        for claim in claims_list:
+        for claim in winners.values():
             val = cast(CreditClaimValue, claim.value)
             if not member_is_present(claim):
                 continue
@@ -474,18 +448,12 @@ def resolve_all_title_abbreviations(
         abbr_qs = abbr_qs.filter(object_id__in=subject_ids)
     abbr_claims = ranked_claims(abbr_qs, "object_id", "claim_key")
 
-    winners_by_title: dict[int, list[Claim]] = {}
-    seen: set[ClaimDedupKey] = set()
-    for claim in abbr_claims:
-        key = ClaimDedupKey(claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_title.setdefault(claim.object_id, []).append(claim)
+    winners_by_title = pick_member_winners(abbr_claims)
 
     desired_by_title: dict[int, set[str]] = {}
-    for title_id, claims_list in winners_by_title.items():
+    for title_id, winners in winners_by_title.items():
         desired: set[str] = set()
-        for claim in claims_list:
+        for claim in winners.values():
             val = cast(AbbreviationClaimValue, claim.value)
             if not member_is_present(claim):
                 continue
@@ -541,18 +509,12 @@ def resolve_all_model_abbreviations(
         abbr_qs = abbr_qs.filter(object_id__in=subject_ids)
     abbr_claims = ranked_claims(abbr_qs, "object_id", "claim_key")
 
-    winners_by_model: dict[int, list[Claim]] = {}
-    seen: set[ClaimDedupKey] = set()
-    for claim in abbr_claims:
-        key = ClaimDedupKey(claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_model.setdefault(claim.object_id, []).append(claim)
+    winners_by_model = pick_member_winners(abbr_claims)
 
     desired_by_model: dict[int, set[str]] = {}
-    for model_id, claims_list in winners_by_model.items():
+    for model_id, winners in winners_by_model.items():
         desired: set[str] = set()
-        for claim in claims_list:
+        for claim in winners.values():
             val = cast(AbbreviationClaimValue, claim.value)
             if not member_is_present(claim):
                 continue
@@ -630,14 +592,7 @@ def _resolve_aliases(parent_model: type[ClaimControlledModel]) -> None:
         "claim_key",
     )
 
-    # Pick winners per (object_id, claim_key).
-    winners_by_parent: dict[int, list[Claim]] = {}
-    seen: set[ClaimDedupKey] = set()
-    for claim in claims_qs:
-        key = ClaimDedupKey(claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_parent.setdefault(claim.object_id, []).append(claim)
+    winners_by_parent = pick_member_winners(claims_qs)
 
     # Build desired aliases per parent: {lower_val → display_val}.
     # alias_display (original case) is preferred via the schema's
@@ -647,9 +602,9 @@ def _resolve_aliases(parent_model: type[ClaimControlledModel]) -> None:
         f"alias namespace {claim_field!r} has no registered relationship schema"
     )
     desired_by_parent: dict[int, dict[str, str]] = {}
-    for parent_id, claims_list in winners_by_parent.items():
+    for parent_id, winners in winners_by_parent.items():
         desired: dict[str, str] = {}
-        for claim in claims_list:
+        for claim in winners.values():
             val = cast(AliasClaimValue, claim.value)
             if not member_is_present(claim):
                 continue
@@ -744,21 +699,14 @@ def _resolve_parents(
         "claim_key",
     )
 
-    # Pick winners per (object_id, claim_key).
-    winners_by_child: dict[int, list[Claim]] = {}
-    seen: set[ClaimDedupKey] = set()
-    for claim in claims_qs:
-        key = ClaimDedupKey(claim.object_id, claim.claim_key)
-        if key not in seen:
-            seen.add(key)
-            winners_by_child.setdefault(claim.object_id, []).append(claim)
+    winners_by_child = pick_member_winners(claims_qs)
 
     valid_pks = set(parent_model.objects.values_list("pk", flat=True))  # type: ignore[attr-defined]
 
     desired_by_child: dict[int, set[int]] = {}
-    for child_id, claims_list in winners_by_child.items():
+    for child_id, winners in winners_by_child.items():
         desired: set[int] = set()
-        for claim in claims_list:
+        for claim in winners.values():
             val = cast(ParentClaimValue, claim.value)
             if not member_is_present(claim):
                 continue
@@ -841,22 +789,19 @@ def resolve_all_corporate_entity_locations(
         claims_qs = claims_qs.filter(object_id__in=subject_ids)
     claims = ranked_claims(claims_qs, "object_id", "claim_key")
 
-    # Pick the winning claim per (object_id, claim_key) by source priority, then
-    # keep only the present locations.  Uniform with the sibling resolvers: a
-    # higher-priority exists=False retraction wins over a lower-priority assertion.
+    # Pick the winning claim per (object_id, claim_key), then keep only the
+    # present locations: a higher-priority exists=False retraction wins over a
+    # lower-priority assertion.
+    winners_by_ce = pick_member_winners(claims)
     desired: dict[int, set[int]] = defaultdict(set)
-    seen: set[ClaimDedupKey] = set()
-    for claim in claims:
-        key = ClaimDedupKey(claim.object_id, claim.claim_key)
-        if key in seen:
-            continue
-        seen.add(key)
-        val = cast(LocationClaimValue, claim.value or {})
-        if not member_is_present(claim):
-            continue
-        loc_pk = val.get("location")
-        if loc_pk and loc_pk in valid_loc_pks:
-            desired[claim.object_id].add(loc_pk)
+    for ce_pk, winners in winners_by_ce.items():
+        for claim in winners.values():
+            val = cast(LocationClaimValue, claim.value or {})
+            if not member_is_present(claim):
+                continue
+            loc_pk = val.get("location")
+            if loc_pk and loc_pk in valid_loc_pks:
+                desired[ce_pk].add(loc_pk)
 
     existing_qs = CorporateEntityLocation.objects.all()
     if subject_ids is not None:

--- a/backend/apps/catalog/resolve/tests/test_engine.py
+++ b/backend/apps/catalog/resolve/tests/test_engine.py
@@ -1,0 +1,70 @@
+"""Unit tests for the catalog-free resolution primitives in ``_engine``."""
+
+from __future__ import annotations
+
+from apps.catalog.resolve._engine import pick_member_winners, pick_winners
+from apps.provenance.models import Claim
+
+
+def test_pick_winners_keeps_first_per_group() -> None:
+    """The first claim seen per (subject, group) wins; later ones are dropped."""
+    # Unsaved instances — pick_winners only reads attributes and never hits the
+    # DB.  Use identity checks (`is`): unsaved Claims share pk=None, so `==`
+    # would treat them all as equal.
+    winner = Claim(object_id=1, claim_key="k", field_name="name")
+    loser = Claim(object_id=1, claim_key="k", field_name="name")  # same group, later
+
+    winners = pick_winners(
+        [winner, loser], lambda c: c.object_id, lambda c: c.claim_key
+    )
+
+    assert winners[1]["k"] is winner
+
+
+def test_pick_winners_partitions_by_subject_and_group() -> None:
+    """Distinct subjects and group keys land in their own slots."""
+    s1k1 = Claim(object_id=1, claim_key="a", field_name="x")
+    s1k2 = Claim(object_id=1, claim_key="b", field_name="x")
+    s2k1 = Claim(object_id=2, claim_key="a", field_name="x")
+
+    winners = pick_winners(
+        [s1k1, s1k2, s2k1], lambda c: c.object_id, lambda c: c.claim_key
+    )
+
+    assert set(winners) == {1, 2}
+    assert winners[1]["a"] is s1k1
+    assert winners[1]["b"] is s1k2
+    assert winners[2]["a"] is s2k1
+
+
+def test_pick_winners_empty() -> None:
+    """No claims yields an empty map, not an error."""
+    assert pick_winners([], lambda c: c.object_id, lambda c: c.claim_key) == {}
+
+
+def test_pick_winners_accepts_a_composite_subject() -> None:
+    """The subject extractor may return a composite (hashable) key — the media
+    ``(content_type_id, object_id)`` shape."""
+    a = Claim(content_type_id=3, object_id=1, claim_key="k", field_name="media")
+    b = Claim(content_type_id=4, object_id=1, claim_key="k", field_name="media")
+
+    winners = pick_winners(
+        [a, b],
+        lambda c: (c.content_type_id, c.object_id),
+        lambda c: c.claim_key,
+    )
+
+    assert winners[(3, 1)]["k"] is a
+    assert winners[(4, 1)]["k"] is b
+
+
+def test_pick_member_winners_groups_by_object_id_and_claim_key() -> None:
+    """The membership wrapper keys subjects on object_id, members on claim_key."""
+    winner = Claim(object_id=7, claim_key="theme:1", field_name="theme")
+    loser = Claim(object_id=7, claim_key="theme:1", field_name="theme")  # later
+    other = Claim(object_id=7, claim_key="theme:2", field_name="theme")
+
+    winners = pick_member_winners([winner, other, loser])
+
+    assert winners[7]["theme:1"] is winner
+    assert winners[7]["theme:2"] is other

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -271,6 +271,28 @@ source_modules = [
 ]
 forbidden_modules = ["apps.provenance.claim_writer"]
 
+# The resolution-engine primitives (apps.catalog.resolve._engine — the shared
+# winner-pick kernel) are deliberately movable to apps.provenance.resolution, so
+# they may import only what provenance already can (provenance/citation/accounts/
+# actors/core/stdlib). Forbid every tier provenance cannot reach — not just a
+# concrete model name — so a stray `from ..engine import X` or `from
+# ._relationships import Y` is caught too, since either equally blocks the hoist.
+# Direct-only (allow_indirect_imports): the module's own imports are the
+# invariant; a transitive provenance -> catalog chain is provenance's baseline,
+# and travels with the module when it moves.
+[[tool.importlinter.contracts]]
+name = "Resolution engine primitives stay catalog-free"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = ["apps.catalog.resolve._engine"]
+forbidden_modules = [
+    "apps.catalog",
+    "apps.media",
+    "apps.claim_edit",
+    "apps.claim_ingest",
+    "apps.kiosk",
+]
+
 # --- Media peer-isolation ---
 
 # Media internals are peer-isolated from the citation/provenance data apps.

--- a/docs/plans/provenance/ClaimResolutionRefactor.md
+++ b/docs/plans/provenance/ClaimResolutionRefactor.md
@@ -54,7 +54,7 @@ It is reached through the only `isinstance(entity, MachineModel)` branch left in
 
 Everything `resolve_model` does is already available generically. `resolve_all_entities` resolves its scalars and FKs; `resolve_unique_conflicts` already implements the slug/opdb_id guard for the bulk path; the six relationship resolvers already take `subject_ids`. `resolve_model` is not load-bearing — it is un-deleted history.
 
-### Current dispatch state
+### Dispatch state
 
 The owner-registered dispatch inversion **already shipped at the provenance seam**. `apps/provenance/resolution/_dispatch.py` holds the registry keyed by concrete model, `register_resolve_handlers`, fail-fast `ImproperlyConfigured` and the two entry points (`resolve_after_mutation`, `resolve_entities_bulk`); catalog registers a handler pair for every model at `CatalogConfig.ready()`. That part is done and correct — it is the right boundary and should be left alone.
 
@@ -225,7 +225,7 @@ REF1 is byte-identical for the claim-derived columns and through-tables, but **n
 
 Extract the primitives, bottoms-up.
 
-##### <a id="REF2">REF2</a> — Extract `pick_winners`
+##### ✅ DONE: <a id="REF2">REF2</a> — Extract `pick_winners`
 
 Replace all 13 copies. A ~3-line function (`for row in ranked_claims(...): winners.setdefault(key, row)`), 13 call sites. The cheapest win and the one that makes the rest readable. Defines the first named type — `Winners` — as its return type. The kernel is "first row per group" (the fold), **parameterized by the grouping key** — `field_name` on the scalar path (one winner per field: a register) and `claim_key` on the membership path (many winners per subject: a set). That parameter is what lets one function cover all 13 sites; register-vs-set is only how the caller consumes the groups, not a second function.
 
@@ -233,7 +233,7 @@ Replace all 13 copies. A ~3-line function (`for row in ranked_claims(...): winne
 
 Build it with `{create, delete, update}` and collapse the 9 copy-pasted loops onto it. Each resolver shrinks to: build queryset → `pick_winners` → build `desired_by_subject` (the only genuinely per-shape part, ~5 lines) → `reconcile`. After the Before phase **every** resolver is claim-local — no bespoke `desired()` hook remains, and the two universal filters — `member_is_present` (tombstone-drop) and valid-PK existence (for FK-referencing members) — move into the engine, so `desired()` is a pure per-shape `claim → (key, payload)` function. Deletes ~500 lines. **The typed vocabulary is born here, not in a later pass** — `Projection[K, P]`, `MemberMap[K, P]`, `RowState[P]` and `Delta[K, P]` (see [The design](#design)) are `reconcile`'s signature, so the generics are what make the 9 copies collapse into one; extracting with loose types and tightening afterward would reintroduce the very drift this removes. The scalar instantiation (`Projection[str, <column value>]`) firms up in REF4.
 
-This is also where the four parallel dispatch tables (see [Current dispatch state](#current-dispatch-state--accurate-as-of-this-writing)) collapse into one `namespace → Projection` registry: the bespoke resolvers (`title_abbreviations`, `corporate_entity_locations`, `series_credits`) become escape-hatch Projections referenced **by object**, retiring `_custom_dispatch`'s string-`getattr` (the one stringly-typed edge in the subsystem). REF1 has already merged the MM vs non-MM relationship-dispatch divergence into this same table, so by REF3 there is a single keyed-by-namespace map to turn into the registry — not four.
+This is also where the four parallel dispatch tables (see [dispatch state](#dispatch-state)) collapse into one `namespace → Projection` registry: the bespoke resolvers (`title_abbreviations`, `corporate_entity_locations`, `series_credits`) become escape-hatch Projections referenced **by object**, retiring `_custom_dispatch`'s string-`getattr` (the one stringly-typed edge in the subsystem). REF1 has already merged the MM vs non-MM relationship-dispatch divergence into this same table, so by REF3 there is a single keyed-by-namespace map to turn into the registry — not four.
 
 #### Fold in the holdout
 
@@ -255,7 +255,7 @@ Scope it to the entity and dimension a reconcile actually touched, replacing the
 
 #### <a id="POST2">POST2</a> — Operator re-resolve command (`manage.py resolve`)
 
-Rebuild the capability [PRE5](#PRE5) deletes, properly. A `manage.py resolve <target>` command that re-materializes the catalog from claims in dependency order (FK targets before dependents) — the operator's tool after a source-priority or license change, which touches no claim and so triggers no automatic re-resolution. It is also the global `resolve` command the [stale-state discussion](#stale-materialized-state-is-a-completeness-concern-not-a-correctness-gate) assumes is unbuilt. Sequenced _after_ the refactor because it should compose the clean unified resolvers (and eventually `reconcile`), not re-encode the pre-refactor MachineModel rebuild it replaces — building it earlier means building it twice. A scriptable command, not a hand-rolled admin HTML view; if an in-app trigger is wanted later it can shell out to the same entry point.
+Rebuild the capability [PRE5](#PRE5) deletes, properly. A `manage.py resolve <target>` command that re-materializes the catalog from claims in dependency order (FK targets before dependents) — the operator's tool after a source-priority or license change, which touches no claim and so triggers no automatic re-resolution. It is also the global `resolve` command the [stale-state discussion](#staleness) assumes is unbuilt. Sequenced _after_ the refactor because it should compose the clean unified resolvers (and eventually `reconcile`), not re-encode the pre-refactor MachineModel rebuild it replaces — building it earlier means building it twice. A scriptable command, not a hand-rolled admin HTML view; if an in-app trigger is wanted later it can shell out to the same entry point.
 
 **The refactor does most of POST2's work in advance.** After REF1–REF4, "resolve everything" is `for model in ORDER: resolve_all_entities(model)` plus the model's relationships, with **no per-type branching** (the dispatch drives the relationship step uniformly — POST2 never hand-lists a model's resolvers the way `resolve_machine_models` did). The model set is introspectable (`catalog_models()`), the dispatch fail-fasts on an unhandled model, and resolution is idempotent/level-triggered, so POST2 needs no locking, draining or deploy-coupling. POST2's only irreducible hand-written part is the cross-type **order** below.
 
@@ -292,6 +292,10 @@ The claim `field_name` (a.k.a. relationship namespace) is bare `str` everywhere:
 ##### Name the claim-field→attribute map (`ClaimFieldMap`)
 
 `get_claim_fields` returns a `dict[str, str]` mapping each claim `field_name` to the model attribute it resolves into, and that bare `dict[str, str]` is threaded unnamed through `get_preserve_fields`, `get_nullable_unique_fields` and `_resolve_bulk`. Both sides are `str`, so the type hides which is which — the latent-compound-type smell from [Strong Typing](../../Python.md). Give it one alias — `type ClaimFieldMap = dict[FieldName, str]` (keys are the `FieldName` above, so this rides on that cleanup) — and apply it across all sites in one pass, never in a single helper alone: the signature parallel between `get_preserve_fields` and its sibling `get_nullable_unique_fields` is load-bearing, and tightening one would diverge it from the other. (Both helpers read only `.values()`, so each is technically over-typed — `Iterable[str]` would do — but the shared `ClaimFieldMap` keeps the sibling pair honest and is the better call than narrowing per-helper.)
+
+##### Name the claim subject/member keys (`ObjectId`, `ClaimKey`)
+
+The entity `object_id` (bare `int`) and `claim_key` (bare `str`) are the two halves of a claim's membership identity, threaded namelessly across provenance (`Claim.object_id`, `Claim.claim_key`, `make_claim`), catalog resolution and claim_ingest — which has already grown its own local `type ClaimKey = str` ([patches/\_types.py](../../../backend/apps/claim_ingest/patches/_types.py)). REF2's `pick_member_winners` surfaces them as the concrete `Winners[int, str]` (the generic `pick_winners` keeps the abstract `Subject`/`Group` type vars). Give each one documentation alias — `type ObjectId = int`, `type ClaimKey = str` — and thread it through in a single pass, retiring claim_ingest's duplicate so there is one spelling. Deliberately **not** introduced in REF2: a lone alias in `_engine.py` while every other site stays bare `int`/`str` would be a fourth divergent spelling, not a consolidation.
 
 ### End-state homes
 


### PR DESCRIPTION
## What

Extracts the claim winner-pick — walk a `ranked_claims` queryset and keep the first (highest-ranked) claim per group key — into a single primitive, replacing 11 copy-pasted loops across the resolvers.

- New catalog-free `apps/catalog/resolve/_engine.py`:
  - `pick_winners(ranked, subject, group)` — generic over subject/group (both bound to `Hashable`, since they index nested dicts), returning the named `Winners` type.
  - `pick_member_winners(ranked)` — thin wrapper for the membership shape (`object_id` × `claim_key`) the relationship resolvers share.
- All 11 sites lose their hand-rolled `seen`-set dedup loop: 2 scalar (`_resolve_single`/`_resolve_bulk`), 8 membership (themes/gameplay/credits/abbreviations/aliases/parents/corporate-locations), 1 media (composite `EntityKey` subject). Membership consumers read the winners map's `.values()`.
- Dead `ClaimDedupKey` removed; unused `ClaimIdentity` import dropped from `_media.py`.

## Boundary

The engine module imports only provenance and names no concrete catalog model, so it can later move wholesale to `apps.provenance.resolution`. A new import-linter contract pins that boundary — forbidding every tier provenance cannot reach (`apps.catalog`, `apps.media`, the two claim engines, `apps.kiosk`), so a stray sibling import that would block the hoist is caught.

## Behavior

Byte-identical materialized output — pure mechanical extraction behind the unchanged dispatch seam. Inner-dict insertion order follows ranked order, so membership `.values()` yields the same sequence the old `list.append` did.

## Tests

- New `test_engine.py`: direct unit coverage of `pick_winners` (first-per-group, subject/group partitioning, empty, composite subject) and `pick_member_winners`.
- Full backend suite green (3668 passed); mypy clean (522 files); import-linter 26/26; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)