### PR TITLE
refactor(resolve): shared apply loop across scalar single/bulk

### DIFF
--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -1,18 +1,26 @@
-"""Resolution logic for non-MachineModel entities.
+"""Scalar and FK claim resolution for claim-controlled entities.
 
-Includes the generic _resolve_single() and _resolve_bulk() helpers,
-entity-specific field maps, and public resolve_*() functions for
-Manufacturer, Person, Theme, CorporateEntity, System, and Title.
-Also handles taxonomy model resolution.
+The generic per-object apply loop (:func:`_apply_claims`) plus the single-object
+and bulk resolvers that drive it, and the public :func:`resolve_entity` /
+:func:`resolve_all_entities` entry points that introspect each model's claim
+fields.
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
+
+from django.db import models
 from django.utils import timezone
 
 from apps.core.types import JsonBody
 from apps.provenance.claim_ranking_in_db import ranked_claims
-from apps.provenance.licensing import build_source_field_license_map
+from apps.provenance.licensing import (
+    SourceFieldLicenseMap,
+    build_source_field_license_map,
+)
 from apps.provenance.models import Claim, ClaimControlledModel
 from apps.provenance.validation import get_relationship_namespaces
 
@@ -44,6 +52,86 @@ def _sync_markdown_references(obj: ClaimControlledModel) -> None:
 
 
 # ------------------------------------------------------------------
+# Per-object apply loop
+# This is shared between bulk and single-object claims resolution.
+# ------------------------------------------------------------------
+
+# Read-only view of FKInfo.lookups — {attr: {slug: instance}}
+type FKLookups = Mapping[str, Mapping[str, models.Model]]
+
+
+@dataclass(frozen=True, slots=True)
+class ScalarApplyContext:
+    """The per-``model_class`` invariants of a scalar resolve pass.
+
+    Built once and passed to :func:`_apply_claims` for every object.
+    ``fk_lookups`` is ``None`` to resolve each FK by querying its target by slug,
+    or a pre-built ``{attr: {slug: instance}}`` map to resolve FKs from memory.
+    """
+
+    model_class: type[ClaimControlledModel]
+    direct_fields: Mapping[str, str]
+    field_defaults: Mapping[str, object]
+    preserve_when_unclaimed: AbstractSet[str]
+    fk_lookups: FKLookups | None
+    sfl_map: SourceFieldLicenseMap | None
+
+
+def _apply_claims(
+    obj: ClaimControlledModel,
+    winners: Mapping[str, Claim],
+    ctx: ScalarApplyContext,
+) -> None:
+    """Reset *obj*'s resolvable fields to defaults, then apply its winning claims.
+
+    FK fields resolve via :func:`_resolve_fk_generic` (querying when
+    ``ctx.fk_lookups`` is ``None``, else the pre-built slug→instance dict),
+    scalars via :func:`_coerce`, and unmatched claims land in ``extra_data`` with
+    the image-license stamp. Mutates *obj*; the caller handles validation,
+    conflict resolution and saving.
+    """
+    model_class = ctx.model_class
+    direct_fields = ctx.direct_fields
+
+    # Reset resolvable fields to defaults. Preserved fields (UNIQUE, non-nullable
+    # FK) keep their existing value unless a winning claim explicitly sets them.
+    winner_attrs = {direct_fields[fn] for fn in winners if fn in direct_fields}
+    for attr, default in ctx.field_defaults.items():
+        if attr in ctx.preserve_when_unclaimed and attr not in winner_attrs:
+            continue
+        setattr(obj, attr, default)
+
+    # Apply winners.
+    has_extra_data = hasattr(model_class, "extra_data")
+    extra_data: JsonBody | None = {} if has_extra_data else None
+    relationship_ns = get_relationship_namespaces()
+    for field_name, claim in winners.items():
+        # Relationship-namespace claims (media_attachment, credit, …) resolve
+        # into their own tables, never extra_data.
+        if field_name in relationship_ns:
+            continue
+        if field_name in direct_fields:
+            attr = direct_fields[field_name]
+            field = model_class._meta.get_field(attr)
+            if field.is_relation:
+                lookup = ctx.fk_lookups.get(attr) if ctx.fk_lookups else None
+                setattr(
+                    obj,
+                    attr,
+                    _resolve_fk_generic(model_class, attr, claim.value, lookup=lookup),
+                )
+            else:
+                setattr(obj, attr, _coerce(model_class, attr, claim.value))
+        elif has_extra_data:
+            assert extra_data is not None
+            extra_data[field_name] = claim.value
+            _stamp_image_license(extra_data, claim, ctx.sfl_map)
+    if has_extra_data:
+        # extra_data lives on a concrete-subclass subset; runtime-guarded above.
+        obj.extra_data = extra_data  # type: ignore[attr-defined]
+
+
+# ------------------------------------------------------------------
 # Generic single-object resolver
 # ------------------------------------------------------------------
 
@@ -54,14 +142,10 @@ def _resolve_single(
 ) -> None:
     """Resolve active claims onto a single object with only direct fields.
 
-    This is the single-object counterpart to ``_resolve_bulk()``.
-
-    Resolvable fields are reset to their defaults, then active claim
-    winners are applied.  UNIQUE fields are preserved when no claim
-    exists (resetting them to a shared default like ``""`` would cause
-    integrity errors in the bulk path and semantic inconsistency in the
-    single path).  Non-unique fields with no active claim are
-    blank/null after resolution.
+    Resolvable fields are reset to their defaults, then active claim winners are
+    applied.  UNIQUE fields are preserved when no claim exists; non-unique fields
+    with no active claim are blank/null after resolution. Uniqueness conflicts
+    are left to the DB constraint — there is no in-batch de-confliction here.
 
     Mutates *obj* in memory; the caller is responsible for saving.
     """
@@ -75,21 +159,7 @@ def _resolve_single(
         obj.pk, {}
     )
 
-    # Reset resolvable fields to defaults.  Some fields must keep their
-    # existing value when no winning claim exists — see _resolve_bulk().
     model_class = type(obj)
-    field_defaults = get_field_defaults(model_class, direct_fields)
-    preserve_when_unclaimed = get_preserve_fields(model_class, direct_fields)
-    winner_attrs = {direct_fields[fn] for fn in winners if fn in direct_fields}
-    for attr, default in field_defaults.items():
-        if attr in preserve_when_unclaimed and attr not in winner_attrs:
-            continue
-        setattr(obj, attr, default)
-
-    # Apply winners.
-    has_extra_data = hasattr(obj, "extra_data")
-    extra_data: JsonBody | None = {} if has_extra_data else None
-    relationship_ns = get_relationship_namespaces()
     # Image fields denormalize their effective license into extra_data; build
     # the SourceFieldLicense map once iff a winning claim is an image field.
     sfl_map = (
@@ -97,33 +167,15 @@ def _resolve_single(
         if any(fn in IMAGE_FIELDS for fn in winners)
         else None
     )
-    for field_name, claim in winners.items():
-        # Relationship-namespace claims (media_attachment, credit, …) resolve
-        # into their own tables, never extra_data.
-        if field_name in relationship_ns:
-            continue
-        if field_name in direct_fields:
-            attr = direct_fields[field_name]
-            field = model_class._meta.get_field(attr)
-            if field.is_relation:
-                setattr(
-                    obj,
-                    attr,
-                    _resolve_fk_generic(
-                        model_class,
-                        attr,
-                        claim.value,
-                    ),
-                )
-            else:
-                setattr(obj, attr, _coerce(model_class, attr, claim.value))
-        elif has_extra_data:
-            assert extra_data is not None
-            extra_data[field_name] = claim.value
-            _stamp_image_license(extra_data, claim, sfl_map)
-    if has_extra_data:
-        # extra_data lives on a concrete-subclass subset; runtime-guarded above.
-        obj.extra_data = extra_data  # type: ignore[attr-defined]
+    ctx = ScalarApplyContext(
+        model_class=model_class,
+        direct_fields=direct_fields,
+        field_defaults=get_field_defaults(model_class, direct_fields),
+        preserve_when_unclaimed=get_preserve_fields(model_class, direct_fields),
+        fk_lookups=None,
+        sfl_map=sfl_map,
+    )
+    _apply_claims(obj, winners, ctx)
 
 
 # ------------------------------------------------------------------
@@ -139,8 +191,7 @@ def _resolve_bulk(
     """Bulk-resolve claims for all (or selected) instances of a model class.
 
     Pre-fetches all active claims in one query, resolves in memory, then
-    writes back with a single bulk_update(). This is the bulk counterpart
-    to _resolve_single().
+    writes back with a single bulk_update().
 
     UNIQUE fields are preserved when no winning claim exists — resetting
     them to a shared default (e.g. ``""``) would cause IntegrityError
@@ -220,49 +271,19 @@ def _resolve_bulk(
     )
     pre_slugs = {obj.pk: obj.slug for obj in all_objs} if has_unique_slug else {}
 
-    # 4. Resolve each object in memory.
+    # 4. Resolve each object in memory.  The pre-built FK lookups resolve every
+    # batch member from memory, with no per-object FK query.
     now = timezone.now()
-    relationship_ns = get_relationship_namespaces()
+    ctx = ScalarApplyContext(
+        model_class=model_class,
+        direct_fields=direct_fields,
+        field_defaults=field_defaults,
+        preserve_when_unclaimed=preserve_when_unclaimed,
+        fk_lookups=fk_info.lookups,
+        sfl_map=sfl_map,
+    )
     for obj in all_objs:
-        winners = claims_by_obj.get(obj.pk, {})
-
-        # Reset direct fields — preserved fields keep their existing
-        # value unless a winning claim explicitly sets them.
-        winner_attrs = {direct_fields[fn] for fn in winners if fn in direct_fields}
-        for attr, default in field_defaults.items():
-            if attr in preserve_when_unclaimed and attr not in winner_attrs:
-                continue
-            setattr(obj, attr, default)
-
-        # Apply winners.
-        extra_data: JsonBody | None = {} if has_extra_data else None
-        for field_name, claim in winners.items():
-            # Relationship-namespace claims (media_attachment, credit, …)
-            # resolve into their own tables, never extra_data.
-            if field_name in relationship_ns:
-                continue
-            if field_name in direct_fields:
-                attr = direct_fields[field_name]
-                if attr in fk_info.fk_fields:
-                    setattr(
-                        obj,
-                        attr,
-                        _resolve_fk_generic(
-                            model_class,
-                            attr,
-                            claim.value,
-                            lookup=fk_info.lookups.get(attr),
-                        ),
-                    )
-                else:
-                    setattr(obj, attr, _coerce(model_class, attr, claim.value))
-            elif has_extra_data:
-                assert extra_data is not None
-                extra_data[field_name] = claim.value
-                _stamp_image_license(extra_data, claim, sfl_map)
-        if has_extra_data:
-            obj.extra_data = extra_data
-
+        _apply_claims(obj, claims_by_obj.get(obj.pk, {}), ctx)
         obj.updated_at = now
 
     # 4b. Detect unique-field conflicts across resolved objects.
@@ -271,16 +292,16 @@ def _resolve_bulk(
     # Nullable single-column unique fields (external IDs like opdb_id,
     # wikidata_id): an in-batch collision clears the loser to None rather than
     # aborting the whole batch with IntegrityError. Discovered by introspection,
-    # so this covers every such field, not just MachineModel opdb_id.
+    # so every such field is covered.
     for unique_field in get_nullable_unique_fields(model_class, direct_fields):
         resolve_unique_conflicts(all_objs, unique_field, model_class)
 
     # 5. Bulk write.  Cross-field CheckConstraints are enforced by the DB
     # on bulk_update — a violation aborts the whole batch with IntegrityError,
     # which is the desired ingest behaviour (source data is broken, stop).
-    # Per-object Python-side validation was removed because each call issued
-    # a savepoint + SELECT round trip, producing thousands of round trips per
-    # bulk and triggering Postgres subtransaction SLRU overflow on managed DBs.
+    # Per-object Python-side validation is deliberately skipped here: a savepoint
+    # + SELECT round trip per object produces thousands of round trips per bulk
+    # and triggers Postgres subtransaction SLRU overflow on managed DBs.
     update_fields = [*set(direct_fields.values()), "updated_at"]
     if has_extra_data:
         update_fields.append("extra_data")

--- a/backend/apps/catalog/resolve/_helpers.py
+++ b/backend/apps/catalog/resolve/_helpers.py
@@ -8,7 +8,7 @@ consumer.
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from decimal import Decimal, InvalidOperation
 from typing import Any, cast
@@ -64,7 +64,7 @@ def _resolve_fk_generic(
     model_class: type[ClaimControlledModel],
     field_name: str,
     value: object,
-    lookup: dict[str, models.Model] | None = None,
+    lookup: Mapping[str, models.Model] | None = None,
 ) -> models.Model | None:
     """Resolve a claim value to an FK instance by introspecting the Django field.
 

--- a/docs/plans/provenance/ClaimResolutionRefactor.md
+++ b/docs/plans/provenance/ClaimResolutionRefactor.md
@@ -10,12 +10,11 @@ The merge policy itself is **not** the problem and is **not** what this document
 
 A structural goal shapes the end state: the resolution _mechanism_ should live in provenance beside the claim store it operates on, leaving only pinball-specific schema and config in catalog. Flipcommons is also meant to prove out reusable collaborative-encyclopedia software, so a future domain (baseball, medicine) could replace the pinball catalog without rewriting the claim machinery. Keep two horizons distinct. **Relocating the already-domain-agnostic mechanism to provenance is a concrete goal of this effort** (it is what makes the boundary real) and the plan is structured to make it a cheap, mechanical follow-on — see [POST4](#POST4). **Building a declaration DSL so a second domain needs no code at all is speculative generality** and is deferred until a real second domain forces its shape. The pain today is duplication and a privileged entity type, not "can't reuse for medicine" — so the mechanism is extracted and moved, but no DSL is built over it.
 
-## Open Questions
+## Open questions
 
-- **~~Can the scalar column projection share the literal `reconcile()` body, or only its winner-picking?~~ RESOLVED (post-REF3): only the winner-picking.** A scalar field is conceptually the degenerate reconcile where the "table" is the entity row and the member set has cardinality ≤1 keyed by `field_name`. Elegant in the abstract — but having built `reconcile`, the scalar write side is confirmed irreducibly different: reset-to-default-unless-preserved (`get_field_defaults`/`get_preserve_fields`), `_coerce`, FK slug→instance resolution, the `extra_data` catch-all, image-license sidecars, `resolve_unique_conflicts`, `validate_check_constraints` and markdown sync, all riding a `bulk_update` of **columns on the entity row** — not `bulk_create`/`delete` of through-rows. Forcing that through `Projection.write`/`diff` buys nothing the shared `pick_winners` (already shared since REF2) doesn't. So REF4 does **not** force one literal `reconcile`; see [REF4](#REF4) for its narrowed scope.
 - **Ordering as data, or just control flow?** "Ordering" decomposes into two things that want opposite representations: (a) the **batch from-scratch rebuild** needs a global order across entity types (FK targets before dependents — because FK lookups read the target's _resolved_ natural key, [\_helpers.py:120](../../../backend/apps/catalog/resolve/_helpers.py#L120)) plus intra-type DAGs (Location tree, Theme/GameplayFeature parents); this is a ~15-line explicit sequence that runs offline once and should stay plain control flow, not a topological-sort engine. (b) The **incremental path** needs no cross-entity order — targets are already resolved — except for genuine cross-projection _cascade_ edges (projection A reads projection B's materialized output, so a change to B must re-run A). The audit found exactly one such edge (model*abbreviations ← title_abbreviations), and [the decision below](#decision-collapse-the-model-abbreviation-cross-entity-edge) removes it — so after the Before phase (PRE1) the incremental-cascade count is **zero** and no cascade-trigger mechanism is warranted. The one residual output-read anywhere is the FK natural-key lookup, and it is a \_batch-order* concern (target resolved before dependent in the rebuild), not an incremental cascade — the target's pk is stable, so a dependent never needs re-resolving when its target changes. Keep it as control flow. If a future projection ever reads another projection's _output_ incrementally, that violates [Purity](#invariants-to-preserve) and should be redesigned to read claims, not patched with a cascade edge.
 
-## The root cause, stated precisely
+## Root cause
 
 **The subsystem is indexed along the wrong axis, so two primitives that should exist once were instead inlined everywhere.**
 
@@ -62,7 +61,7 @@ But the inversion landed at the outer boundary and stopped. The `isinstance(Mach
 
 Beneath the per-entity switch sit **four parallel namespace→resolver tables** — `_get_alias_dispatch` (keyed by model), `_get_parent_dispatch` (keyed by spec), `_get_custom_dispatch` (keyed by a **string** method name, resolved via `getattr` — so grep and mypy can't see which function a namespace resolves to), and the MM-only `_get_mm_relationship_resolvers` (MM relationships dispatch through this; non-MM relationships through the other three — itself a divergence). These are four fragments of the one introspected registry [the design](#design) describes; REF unifies them, and the string-`getattr` in `_custom_dispatch` is the most visible symptom of the fragmentation, not a separate wart.
 
-## <a id="design-patterns"></a> The design patterns and data structures
+## <a id="design-patterns"></a> Design patterns & data structures
 
 Naming the load-bearing constructs keeps the redesign honest — it pins which invariants to preserve and lets a reviewer check each pattern against its known failure modes.
 
@@ -209,7 +208,7 @@ So the discipline to enforce in review is **stale-tolerant reads**, not backfill
 
 A migration must **not** run the global resolve inline — it is a heavy whole-corpus fold in the migrate window (lock, timeout and ordering risk) and it couples the frozen migration DAG to resolution code the Refactor/After phases are about to move/rename. If a _scoped_ re-resolve is ever wanted, the clean split is: the **migration computes _who_ is stale** (a cheap frozen set-query over historical models — no resolver import, and a safe over-approximation is fine because the resolver is idempotent/level-triggered), while the **live resolver computes _what_ is correct** (the single-sourced winner-pick it owns). Defer that migration→scope→drain plumbing until a second customer (PRE2) forces its shape — [DEFER1](#DEFER1)'s defer-speculative-generality rule applies.
 
-### <a id="REF">REF</a> The refactor
+### ✅ DONE: <a id="REF">REF</a> The refactor
 
 With the Before phase done, this becomes a mechanical extraction: no product decisions, byte-identical materialized claim-view (columns + through-tables) at every step (idempotent) and entirely behind the unchanged dispatch seam, so the existing suite stays green by construction.
 
@@ -235,9 +234,9 @@ Build it with `{create, delete, update}` and collapse the 9 copy-pasted loops on
 
 This is also where the four parallel dispatch tables (see [dispatch state](#dispatch-state)) collapse into one `namespace → Projection` registry: the bespoke resolvers (`title_abbreviations`, `corporate_entity_locations`, `series_credits`) become escape-hatch Projections referenced **by object**, retiring `_custom_dispatch`'s string-`getattr` (the one stringly-typed edge in the subsystem). REF1 has already merged the MM vs non-MM relationship-dispatch divergence into this same table, so by REF3 there is a single keyed-by-namespace map to turn into the registry — not four.
 
-#### Fold in the holdout
+#### ✅ DONE: Fold in the holdout
 
-##### <a id="REF4">REF4</a> — Unify the scalar single/bulk split
+##### ✅ DONE: <a id="REF4">REF4</a> — Unify the scalar single/bulk split
 
 Fold in the holdout: collapse it onto `subject_ids` the way the relationship path already is — collapsing `_resolve_single` / `_resolve_bulk` (and the now-deleted `_apply_resolution`). Share `pick_winners` (already done in REF2); do **not** force the literal `reconcile` write body over columns ([Open Question, RESOLVED](#open-questions) — the scalar write side is irreducibly different). So REF4's scope is narrow: one subject-parameterized apply loop replacing the two near-clones, with the scalar write body kept out of `reconcile`. It is the **lowest-leverage** REF item — the high-value sharing (`pick_winners`) already landed — so do it for the single-mental-model payoff, not for line count.
 
@@ -249,7 +248,7 @@ The Refactor phase alone retires four of the five things that make this subsyste
 
 ### <a id="POST"></a> After the refactor
 
-Each is its own PR on the clean base. None gates the refactor. Each carries behavior change or risk the behavior-preserving core does not.
+Each is its own PR on the clean base. Each carries behavior change or risk the behavior-preserving core does not.
 
 #### <a id="POST1">POST1</a> — Scope cache invalidation
 


### PR DESCRIPTION
## Summary

This is the final refactor of the claim-resolution rationalization.  The scalar/column path's last duplication — the ~40-line per-object reset+apply block that was re-implemented by both bulk and the single-object resolution at`_resolve_single` and `_resolve_bulk`.  It collapses into a single implementation, one `_apply_claims` helper over a named `ScalarApplyContext`. 

This is behavior-preserving; the materialized claim-view is byte-identical.

- Both paths build the context and share the loop; the spines that genuinely differ stay inline — single: per-FK query → `validate_check_constraints` → `save()` (→ 422); bulk: prebuilt FK lookups → `resolve_unique_conflicts` → `bulk_update`.
- FK strategy is the context's only per-path knob (`fk_lookups=None` ⇒ query per FK; a prebuilt map ⇒ serve the whole batch from memory).
- This did not collapse the "single delegates to bulk + refresh_from_db": it would have dropped the interactive path's Python check-constraint validation (bulk omits it for SLRU perf), and a `Projection`-style interface for two closed implementers was over-machinery.
- One-line read-only typing widening of `_resolve_fk_generic`'s `lookup` param to `Mapping`; `_engine.py` and the dispatch seam untouched.
- Scalar field-level scoping (the rest of #558) is explicitly out of scope — REF4 neither completes nor regresses it.

## Test plan

- [x] Focused suite green: parity sentinel (`test_single_and_bulk_produce_same_result`), unique/non-null-FK preservation, slug + opdb_id conflicts, image-license sidecar, `TestValidateCheckConstraints` (resolver-path ValidationError + API 422) — 145 passed
- [x] Broad apps (catalog, provenance, claim_ingest, claim_edit) — 2088 passed
- [x] `uv run mypy .` clean (521 files); `ruff check apps/catalog/resolve` clean; import-linter passed
- [x] Both intentional divergences preserved: single raises on slug conflict vs bulk reverts the loser; interactive cross-field violation returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)