### PR TITLE
refactor(provenance): name latent claim-machinery types

### DIFF
--- a/backend/apps/accounts/models.py
+++ b/backend/apps/accounts/models.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models.functions import Length, Lower
 
 from apps.actors.models import ActorModel, ActorResolutionStatus
+from apps.actors.types import ActorResolutionPriority
 from apps.core.models import field_not_blank
 
 from .usernames import USERNAME_MAX_LEN, USERNAME_MIN_LEN, validate_username_format
@@ -170,7 +171,7 @@ class User(ActorModel, AbstractUser):
 
     # ActorModel hooks: the user's Actor mirrors these fields for resolution.
     @property
-    def actor_priority(self) -> int:
+    def actor_priority(self) -> ActorResolutionPriority:
         return self.priority
 
     @property

--- a/backend/apps/actors/models/base.py
+++ b/backend/apps/actors/models/base.py
@@ -21,6 +21,7 @@ from typing import Any, ClassVar
 from django.db import models, transaction
 from django.db.models.signals import pre_delete
 
+from ..types import ActorId, ActorResolutionPriority
 from .actor import Actor, ActorResolutionStatus
 
 
@@ -38,7 +39,7 @@ class ActorModel(models.Model):
     is_machine: ClassVar[bool]
 
     # Django sets this descriptor; declared for strong typing of the save() path.
-    actor_id: int | None
+    actor_id: ActorId | None
 
     actor = models.OneToOneField(
         "actors.Actor",
@@ -86,7 +87,7 @@ class ActorModel(models.Model):
     # bulk-mutate a mirrored field without re-syncing its Actor. (Regression-pinned
     # in tests/test_actor_sync.py::test_queryset_update_bypasses_mirror.)
     @property
-    def actor_priority(self) -> int:
+    def actor_priority(self) -> ActorResolutionPriority:
         """Priority for this instance's Actor. Subclass returns its column."""
         raise NotImplementedError(
             f"{type(self).__name__} must implement actor_priority"

--- a/backend/apps/actors/types.py
+++ b/backend/apps/actors/types.py
@@ -1,0 +1,13 @@
+"""Named scalar types owned by the actors app.
+
+Transparent aliases (``type X = …``) — they document intent at signature sites
+without changing interop with the bare ``int`` the Django ORM returns.
+"""
+
+from __future__ import annotations
+
+type ActorId = int
+"""The primary key of an Actor — who an assertion or change is attributed to."""
+
+type ActorResolutionPriority = int
+"""An actor's precedence when its claims compete for a field. Higher wins. """

--- a/backend/apps/catalog/api/edit_claims.py
+++ b/backend/apps/catalog/api/edit_claims.py
@@ -23,6 +23,7 @@ from apps.catalog.models import (
 )
 from apps.claim_edit.claim_write import ClaimSpec, ValidationErrors, raise_form_error
 from apps.core.models import SluggedModel
+from apps.core.types import ClaimFieldName
 from apps.provenance.claims import (
     build_relationship_claim,
     normalize_abbreviation_value,
@@ -46,7 +47,7 @@ def plan_parent_claims(
     desired_slugs: set[str],
     *,
     model_class: type[_ParentEntity],
-    claim_field_name: str,
+    claim_field_name: ClaimFieldName,
 ) -> list[ClaimSpec]:
     """Validate parent hierarchy changes and return diff-based ClaimSpecs.
 
@@ -118,7 +119,7 @@ def plan_alias_claims(
     entity: _AliasEntity,
     desired_aliases: list[str],
     *,
-    claim_field_name: str,
+    claim_field_name: ClaimFieldName,
 ) -> list[ClaimSpec]:
     """Validate alias changes and return diff-based ClaimSpecs.
 
@@ -169,7 +170,7 @@ def plan_m2m_claims(
     desired_slugs: set[str],
     *,
     target_model: type[SluggedModel],
-    claim_field_name: str,
+    claim_field_name: ClaimFieldName,
     m2m_attr: str,
 ) -> list[ClaimSpec]:
     """Validate and diff a simple slug-set M2M relationship.
@@ -206,7 +207,7 @@ def build_m2m_claim_specs(
     *,
     current: set[int],
     desired: set[int],
-    claim_field_name: str,
+    claim_field_name: ClaimFieldName,
 ) -> list[ClaimSpec]:
     """Build diff-based ClaimSpecs for simple PK-set M2M relationships."""
     specs: list[ClaimSpec] = []

--- a/backend/apps/catalog/engine/aliases.py
+++ b/backend/apps/catalog/engine/aliases.py
@@ -20,6 +20,7 @@ from typing import NamedTuple
 
 from django.db.models import Model
 
+from apps.core.types import ClaimFieldName
 from apps.provenance.models import ClaimControlledModel
 
 from .models import AliasModel
@@ -39,7 +40,7 @@ class AliasType(NamedTuple):
     """
 
     parent_model: type[ClaimControlledModel]
-    claim_field: str
+    claim_field: ClaimFieldName
     alias_model: type[AliasModel]
     fk_name: str
 

--- a/backend/apps/catalog/engine/rich_text.py
+++ b/backend/apps/catalog/engine/rich_text.py
@@ -13,6 +13,7 @@ from collections.abc import Iterable
 from django.db import models
 
 from apps.core.markdown import convert_storage_to_authoring, render_markdown_field
+from apps.core.types import ClaimFieldName
 from apps.provenance.attribution import source_backing
 from apps.provenance.helpers import active_claims
 from apps.provenance.licensing import (
@@ -58,7 +59,7 @@ def _extract_description_attribution(
 
 def build_rich_text(
     obj: models.Model,
-    field_name: str,
+    field_name: ClaimFieldName,
     active_claims: Iterable[Claim] | None = None,
 ) -> RichTextSchema:
     """Build a RichTextSchema for a text field with attribution.

--- a/backend/apps/catalog/resolve/_dispatch.py
+++ b/backend/apps/catalog/resolve/_dispatch.py
@@ -45,8 +45,7 @@ class RelationshipDispatchKey(NamedTuple):
     The conceptual identity of a relationship resolver is the *pair*
     ``(field_name, entity_model)``, not the ``field_name`` alone: ``credit``
     resolves differently for ``MachineModel`` and ``Series``, and
-    ``abbreviation`` differently for ``MachineModel`` and ``Title``. Keying by
-    the pair lets both coexist and turns dispatch into a direct lookup.
+    ``abbreviation`` differently for ``MachineModel`` and ``Title``.
     """
 
     field_name: ClaimFieldName
@@ -68,18 +67,22 @@ class ScopePolicy(Enum):
     FULL_TYPE = auto()
 
 
-class RegistryEntry(NamedTuple):
-    """A relationship namespace's projection builder and scope policy.
+type ProjectionBuilder = Callable[[], Projection[ClaimSubjectId, Any, Any] | None]
+"""Builds a fresh projection for a relationship namespace on each resolve (so
+valid-PK sets stay current), or ``None`` to skip the namespace — e.g. credits
+when the ``CreditRole`` vocabulary is unseeded. ``Member`` and ``Payload`` are
+``Any`` because they vary across namespaces; the registry holds heterogeneous
+projections."""
 
-    ``build`` constructs a fresh projection on each call so valid-PK sets are
-    current; it returns ``None`` to skip resolution entirely (credits when the
-    ``CreditRole`` vocabulary is unseeded). Its ``Subject`` is always ``int``
-    (the entity ``object_id``) — the composite-``EntityKey`` media projection is
-    content-type keyed and never registered here. ``Member`` and ``Payload``
-    genuinely vary across namespaces, so they stay ``Any``.
+
+class RegistryEntry(NamedTuple):
+    """A relationship namespace's projection builder paired with its scope policy.
+
+    Only entity-``object_id``-keyed projections are registered here; the
+    content-type-keyed media projection resolves on its own path.
     """
 
-    build: Callable[[], Projection[int, Any, Any] | None]
+    build: ProjectionBuilder
     scope: ScopePolicy
 
 
@@ -124,7 +127,7 @@ def _get_relationship_registry() -> dict[RelationshipDispatchKey, RegistryEntry]
     def add(
         field_name: ClaimFieldName,
         model: type[ClaimControlledModel],
-        build: Callable[[], Projection[int, Any, Any] | None],
+        build: ProjectionBuilder,
         scope: ScopePolicy = ScopePolicy.SUBJECTS,
     ) -> None:
         registry[RelationshipDispatchKey(field_name, model)] = RegistryEntry(
@@ -350,7 +353,7 @@ def resolve_relationships_bulk(
 
 
 def _resolve_media_bulk(
-    model_class: type[ClaimControlledModel], subject_ids: set[int]
+    model_class: type[ClaimControlledModel], subject_ids: set[ClaimSubjectId]
 ) -> None:
     """Bulk-resolve media attachments for a media-supported entity type."""
     from apps.media.models import MediaSupportedModel

--- a/backend/apps/catalog/resolve/_dispatch.py
+++ b/backend/apps/catalog/resolve/_dispatch.py
@@ -27,6 +27,7 @@ from typing import Any, NamedTuple
 
 from django.db import transaction
 
+from apps.core.types import ClaimFieldName, ClaimSubjectId
 from apps.provenance.models import ClaimControlledModel
 
 from ..cache import invalidate_all
@@ -48,7 +49,7 @@ class RelationshipDispatchKey(NamedTuple):
     the pair lets both coexist and turns dispatch into a direct lookup.
     """
 
-    field_name: str
+    field_name: ClaimFieldName
     entity_model: type[ClaimControlledModel]
 
 
@@ -121,7 +122,7 @@ def _get_relationship_registry() -> dict[RelationshipDispatchKey, RegistryEntry]
     registry: dict[RelationshipDispatchKey, RegistryEntry] = {}
 
     def add(
-        field_name: str,
+        field_name: ClaimFieldName,
         model: type[ClaimControlledModel],
         build: Callable[[], Projection[int, Any, Any] | None],
         scope: ScopePolicy = ScopePolicy.SUBJECTS,
@@ -170,9 +171,9 @@ def _get_relationship_registry() -> dict[RelationshipDispatchKey, RegistryEntry]
 
 def resolve_relationship(
     model: type[ClaimControlledModel],
-    field_name: str,
+    field_name: ClaimFieldName,
     *,
-    subject_ids: set[int] | None = None,
+    subject_ids: set[ClaimSubjectId] | None = None,
 ) -> bool:
     """Resolve one relationship namespace via its registered projection.
 
@@ -201,7 +202,7 @@ def resolve_relationship(
 
 def _per_entity_handler(
     entity: ClaimControlledModel,
-    field_names: list[str] | None = None,
+    field_names: list[ClaimFieldName] | None = None,
 ) -> None:
     """Per-entity resolve handler — catalog's ``PerEntityResolver``.
 
@@ -224,8 +225,8 @@ def _per_entity_handler(
 
 def _bulk_handler(
     model_class: type[ClaimControlledModel],
-    subject_ids: set[int],
-    field_names: Collection[str],
+    subject_ids: set[ClaimSubjectId],
+    field_names: Collection[ClaimFieldName],
 ) -> None:
     """Bulk resolve handler — catalog's ``BulkResolver``.
 
@@ -264,7 +265,7 @@ def register_catalog_resolve_handlers() -> None:
 
 def _resolve_entity_relationships(
     entity: ClaimControlledModel,
-    field_names: list[str] | None,
+    field_names: list[ClaimFieldName] | None,
 ) -> None:
     """Per-entity path — dispatch relationship resolvers then scalars."""
     from apps.provenance.validation import get_relationship_namespaces
@@ -318,8 +319,8 @@ def _resolve_entity_relationships(
 
 def resolve_relationships_bulk(
     model_class: type[ClaimControlledModel],
-    field_names: Collection[str],
-    subject_ids: set[int],
+    field_names: Collection[ClaimFieldName],
+    subject_ids: set[ClaimSubjectId],
 ) -> None:
     """Bulk re-resolve relationship namespaces for many subjects in one pass.
 

--- a/backend/apps/catalog/resolve/_engine.py
+++ b/backend/apps/catalog/resolve/_engine.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, NamedTuple, Protocol, cast
 
 from django.contrib.contenttypes.models import ContentType
 
+from apps.core.types import ClaimFieldName, ClaimKey, ClaimSubjectId
 from apps.provenance.claim_presence import member_is_present
 from apps.provenance.claim_ranking_in_db import ranked_claims
 from apps.provenance.models import Claim
@@ -65,7 +66,7 @@ def pick_winners[Subject: Hashable, Group: Hashable](
     return winners
 
 
-def pick_member_winners(ranked: Iterable[Claim]) -> Winners[int, str]:
+def pick_member_winners(ranked: Iterable[Claim]) -> Winners[ClaimSubjectId, ClaimKey]:
     """Membership winner-pick: one winner per ``claim_key`` per entity.
 
     Subject is the entity ``object_id``, group is the ``claim_key`` — a thin
@@ -193,7 +194,7 @@ def reconcile[Subject: Hashable, Member: Hashable, Payload](
 
 def _build_desired[Subject: Hashable, Member: Hashable, Payload](
     projection: Projection[Subject, Member, Payload],
-    winners: Winners[Subject, str],
+    winners: Winners[Subject, ClaimKey],
 ) -> MemberMap[Subject, Member, Payload]:
     """Fold winning claims into the desired member map, dropping tombstones.
 
@@ -305,7 +306,7 @@ class ThroughRowProjection[Member: Hashable, Payload]:
     """
 
     subject_model: type[ClaimControlledModel]
-    field_name: str
+    field_name: ClaimFieldName
     through_model: type[Model]
     subject_column: str
     key_columns: tuple[str, ...]
@@ -317,22 +318,22 @@ class ThroughRowProjection[Member: Hashable, Payload]:
     payload_to_columns: Callable[[Payload], tuple[object, ...]]
     ignore_conflicts: bool = False
 
-    def claims(self, subjects: set[int] | None) -> Iterable[Claim]:
+    def claims(self, subjects: set[ClaimSubjectId] | None) -> Iterable[Claim]:
         ct = ContentType.objects.get_for_model(self.subject_model)
         claims_qs = Claim.objects.filter(content_type=ct, field_name=self.field_name)
         if subjects is not None:
             claims_qs = claims_qs.filter(object_id__in=subjects)
         return ranked_claims(claims_qs, "object_id", "claim_key")
 
-    def subject(self, claim: Claim) -> int:
+    def subject(self, claim: Claim) -> ClaimSubjectId:
         return claim.object_id
 
     def extract(self, claim: Claim) -> ExtractedMember[Member, Payload] | None:
         return self.extract_member(claim)
 
     def read(
-        self, subjects: set[int] | None
-    ) -> MemberMap[int, Member, RowState[Payload]]:
+        self, subjects: set[ClaimSubjectId] | None
+    ) -> MemberMap[ClaimSubjectId, Member, RowState[Payload]]:
         manager = self.through_model._default_manager
         if subjects is not None:
             rows_qs = manager.filter(**{f"{self.subject_column}__in": subjects})
@@ -345,7 +346,7 @@ class ThroughRowProjection[Member: Hashable, Payload]:
 
         nkeys = len(self.key_columns)
         columns = ("pk", self.subject_column, *self.key_columns, *self.payload_columns)
-        existing: MemberMap[int, Member, RowState[Payload]] = {}
+        existing: MemberMap[ClaimSubjectId, Member, RowState[Payload]] = {}
         for row in rows_qs.values_list(*columns):
             pk, subject_id = row[0], row[1]
             key = self.columns_to_key(row[2 : 2 + nkeys])
@@ -353,7 +354,7 @@ class ThroughRowProjection[Member: Hashable, Payload]:
             existing.setdefault(subject_id, {})[key] = RowState(pk, payload)
         return existing
 
-    def write(self, delta: Delta[int, Member, Payload]) -> None:
+    def write(self, delta: Delta[ClaimSubjectId, Member, Payload]) -> None:
         manager = self.through_model._default_manager
         if delta.delete:
             manager.filter(pk__in=delta.delete).delete()

--- a/backend/apps/catalog/resolve/_engine.py
+++ b/backend/apps/catalog/resolve/_engine.py
@@ -89,11 +89,10 @@ def pick_member_winners(ranked: Iterable[Claim]) -> Winners[ClaimSubjectId, Clai
 #   * ``Payload`` — the member's attribute (``None`` for a set; a value for a map)
 
 
-type RowId = int
-"""A materialized through-row's primary key — what a delete/update targets.
-Distinct from ``Subject`` (often the entity ``object_id``): a documentation
-alias so the ``pk`` fields and the delete list read as row identities, not bare
-ints."""
+type MaterializedRowId = int
+"""The primary key of a row in the materialized catalog view — the identity a
+reconcile deletes or updates by. Distinct from the entity ``ClaimSubjectId`` and
+a member's target pk it sits beside."""
 
 
 type MemberMap[Subject: Hashable, Member: Hashable, Payload] = dict[
@@ -106,7 +105,7 @@ member.  A set membership is ``Payload = None``; a map membership carries a valu
 class RowState[Payload](NamedTuple):
     """An existing materialized row: its pk (for delete/update) and payload."""
 
-    pk: RowId
+    pk: MaterializedRowId
     payload: Payload
 
 
@@ -128,7 +127,7 @@ class CreateRow[Subject: Hashable, Member: Hashable, Payload](NamedTuple):
 class UpdateRow[Payload](NamedTuple):
     """An existing row whose payload changed (a map-membership value edit)."""
 
-    pk: RowId
+    pk: MaterializedRowId
     payload: Payload
 
 
@@ -136,7 +135,7 @@ class Delta[Subject: Hashable, Member: Hashable, Payload](NamedTuple):
     """What :func:`reconcile` writes — the create/delete/update partition."""
 
     create: list[CreateRow[Subject, Member, Payload]]
-    delete: list[RowId]
+    delete: list[MaterializedRowId]
     update: list[UpdateRow[Payload]]
 
 
@@ -228,7 +227,7 @@ def diff[Subject: Hashable, Member: Hashable, Payload](
     differ on), so plain through-rows get ``{create, delete}`` for free.
     """
     create: list[CreateRow[Subject, Member, Payload]] = []
-    delete: list[RowId] = []
+    delete: list[MaterializedRowId] = []
     update: list[UpdateRow[Payload]] = []
     for subject in desired.keys() | existing.keys():
         want = desired.get(subject, {})
@@ -257,38 +256,53 @@ def diff[Subject: Hashable, Member: Hashable, Payload](
 # (composite EntityKey subject) — stay in their domain modules.
 
 
+type ColumnValues = tuple[object, ...]
+"""The values of one materialized row's key or payload columns, in positional
+order."""
+
+type ColumnNames = tuple[str, ...]
+"""The through-table column names that back a member key or a payload, in
+positional order."""
+
+type MemberExtractor[Member: Hashable, Payload] = Callable[
+    [Claim], ExtractedMember[Member, Payload] | None
+]
+"""Derives a through-row's desired key and payload from a winning claim, or
+``None`` to drop it. The single per-shape step in an otherwise uniform reconcile."""
+
+
 # Column <-> Member/Payload converters.  The ``*_to_columns`` direction takes
 # ``object`` (a Member or Payload) — contravariantly assignable to any concrete
 # param type — while the ``columns_to_*`` direction must return the precise type,
 # so the scalar cases are spelled per result type (int / str / int|None).
 
 
-def _int_from_column(columns: tuple[object, ...]) -> int:
+def _int_from_column(columns: ColumnValues) -> int:
     """Single int column → its value (FK target pk)."""
     return cast(int, columns[0])
 
 
-def _str_from_column(columns: tuple[object, ...]) -> str:
+def _str_from_column(columns: ColumnValues) -> str:
     """Single str column → its value (abbreviation string)."""
     return cast(str, columns[0])
 
 
-def _int_or_none_from_column(columns: tuple[object, ...]) -> int | None:
+def _int_or_none_from_column(columns: ColumnValues) -> int | None:
     """Single nullable int column → its value (gameplay count)."""
     return cast(int | None, columns[0])
 
 
-def _one_column(value: object) -> tuple[object, ...]:
+def _one_column(value: object) -> ColumnValues:
     """A scalar Member/Payload → its single column."""
     return (value,)
 
 
-def _no_payload(columns: tuple[object, ...]) -> None:
+def _no_payload(columns: ColumnValues) -> None:
     """Set membership: no payload columns → ``None`` payload."""
     return None
 
 
-def _no_columns(payload: object) -> tuple[object, ...]:
+def _no_columns(payload: object) -> ColumnValues:
     """Set membership: ``None`` payload → no payload columns."""
     return ()
 
@@ -309,13 +323,13 @@ class ThroughRowProjection[Member: Hashable, Payload]:
     field_name: ClaimFieldName
     through_model: type[Model]
     subject_column: str
-    key_columns: tuple[str, ...]
-    payload_columns: tuple[str, ...]
-    extract_member: Callable[[Claim], ExtractedMember[Member, Payload] | None]
-    columns_to_key: Callable[[tuple[object, ...]], Member]
-    key_to_columns: Callable[[Member], tuple[object, ...]]
-    columns_to_payload: Callable[[tuple[object, ...]], Payload]
-    payload_to_columns: Callable[[Payload], tuple[object, ...]]
+    key_columns: ColumnNames
+    payload_columns: ColumnNames
+    extract_member: MemberExtractor[Member, Payload]
+    columns_to_key: Callable[[ColumnValues], Member]
+    key_to_columns: Callable[[Member], ColumnValues]
+    columns_to_payload: Callable[[ColumnValues], Payload]
+    payload_to_columns: Callable[[Payload], ColumnValues]
     ignore_conflicts: bool = False
 
     def claims(self, subjects: set[ClaimSubjectId] | None) -> Iterable[Claim]:

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -15,7 +15,13 @@ from dataclasses import dataclass
 from django.db import models
 from django.utils import timezone
 
-from apps.core.types import ClaimFieldMap, ClaimFieldName, ClaimSubjectId, JsonBody
+from apps.core.types import (
+    ClaimFieldMap,
+    ClaimFieldName,
+    ClaimSubjectId,
+    JsonBody,
+    PublicId,
+)
 from apps.provenance.claim_ranking_in_db import ranked_claims
 from apps.provenance.licensing import (
     SourceFieldLicenseMap,
@@ -56,7 +62,7 @@ def _sync_markdown_references(obj: ClaimControlledModel) -> None:
 # This is shared between bulk and single-object claims resolution.
 # ------------------------------------------------------------------
 
-type FKLookups = Mapping[str, Mapping[str, models.Model]]
+type FKLookups = Mapping[str, Mapping[PublicId, models.Model]]
 """Read-only covariant view of ``FKTargetLookups`` — the apply loop only reads
 the prefetched FK index, so the param accepts any mapping shape."""
 

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -56,8 +56,9 @@ def _sync_markdown_references(obj: ClaimControlledModel) -> None:
 # This is shared between bulk and single-object claims resolution.
 # ------------------------------------------------------------------
 
-# Read-only view of FKInfo.lookups — {attr: {slug: instance}}
 type FKLookups = Mapping[str, Mapping[str, models.Model]]
+"""Read-only covariant view of ``FKTargetLookups`` — the apply loop only reads
+the prefetched FK index, so the param accepts any mapping shape."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/apps/catalog/resolve/_entities.py
+++ b/backend/apps/catalog/resolve/_entities.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from django.db import models
 from django.utils import timezone
 
-from apps.core.types import JsonBody
+from apps.core.types import ClaimFieldMap, ClaimFieldName, ClaimSubjectId, JsonBody
 from apps.provenance.claim_ranking_in_db import ranked_claims
 from apps.provenance.licensing import (
     SourceFieldLicenseMap,
@@ -70,7 +70,7 @@ class ScalarApplyContext:
     """
 
     model_class: type[ClaimControlledModel]
-    direct_fields: Mapping[str, str]
+    direct_fields: ClaimFieldMap
     field_defaults: Mapping[str, object]
     preserve_when_unclaimed: AbstractSet[str]
     fk_lookups: FKLookups | None
@@ -79,7 +79,7 @@ class ScalarApplyContext:
 
 def _apply_claims(
     obj: ClaimControlledModel,
-    winners: Mapping[str, Claim],
+    winners: Mapping[ClaimFieldName, Claim],
     ctx: ScalarApplyContext,
 ) -> None:
     """Reset *obj*'s resolvable fields to defaults, then apply its winning claims.
@@ -138,7 +138,7 @@ def _apply_claims(
 
 def _resolve_single(
     obj: ClaimControlledModel,
-    direct_fields: dict[str, str],
+    direct_fields: ClaimFieldMap,
 ) -> None:
     """Resolve active claims onto a single object with only direct fields.
 
@@ -185,8 +185,8 @@ def _resolve_single(
 
 def _resolve_bulk(
     model_class: type[ClaimControlledModel],
-    direct_fields: dict[str, str],
-    object_ids: set[int] | None = None,
+    direct_fields: ClaimFieldMap,
+    object_ids: set[ClaimSubjectId] | None = None,
 ) -> int:
     """Bulk-resolve claims for all (or selected) instances of a model class.
 
@@ -346,7 +346,9 @@ def resolve_entity[T: ClaimControlledModel](obj: T) -> T:
 
 
 def resolve_all_entities(
-    model_class: type[ClaimControlledModel], *, object_ids: set[int] | None = None
+    model_class: type[ClaimControlledModel],
+    *,
+    object_ids: set[ClaimSubjectId] | None = None,
 ) -> int:
     """Bulk-resolve all claim-controlled fields for all instances of a model.
 

--- a/backend/apps/catalog/resolve/_helpers.py
+++ b/backend/apps/catalog/resolve/_helpers.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 from django.db import models
 
 from apps.core.models import meta_unique_fields
-from apps.core.types import ClaimFieldMap, ClaimFieldName
+from apps.core.types import ClaimFieldMap, ClaimFieldName, PublicId
 from apps.provenance.claims import normalize_fk_value
 from apps.provenance.models import ClaimControlledModel
 
@@ -46,10 +46,10 @@ def validate_check_constraints(obj: models.Model) -> None:
             validate(type(obj), obj)
 
 
-type FKTargetLookups = dict[str, dict[str, models.Model]]
-"""Per FK field, a map from a target's lookup value (typically slug) to its
-resolved instance — the prefetched index that turns a claimed slug into a foreign
-key without a query per claim."""
+type FKTargetLookups = dict[str, dict[PublicId, models.Model]]
+"""Per FK field, a map from a target's public_id (typically slug) to its resolved
+instance — the prefetched index that turns a claimed slug into a foreign key
+without a query per claim."""
 
 
 @dataclass

--- a/backend/apps/catalog/resolve/_helpers.py
+++ b/backend/apps/catalog/resolve/_helpers.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 from django.db import models
 
 from apps.core.models import meta_unique_fields
+from apps.core.types import ClaimFieldMap, ClaimFieldName
 from apps.provenance.claims import normalize_fk_value
 from apps.provenance.models import ClaimControlledModel
 
@@ -62,7 +63,7 @@ class FKInfo:
 
 def _resolve_fk_generic(
     model_class: type[ClaimControlledModel],
-    field_name: str,
+    field_name: ClaimFieldName,
     value: object,
     lookup: Mapping[str, models.Model] | None = None,
 ) -> models.Model | None:
@@ -103,7 +104,7 @@ def _resolve_fk_generic(
 
 def build_fk_info(
     model_class: type[ClaimControlledModel],
-    claim_fields: dict[str, str],
+    claim_fields: ClaimFieldMap,
 ) -> FKInfo:
     """Identify FK fields and pre-build slug-to-instance lookups for bulk resolution."""
     info = FKInfo()
@@ -177,7 +178,7 @@ def _coerce(
 
 def get_field_defaults(
     model_class: type[ClaimControlledModel],
-    direct_fields: dict[str, str],
+    direct_fields: ClaimFieldMap,
 ) -> dict[str, Any]:
     """Compute reset values for direct fields by inspecting Django model metadata.
 
@@ -207,7 +208,7 @@ def get_field_defaults(
 
 def get_preserve_fields(
     model_class: type[ClaimControlledModel],
-    direct_fields: dict[str, str],
+    direct_fields: ClaimFieldMap,
 ) -> set[str]:
     """Identify fields that must keep their existing value when no claim exists.
 
@@ -233,7 +234,7 @@ def get_preserve_fields(
 
 def get_nullable_unique_fields(
     model_class: type[ClaimControlledModel],
-    direct_fields: dict[str, str],
+    direct_fields: ClaimFieldMap,
 ) -> list[str]:
     """Claim-controlled fields that are single-column ``unique=True`` AND nullable.
 
@@ -261,7 +262,7 @@ def get_nullable_unique_fields(
 
 def resolve_unique_conflicts(
     all_objs: Sequence[ClaimControlledModel],
-    field_name: str,
+    field_name: ClaimFieldName,
     model_class: type[ClaimControlledModel],
     pre_values: dict[int, Any] | None = None,
 ) -> None:

--- a/backend/apps/catalog/resolve/_helpers.py
+++ b/backend/apps/catalog/resolve/_helpers.py
@@ -46,14 +46,18 @@ def validate_check_constraints(obj: models.Model) -> None:
             validate(type(obj), obj)
 
 
+type FKTargetLookups = dict[str, dict[str, models.Model]]
+"""Per FK field, a map from a target's lookup value (typically slug) to its
+resolved instance — the prefetched index that turns a claimed slug into a foreign
+key without a query per claim."""
+
+
 @dataclass
 class FKInfo:
     """FK field metadata and pre-fetched lookups for bulk resolution."""
 
     fk_fields: set[str] = field(default_factory=set)
-    # {attr: {lookup_value: related_instance}} — inner dict maps the claim's
-    # string payload (typically slug) to the fully-fetched target model row.
-    lookups: dict[str, dict[str, models.Model]] = field(default_factory=dict)
+    lookups: FKTargetLookups = field(default_factory=dict)
 
 
 # ------------------------------------------------------------------

--- a/backend/apps/catalog/resolve/_media.py
+++ b/backend/apps/catalog/resolve/_media.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, NamedTuple, cast
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
-from apps.core.types import EntityKey
+from apps.core.types import ClaimSubjectId, ContentTypeId, EntityKey
 from apps.media.models import EntityMedia, MediaAsset, MediaSupportedModel
 from apps.provenance.claim_ranking_in_db import ranked_claims
 from apps.provenance.models import Claim
@@ -56,7 +56,10 @@ class MediaProjection:
     """
 
     def __init__(
-        self, *, content_type_id: int | None, subject_ids: set[int] | None
+        self,
+        *,
+        content_type_id: ContentTypeId | None,
+        subject_ids: set[ClaimSubjectId] | None,
     ) -> None:
         self.content_type_id = content_type_id
         self.subject_ids = subject_ids
@@ -177,8 +180,8 @@ class MediaProjection:
 
 def resolve_media_attachments(
     *,
-    content_type_id: int | None = None,
-    subject_ids: set[int] | None = None,
+    content_type_id: ContentTypeId | None = None,
+    subject_ids: set[ClaimSubjectId] | None = None,
 ) -> None:
     """Bulk-resolve ``media_attachment`` claims into :class:`EntityMedia` rows.
 

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -393,12 +393,12 @@ class AliasProjection:
         rows_qs = manager.all()
         if subjects is not None:
             rows_qs = rows_qs.filter(**{f"{self.fk_column}__in": subjects})
-        existing: MemberMap[int, str, RowState[str]] = {}
+        existing: MemberMap[ClaimSubjectId, str, RowState[str]] = {}
         for pk, parent_id, value in rows_qs.values_list("pk", self.fk_column, "value"):
             existing.setdefault(parent_id, {})[value.lower()] = RowState(pk, value)
         return existing
 
-    def write(self, delta: Delta[int, str, str]) -> None:
+    def write(self, delta: Delta[ClaimSubjectId, str, str]) -> None:
         manager = self.alias_model._default_manager
         if delta.delete:
             manager.filter(pk__in=delta.delete).delete()

--- a/backend/apps/catalog/resolve/_relationships.py
+++ b/backend/apps/catalog/resolve/_relationships.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Literal, NamedTuple, cast
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Model
 
+from apps.core.types import ClaimFieldName, ClaimSubjectId
 from apps.provenance.claim_ranking_in_db import ranked_claims
 from apps.provenance.models import Claim, ClaimControlledModel
 from apps.provenance.validation import (
@@ -112,7 +113,7 @@ def _get_parents_through(parent: type[ClaimControlledModel]) -> type[Model]:
 class M2MFieldSpec:
     """Descriptor for a simple M2M relationship resolved from claims."""
 
-    field_name: str  # claim field_name (also the value dict key): "theme", "tag"
+    field_name: ClaimFieldName  # also the value dict key: "theme", "tag"
     m2m_attr: str  # model attribute: "themes", "tags", "gameplay_features"
     target_model: type[CatalogModel]  # Theme, Tag, GameplayFeature
 
@@ -361,10 +362,10 @@ class AliasProjection:
     parent_model: type[ClaimControlledModel]
     alias_model: type[Model]
     fk_column: str
-    claim_field: str
+    claim_field: ClaimFieldName
     schema: RelationshipSchema
 
-    def claims(self, subjects: set[int] | None) -> Iterable[Claim]:
+    def claims(self, subjects: set[ClaimSubjectId] | None) -> Iterable[Claim]:
         ct = ContentType.objects.get_for_model(self.parent_model)
         claims_qs = Claim.objects.filter(content_type=ct, field_name=self.claim_field)
         if subjects is not None:
@@ -385,7 +386,9 @@ class AliasProjection:
         display = str(override) if override is not None else alias_val
         return ExtractedMember(alias_val, display)  # alias_val is already lowercase
 
-    def read(self, subjects: set[int] | None) -> MemberMap[int, str, RowState[str]]:
+    def read(
+        self, subjects: set[ClaimSubjectId] | None
+    ) -> MemberMap[ClaimSubjectId, str, RowState[str]]:
         manager = self.alias_model._default_manager
         rows_qs = manager.all()
         if subjects is not None:

--- a/backend/apps/catalog/tests/test_claims.py
+++ b/backend/apps/catalog/tests/test_claims.py
@@ -206,11 +206,12 @@ class TestBuildRelationshipClaimCanonicalKey:
     """
 
     def test_every_schema_produces_canonical_claim_key(self, db):
-        from apps.provenance.models import IdentityPart
+        from apps.provenance.models import IdentityPartValue
+        from apps.provenance.types import ClaimValueKey
         from apps.provenance.validation import get_all_relationship_schemas
 
         for namespace, schema in get_all_relationship_schemas().items():
-            identity_kwargs: dict[str, IdentityPart] = {}
+            identity_kwargs: dict[ClaimValueKey, IdentityPartValue] = {}
             for spec in schema.value_keys:
                 if spec.identity is None:
                     continue

--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -656,7 +656,9 @@ def update_citation_source(
 )
 @requires(Activity.CITATION_EDIT)
 def create_citation_source_link(
-    request: HttpRequest, source_id: int, data: CitationSourceLinkCreateSchema
+    request: HttpRequest,
+    source_id: int,
+    data: CitationSourceLinkCreateSchema,
 ) -> Status[CitationSourceLinkSchema]:
     """Create a link on a Citation Source."""
     user = authed_user(request)

--- a/backend/apps/citation/hosts.py
+++ b/backend/apps/citation/hosts.py
@@ -27,6 +27,8 @@ import re
 from collections.abc import Sequence
 from typing import NamedTuple, NewType
 
+from apps.core.types import CitationSourceId
+
 Host = NewType("Host", str)
 """A recognition host **already normalized** by :func:`normalize_host`.
 
@@ -140,7 +142,7 @@ class RootDomainMatch(NamedTuple):
     :func:`longest_suffix_match` compares it verbatim.
     """
 
-    source_id: int
+    source_id: CitationSourceId
     source_name: str
     host: Host
 

--- a/backend/apps/claim_ingest/apply/persist.py
+++ b/backend/apps/claim_ingest/apply/persist.py
@@ -32,7 +32,6 @@ from apps.claim_ingest.apply.claims import (
 from apps.claim_ingest.plan import (
     CitationRef,
     CiteHandle,
-    ContentTypeId,
     EntryIndex,
     Handle,
     IngestPlan,
@@ -41,7 +40,7 @@ from apps.claim_ingest.plan import (
     SchemeCitationRef,
     WebCitationRef,
 )
-from apps.core.types import ClaimIdentity, EntityKey
+from apps.core.types import ClaimIdentity, ContentTypeId, EntityKey
 from apps.provenance.models import ChangeSet, Claim, ClaimControlledModel, IngestRun
 
 # Per-entry / per-claim provenance maps produced by ``_collect_plan_provenance``

--- a/backend/apps/claim_ingest/patches/_types.py
+++ b/backend/apps/claim_ingest/patches/_types.py
@@ -13,21 +13,7 @@ from typing import NamedTuple
 from django.db import models
 
 from apps.claim_ingest.plan import Handle
-
-# The composite key identifying one claim — a scalar/FK field name or a
-# relationship member key from ``build_relationship_claim`` (e.g.
-# ``"location:germany"``). A transparent alias of ``str``: it documents the
-# concept where it recurs across the adapter without changing any interop with
-# the ``str``-typed claim machinery (``apps.catalog.claims``, apply's ClaimIdentity).
-type ClaimKey = str
-
-# A catalog entity's public_id — the URL-identity value of its ``public_id_field``
-# (``slug`` for most entities, ``location_path`` for Location), and what an FK or
-# relationship member names its target by. A transparent alias of ``str`` like
-# ``ClaimKey``: it distinguishes a public_id from the other ``str``s in the adapter
-# (a handle/entry ``ref``, a relationship ``namespace``) at the points where the
-# distinction is otherwise invisible — e.g. a ``dict[str, set[str]]`` adjacency map.
-type PublicId = str
+from apps.core.types import ClaimSubjectId, ContentTypeId, PublicId
 
 
 class PatchError(Exception):
@@ -40,8 +26,8 @@ class PatchError(Exception):
 class _Target(NamedTuple):
     """Where a claim assertion lands: an existing entity or a planned handle."""
 
-    content_type_id: int | None = None
-    object_id: int | None = None
+    content_type_id: ContentTypeId | None = None
+    object_id: ClaimSubjectId | None = None
     handle: Handle | None = None
 
 

--- a/backend/apps/claim_ingest/patches/emit.py
+++ b/backend/apps/claim_ingest/patches/emit.py
@@ -18,9 +18,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 from apps.claim_ingest.patches._types import (
-    ClaimKey,
     PatchError,
-    PublicId,
     _Target,
 )
 from apps.claim_ingest.patches.entity_registry import PatchEntityRegistry
@@ -48,7 +46,7 @@ from apps.core.soft_delete import (
     require_linkable,
     soft_delete_walk,
 )
-from apps.core.types import EntityKey
+from apps.core.types import ClaimKey, EntityKey, PublicId
 from apps.provenance.claim_presence import member_is_present
 from apps.provenance.claims import (
     build_relationship_claim,

--- a/backend/apps/claim_ingest/patches/emit.py
+++ b/backend/apps/claim_ingest/patches/emit.py
@@ -56,7 +56,7 @@ from apps.provenance.claims import (
 )
 from apps.provenance.models import (
     Claim,
-    IdentityPart,
+    IdentityPartValue,
     LinkableClaimModel,
     Source,
     get_claim_fields,
@@ -358,7 +358,7 @@ def _relationship_member_spec(
     # gameplay_feature (one slot, ``count`` — patch-authorable below) and
     # media_attachment (two slots, ``category`` + ``is_primary`` — rejected by the
     # guards below; media is authored through the media API, not data patches).
-    display_keys = {
+    display_keys: set[ClaimValueKey] = {
         s.display_key for s in schema.value_keys if s.display_key is not None
     }
     payload_specs = [
@@ -447,7 +447,7 @@ def _unpack_fk_member(
     rel_spec: _FkMemberSpec,
     namespace: Namespace,
     entry: PatchEntry,
-) -> tuple[PublicId, dict[ClaimValueKey, IdentityPart]]:
+) -> tuple[PublicId, dict[ClaimValueKey, IdentityPartValue]]:
     """Split an FK member into its public_id and optional non-identity payload.
 
     A bare ``str`` ⇒ ``(member, {})`` — the universal form (tag, theme, location,
@@ -461,7 +461,7 @@ def _unpack_fk_member(
 
     ``member`` is untyped parsed YAML, so this re-checks the shape at the boundary.
     """
-    empty: dict[ClaimValueKey, IdentityPart] = {}
+    empty: dict[ClaimValueKey, IdentityPartValue] = {}
     if isinstance(member, str):
         return member, empty
     if rel_spec.payload is not None and isinstance(member, dict) and len(member) == 1:
@@ -490,7 +490,7 @@ def _coerce_payload_value(
     public_id: str,
     namespace: Namespace,
     entry: PatchEntry,
-) -> IdentityPart:
+) -> IdentityPartValue:
     """Validate one authored payload value against its slot, or raise.
 
     Returns ``None`` for an explicit ``null`` on a nullable slot (the caller omits
@@ -528,7 +528,7 @@ def _member_identity(
     namespace: Namespace,
     rel_spec: _RelationshipMemberSpec,
     entry: PatchEntry,
-) -> dict[ClaimValueKey, IdentityPart]:
+) -> dict[ClaimValueKey, IdentityPartValue]:
     """Build the value-dict identity for one relationship member, or raise.
 
     Returns the **same** dict for assert and remove — the removal caller passes
@@ -585,7 +585,7 @@ def _member_identity(
             # multi-FK members itself (committed or deferred) and never delegates
             # here. Removal targets committed credits only, so resolve every slot
             # against a committed row.
-            identity: dict[ClaimValueKey, IdentityPart] = {}
+            identity: dict[ClaimValueKey, IdentityPartValue] = {}
             for slot_ref in _unpack_credit_member(member, rel_spec, namespace, entry):
                 identity[slot_ref.slot.value_key] = _resolve_committed_slot(
                     slot_ref.slot, slot_ref.ref, namespace=namespace, entry=entry
@@ -648,7 +648,7 @@ class _ResolvedMember(NamedTuple):
     concretely; a non-empty ``refs`` means at least one slot defers to a create.
     """
 
-    concrete: dict[ClaimValueKey, IdentityPart]
+    concrete: dict[ClaimValueKey, IdentityPartValue]
     refs: dict[ClaimValueKey, Handle]
     key: _DeferredMemberKey
 
@@ -661,7 +661,7 @@ def _resolve_member_slots(
     entry: PatchEntry,
 ) -> _ResolvedMember:
     """Resolve each slot to a committed pk or a same-patch-create handle."""
-    concrete: dict[ClaimValueKey, IdentityPart] = {}
+    concrete: dict[ClaimValueKey, IdentityPartValue] = {}
     refs: dict[ClaimValueKey, Handle] = {}
     key_parts: list[_DeferredSlotRef] = []
     for slot, ref in slot_refs:

--- a/backend/apps/claim_ingest/patches/emit.py
+++ b/backend/apps/claim_ingest/patches/emit.py
@@ -61,6 +61,7 @@ from apps.provenance.models import (
     Source,
     get_claim_fields,
 )
+from apps.provenance.types import ClaimValueKey
 from apps.provenance.validation import get_relationship_schema
 
 
@@ -107,7 +108,7 @@ class _DeferredSlotRef(NamedTuple):
     :data:`_DeferredMemberKey`.
     """
 
-    value_key: str
+    value_key: ClaimValueKey
     target: int | Handle
 
 
@@ -256,7 +257,7 @@ class _PayloadSlot(NamedTuple):
     ``_relationship_member_spec`` before any slot is built, so this stays singular.
     """
 
-    value_key: str  # the value-dict key carrying the payload (``spec.name``)
+    value_key: ClaimValueKey  # the value-dict key carrying the payload (``spec.name``)
     scalar_type: type  # int/str — the authored value is type-checked against it
     nullable: bool  # whether an explicit ``null`` is allowed (else omit ⇒ NULL)
     # Inclusive lower bound for an int payload (the model field's own
@@ -268,7 +269,7 @@ class _PayloadSlot(NamedTuple):
 class _FkMemberSpec(NamedTuple):
     """Member is a public_id resolving to an FK on another entity (tag, theme, location)."""
 
-    value_key: str  # the value-dict key carrying the member FK (``spec.name``)
+    value_key: ClaimValueKey  # the value-dict key carrying the FK (``spec.name``)
     target_model: type[models.Model]  # what a member public_id resolves to
     # An optional non-identity scalar carried alongside the FK via the one-key
     # ``{public_id: value}`` form (gameplay_feature's ``count``). ``None`` ⇒ the
@@ -280,14 +281,14 @@ class _FkMemberSpec(NamedTuple):
 class _StringMemberSpec(NamedTuple):
     """Member is a bare string (alias, abbreviation)."""
 
-    value_key: str  # the value-dict key carrying the member string (``spec.name``)
+    value_key: ClaimValueKey  # the value-dict key carrying the string (``spec.name``)
     max_length: int  # the target CharField bound; over-length members are rejected
     # ``display_key`` is the either/or *within* string members: a sibling
     # value-key name (alias ⇒ case-fold via ``.lower()`` and carry display) or
     # ``None`` (abbreviation ⇒ stored verbatim). It is also the proxy for "this
     # identity case-folds" — a future string identity needing a different fold
     # must extend ``_member_identity``, not ride the ``.lower()`` default.
-    display_key: str | None
+    display_key: ClaimValueKey | None
 
 
 class _MultiFkMemberSpec(NamedTuple):
@@ -446,7 +447,7 @@ def _unpack_fk_member(
     rel_spec: _FkMemberSpec,
     namespace: Namespace,
     entry: PatchEntry,
-) -> tuple[PublicId, dict[str, IdentityPart]]:
+) -> tuple[PublicId, dict[ClaimValueKey, IdentityPart]]:
     """Split an FK member into its public_id and optional non-identity payload.
 
     A bare ``str`` ⇒ ``(member, {})`` — the universal form (tag, theme, location,
@@ -460,7 +461,7 @@ def _unpack_fk_member(
 
     ``member`` is untyped parsed YAML, so this re-checks the shape at the boundary.
     """
-    empty: dict[str, IdentityPart] = {}
+    empty: dict[ClaimValueKey, IdentityPart] = {}
     if isinstance(member, str):
         return member, empty
     if rel_spec.payload is not None and isinstance(member, dict) and len(member) == 1:
@@ -527,7 +528,7 @@ def _member_identity(
     namespace: Namespace,
     rel_spec: _RelationshipMemberSpec,
     entry: PatchEntry,
-) -> dict[str, IdentityPart]:
+) -> dict[ClaimValueKey, IdentityPart]:
     """Build the value-dict identity for one relationship member, or raise.
 
     Returns the **same** dict for assert and remove — the removal caller passes
@@ -584,7 +585,7 @@ def _member_identity(
             # multi-FK members itself (committed or deferred) and never delegates
             # here. Removal targets committed credits only, so resolve every slot
             # against a committed row.
-            identity: dict[str, IdentityPart] = {}
+            identity: dict[ClaimValueKey, IdentityPart] = {}
             for slot_ref in _unpack_credit_member(member, rel_spec, namespace, entry):
                 identity[slot_ref.slot.value_key] = _resolve_committed_slot(
                     slot_ref.slot, slot_ref.ref, namespace=namespace, entry=entry
@@ -647,8 +648,8 @@ class _ResolvedMember(NamedTuple):
     concretely; a non-empty ``refs`` means at least one slot defers to a create.
     """
 
-    concrete: dict[str, IdentityPart]
-    refs: dict[str, Handle]
+    concrete: dict[ClaimValueKey, IdentityPart]
+    refs: dict[ClaimValueKey, Handle]
     key: _DeferredMemberKey
 
 
@@ -660,8 +661,8 @@ def _resolve_member_slots(
     entry: PatchEntry,
 ) -> _ResolvedMember:
     """Resolve each slot to a committed pk or a same-patch-create handle."""
-    concrete: dict[str, IdentityPart] = {}
-    refs: dict[str, Handle] = {}
+    concrete: dict[ClaimValueKey, IdentityPart] = {}
+    refs: dict[ClaimValueKey, Handle] = {}
     key_parts: list[_DeferredSlotRef] = []
     for slot, ref in slot_refs:
         handle = registry.created_handle(slot.target_model, normalize_fk_value(ref))

--- a/backend/apps/claim_ingest/patches/planning.py
+++ b/backend/apps/claim_ingest/patches/planning.py
@@ -27,9 +27,7 @@ from apps.citation.source_upsert import (
     validate_root_source,
 )
 from apps.claim_ingest.patches._types import (
-    ClaimKey,
     PatchError,
-    PublicId,
     _CreatedKey,
     _Target,
 )
@@ -72,7 +70,7 @@ from apps.core.models import (
     LinkableModel,
 )
 from apps.core.soft_delete import cascade_targets, require_linkable
-from apps.core.types import EntityKey
+from apps.core.types import ClaimKey, EntityKey, PublicId
 from apps.provenance.claims import normalize_fk_value
 from apps.provenance.models import LinkableClaimModel, Source, get_claim_fields
 from apps.provenance.validation import get_relationship_namespaces

--- a/backend/apps/claim_ingest/plan.py
+++ b/backend/apps/claim_ingest/plan.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from apps.core.types import LicenseId
+from apps.core.types import ContentTypeId, LicenseId
 from apps.provenance.models import ClaimControlledModel, Source
 
 
@@ -114,11 +114,6 @@ type CiteHandle = str
 # Typed ``| None`` on the carriers only because the front end stamps it in a
 # second pass (see ``planning.build_plan``); it is always set by apply time.
 type EntryIndex = int
-
-# A ``ContentType`` pk — the key of ``IngestPlan.changed_relationship_fields``.
-# A transparent alias of ``int`` (like ``CiteHandle``/``EntryIndex`` above) that
-# names the role so a bare ``int`` isn't mistaken for an object pk or count.
-type ContentTypeId = int
 
 # A plan-local temporary identifier for a not-yet-created entity — the label a
 # ``PlannedClaimAssert`` (or another create's ``handle_refs``) uses to point at a

--- a/backend/apps/claim_ingest/plan.py
+++ b/backend/apps/claim_ingest/plan.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+from apps.core.types import LicenseId
 from apps.provenance.models import ClaimControlledModel, Source
 
 
@@ -209,7 +210,7 @@ class PlannedClaimAssert:
     content_type_id: int | None = None
     object_id: int | None = None
     handle: Handle | None = None
-    license_id: int | None = None
+    license_id: LicenseId | None = None
     # Deferred relationship claim identity:
     relationship_namespace: Namespace = ""
     # identity values mix PKs (int) and tag values (str/bool) per the

--- a/backend/apps/claim_ingest/plan.py
+++ b/backend/apps/claim_ingest/plan.py
@@ -26,6 +26,7 @@ from typing import Any, Protocol
 
 from apps.core.types import ContentTypeId, LicenseId
 from apps.provenance.models import ClaimControlledModel, Source
+from apps.provenance.types import ClaimValueKey
 
 
 class PreWriteHook(Protocol):
@@ -210,9 +211,9 @@ class PlannedClaimAssert:
     relationship_namespace: Namespace = ""
     # identity values mix PKs (int) and tag values (str/bool) per the
     # relationship's claim-key schema; truly heterogeneous.
-    identity: dict[str, Any] = field(default_factory=dict)
+    identity: dict[ClaimValueKey, Any] = field(default_factory=dict)
     # value-key → the handle of the planned entity whose PK fills that identity slot.
-    identity_refs: dict[str, Handle] = field(default_factory=dict)
+    identity_refs: dict[ClaimValueKey, Handle] = field(default_factory=dict)
 
 
 @dataclass

--- a/backend/apps/core/types.py
+++ b/backend/apps/core/types.py
@@ -43,6 +43,11 @@ column, an FK, or the shared namespace of a relationship's members."""
 type ClaimFieldMap = dict[ClaimFieldName, str]
 """Maps each claim-controlled field name to the model attribute it resolves into."""
 
+type PublicId = str
+"""An entity's URL-identity: the value of its public_id field, by which an FK or
+relationship member names its target. It's usually a slug, but is a path for
+hierarchical entities like Location, whose nesting a flat slug can't express."""
+
 
 # ---------------------------------------------------------------------------
 # Primary keys of models owned by other apps

--- a/backend/apps/core/types.py
+++ b/backend/apps/core/types.py
@@ -5,20 +5,24 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import NamedTuple, TypedDict
 
-# JSON-shaped dict — object keys, arbitrary JSON values. ``object`` (not
-# ``Any``) forces callers to isinstance-narrow before use, which matches
-# the free-form-but-typed nature of JSON.
-#
-# ``JsonBody`` (invariant dict): test-client request/response bodies.
-# ``JsonData`` (covariant Mapping): read-only views of JSON — function
-# params that only read, e.g. ``extra_data`` JSONField contents. A
-# covariant alias is needed because dict literals like
-# ``{"k": [1, 2]}`` have inferred type ``dict[str, list[int]]``, which
-# is not a subtype of ``dict[str, object]`` but is a subtype of
-# ``Mapping[str, object]``.
-type JsonBody = dict[str, object]
-type JsonData = Mapping[str, object]
+# ---------------------------------------------------------------------------
+# JSON payloads
+# ---------------------------------------------------------------------------
 
+type JsonBody = dict[str, object]
+"""A JSON object as an invariant dict — string keys, arbitrary JSON values.
+``object`` (not ``Any``) forces callers to isinstance-narrow before use. For
+read-write payloads, e.g. test-client request/response bodies."""
+
+type JsonData = Mapping[str, object]
+"""A read-only, covariant view of a JSON object — for params that only read it,
+e.g. ``extra_data`` contents. Covariant because a dict literal like
+``{"k": [1, 2]}`` is a ``Mapping[str, object]`` but not a ``dict[str, object]``."""
+
+
+# ---------------------------------------------------------------------------
+# Claim and entity identity scalars
+# ---------------------------------------------------------------------------
 
 type ContentTypeId = int
 """The primary key of a Django ContentType — the entity-type half of a claim's
@@ -38,6 +42,26 @@ column, an FK, or the shared namespace of a relationship's members."""
 
 type ClaimFieldMap = dict[ClaimFieldName, str]
 """Maps each claim-controlled field name to the model attribute it resolves into."""
+
+
+# ---------------------------------------------------------------------------
+# Primary keys of models owned by other apps
+#
+# Parked here (rather than beside their models) so annotation-only importers
+# stay dependency-free: a leaf alias never drags in the owning Django model.
+# ---------------------------------------------------------------------------
+
+type LicenseId = int
+"""The primary key of a License — the reuse terms attached to a claim's value."""
+
+type CitationSourceId = int
+"""The primary key of a Citation Source — a citable work (book, web page) to
+which evidence (aka Citation Instances) attach."""
+
+
+# ---------------------------------------------------------------------------
+# Identity tuples
+# ---------------------------------------------------------------------------
 
 
 class EntityKey(NamedTuple):

--- a/backend/apps/core/types.py
+++ b/backend/apps/core/types.py
@@ -20,6 +20,26 @@ type JsonBody = dict[str, object]
 type JsonData = Mapping[str, object]
 
 
+type ContentTypeId = int
+"""The primary key of a Django ContentType — the entity-type half of a claim's
+polymorphic target."""
+
+type ClaimSubjectId = int
+"""The primary key of the entity a claim is about — the subject its claims are
+grouped and resolved under."""
+
+type ClaimKey = str
+"""Identifies one assertable slot on an entity: a scalar field, or a single
+member of a relationship set. The unit a winner is picked for."""
+
+type ClaimFieldName = str
+"""Identifies which claim-controlled field an assertion targets — a scalar
+column, an FK, or the shared namespace of a relationship's members."""
+
+type ClaimFieldMap = dict[ClaimFieldName, str]
+"""Maps each claim-controlled field name to the model attribute it resolves into."""
+
+
 class EntityKey(NamedTuple):
     """Hashable reference to a catalog entity via content-type + object id.
 
@@ -27,8 +47,8 @@ class EntityKey(NamedTuple):
     across content types (e.g. ``batch_resolve_entities``).
     """
 
-    content_type_id: int
-    object_id: int
+    content_type_id: ContentTypeId
+    object_id: ClaimSubjectId
 
 
 class ClaimTarget(TypedDict):
@@ -38,8 +58,8 @@ class ClaimTarget(TypedDict):
     spread it into dataclass kwargs; NamedTuple doesn't unpack as ``**``.
     """
 
-    content_type_id: int
-    object_id: int
+    content_type_id: ContentTypeId
+    object_id: ClaimSubjectId
 
 
 class ClaimIdentity(NamedTuple):
@@ -50,6 +70,6 @@ class ClaimIdentity(NamedTuple):
     pending claims or joining against existing active rows.
     """
 
-    content_type_id: int
-    object_id: int
-    claim_key: str
+    content_type_id: ContentTypeId
+    object_id: ClaimSubjectId
+    claim_key: ClaimKey

--- a/backend/apps/provenance/claim_writer.py
+++ b/backend/apps/provenance/claim_writer.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
+from apps.core.types import ClaimFieldName, ClaimKey
 from apps.provenance.models import Claim, ClaimControlledModel
 from apps.provenance.validation import (
     DIRECT,
@@ -34,12 +35,12 @@ if TYPE_CHECKING:
 
 def _assert_claim(
     subject: ClaimControlledModel,
-    field_name: str,
+    field_name: ClaimFieldName,
     value: object,
     citation: str = "",
     *,
     changeset: ChangeSet,
-    claim_key: str = "",
+    claim_key: ClaimKey = "",
     license: License | None = None,
 ) -> Claim:
     """Create a claim, deactivating any existing active claim for the same claim_key+actor.

--- a/backend/apps/provenance/claims.py
+++ b/backend/apps/provenance/claims.py
@@ -17,7 +17,11 @@ from collections.abc import Mapping
 from typing import NamedTuple
 
 from apps.core.types import ClaimFieldName, ClaimKey, JsonBody, PublicId
-from apps.provenance.models import IdentityPart, make_claim_key
+from apps.provenance.models import (
+    IdentityPartName,
+    IdentityPartValue,
+    make_claim_key,
+)
 from apps.provenance.types import ClaimValueKey
 from apps.provenance.validation import get_relationship_schema
 
@@ -82,7 +86,7 @@ def normalize_fk_value(value: object) -> PublicId | None:
 
 def build_relationship_claim(
     field_name: ClaimFieldName,
-    identity: Mapping[ClaimValueKey, IdentityPart],
+    identity: Mapping[ClaimValueKey, IdentityPartValue],
     exists: bool = True,
 ) -> RelationshipClaim:
     """Return ``(claim_key, value)`` for a relationship claim.
@@ -108,7 +112,7 @@ def build_relationship_claim(
     if schema is None:
         raise ValueError(f"Unknown relationship namespace: {field_name!r}")
 
-    identity_parts: dict[str, IdentityPart] = {}
+    identity_parts: dict[IdentityPartName, IdentityPartValue] = {}
     identity_key_names: list[ClaimValueKey] = []
     for spec in schema.value_keys:
         if spec.identity is None:

--- a/backend/apps/provenance/claims.py
+++ b/backend/apps/provenance/claims.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import NamedTuple
 
-from apps.core.types import ClaimFieldName, ClaimKey, JsonBody
+from apps.core.types import ClaimFieldName, ClaimKey, JsonBody, PublicId
 from apps.provenance.models import IdentityPart, make_claim_key
 from apps.provenance.validation import get_relationship_schema
 
@@ -60,7 +60,7 @@ def normalize_abbreviation_value(raw: str) -> str:
     return raw.strip()
 
 
-def normalize_fk_value(value: object) -> str | None:
+def normalize_fk_value(value: object) -> PublicId | None:
     """Canonicalize an FK claim value to its public_id lookup key.
 
     The single normalization an FK claim value passes through before it becomes a

--- a/backend/apps/provenance/claims.py
+++ b/backend/apps/provenance/claims.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import NamedTuple
 
-from apps.core.types import JsonBody
+from apps.core.types import ClaimFieldName, ClaimKey, JsonBody
 from apps.provenance.models import IdentityPart, make_claim_key
 from apps.provenance.validation import get_relationship_schema
 
@@ -30,7 +30,7 @@ class RelationshipClaim(NamedTuple):
     type level while staying tuple-unpackable (``claim_key, value = ...``).
     """
 
-    claim_key: str
+    claim_key: ClaimKey
     value: JsonBody
 
 
@@ -80,7 +80,7 @@ def normalize_fk_value(value: object) -> str | None:
 
 
 def build_relationship_claim(
-    field_name: str,
+    field_name: ClaimFieldName,
     identity: Mapping[str, IdentityPart],
     exists: bool = True,
 ) -> RelationshipClaim:

--- a/backend/apps/provenance/claims.py
+++ b/backend/apps/provenance/claims.py
@@ -18,6 +18,7 @@ from typing import NamedTuple
 
 from apps.core.types import ClaimFieldName, ClaimKey, JsonBody, PublicId
 from apps.provenance.models import IdentityPart, make_claim_key
+from apps.provenance.types import ClaimValueKey
 from apps.provenance.validation import get_relationship_schema
 
 
@@ -81,7 +82,7 @@ def normalize_fk_value(value: object) -> PublicId | None:
 
 def build_relationship_claim(
     field_name: ClaimFieldName,
-    identity: Mapping[str, IdentityPart],
+    identity: Mapping[ClaimValueKey, IdentityPart],
     exists: bool = True,
 ) -> RelationshipClaim:
     """Return ``(claim_key, value)`` for a relationship claim.
@@ -108,7 +109,7 @@ def build_relationship_claim(
         raise ValueError(f"Unknown relationship namespace: {field_name!r}")
 
     identity_parts: dict[str, IdentityPart] = {}
-    identity_key_names: list[str] = []
+    identity_key_names: list[ClaimValueKey] = []
     for spec in schema.value_keys:
         if spec.identity is None:
             continue

--- a/backend/apps/provenance/display.py
+++ b/backend/apps/provenance/display.py
@@ -48,6 +48,7 @@ from .schemas import (
     ClaimValueSchema,
     MarkdownClaimDisplaySchema,
 )
+from .types import ClaimValueKey
 from .validation import (
     RelationshipSchema,
     ValueKeySpec,
@@ -351,7 +352,7 @@ def _build_relationship_display(
     """
     # display_key targets are consumed by their identity spec's rendering;
     # they must not also surface as qualifiers.
-    consumed_by_display: set[str] = {
+    consumed_by_display: set[ClaimValueKey] = {
         s.display_key for s in schema.value_keys if s.display_key is not None
     }
 

--- a/backend/apps/provenance/display.py
+++ b/backend/apps/provenance/display.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import NamedTuple
 
@@ -48,7 +48,7 @@ from .schemas import (
     ClaimValueSchema,
     MarkdownClaimDisplaySchema,
 )
-from .types import ClaimValueKey
+from .types import ClaimValueKey, RelationshipClaimValue
 from .validation import (
     RelationshipSchema,
     ValueKeySpec,
@@ -70,13 +70,6 @@ class _LabelResult(NamedTuple):
 
     label: str | None
     state: ClaimDisplayIdentityState
-
-
-# A relationship claim's value payload: a dict with ``exists: bool`` plus
-# the namespace-specific keys declared in :class:`ValueKeySpec`. Per-key
-# types vary by namespace (int pks, optional counts, str literals); schema
-# validation enforces shape at the data-layer boundary.
-RelationshipClaimValue = Mapping[str, object]
 
 
 class FieldValue(NamedTuple):
@@ -339,7 +332,7 @@ def build_display_value(
 
 
 def _build_relationship_display(
-    value: dict[str, object], schema: RelationshipSchema, labels: LabelLookup
+    value: RelationshipClaimValue, schema: RelationshipSchema, labels: LabelLookup
 ) -> ClaimDisplayValueSchema:
     """Structured rendering for a relationship-claim value.
 

--- a/backend/apps/provenance/display.py
+++ b/backend/apps/provenance/display.py
@@ -36,6 +36,7 @@ from apps.core.markdown import (
     get_markdown_fields,
     resolve_wikilink_authoring,
 )
+from apps.core.types import ClaimFieldName
 
 from .models import ClaimControlledModel
 from .schemas import (
@@ -85,7 +86,7 @@ class FieldValue(NamedTuple):
     can be collected for batched resolution.
     """
 
-    field_name: str
+    field_name: ClaimFieldName
     value: object
 
 
@@ -307,7 +308,7 @@ def resolve_display_context(items: Iterable[FieldValue]) -> ClaimDisplayContext:
 
 def build_display_value(
     model: type[ClaimControlledModel],
-    field_name: str,
+    field_name: ClaimFieldName,
     value: object,
     ctx: ClaimDisplayContext,
 ) -> ClaimDisplaySchema | None:
@@ -410,7 +411,7 @@ def _build_relationship_display(
 
 def claim_value(
     model: type[ClaimControlledModel],
-    field_name: str,
+    field_name: ClaimFieldName,
     value: object,
     ctx: ClaimDisplayContext,
 ) -> ClaimValueSchema:

--- a/backend/apps/provenance/evidence.py
+++ b/backend/apps/provenance/evidence.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 
+from apps.actors.types import ActorId
+
 from .attribution import actor_user
 from .helpers import citation_instances
 from .models import Claim
+from .types import ChangeSetId
 
 
 @dataclass(frozen=True)
@@ -28,10 +31,10 @@ class CitedCitation:
 
 @dataclass(frozen=True)
 class CitedChangeset:
-    id: int
+    id: ChangeSetId
     # The changeset's actor id — satisfies ChangeSetPolicyView for the
     # CHANGESET_UNDO capability check. ``user_username`` carries display.
-    actor_id: int
+    actor_id: ActorId
     user_username: str
     note: str
     created_at: str
@@ -43,8 +46,8 @@ class CitedChangeset:
 class _CitedChangesetBuilder:
     """Mutable scratch state while grouping citations per changeset."""
 
-    id: int
-    actor_id: int
+    id: ChangeSetId
+    actor_id: ActorId
     user_username: str
     note: str
     created_at: str

--- a/backend/apps/provenance/licensing.py
+++ b/backend/apps/provenance/licensing.py
@@ -8,13 +8,14 @@ from apps.core.models import License
 from apps.core.types import ClaimFieldName
 from apps.provenance.attribution import source_backing
 from apps.provenance.models import Claim, SourceFieldLicense
+from apps.provenance.types import IngestSourceId
 
 
 class SourceField(NamedTuple):
-    """A (source, claim-field) pair — the granularity at which a source
+    """An (ingest source, claim-field) pair — the granularity at which a source
     declares a license."""
 
-    source_id: int
+    source_id: IngestSourceId
     field_name: ClaimFieldName
 
 

--- a/backend/apps/provenance/licensing.py
+++ b/backend/apps/provenance/licensing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import NamedTuple
 
 from apps.core.models import License
+from apps.core.types import ClaimFieldName
 from apps.provenance.attribution import source_backing
 from apps.provenance.models import Claim, SourceFieldLicense
 
@@ -14,7 +15,7 @@ class SourceField(NamedTuple):
     declares a license."""
 
     source_id: int
-    field_name: str
+    field_name: ClaimFieldName
 
 
 # Prefetched SourceField → license lookup, built once per request by

--- a/backend/apps/provenance/models/__init__.py
+++ b/backend/apps/provenance/models/__init__.py
@@ -14,7 +14,8 @@ from .citation_instance import CITATION_INSTANCE_LOCATOR_MAX_LENGTH, CitationIns
 from .claim import (
     Claim,
     ExistingClaimRow,
-    IdentityPart,
+    IdentityPartName,
+    IdentityPartValue,
     make_claim_key,
 )
 from .ingest_run import IngestRun

--- a/backend/apps/provenance/models/changeset.py
+++ b/backend/apps/provenance/models/changeset.py
@@ -8,7 +8,10 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models.functions import Now
 
+from apps.actors.types import ActorId
 from apps.core.models import BoundedTextField
+
+from ..types import IngestRunId
 
 if TYPE_CHECKING:
     from .claim import Claim
@@ -40,8 +43,8 @@ class ChangeSet(models.Model):
 
     claims: models.Manager[Claim]
     retracted_claims: models.Manager[Claim]
-    ingest_run_id: int | None
-    actor_id: int
+    ingest_run_id: IngestRunId | None
+    actor_id: ActorId
 
     ingest_run = models.ForeignKey(
         "provenance.IngestRun",

--- a/backend/apps/provenance/models/citation_instance.py
+++ b/backend/apps/provenance/models/citation_instance.py
@@ -10,6 +10,7 @@ from django.db import IntegrityError, models, transaction
 from django.db.models.functions import Length, Now
 from django.utils.crypto import get_random_string
 
+from apps.core.types import CitationSourceId
 from apps.core.validators import validate_no_mojibake
 
 CITATION_INSTANCE_LOCATOR_MAX_LENGTH = 200
@@ -109,7 +110,7 @@ class CitationInstance(models.Model):
     uniform column beats a conditional constraint. Assigned at mint, immutable.
     """
 
-    citation_source_id: int
+    citation_source_id: CitationSourceId
     claim_id: int | None
 
     slug = models.CharField(max_length=CITATION_SLUG_LENGTH, unique=True)

--- a/backend/apps/provenance/models/claim.py
+++ b/backend/apps/provenance/models/claim.py
@@ -15,10 +15,12 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models.functions import Now
 
+from apps.actors.types import ActorId
 from apps.core.models import BoundedTextField, field_not_blank
-from apps.core.types import ClaimFieldName, ClaimKey, ContentTypeId
+from apps.core.types import ClaimFieldName, ClaimKey, ContentTypeId, LicenseId
 
 from ..model_bases import ClaimControlledModel
+from ..types import ChangeSetId
 from .changeset import ChangeSet
 
 CLAIM_CITATION_MAX_LENGTH = 2_000
@@ -42,7 +44,7 @@ class ExistingClaimRow(NamedTuple):
 
     # ``value`` is the raw JSONField payload — scalar, dict, list, or null.
     value: object
-    license_id: int | None
+    license_id: LicenseId | None
     pk: int
 
 
@@ -83,10 +85,10 @@ class Claim(models.Model):
     """
 
     content_type_id: ContentTypeId
-    actor_id: int
-    license_id: int | None
-    changeset_id: int
-    retracted_by_changeset_id: int | None
+    actor_id: ActorId
+    license_id: LicenseId | None
+    changeset_id: ChangeSetId
+    retracted_by_changeset_id: ChangeSetId | None
     citation_instances: models.Manager[CitationInstance]
 
     content_type = models.ForeignKey(ContentType, on_delete=models.PROTECT)

--- a/backend/apps/provenance/models/claim.py
+++ b/backend/apps/provenance/models/claim.py
@@ -29,7 +29,13 @@ CLAIM_NEEDS_REVIEW_NOTES_MAX_LENGTH = 2_000
 if TYPE_CHECKING:
     from .citation_instance import CitationInstance
 
-type IdentityPart = str | int | None
+type IdentityPartName = str
+"""One key in a claim_key's identity-parts mapping — the label of an identity
+slot (e.g. ``person``, ``role``, ``alias``). Distinct from the relationship
+value-dict key it derives from: usually equal, occasionally not (``alias`` for
+the ``alias_value`` slot)."""
+
+type IdentityPartValue = str | int | None
 """One value in a claim_key's identity-parts mapping: an entity-reference PK
 (``int``), a literal key like an alias value (``str``), or ``None``
 (serialized as the literal ``"null"`` in the key)."""
@@ -54,7 +60,7 @@ def _escape_claim_value(s: str) -> str:
 
 
 def make_claim_key(
-    field_name: ClaimFieldName, **identity_parts: IdentityPart
+    field_name: ClaimFieldName, **identity_parts: IdentityPartValue
 ) -> ClaimKey:
     """Build a canonical claim_key from field_name and sorted identity parts.
 

--- a/backend/apps/provenance/models/claim.py
+++ b/backend/apps/provenance/models/claim.py
@@ -16,6 +16,7 @@ from django.db import models
 from django.db.models.functions import Now
 
 from apps.core.models import BoundedTextField, field_not_blank
+from apps.core.types import ClaimFieldName, ClaimKey, ContentTypeId
 
 from ..model_bases import ClaimControlledModel
 from .changeset import ChangeSet
@@ -50,7 +51,9 @@ def _escape_claim_value(s: str) -> str:
     return s.replace("%", "%25").replace("|", "%7C").replace(":", "%3A")
 
 
-def make_claim_key(field_name: str, **identity_parts: IdentityPart) -> str:
+def make_claim_key(
+    field_name: ClaimFieldName, **identity_parts: IdentityPart
+) -> ClaimKey:
     """Build a canonical claim_key from field_name and sorted identity parts.
 
     For scalar claims, call with just field_name (returns field_name unchanged).
@@ -79,7 +82,7 @@ class Claim(models.Model):
     ``changeset.actor``) — set on every row by ``claim_writer._assert_claim``.
     """
 
-    content_type_id: int
+    content_type_id: ContentTypeId
     actor_id: int
     license_id: int | None
     changeset_id: int
@@ -194,9 +197,9 @@ class Claim(models.Model):
         cls,
         obj: ClaimControlledModel,
         *,
-        field_name: str,
+        field_name: ClaimFieldName,
         value: object,
-        claim_key: str = "",
+        claim_key: ClaimKey = "",
         **kwargs: object,
     ) -> Claim:
         """Construct an unsaved Claim for a model instance.

--- a/backend/apps/provenance/models/introspection.py
+++ b/backend/apps/provenance/models/introspection.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from django.db import models
 
+from apps.core.types import ClaimFieldMap
+
 from ..model_bases import ClaimControlledModel
 
 __all__ = ["get_claim_fields"]
@@ -15,7 +17,7 @@ _CLAIMS_EXEMPT_NAMES = frozenset(
 )
 
 
-def get_claim_fields(model_class: type[ClaimControlledModel]) -> dict[str, str]:
+def get_claim_fields(model_class: type[ClaimControlledModel]) -> ClaimFieldMap:
     """Discover claim-controlled fields by introspecting a Django model.
 
     Returns ``{field_name: field_name}`` for every concrete field that is
@@ -29,7 +31,7 @@ def get_claim_fields(model_class: type[ClaimControlledModel]) -> dict[str, str]:
     FK fields are included — the resolver handles slug lookup automatically.
     """
     per_model_exempt = model_class.claims_exempt
-    fields: dict[str, str] = {}
+    fields: ClaimFieldMap = {}
     for f in model_class._meta.get_fields():
         if not isinstance(f, models.Field):
             continue

--- a/backend/apps/provenance/models/source.py
+++ b/backend/apps/provenance/models/source.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar
 from django.db import models
 
 from apps.actors.models import ActorModel, ActorResolutionStatus
+from apps.actors.types import ActorResolutionPriority
 from apps.core.models import (
     BoundedTextField,
     SluggedModel,
@@ -17,6 +18,7 @@ from apps.core.models import (
     unique_ci,
     unique_slug,
 )
+from apps.provenance.types import IngestSourceId
 
 SOURCE_DESCRIPTION_MAX_LENGTH = 2_000
 
@@ -87,7 +89,7 @@ class Source(ActorModel, SluggedModel, TimeStampedModel):
 
     # ActorModel hooks: the source's Actor mirrors these fields for resolution.
     @property
-    def actor_priority(self) -> int:
+    def actor_priority(self) -> ActorResolutionPriority:
         return self.priority
 
     @property
@@ -118,7 +120,7 @@ class SourceFieldLicense(models.Model):
     This model captures that relationship without denormalizing to per-claim.
     """
 
-    source_id: int
+    source_id: IngestSourceId
 
     source = models.ForeignKey(
         Source,

--- a/backend/apps/provenance/resolution/_dispatch.py
+++ b/backend/apps/provenance/resolution/_dispatch.py
@@ -26,6 +26,7 @@ from typing import NamedTuple, Protocol
 
 from django.core.exceptions import ImproperlyConfigured
 
+from apps.core.types import ClaimFieldName, ClaimSubjectId
 from apps.provenance.models import ClaimControlledModel
 
 
@@ -39,7 +40,9 @@ class PerEntityResolver(Protocol):
     """
 
     def __call__(
-        self, entity: ClaimControlledModel, field_names: list[str] | None = None
+        self,
+        entity: ClaimControlledModel,
+        field_names: list[ClaimFieldName] | None = None,
     ) -> None: ...
 
 
@@ -55,8 +58,8 @@ class BulkResolver(Protocol):
     def __call__(
         self,
         model_class: type[ClaimControlledModel],
-        subject_ids: set[int],
-        field_names: Collection[str],
+        subject_ids: set[ClaimSubjectId],
+        field_names: Collection[ClaimFieldName],
     ) -> None: ...
 
 
@@ -115,7 +118,7 @@ def _handlers_for(concrete_model: type[ClaimControlledModel]) -> ResolveHandlers
 
 
 def resolve_after_mutation(
-    entity: ClaimControlledModel, field_names: list[str] | None = None
+    entity: ClaimControlledModel, field_names: list[ClaimFieldName] | None = None
 ) -> None:
     """Per-entity dispatch: re-resolve a single mutated entity.
 
@@ -129,8 +132,8 @@ def resolve_after_mutation(
 
 def resolve_entities_bulk(
     model_class: type[ClaimControlledModel],
-    subject_ids: set[int],
-    field_names: Collection[str],
+    subject_ids: set[ClaimSubjectId],
+    field_names: Collection[ClaimFieldName],
 ) -> None:
     """Bulk dispatch: re-resolve many subjects of one model class in one pass.
 

--- a/backend/apps/provenance/test_factories.py
+++ b/backend/apps/provenance/test_factories.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from apps.accounts.models import User
+from apps.core.types import ClaimFieldName, ClaimKey
 
 from .changeset_writer import record_changeset
 from .claim_writer import _assert_claim
@@ -27,13 +28,13 @@ if TYPE_CHECKING:
 
 def make_claim(
     subject: ClaimControlledModel,
-    field_name: str,
+    field_name: ClaimFieldName,
     value: object,
     citation: str = "",
     *,
     source: Source | None = None,
     user: User | None = None,
-    claim_key: str = "",
+    claim_key: ClaimKey = "",
     license: License | None = None,
     changeset: ChangeSet | None = None,
 ) -> Claim:

--- a/backend/apps/provenance/types.py
+++ b/backend/apps/provenance/types.py
@@ -1,0 +1,19 @@
+"""Named scalar types owned by provenance's own models.
+
+Transparent aliases (``type X = …``) — they document intent at signature sites
+without changing interop with the bare ``int`` the Django ORM returns.
+"""
+
+from __future__ import annotations
+
+type IngestSourceId = int
+"""The primary key of an Ingest Source — the non-human Actor, such as the data
+patch pipeline or a bot, to which a claim may be attributed."""
+
+type ChangeSetId = int
+"""The primary key of a ChangeSet — the atomic, attributed edit in which a
+claim was written or retracted."""
+
+type IngestRunId = int
+"""The primary key of an IngestRun — the bulk import to which a change belongs,
+which marks it as ingested rather than interactively created by a human."""

--- a/backend/apps/provenance/types.py
+++ b/backend/apps/provenance/types.py
@@ -1,9 +1,12 @@
 """
-The named scalar types are transparent aliases (``type X = …``); they document
-intent without changing interop with the bare ``int``/``str`` the Django ORM returns.
+The named types here are transparent aliases (``type X = …``); they document
+intent without changing interop with the bare ``int``/``str``/``dict`` the Django
+ORM and JSONField return.
 """
 
 from __future__ import annotations
+
+from collections.abc import Mapping
 
 type IngestSourceId = int
 """The primary key of an Ingest Source — the non-human Actor, such as the data
@@ -21,3 +24,10 @@ type ClaimValueKey = str
 """Names one slot inside a relationship claim's value — the person and role of a
 credit, the count of a gameplay feature. The schema fixes which slots form member
 identity and which carry payload."""
+
+type RelationshipClaimValue = Mapping[ClaimValueKey, object]
+"""A relationship claim's stored value payload: the namespace-specific slots its
+ValueKeySpecs declare, plus the ``exists`` presence flag. Values are deliberately
+wide — an FK pk (``int``), a literal identity (``str``), a payload scalar
+(``int``/``bool``/``None``) — with schema validation fixing the per-slot shape at
+the write boundary."""

--- a/backend/apps/provenance/types.py
+++ b/backend/apps/provenance/types.py
@@ -1,7 +1,6 @@
-"""Named scalar types owned by provenance's own models.
-
-Transparent aliases (``type X = …``) — they document intent at signature sites
-without changing interop with the bare ``int`` the Django ORM returns.
+"""
+The named scalar types are transparent aliases (``type X = …``); they document
+intent without changing interop with the bare ``int``/``str`` the Django ORM returns.
 """
 
 from __future__ import annotations
@@ -17,3 +16,8 @@ claim was written or retracted."""
 type IngestRunId = int
 """The primary key of an IngestRun — the bulk import to which a change belongs,
 which marks it as ingested rather than interactively created by a human."""
+
+type ClaimValueKey = str
+"""Names one slot inside a relationship claim's value — the person and role of a
+credit, the count of a gameplay feature. The schema fixes which slots form member
+identity and which carry payload."""

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -28,6 +28,7 @@ from apps.core.types import ClaimFieldMap, ClaimFieldName, ClaimKey
 from apps.core.validators import SLUG_FORMAT_MESSAGE, SLUG_RE
 from apps.provenance.claim_presence import member_is_present
 from apps.provenance.models import ClaimControlledModel, get_claim_fields
+from apps.provenance.types import ClaimValueKey
 
 if TYPE_CHECKING:
     from apps.provenance.models import Claim
@@ -84,13 +85,13 @@ class ValueKeySpec:
     when the resolver materializes the row. ``None`` for unbounded keys.
     """
 
-    name: str
+    name: ClaimValueKey
     scalar_type: type
     required: bool
     nullable: bool = False
     identity: str | None = None
     fk_target: FkTarget | None = None
-    display_key: str | None = None
+    display_key: ClaimValueKey | None = None
     max_length: int | None = None
     min_value: int | None = None
 
@@ -119,7 +120,7 @@ class RelationshipTargetKey(NamedTuple):
     """Group key for batched relationship target existence checks."""
 
     namespace: str
-    value_key: str
+    value_key: ClaimValueKey
 
 
 class FkTarget(NamedTuple):
@@ -198,8 +199,11 @@ def register_relationship_schema(
     # both the resolver (which stores the override into AliasModel.value) and
     # the display engine (which renders identity slots in edit history). The
     # checks below catch malformed declarations at app-ready time.
-    specs_by_name = {spec.name: spec for spec in value_keys}
-    seen_display_keys: dict[str, str] = {}  # display_key → identity spec name
+    specs_by_name: dict[ClaimValueKey, ValueKeySpec] = {
+        spec.name: spec for spec in value_keys
+    }
+    # display_key → identity spec name
+    seen_display_keys: dict[ClaimValueKey, ClaimValueKey] = {}
     for spec in value_keys:
         if spec.display_key is None:
             continue
@@ -292,7 +296,7 @@ def get_relationship_namespaces() -> frozenset[str]:
 def get_display_override(
     value: Mapping[str, object],
     schema: RelationshipSchema,
-    identity_spec_name: str,
+    identity_spec_name: ClaimValueKey,
 ) -> object | None:
     """Return the user-facing rendering override for one identity slot, or None.
 
@@ -434,7 +438,9 @@ def validate_single_relationship_claim(
     # rather than `isinstance(v, T)` rejects `bool` where `int` is expected
     # (PKs, counts) and rejects enum / numpy scalars that would slip past
     # `isinstance`. For `nullable=True`, accept `None` in addition.
-    specs_by_name = {spec.name: spec for spec in schema.value_keys}
+    specs_by_name: dict[ClaimValueKey, ValueKeySpec] = {
+        spec.name: spec for spec in schema.value_keys
+    }
     for spec in schema.value_keys:
         if spec.name not in value:
             continue

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -27,7 +27,12 @@ from django.db import models
 from apps.core.types import ClaimFieldMap, ClaimFieldName, ClaimKey
 from apps.core.validators import SLUG_FORMAT_MESSAGE, SLUG_RE
 from apps.provenance.claim_presence import member_is_present
-from apps.provenance.models import ClaimControlledModel, get_claim_fields
+from apps.provenance.models import (
+    ClaimControlledModel,
+    IdentityPartName,
+    IdentityPartValue,
+    get_claim_fields,
+)
 from apps.provenance.types import ClaimValueKey
 
 if TYPE_CHECKING:
@@ -89,7 +94,7 @@ class ValueKeySpec:
     scalar_type: type
     required: bool
     nullable: bool = False
-    identity: str | None = None
+    identity: IdentityPartName | None = None
     fk_target: FkTarget | None = None
     display_key: ClaimValueKey | None = None
     max_length: int | None = None
@@ -470,7 +475,7 @@ def validate_single_relationship_claim(
 
     # 7. Non-canonical claim_key. `make_claim_key` sorts its kwargs, so the
     # dict-comprehension order doesn't matter.
-    identity_parts = {
+    identity_parts: dict[IdentityPartName, IdentityPartValue] = {
         spec.identity: value[spec.name]
         for spec in schema.value_keys
         if spec.identity is not None

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -33,7 +33,7 @@ from apps.provenance.models import (
     IdentityPartValue,
     get_claim_fields,
 )
-from apps.provenance.types import ClaimValueKey
+from apps.provenance.types import ClaimValueKey, RelationshipClaimValue
 
 if TYPE_CHECKING:
     from apps.provenance.models import Claim
@@ -299,7 +299,7 @@ def get_relationship_namespaces() -> frozenset[str]:
 
 
 def get_display_override(
-    value: Mapping[str, object],
+    value: RelationshipClaimValue,
     schema: RelationshipSchema,
     identity_spec_name: ClaimValueKey,
 ) -> object | None:

--- a/backend/apps/provenance/validation.py
+++ b/backend/apps/provenance/validation.py
@@ -24,6 +24,7 @@ from django.core.exceptions import (
 )
 from django.db import models
 
+from apps.core.types import ClaimFieldMap, ClaimFieldName, ClaimKey
 from apps.core.validators import SLUG_FORMAT_MESSAGE, SLUG_RE
 from apps.provenance.claim_presence import member_is_present
 from apps.provenance.models import ClaimControlledModel, get_claim_fields
@@ -321,11 +322,11 @@ def get_display_override(
 
 def classify_claim(
     model_class: type[ClaimControlledModel],
-    field_name: str,
-    claim_key: str,
+    field_name: ClaimFieldName,
+    claim_key: ClaimKey,
     value: Any,  # noqa: ANN401 - signature preserved for call-site stability
     *,
-    claim_fields: dict[str, str] | None = None,
+    claim_fields: ClaimFieldMap | None = None,
 ) -> str:
     """Classify a claim from its ``field_name`` and the registered schemas.
 
@@ -371,8 +372,8 @@ def classify_claim(
 def validate_single_relationship_claim(
     *,
     subject_model: type[ClaimControlledModel],
-    field_name: str,
-    claim_key: str,
+    field_name: ClaimFieldName,
+    claim_key: ClaimKey,
     value: Any,  # noqa: ANN401 - claim value is arbitrary JSON
 ) -> None:
     """Validate one relationship claim's shape. Raises ``ValidationError``.
@@ -495,7 +496,7 @@ def _has_extra_data(model_class: type[ClaimControlledModel]) -> bool:
 
 
 def validate_claim_value(
-    field_name: str,
+    field_name: ClaimFieldName,
     value: Any,  # noqa: ANN401 - claim value is arbitrary JSON (scalar/dict/list/null)
     model_class: type[ClaimControlledModel],
 ) -> Any:  # noqa: ANN401 - returns the (possibly coerced) claim value, same shape as input

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -430,7 +430,7 @@ layers = [
     "engine", # domain-neutral; will eventually be moved out of catalog
 ]
 
-# The generic resolver core — scalar/bulk claim projection (_entities), its
+# The generic resolver core — claim projection (_entities), its
 # coercion/FK/constraint helpers (_helpers), and the read-side payload
 # vocabulary (_claim_values) — is domain-agnostic substrate that merely lives
 # in catalog: it names no concrete model and drives entirely off claim-field
@@ -546,6 +546,7 @@ layers = [
     # since the global tiers would otherwise let it import down into citation /
     # accounts. Together they keep the package lift-out-ready (below citation).
     "model_bases",
+    "types",
 ]
 
 [[tool.importlinter.contracts]]
@@ -623,6 +624,7 @@ containers = ["apps.actors"]
 layers = [
     "admin | registry | checks",
     "models",
+    "types",
 ]
 
 # ----- core -----

--- a/docs/Python.md
+++ b/docs/Python.md
@@ -31,6 +31,10 @@ The second job is not a smell to remove but a practice to apply: name a value's 
 
 The codebase already does this: `JsonData` / `JsonBody` are preferred over a bare `dict[str, Any]` because the name carries the contract.
 
+**Prefer a transparent `type X = …` alias to `NewType`** for any value that flows through the Django ORM. The ORM hands back bare `int` / `str`, so a `NewType` forces a wrap (`ChangeSetId(row.changeset_id)`) — and the `cast` noise it invites — at every read, for no checker gain the alias doesn't already give as documentation. Reserve `NewType` for values that never touch the ORM and are genuinely dangerous to mix (rare). Don't redeclare the same alias locally in two apps — import the one canonical spelling.
+
+**Keep a semantic scalar alias in a dependency-free leaf module** — `apps/core/types.py`, or an app's own `types.py` — never beside its Django model. `from apps.core.models.license import LicenseId` would drag the `License` model into every annotation-only importer, which is exactly what the alias exists to avoid. Put it in the lowest app that uses it, so even `core` can name its own fields (e.g. `EntityKey.object_id: ClaimSubjectId`).
+
 ### Valid exceptions to strong types
 
 Broad types are acceptable when required by a third party:
@@ -111,6 +115,8 @@ Serialization helpers should usually return Ninja/Pydantic `Schema` instances, n
 Use dict returns only when the dict is the real runtime contract, such as cached JSON-byte hot paths.
 
 When a Ninja response type is a union of schemas with shared fields, make dispatch structurally unambiguous: required distinguishing fields on the richer schema, and `extra="forbid"` on the minimal schema where needed.
+
+**Don't put a semantic scalar alias on the wire.** A transparent alias (`type ChangeSetId = int`) used as a Ninja route param or a `Schema` field surfaces as a _named_ OpenAPI component — `ChangeSetId` lands in the generated schema and the frontend's `schema.d.ts`, and `apps/core/tests/test_openapi_boundaries.py` fails it (component names must end in `Schema` / `Ref` or be allowlisted). Keep route params and `Schema` fields bare `int` / `str`; the alias is for internal Python signatures (`claim.changeset_id`, helper params, `NamedTuple` / dataclass fields). Keeping the wire bare also lets the internal alias be renamed without a frontend-visible schema or codegen diff.
 
 ### Suppressions
 

--- a/docs/plans/provenance/ClaimResolutionRefactor.md
+++ b/docs/plans/provenance/ClaimResolutionRefactor.md
@@ -284,7 +284,7 @@ The home where the dispatch seam already lives. `git mv` the catalog-free tier (
 
 **The whole catalog-free tier already lives in `_engine.py` — POST4 is a one-file `git mv`.** REF3 introduced a generic `ThroughRowProjection` (plus the `_*_from_column` converters) the plan didn't anticipate as a named class: it covers 7 of the 9 shapes, names no concrete model (through models arrive as constructor args), and a post-REF3 cleanup folded it into `_engine.py` beside `pick_winners`, `reconcile`, the `Projection` Protocol and the typed vocabulary — all import-linter-pinned catalog-free. So the movable tier is exactly `_engine.py`, and POST4 `git mv`s that single module to `provenance/resolution/`. The concrete builders that configure `ThroughRowProjection`, and the two genuinely bespoke projections — `AliasProjection` (case-folded keys) and `MediaProjection` (composite `EntityKey` subject) — name domain models and correctly stay in `_relationships.py` / `_media.py`.
 
-#### <a id="POST5">POST5</a> — Name latent types
+#### ✅ DONE: <a id="POST5">POST5</a> — Name latent types
 
 Name latent types that we found during the refactor, but are too cross-cutting to deal with during the refactor.
 


### PR DESCRIPTION
## Summary

Names latent types in the claim-resolution machinery — the bare `str`/`int` scalars and unnamed compound types that recur or cross module boundaries across provenance, catalog resolution and claim_ingest. No behavior change: these are transparent type aliases and docstrings threaded through existing signatures, with the checker as the proof. Sets a durable precedent (captured in `docs/Python.md`) so future work names these concepts by default instead of re-deriving them as bare primitives.

### What got named

- **Claim-identity scalars** (core) — `ClaimFieldName`, `ClaimSubjectId`, `ClaimKey`, `ClaimFieldMap`, `ContentTypeId`, plus cross-cutting `PublicId` / `LicenseId` / `CitationSourceId`.
- **Actor + attribution scalars** — `ActorId`, `ActorResolutionPriority` (actors); `IngestSourceId`, `ChangeSetId`, `IngestRunId` (provenance).
- **Resolution-engine vocabulary** — `MaterializedRowId` (rename from `RowId`), `MemberExtractor`, `ColumnValues`, `ColumnNames`, `ProjectionBuilder`, `FKTargetLookups`.
- **Relationship-schema vocabulary** — `ClaimValueKey` (the value-dict slot key), `IdentityPartName` + `IdentityPartValue` (the two halves of a claim_key identity part, renamed from the asymmetric `IdentityPart`), and `RelationshipClaimValue` (the stored value-dict payload, canonicalized from a display-local alias to `Mapping[ClaimValueKey, object]`).

### Conventions established (in `docs/Python.md`)

- Transparent `type X = …` aliases for ORM-adjacent scalars, never `NewType` (the ORM returns bare `int`/`str`; `NewType` would force `cast` noise).
- Leaf `types.py` homing to avoid circular imports.
- **Wire boundary stays bare** — never annotate a django-ninja route param or `Schema` field with these aliases (they leak into OpenAPI component names; caught by `test_openapi_boundaries`).
- Disambiguate overloaded domain words — never a bare `Source` (Ingest Source vs Citation Source).

## Test plan

- [x] `make mypy` clean — the aliases type-check at every threaded site (a wrong-direction map key/value or mismatched id would fail)
- [x] Backend suite green (provenance, claim_ingest, catalog resolve slices)
- [x] `test_openapi_boundaries` green — no alias leaks onto the wire
- [x] `make lint` (ruff check + format) clean
- [x] import-linter app-boundary contracts pass

No new tests: there is no behavior to assert; the type checker is the proof.