### PR TITLE
refactor(provenance): name the per-slot claim-history grouping

### DIFF
--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -11,6 +11,7 @@ from django.db.models import Prefetch, Q
 
 from apps.citation.models import CitationSourceLink
 from apps.core.authz import PolicyUser, compute_row_capabilities
+from apps.core.types import ClaimKey
 
 from .attribution import actor_user_id
 from .claim_ranking_in_db import ranked_claims
@@ -33,6 +34,11 @@ from .schemas import (
     FieldChangeSchema,
     RetractionSchema,
 )
+
+type ClaimsByKey = dict[ClaimKey, list[Claim]]
+"""An entity's claims grouped by claim_key into per-slot history chains, each
+ordered newest-first. A chain yields a field's prior value and the full set of
+values a change is displayed against."""
 
 
 def _field_change_citations(claim: Claim) -> list[FieldChangeCitationSchema]:
@@ -88,7 +94,7 @@ def build_changes(
     model: type[ClaimControlledModel],
     own_claims: Iterable[Claim],
     retracted: Iterable[Claim],
-    history_by_key: Mapping[str, Sequence[Claim]],
+    history_by_key: Mapping[ClaimKey, Sequence[Claim]],
     *,
     winning_ids: set[int] | None = None,
     ctx: ClaimDisplayContext | None = None,
@@ -234,7 +240,7 @@ def build_edit_history(
     )
 
     # Build lookup: claim_key → list of claims ordered newest-first.
-    history: dict[str, list[Claim]] = defaultdict(list)
+    history: ClaimsByKey = defaultdict(list)
     for c in all_claims:
         history[c.claim_key].append(c)
 

--- a/backend/apps/provenance/page_endpoints.py
+++ b/backend/apps/provenance/page_endpoints.py
@@ -37,7 +37,7 @@ from .helpers import (
     citation_instances_prefetch,
     claims_prefetch,
 )
-from .history import build_changes, build_edit_history
+from .history import ClaimsByKey, build_changes, build_edit_history
 from .models import ClaimControlledModel
 from .models.changeset import ChangeSet
 from .schemas import (
@@ -396,7 +396,7 @@ def change_detail(
         history_claims = []
 
     # Group by claim_key for O(1) lookup.
-    by_key: dict[str, list[Claim]] = defaultdict(list)
+    by_key: ClaimsByKey = defaultdict(list)
     for c in history_claims:
         by_key[c.claim_key].append(c)
 


### PR DESCRIPTION
## What

Introduce `ClaimsByKey = dict[ClaimKey, list[Claim]]` for the `claim_key` → newest-first history chains that back the edit-history display.

- Defined in `provenance/history.py` beside its primary consumer.
- Applied at the two producer sites (`build_edit_history` and the changeset-detail endpoint), replacing the raw `dict[str, list[Claim]]`.
- `build_changes`'s param keeps its covariant `Mapping[ClaimKey, Sequence[Claim]]` read view — `ClaimKey` is threaded in, the variance is preserved (matching the `FKTargetLookups`/`FKLookups` split rather than narrowing the contract).

## Why

Names a grouping that recurs across `history.py` and `page_endpoints.py` and crosses the page-endpoint → `build_changes` seam, with its key (`ClaimKey`) already named. Documents the per-slot, newest-first history-chain invariant in one declaration.

## Verification

No behavior change — type alias only. `make mypy` clean, `pytest apps/provenance` green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)