### PR TITLE
chore(backend): drop resolved provenance→catalog import baseline

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -184,7 +184,6 @@ ignore_imports = [
     "apps.accounts.api.* -> apps.provenance.**",
     "apps.core.api.admin_dashboard_page -> apps.**",
     # --- BASELINE: existing violations to fix; do NOT add to this list ---
-    "apps.provenance.api -> apps.catalog.models",
     "apps.core.api_helpers -> apps.accounts.models",
     "apps.core.middleware.sentry_scope -> apps.accounts.models",
 ]


### PR DESCRIPTION
## Summary

The `apps.provenance.api -> apps.catalog.models` import was the deleted needs-review feature leaking the catalog into provenance. With that feature gone the import no longer exists, so its import-linter baseline exception is stale — removing it lets the "App layer tiers" contract enforce the boundary going forward.

## Test plan

- [x] `uv run lint-imports` — 26 contracts kept, 0 broken
- [x] pre-commit import-linter hook passes