### PR TITLE
feat(citation): attribute editorial provenance to Actor, not User

### DIFF
--- a/backend/apps/actors/models/__init__.py
+++ b/backend/apps/actors/models/__init__.py
@@ -1,10 +1,12 @@
 """Actors layer: the Actor table and the ActorModel base its satellites inherit."""
 
 from .actor import Actor, ActorResolutionStatus
+from .attributed import ActorAttributedModel
 from .base import ActorModel
 
 __all__ = [
     "Actor",
+    "ActorAttributedModel",
     "ActorModel",
     "ActorResolutionStatus",
 ]

--- a/backend/apps/actors/models/attributed.py
+++ b/backend/apps/actors/models/attributed.py
@@ -1,0 +1,47 @@
+"""Editorial attribution for directly-edited, non-claims-controlled models."""
+
+from __future__ import annotations
+
+from django.db import models
+
+
+class ActorAttributedModel(models.Model):
+    """Abstract base adding editorial attribution: who created / last updated.
+
+    Two nullable FKs to :class:`~apps.actors.models.actor.Actor`
+    (``created_by`` / ``updated_by``), both ``PROTECT`` so the durable
+    attribution anchor outlives the rows that reference it, and
+    ``related_name="+"`` because no reverse "things this actor authored"
+    accessor is wanted. ``null`` because a row may be authored by no one — an
+    extractor-minted source can stay unattributed.
+
+    This is *editorial* attribution for directly-edited, non-claims-controlled
+    models (the citation-source family). It is **not** the claims/provenance
+    system — claim-controlled catalog fields record authorship through
+    ``ChangeSet``/``Claim``, which point at the same ``Actor``. Routing
+    editorial attribution through ``Actor`` too means an ingest ``Source`` (a
+    data patch) attributes the rows it creates exactly as a user does, via
+    ``user.actor`` / ``source.actor``.
+
+    Callers set the fields explicitly (admin ``save_model``/``save_formset``,
+    the interactive API create paths, the patch ``sources:`` upsert); the base
+    only declares the columns so the two FK blocks aren't copy-pasted per model.
+    """
+
+    created_by = models.ForeignKey(
+        "actors.Actor",
+        null=True,
+        blank=True,
+        on_delete=models.PROTECT,
+        related_name="+",
+    )
+    updated_by = models.ForeignKey(
+        "actors.Actor",
+        null=True,
+        blank=True,
+        on_delete=models.PROTECT,
+        related_name="+",
+    )
+
+    class Meta:
+        abstract = True

--- a/backend/apps/catalog/tests/test_patch_inline_cites.py
+++ b/backend/apps/catalog/tests/test_patch_inline_cites.py
@@ -132,6 +132,32 @@ claims:
     assert f"[[cite:id:{ci.pk}]]" in _description_value(mfr)
 
 
+def test_inline_cite_minted_sources_attributed_to_patch_actor(
+    flipcommons_catalog, ipdb_root, kineticist_root, pm
+):
+    """A cite: that mints a new citation source attributes it to the patch's
+    Source actor — both the scheme path (ipdb child) and the web path
+    (kineticist child) — closing the gap for inline cites as for `sources:`."""
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      description: "Scheme.[[cite:1]] Web.[[cite:2]]"
+      cites:
+        '1': ipdb:4443
+        '2': https://kineticist.com/mm
+"""
+    _apply(text)
+
+    actor = Source.objects.get(slug="flipcommons-catalog").actor
+    minted = list(_floating())
+    assert len(minted) == 2
+    for ci in minted:
+        child = ci.citation_source
+        assert child.created_by == actor, child
+        assert child.updated_by == actor, child
+
+
 def test_url_archive_spec_backfills_archive_link(
     flipcommons_catalog, kineticist_root, pm
 ):

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -2433,6 +2433,30 @@ def test_sources_only_patch_is_valid_and_applies():
     ).exists()
 
 
+def test_sources_attributed_to_patch_source_actor():
+    """A patch's `sources:` rows are attributed to the patch's Source actor.
+
+    The motivating fix: before editorial attribution moved to ``Actor``, a
+    data patch could not attribute the citation sources it created (no acting
+    user), so they landed with ``created_by``/``updated_by`` null. Now every
+    created row — the source, its link and its recognition domain — carries the
+    attributing ``Source``'s actor.
+    """
+    report = _apply(_WIKIPEDIA, patch_id="0001-wiki-attr")
+    assert report.sources_created == 1
+
+    actor = Source.objects.get(slug="flipcommons-catalog").actor
+    src = CitationSource.objects.get(name="Wikipedia", source_type="web")
+    assert src.created_by == actor
+    assert src.updated_by == actor
+    link = CitationSourceLink.objects.get(citation_source=src)
+    assert link.created_by == actor
+    assert link.updated_by == actor
+    domain = CitationSourceRootDomain.objects.get(source=src)
+    assert domain.created_by == actor
+    assert domain.updated_by == actor
+
+
 def test_empty_patch_rejected():
     with pytest.raises(PatchError, match="non-empty"):
         load_patch("attribution: flipcommons-catalog\nclaims: []\n")

--- a/backend/apps/citation/admin.py
+++ b/backend/apps/citation/admin.py
@@ -78,10 +78,10 @@ class CitationSourceAdmin(admin.ModelAdmin[CitationSource]):
         change: bool,
     ) -> None:
         assert request.user.is_authenticated
-        user = request.user
+        actor = request.user.actor
         if not change:
-            obj.created_by = user
-        obj.updated_by = user
+            obj.created_by = actor
+        obj.updated_by = actor
         super().save_model(request, obj, form, change)
 
     def save_formset(
@@ -99,14 +99,14 @@ class CitationSourceAdmin(admin.ModelAdmin[CitationSource]):
         change: bool,
     ) -> None:
         assert request.user.is_authenticated
-        user = request.user
+        actor = request.user.actor
         instances = formset.save(commit=False)
         for instance in instances:
             # Both inline models (links and recognition domains) carry editorial
-            # attribution via AttributedModel.
+            # attribution via ActorAttributedModel.
             if not instance.pk:
-                instance.created_by = user
-            instance.updated_by = user
+                instance.created_by = actor
+            instance.updated_by = actor
             instance.save()
         for obj in formset.deleted_objects:
             obj.delete()

--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -21,7 +21,7 @@ from ninja.responses import Status
 from ninja.security import django_auth
 from ninja.throttling import AuthRateThrottle
 
-from apps.accounts.models import User
+from apps.actors.models import Actor
 from apps.core.api_helpers import authed_user
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
@@ -310,8 +310,8 @@ def create_citation_source(
         isbn=data.isbn,
         description=data.description,
         parent=parent,
-        created_by=user,
-        updated_by=user,
+        created_by=user.actor,
+        updated_by=user.actor,
     )
     _clean_and_save(source, integrity_msg="A source with this ISBN already exists.")
 
@@ -320,7 +320,7 @@ def create_citation_source(
 
 
 def _mint_web_child(
-    parent_id: int, url: str, page_name: str, user: User
+    parent_id: int, url: str, page_name: str, actor: Actor
 ) -> CitationSource:
     """Mint a page child via ``create_web_child``, mapping its error to a 422.
 
@@ -328,7 +328,7 @@ def _mint_web_child(
     ``ValidationError`` (e.g. a malformed *url*); surface that as a 422.
     """
     try:
-        return create_web_child(parent_id, url, page_name, created_by=user)
+        return create_web_child(parent_id, url, page_name, created_by=actor)
     except ValidationError as exc:
         raise HttpError(422, _validation_detail(exc)) from exc
 
@@ -357,7 +357,7 @@ def _host_error_detail(reason: HostRejection) -> str:
 
 
 def _create_root_and_child(
-    url: str, data: CitationCiteUrlSchema, user: User
+    url: str, data: CitationCiteUrlSchema, actor: Actor
 ) -> CitationSource:
     """Create a new site root (homepage link + recognition domain) and a child.
 
@@ -381,20 +381,20 @@ def _create_root_and_child(
                 name=data.site_name or host,
                 source_type=CitationSource.SourceType.WEB,
                 description=data.site_description,
-                created_by=user,
-                updated_by=user,
+                created_by=actor,
+                updated_by=actor,
             )
             _clean_and_save(root)
             homepage = CitationSourceLink(
                 citation_source=root,
                 link_type=CitationSourceLink.LinkType.HOMEPAGE,
                 url=f"https://{host}/",
-                created_by=user,
-                updated_by=user,
+                created_by=actor,
+                updated_by=actor,
             )
             _clean_and_save(homepage)
             domain = CitationSourceRootDomain(
-                source=root, host=host, created_by=user, updated_by=user
+                source=root, host=host, created_by=actor, updated_by=actor
             )
             # validate_unique=False so the model guards (root-only clean(),
             # CHECK constraints) still fire — as a 422 — while the host-unique
@@ -414,7 +414,7 @@ def _create_root_and_child(
             raise
         parent_id = rec.parent_id
 
-    return _mint_web_child(parent_id, url, data.page_name, user)
+    return _mint_web_child(parent_id, url, data.page_name, actor)
 
 
 @citation_sources_router.post(
@@ -465,9 +465,9 @@ def cite_url(
                 ),
             )
         if rec is not None:
-            child = _mint_web_child(rec.parent_id, url, data.page_name, user)
+            child = _mint_web_child(rec.parent_id, url, data.page_name, user.actor)
         else:
-            child = _create_root_and_child(url, data, user)
+            child = _create_root_and_child(url, data, user.actor)
 
     return Status(201, _serialize_match(child))
 
@@ -571,7 +571,7 @@ def create_citation_source_page(
     """
     user = authed_user(request)
     parent = get_object_or_404(CitationSource, pk=source_id)
-    child = _mint_web_child(parent.pk, data.url, data.page_name, user)
+    child = _mint_web_child(parent.pk, data.url, data.page_name, user.actor)
     return Status(201, _serialize_match(child))
 
 
@@ -593,7 +593,9 @@ def create_citation_source_record(
     user = authed_user(request)
     parent = get_object_or_404(CitationSource, pk=source_id)
     try:
-        child = get_or_create_scheme_child(parent, data.identifier, created_by=user)
+        child = get_or_create_scheme_child(
+            parent, data.identifier, created_by=user.actor
+        )
     except ValidationError as exc:
         raise HttpError(422, _validation_detail(exc)) from exc
     except ValueError as exc:
@@ -632,7 +634,7 @@ def update_citation_source(
 
     for attr, value in fields.items():
         setattr(source, attr, value)
-    source.updated_by = user
+    source.updated_by = user.actor
 
     _clean_and_save(
         source,
@@ -668,8 +670,8 @@ def create_citation_source_link(
         link_type=data.link_type,
         url=data.url,
         label=data.label,
-        created_by=user,
-        updated_by=user,
+        created_by=user.actor,
+        updated_by=user.actor,
     )
     _clean_and_save(link, integrity_msg="This URL is already linked to this source.")
 
@@ -701,7 +703,7 @@ def update_citation_source_link(
 
     for attr, value in fields.items():
         setattr(link, attr, value)
-    link.updated_by = user
+    link.updated_by = user.actor
 
     _clean_and_save(
         link,

--- a/backend/apps/citation/extractors.py
+++ b/backend/apps/citation/extractors.py
@@ -35,7 +35,7 @@ from apps.citation.models import (
 )
 
 if TYPE_CHECKING:
-    from apps.accounts.models import User
+    from apps.actors.models import Actor
 
 
 @dataclass(frozen=True)
@@ -312,7 +312,7 @@ def create_web_child(
     url: str,
     name: str = "",
     *,
-    created_by: User | None = None,
+    created_by: Actor | None = None,
 ) -> CitationSource:
     """Mint a validated web-page child under *parent_id*, linked at *url*.
 
@@ -350,7 +350,7 @@ def get_or_create_scheme_child(
     root: CitationSource,
     identifier: str,
     *,
-    created_by: User | None = None,
+    created_by: Actor | None = None,
 ) -> CitationSource:
     """Get-or-create the ``(root, identifier)`` scheme child under *root*.
 
@@ -412,13 +412,16 @@ def get_or_create_scheme_child(
     return source
 
 
-def get_or_create_external_source(scheme: str, identifier: str) -> CitationSource:
+def get_or_create_external_source(
+    scheme: str, identifier: str, *, created_by: Actor | None = None
+) -> CitationSource:
     """Get-or-create the child ``CitationSource`` for ``scheme:identifier``.
 
     Resolves the root source owning *scheme* (e.g. the IPDB root), then
     get-or-creates the ``(root, identifier)`` child under it via
     ``get_or_create_scheme_child``.
 
+    ``created_by`` attributes a newly minted child; ``None`` leaves it null.
     Raises ``CitationSource.DoesNotExist`` if no root for *scheme* is seeded,
     and ``ValueError`` if the scheme or identifier is invalid.
     """
@@ -436,10 +439,12 @@ def get_or_create_external_source(scheme: str, identifier: str) -> CitationSourc
             f"No root CitationSource seeded for scheme {scheme!r}; "
             f"seed citation sources before applying a patch that cites it."
         )
-    return get_or_create_scheme_child(root, identifier)
+    return get_or_create_scheme_child(root, identifier, created_by=created_by)
 
 
-def get_or_create_web_source(url: str, archive_url: str = "") -> CitationSource:
+def get_or_create_web_source(
+    url: str, archive_url: str = "", *, created_by: Actor | None = None
+) -> CitationSource:
     """Get-or-create the web ``CitationSource`` a raw ``url`` cites.
 
     When ``archive_url`` is given (e.g. a Wayback permalink), it is additively
@@ -479,6 +484,9 @@ def get_or_create_web_source(url: str, archive_url: str = "") -> CitationSource:
     The caller is responsible for rejecting URLs that match a known scheme;
     those must be cited as ``scheme:identifier`` so they dedup through the
     scheme path.
+
+    ``created_by`` attributes a newly minted child and archive link (the citing
+    patch's Source actor); ``None`` leaves them null.
     """
     with transaction.atomic():
         # Children only: a root's own homepage link can equal the cited URL, but
@@ -507,8 +515,11 @@ def get_or_create_web_source(url: str, archive_url: str = "") -> CitationSource:
                 source = CitationSource.objects.get(pk=recognition.child.id)
             else:
                 # Domain match: mint a new validated child under the recognized
-                # root, unattributed (created_by stays null).
-                source = create_web_child(recognition.parent_id, url)
+                # root, attributed to ``created_by`` (the citing patch's Source
+                # actor) when given, else null.
+                source = create_web_child(
+                    recognition.parent_id, url, created_by=created_by
+                )
 
         # The durable snapshot (Wayback/archive.today) rides as a second,
         # validated link — not domain-matched, it intentionally lives on a
@@ -524,6 +535,8 @@ def get_or_create_web_source(url: str, archive_url: str = "") -> CitationSource:
                 citation_source=source,
                 url=archive_url,
                 link_type=CitationSourceLink.LinkType.ARCHIVE,
+                created_by=created_by,
+                updated_by=created_by,
             )
             archive.full_clean()
             archive.save()

--- a/backend/apps/citation/migrations/0008_expand_attribution_actor_fks.py
+++ b/backend/apps/citation/migrations/0008_expand_attribution_actor_fks.py
@@ -1,0 +1,97 @@
+"""Expand: add the actor-backed editorial-attribution columns.
+
+Editorial attribution (``created_by`` / ``updated_by`` on the citation-source
+family) moves from a FK to ``User`` to a FK to ``Actor`` — the same durable
+attribution anchor the claims/provenance system points at, so a data patch's
+``Source`` can attribute the citation rows it creates (its `sources:` block).
+
+Staged expand → backfill → contract, because a FK can't be retargeted to a
+different table in place without reinterpreting the stored ids. This first step
+adds the new ``*_actor`` columns nullable alongside the legacy User columns; the
+backfill copies each user's actor across, and the contract step drops the old
+columns and renames the new ones into place. Hand-authored — letting
+``makemigrations`` diff the final model state would emit a single unsafe
+``AlterField`` that recasts User ids as Actor ids.
+"""
+
+from __future__ import annotations
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("citation", "0007_citationsourcerootdomain_created_by_and_more"),
+        # The new columns FK to actors.Actor, so its table must exist.
+        ("actors", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="citationsource",
+            name="created_by_actor",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="+",
+                to="actors.actor",
+            ),
+        ),
+        migrations.AddField(
+            model_name="citationsource",
+            name="updated_by_actor",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="+",
+                to="actors.actor",
+            ),
+        ),
+        migrations.AddField(
+            model_name="citationsourcelink",
+            name="created_by_actor",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="+",
+                to="actors.actor",
+            ),
+        ),
+        migrations.AddField(
+            model_name="citationsourcelink",
+            name="updated_by_actor",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="+",
+                to="actors.actor",
+            ),
+        ),
+        migrations.AddField(
+            model_name="citationsourcerootdomain",
+            name="created_by_actor",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="+",
+                to="actors.actor",
+            ),
+        ),
+        migrations.AddField(
+            model_name="citationsourcerootdomain",
+            name="updated_by_actor",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="+",
+                to="actors.actor",
+            ),
+        ),
+    ]

--- a/backend/apps/citation/migrations/0009_backfill_attribution_actor_fks.py
+++ b/backend/apps/citation/migrations/0009_backfill_attribution_actor_fks.py
@@ -1,0 +1,78 @@
+"""Backfill: project each legacy User attribution to that user's Actor.
+
+Pure FK projection across an existing join — no row creation — so it is a
+set-based ``update()`` with ``Subquery``, not a per-row loop. Every ``User`` has
+a non-null ``Actor`` (the user→actor FK is mandatory), so a non-null
+``created_by``/``updated_by`` always resolves to a non-null ``actor_id``; null
+attribution (an unattributed extractor-created row, or a row predating
+attribution) stays null.
+
+Pure DML with no schema ops, so the default ``atomic=True`` is correct — one
+all-or-nothing transaction. (``atomic=False`` is only needed when a migration
+mixes DDL ``AlterField`` with DML in a single file.)
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+from django.db.models import OuterRef, Subquery
+
+_MODELS = ["CitationSource", "CitationSourceLink", "CitationSourceRootDomain"]
+
+
+def _forward(apps, schema_editor):
+    User = apps.get_model("accounts", "User")
+    for model_name in _MODELS:
+        model = apps.get_model("citation", model_name)
+        model.objects.filter(created_by__isnull=False).update(
+            created_by_actor_id=Subquery(
+                User.objects.filter(pk=OuterRef("created_by_id")).values("actor_id")[:1]
+            )
+        )
+        model.objects.filter(updated_by__isnull=False).update(
+            updated_by_actor_id=Subquery(
+                User.objects.filter(pk=OuterRef("updated_by_id")).values("actor_id")[:1]
+            )
+        )
+
+
+def _reverse(apps, schema_editor):
+    """Project actor attribution back onto the legacy User columns.
+
+    On a full rollback the contract step is reversed first, re-adding the
+    *empty* legacy ``created_by``/``updated_by`` User columns and renaming the
+    actor columns back to ``*_actor``. So the actor columns hold the only copy
+    of the attribution here; map each back to its backing user. A source-backed
+    or orphaned actor (no user) leaves the legacy column null — the legacy
+    User-FK schema cannot represent non-user attribution.
+    """
+    User = apps.get_model("accounts", "User")
+    for model_name in _MODELS:
+        model = apps.get_model("citation", model_name)
+        model.objects.filter(created_by_actor__isnull=False).update(
+            created_by_id=Subquery(
+                User.objects.filter(actor_id=OuterRef("created_by_actor_id")).values(
+                    "pk"
+                )[:1]
+            )
+        )
+        model.objects.filter(updated_by_actor__isnull=False).update(
+            updated_by_id=Subquery(
+                User.objects.filter(actor_id=OuterRef("updated_by_actor_id")).values(
+                    "pk"
+                )[:1]
+            )
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("citation", "0008_expand_attribution_actor_fks"),
+        # The projection reads User.actor_id, added in accounts 0004 — not
+        # transitive via 0008, so name it explicitly.
+        ("accounts", "0004_user_actor"),
+    ]
+
+    operations = [
+        migrations.RunPython(_forward, _reverse),
+    ]

--- a/backend/apps/citation/migrations/0010_contract_attribution_actor_fks.py
+++ b/backend/apps/citation/migrations/0010_contract_attribution_actor_fks.py
@@ -1,0 +1,40 @@
+"""Contract: drop the legacy User columns and rename the Actor columns into place.
+
+Per model, in order: remove the old ``created_by``/``updated_by`` (FK to User),
+then rename ``created_by_actor``/``updated_by_actor`` to ``created_by`` /
+``updated_by`` (the remove must precede the rename so the target name is free).
+The end state — ``created_by``/``updated_by`` as nullable ``PROTECT`` FKs to
+``actors.Actor`` — is exactly what ``ActorAttributedModel`` declares, so
+``makemigrations --check`` reports no drift after this migration.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+
+_MODELS = ["citationsource", "citationsourcelink", "citationsourcerootdomain"]
+
+
+def _contract(model_name: str) -> list[migrations.operations.base.Operation]:
+    return [
+        migrations.RemoveField(model_name=model_name, name="created_by"),
+        migrations.RemoveField(model_name=model_name, name="updated_by"),
+        migrations.RenameField(
+            model_name=model_name,
+            old_name="created_by_actor",
+            new_name="created_by",
+        ),
+        migrations.RenameField(
+            model_name=model_name,
+            old_name="updated_by_actor",
+            new_name="updated_by",
+        ),
+    ]
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("citation", "0009_backfill_attribution_actor_fks"),
+    ]
+
+    operations = [op for model_name in _MODELS for op in _contract(model_name)]

--- a/backend/apps/citation/migrations/0011_attribute_seed_citation_sources.py
+++ b/backend/apps/citation/migrations/0011_attribute_seed_citation_sources.py
@@ -1,0 +1,79 @@
+"""Backfill: attribute legacy unattributed citation rows to the catalog source.
+
+The pre-fix ingest path created citation sources/links/recognition domains
+without recording attribution (the bug this series fixes), leaving
+``created_by``/``updated_by`` null. The interactive path always set a user
+(carried to an Actor by 0009), so a remaining null ``created_by`` means the row
+was created by the baseline seed ingest — which is the ``flipcommons-catalog``
+source. Attribute those rows to its Actor, matching how the fixed ingest path
+now stamps freshly-created rows.
+
+The forward fails fast if any null attribution remains afterward (it is the
+precursor to enforcing the column ``NOT NULL``), so a drifted DB surfaces the
+gap here with context rather than at the later schema-tightening step.
+
+The reverse clears *source*-backed citation attribution (nulls it). It must: a
+rollback below ``provenance.0012`` runs that migration's reverse, which deletes
+every source-backed ``Actor`` — and ``created_by``/``updated_by`` are
+``PROTECT``, so any citation row still pointing at a source actor would block
+the delete. Only ``0011`` depends on ``provenance.0012`` (the expand/contract
+steps don't), so this reverse is the one place guaranteed to run first and drop
+those references. User-backed attribution is left alone — it's torn down by the
+``0009``/``0008`` reverses, which the ``accounts.0004`` dependency orders ahead
+of the user-actor delete.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+from django.db.models import Q
+
+_MODELS = ["CitationSource", "CitationSourceLink", "CitationSourceRootDomain"]
+_CATALOG_SOURCE_SLUG = "flipcommons-catalog"
+
+
+def _forward(apps, schema_editor):
+    Source = apps.get_model("provenance", "Source")
+    catalog = Source.objects.filter(slug=_CATALOG_SOURCE_SLUG).first()
+    if catalog is not None:
+        actor_id = catalog.actor_id
+        for model_name in _MODELS:
+            model = apps.get_model("citation", model_name)
+            model.objects.filter(created_by__isnull=True).update(created_by_id=actor_id)
+            model.objects.filter(updated_by__isnull=True).update(updated_by_id=actor_id)
+
+    # Fail fast: this is the precursor to a NOT NULL constraint, so a remaining
+    # null (a null row with no flipcommons-catalog source to claim it — a drifted
+    # DB) must surface here, not at the later tightening with less context.
+    for model_name in _MODELS:
+        model = apps.get_model("citation", model_name)
+        if model.objects.filter(
+            Q(created_by__isnull=True) | Q(updated_by__isnull=True)
+        ).exists():
+            raise RuntimeError(
+                f"{model_name}: null editorial attribution remains after the "
+                f"backfill — no {_CATALOG_SOURCE_SLUG!r} source to attribute it to, "
+                "or unexpected null rows. Resolve before tightening to NOT NULL."
+            )
+
+
+def _reverse(apps, schema_editor):
+    # Drop references to source-backed actors so a rollback below provenance.0012
+    # (which deletes those actors) isn't blocked by the PROTECT FKs. See the
+    # module docstring.
+    for model_name in _MODELS:
+        model = apps.get_model("citation", model_name)
+        model.objects.filter(created_by__backing_model="source").update(created_by=None)
+        model.objects.filter(updated_by__backing_model="source").update(updated_by=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("citation", "0010_contract_attribution_actor_fks"),
+        # Reads Source.actor_id, added + minted in provenance 0012.
+        ("provenance", "0012_source_actor_and_changeset_claim_actor"),
+    ]
+
+    operations = [
+        migrations.RunPython(_forward, _reverse),
+    ]

--- a/backend/apps/citation/models.py
+++ b/backend/apps/citation/models.py
@@ -6,11 +6,11 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
+from apps.actors.models import ActorAttributedModel
 from apps.citation.hosts import is_dns_host, normalize_host
 from apps.citation.psl import is_public_suffix
 from apps.citation.source_type_traits import SourceType, source_type_traits
 from apps.core.models import (
-    AttributedModel,
     BoundedTextField,
     TimeStampedModel,
     field_lowercase,
@@ -59,7 +59,7 @@ class CitationSourceQuerySet(models.QuerySet["CitationSource"]):
 CitationSourceManager = models.Manager.from_queryset(CitationSourceQuerySet)
 
 
-class CitationSource(TimeStampedModel, AttributedModel):
+class CitationSource(TimeStampedModel, ActorAttributedModel):
     """A work or evidence object that can be cited: book, flyer, web page, etc.
 
     NOT claims-controlled — edited directly through admin or future UI.
@@ -322,7 +322,7 @@ class CitationSource(TimeStampedModel, AttributedModel):
         return self.name
 
 
-class CitationSourceLink(TimeStampedModel, AttributedModel):
+class CitationSourceLink(TimeStampedModel, ActorAttributedModel):
     """A URL where a reader can inspect a CitationSource.
 
     Wholly owned by its parent CitationSource — CASCADE on delete.
@@ -379,7 +379,7 @@ class CitationSourceLink(TimeStampedModel, AttributedModel):
         return self.url
 
 
-class CitationSourceRootDomain(TimeStampedModel, AttributedModel):
+class CitationSourceRootDomain(TimeStampedModel, ActorAttributedModel):
     """A recognition host owned by a root ``CitationSource``.
 
     The signal ``recognize_url`` keys off: a normalized host (lowercased,

--- a/backend/apps/citation/source_upsert.py
+++ b/backend/apps/citation/source_upsert.py
@@ -16,6 +16,7 @@ from apps.citation.hosts import Host, normalize_host
 from apps.citation.source_node import SourceLinkNode, SourceNode
 
 if TYPE_CHECKING:
+    from apps.actors.models import Actor
     from apps.citation.models import CitationSource
 
 
@@ -127,18 +128,18 @@ def _lookup_source(fields: SourceFields) -> SourceMatch:
 
 
 def _create_source(
-    fields: SourceFields, *, parent: CitationSource | None = None
+    fields: SourceFields, *, actor: Actor, parent: CitationSource | None = None
 ) -> CitationSource:
     """Validate + save a new ``CitationSource`` under ``parent`` (default root)."""
     from apps.citation.models import CitationSource
 
-    obj = CitationSource(**fields, parent=parent)
+    obj = CitationSource(**fields, parent=parent, created_by=actor, updated_by=actor)
     obj.full_clean()
     obj.save()
     return obj
 
 
-def _create_link(source: CitationSource, link: SourceLinkNode) -> None:
+def _create_link(source: CitationSource, link: SourceLinkNode, *, actor: Actor) -> None:
     """Validate + save a single ``CitationSourceLink`` on ``source``."""
     from apps.citation.models import CitationSourceLink
 
@@ -147,6 +148,8 @@ def _create_link(source: CitationSource, link: SourceLinkNode) -> None:
         url=link["url"],
         label=link.get("label", ""),
         link_type=link["link_type"],
+        created_by=actor,
+        updated_by=actor,
     )
     obj.full_clean()
     obj.save()
@@ -255,7 +258,7 @@ def _spans_two_roots_warning(name: str, host_roots: Sequence[CitationSource]) ->
 
 
 def _ensure_root_domains(
-    source: CitationSource, hosts: Sequence[Host], *, warnings: list[str]
+    source: CitationSource, hosts: Sequence[Host], *, warnings: list[str], actor: Actor
 ) -> None:
     """Additively mint a recognition domain on ``source`` for each unowned host.
 
@@ -283,7 +286,9 @@ def _ensure_root_domains(
                     f"{owner.source.name!r}; not minted on {source.name!r}."
                 )
             continue
-        domain = CitationSourceRootDomain(source=source, host=host)
+        domain = CitationSourceRootDomain(
+            source=source, host=host, created_by=actor, updated_by=actor
+        )
         domain.full_clean()
         domain.save()
 
@@ -369,6 +374,7 @@ def detect_host_collision(node: SourceNode) -> str | None:
 def ensure_root_source(
     node: SourceNode,
     *,
+    actor: Actor,
     warnings: list[str],
 ) -> SourceUpsertResult:
     """Additively get-or-create a flat (root) citation source. Never overwrites.
@@ -420,10 +426,10 @@ def ensure_root_source(
             )
 
     if obj is None:
-        obj = _create_source(fields)
+        obj = _create_source(fields, actor=actor)
         for link in links:
-            _create_link(obj, link)
-        _ensure_root_domains(obj, recognition_hosts, warnings=warnings)
+            _create_link(obj, link, actor=actor)
+        _ensure_root_domains(obj, recognition_hosts, warnings=warnings, actor=actor)
         return SourceUpsertResult(source_created=True, links_created=len(links))
 
     # Found: never overwrite the row; warn on any declared-field divergence.
@@ -449,7 +455,7 @@ def ensure_root_source(
         url = link["url"]
         current = existing.get(url)
         if current is None:
-            _create_link(obj, link)
+            _create_link(obj, link, actor=actor)
             links_created += 1
         elif current.link_type != link["link_type"] or current.label != link.get(
             "label", ""
@@ -458,5 +464,5 @@ def ensure_root_source(
                 f"Citation source {name!r} link {url!r} already exists with a "
                 f"different type/label; left unchanged."
             )
-    _ensure_root_domains(obj, recognition_hosts, warnings=warnings)
+    _ensure_root_domains(obj, recognition_hosts, warnings=warnings, actor=actor)
     return SourceUpsertResult(source_created=False, links_created=links_created)

--- a/backend/apps/citation/tests/test_admin.py
+++ b/backend/apps/citation/tests/test_admin.py
@@ -113,8 +113,8 @@ class TestCitationSourceAdminAttribution:
         request.user = superuser
         obj = CitationSource(name="Test", source_type="book")
         admin_instance.save_model(request, obj, form=None, change=False)
-        assert obj.created_by == superuser
-        assert obj.updated_by == superuser
+        assert obj.created_by == superuser.actor
+        assert obj.updated_by == superuser.actor
 
     def test_updated_by_set_on_change(
         self, admin_instance, request_factory, superuser, citation_source
@@ -122,7 +122,7 @@ class TestCitationSourceAdminAttribution:
         request = request_factory.post("/")
         request.user = superuser
         admin_instance.save_model(request, citation_source, form=None, change=True)
-        assert citation_source.updated_by == superuser
+        assert citation_source.updated_by == superuser.actor
         # created_by should not be overwritten on change
         assert citation_source.created_by is None
 
@@ -148,8 +148,8 @@ class TestCitationSourceLinkInlineAttribution:
         admin_instance.save_formset(request, form=None, formset=formset, change=True)
 
         link = CitationSourceLink.objects.get(citation_source=citation_source)
-        assert link.created_by == superuser
-        assert link.updated_by == superuser
+        assert link.created_by == superuser.actor
+        assert link.updated_by == superuser.actor
 
     def test_updated_by_set_on_existing_link(
         self, admin_instance, request_factory, superuser, citation_source
@@ -178,7 +178,7 @@ class TestCitationSourceLinkInlineAttribution:
         admin_instance.save_formset(request, form=None, formset=formset, change=True)
 
         link.refresh_from_db()
-        assert link.updated_by == superuser
+        assert link.updated_by == superuser.actor
         # created_by should NOT be set on update of existing record
         assert link.created_by is None
 
@@ -208,8 +208,8 @@ class TestCitationSourceRootDomainInline:
         domain = CitationSourceRootDomain.objects.get(source=citation_source)
         assert domain.host == "example.com"
         # The inline stamps editorial attribution like the link inline does.
-        assert domain.created_by == superuser
-        assert domain.updated_by == superuser
+        assert domain.created_by == superuser.actor
+        assert domain.updated_by == superuser.actor
 
     def test_domain_removed_through_admin_form(
         self, admin_instance, request_factory, superuser, citation_source

--- a/backend/apps/citation/tests/test_api.py
+++ b/backend/apps/citation/tests/test_api.py
@@ -455,8 +455,8 @@ class TestCreateCitationSource:
             },
         )
         source = CitationSource.objects.get(name="Test")
-        assert source.created_by == user
-        assert source.updated_by == user
+        assert source.created_by == user.actor
+        assert source.updated_by == user.actor
 
     def test_invalid_source_type_returns_422(self, client, user):
         client.force_login(user)
@@ -670,20 +670,20 @@ class TestCiteUrl:
         child = CitationSource.objects.get(pk=resp.json()["id"])
         root = child.parent
         assert root is not None
-        assert child.created_by == user
-        assert child.updated_by == user
-        assert root.created_by == user
-        assert root.updated_by == user
+        assert child.created_by == user.actor
+        assert child.updated_by == user.actor
+        assert root.created_by == user.actor
+        assert root.updated_by == user.actor
         for link in CitationSourceLink.objects.filter(
             citation_source__in=[root, child]
         ):
-            assert link.created_by == user
-            assert link.updated_by == user
+            assert link.created_by == user.actor
+            assert link.updated_by == user.actor
         # The minted recognition domain is attributed too — it is a row the
         # caller's action created, same as the source and its links.
         domain = CitationSourceRootDomain.objects.get(source=root)
-        assert domain.created_by == user
-        assert domain.updated_by == user
+        assert domain.created_by == user.actor
+        assert domain.updated_by == user.actor
 
     def test_blank_site_name_falls_back_to_rounded_host(self, client, user):
         client.force_login(user)
@@ -742,11 +742,11 @@ class TestCiteUrl:
         # The child and its link are attributed to the caller (this path mints
         # via the same _create_web_child helper but isn't covered by the
         # no-match attribution test).
-        assert child.created_by == user
-        assert child.updated_by == user
+        assert child.created_by == user.actor
+        assert child.updated_by == user.actor
         ref = child.links.get(link_type="reference")
-        assert ref.created_by == user
-        assert ref.updated_by == user
+        assert ref.created_by == user.actor
+        assert ref.updated_by == user.actor
         # The root is never renamed/redescribed from here.
         root.refresh_from_db()
         assert root.name == "Existing"
@@ -1169,7 +1169,7 @@ class TestUpdateCitationSource:
             },
         )
         citation_source.refresh_from_db()
-        assert citation_source.updated_by == user
+        assert citation_source.updated_by == user.actor
 
     def test_clear_nullable_field(self, client, user, citation_source_full):
         client.force_login(user)
@@ -1287,8 +1287,8 @@ class TestCreateCitationSourceLink:
             {"link_type": "homepage", "url": "https://example.com"},
         )
         link = CitationSourceLink.objects.get(citation_source=citation_source)
-        assert link.created_by == user
-        assert link.updated_by == user
+        assert link.created_by == user.actor
+        assert link.updated_by == user.actor
 
     def test_duplicate_url_returns_422(
         self, client, user, citation_source, citation_source_link
@@ -1364,7 +1364,7 @@ class TestUpdateCitationSourceLink:
             {"label": "updated"},
         )
         citation_source_link.refresh_from_db()
-        assert citation_source_link.updated_by == user
+        assert citation_source_link.updated_by == user.actor
 
     def test_link_on_wrong_source_returns_404(self, client, user, citation_source_link):
         other_source = CitationSource.objects.create(name="Other", source_type="web")
@@ -1581,11 +1581,11 @@ class TestCreateCitationSourcePage:
         assert data["skip_locator"] is True
         child = CitationSource.objects.get(pk=data["id"])
         assert child.parent_id == root.pk
-        assert child.created_by == user
-        assert child.updated_by == user
+        assert child.created_by == user.actor
+        assert child.updated_by == user.actor
         ref = child.links.get(link_type="reference")
         assert ref.url == "https://site.example/article"
-        assert ref.created_by == user
+        assert ref.created_by == user.actor
 
     def test_blank_page_name_falls_back_to_url(self, client, user):
         client.force_login(user)
@@ -1672,7 +1672,7 @@ class TestCreateCitationSourceRecord:
         child = CitationSource.objects.get(pk=data["id"])
         assert child.parent_id == root.pk
         assert child.identifier == "4443"
-        assert child.created_by == user
+        assert child.created_by == user.actor
         ref = child.links.get(link_type="reference")
         assert ref.url == "https://www.ipdb.org/machine.cgi?id=4443"
 

--- a/backend/apps/citation/tests/test_extractors.py
+++ b/backend/apps/citation/tests/test_extractors.py
@@ -244,10 +244,10 @@ class TestCreateWebChild:
 
     def test_attribution_follows_created_by(self, root, user):
         attributed = create_web_child(
-            root.pk, "https://kineticist.com/a", created_by=user
+            root.pk, "https://kineticist.com/a", created_by=user.actor
         )
-        assert attributed.created_by_id == user.pk
-        assert attributed.links.get().created_by_id == user.pk
+        assert attributed.created_by_id == user.actor_id
+        assert attributed.links.get().created_by_id == user.actor_id
 
         anon = create_web_child(root.pk, "https://kineticist.com/b")
         assert anon.created_by_id is None
@@ -296,9 +296,9 @@ class TestGetOrCreateSchemeChild:
         assert not CitationSource.objects.children().exists()
 
     def test_attribution_follows_created_by(self, root, user):
-        child = get_or_create_scheme_child(root, "4443", created_by=user)
-        assert child.created_by_id == user.pk
-        assert child.links.get().created_by_id == user.pk
+        child = get_or_create_scheme_child(root, "4443", created_by=user.actor)
+        assert child.created_by_id == user.actor_id
+        assert child.links.get().created_by_id == user.actor_id
 
     def test_external_source_helper_resolves_the_same_child(self, root):
         # The patch helper (scheme→root lookup) and the leaf mint one child —

--- a/backend/apps/citation/tests/test_migration_attribution_actor.py
+++ b/backend/apps/citation/tests/test_migration_attribution_actor.py
@@ -1,0 +1,173 @@
+"""Round-trip guard for the editorial-attribution User->Actor data migration.
+
+The deploy-critical bit is the data move, both directions: the forward backfill
+(citation 0009) projects each legacy ``created_by``/``updated_by`` User FK to that
+user's Actor, and its reverse projects back to the User — leaving a source-backed
+actor (a patch-created row) null, since the legacy User-FK schema can't represent
+non-user attribution. Driven through the real historical schema with
+``MigrationExecutor`` (the columns are renamed/dropped across the staged
+expand/backfill/contract, so the RunPython can't run against the live schema).
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+
+# Pin accounts/actors at their leaves so ``project_state`` materializes those
+# apps too — citation 0007 predates the actors dependency (added in 0008), so a
+# citation-only target would leave ``actors``/``accounts`` out of the state.
+_DEPS = [
+    ("accounts", "0004_user_actor"),
+    ("actors", "0002_alter_actor_priority_help_text"),
+]
+_BEFORE = [("citation", "0007_citationsourcerootdomain_created_by_and_more"), *_DEPS]
+_AFTER = [("citation", "0010_contract_attribution_actor_fks"), *_DEPS]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_attribution_actor_backfill_round_trips():
+    executor = MigrationExecutor(connection)
+    try:
+        # Rewind citation to the pre-actor state: created_by/updated_by are still
+        # User FKs, no *_actor columns yet.
+        executor.migrate(_BEFORE)
+        executor.loader.build_graph()
+        before = executor.loader.project_state(_BEFORE).apps
+        Actor = before.get_model("actors", "Actor")
+        User = before.get_model("accounts", "User")
+        CitationSource = before.get_model("citation", "CitationSource")
+
+        user_actor = Actor.objects.create(
+            backing_model="user", priority=100, resolution_status="active"
+        )
+        user = User.objects.create(
+            username="alice",
+            email="alice@example.com",
+            password="!",
+            priority=100,
+            actor=user_actor,
+        )
+        CitationSource.objects.create(
+            name="By user",
+            source_type="web",
+            created_by_id=user.pk,
+            updated_by_id=user.pk,
+        )
+
+        # Forward through expand -> backfill -> contract.
+        executor.loader.build_graph()
+        executor.migrate(_AFTER)
+        after = executor.loader.project_state(_AFTER).apps
+        Actor = after.get_model("actors", "Actor")
+        CitationSource = after.get_model("citation", "CitationSource")
+
+        by_user = CitationSource.objects.get(name="By user")
+        assert by_user.created_by_id == user_actor.pk
+        assert by_user.updated_by_id == user_actor.pk
+
+        # A row a data patch created post-migration: attributed to a source actor
+        # (no backing user) — the reverse must leave it null, not crash.
+        source_actor = Actor.objects.create(
+            backing_model="source", priority=50, resolution_status="active"
+        )
+        CitationSource.objects.create(
+            name="By patch",
+            source_type="web",
+            created_by_id=source_actor.pk,
+            updated_by_id=source_actor.pk,
+        )
+
+        # Reverse all the way back: contract -> backfill -> expand.
+        executor.loader.build_graph()
+        executor.migrate(_BEFORE)
+        back = executor.loader.project_state(_BEFORE).apps
+        CitationSource = back.get_model("citation", "CitationSource")
+
+        by_user = CitationSource.objects.get(name="By user")
+        assert by_user.created_by_id == user.pk  # projected back to the user
+        assert by_user.updated_by_id == user.pk
+
+        by_patch = CitationSource.objects.get(name="By patch")
+        assert by_patch.created_by_id is None  # source actor → no user
+        assert by_patch.updated_by_id is None
+
+        # Drop the synthetic rows before restoring to leaf: the leaf includes
+        # 0011, whose fail-fast assertion rejects a null-attribution row with no
+        # flipcommons-catalog source to claim it (this test creates neither a
+        # catalog source nor re-attributable rows).
+        CitationSource.objects.all().delete()
+    finally:
+        # Restore the DB to the latest schema for subsequent tests.
+        executor.loader.build_graph()
+        executor.migrate(executor.loader.graph.leaf_nodes())
+
+
+# 0011 attributes legacy unattributed citation rows to the catalog source, so it
+# needs provenance (for Source.actor) pinned in the state too.
+_DEPS_0011 = [
+    ("accounts", "0004_user_actor"),
+    ("actors", "0002_alter_actor_priority_help_text"),
+    (
+        "provenance",
+        "0016_remove_claim_provenance_claim_needs_review_notes_max_length_and_more",
+    ),
+]
+_BEFORE_0011 = [("citation", "0010_contract_attribution_actor_fks"), *_DEPS_0011]
+_AFTER_0011 = [("citation", "0011_attribute_seed_citation_sources"), *_DEPS_0011]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_seed_attribution_backfill_attributes_and_reverse_clears():
+    """0011 attributes legacy null citation rows to the flipcommons-catalog actor.
+
+    Forward: a seed-ingest row (null attribution) is attributed to the catalog
+    Source's actor. Reverse: source-backed attribution is cleared — required so a
+    rollback below provenance.0012 (which deletes source actors) isn't blocked by
+    the PROTECT ``created_by``/``updated_by`` FKs.
+    """
+    executor = MigrationExecutor(connection)
+    try:
+        executor.migrate(_BEFORE_0011)
+        executor.loader.build_graph()
+        before = executor.loader.project_state(_BEFORE_0011).apps
+        Actor = before.get_model("actors", "Actor")
+        Source = before.get_model("provenance", "Source")
+        CitationSource = before.get_model("citation", "CitationSource")
+
+        catalog_actor = Actor.objects.create(
+            backing_model="source", priority=10, resolution_status="active"
+        )
+        Source.objects.create(
+            name="Flipcommons Catalog",
+            slug="flipcommons-catalog",
+            source_type="database",
+            priority=10,
+            actor=catalog_actor,
+        )
+        # A legacy seed-ingest row: created by the old path with no attribution.
+        CitationSource.objects.create(name="Legacy", source_type="web")
+
+        # Forward: the null row is attributed to the catalog source actor.
+        executor.loader.build_graph()
+        executor.migrate(_AFTER_0011)
+        after = executor.loader.project_state(_AFTER_0011).apps
+        CitationSource = after.get_model("citation", "CitationSource")
+        cs = CitationSource.objects.get(name="Legacy")
+        assert cs.created_by_id == catalog_actor.pk
+        assert cs.updated_by_id == catalog_actor.pk
+
+        # Reverse: source-backed attribution is nulled, dropping the PROTECT
+        # references that would otherwise block provenance.0012's source-actor
+        # delete on a deeper rollback.
+        executor.loader.build_graph()
+        executor.migrate(_BEFORE_0011)
+        back = executor.loader.project_state(_BEFORE_0011).apps
+        CitationSource = back.get_model("citation", "CitationSource")
+        cs = CitationSource.objects.get(name="Legacy")
+        assert cs.created_by_id is None
+        assert cs.updated_by_id is None
+    finally:
+        executor.loader.build_graph()
+        executor.migrate(executor.loader.graph.leaf_nodes())

--- a/backend/apps/citation/tests/test_source_upsert.py
+++ b/backend/apps/citation/tests/test_source_upsert.py
@@ -37,6 +37,19 @@ def _node(name, source_type="web", links=None, domains=None):
     return node
 
 
+@pytest.fixture
+def actor(db):
+    """A patch ``Source`` actor — the real attributor of `sources:` rows."""
+    from apps.provenance.models import Source
+
+    return Source.objects.create(
+        name="Patch Source",
+        slug="patch-source",
+        source_type="database",
+        priority=50,
+    ).actor
+
+
 class TestDeclaredHomepageHosts:
     """Pure host extraction — no DB."""
 
@@ -66,13 +79,14 @@ class TestDeclaredHomepageHosts:
 
 
 class TestRootDomainMinting:
-    def test_new_root_mints_normalized_domain(self):
+    def test_new_root_mints_normalized_domain(self, actor):
         warnings: list[str] = []
         result = ensure_root_source(
             _node(
                 "American Pinball",
                 links=[_homepage("https://www.American-Pinball.com/")],
             ),
+            actor=actor,
             warnings=warnings,
         )
         assert result.source_created
@@ -81,7 +95,7 @@ class TestRootDomainMinting:
             "american-pinball.com"
         ]
 
-    def test_any_root_type_mints_domain(self):
+    def test_any_root_type_mints_domain(self, actor):
         """Any-root, not web-only: a book root with a homepage link gets one."""
         ensure_root_source(
             _node(
@@ -89,23 +103,25 @@ class TestRootDomainMinting:
                 source_type="book",
                 links=[_homepage("https://pinball-book.example/")],
             ),
+            actor=actor,
             warnings=[],
         )
         root = CitationSource.objects.get(name="A Pinball Book")
         assert root.root_domains.filter(host="pinball-book.example").exists()
 
-    def test_non_homepage_link_mints_no_domain(self):
+    def test_non_homepage_link_mints_no_domain(self, actor):
         ensure_root_source(
             _node(
                 "Catalog Only",
                 links=[{"url": "https://example.com/c", "link_type": "catalog"}],
             ),
+            actor=actor,
             warnings=[],
         )
         root = CitationSource.objects.get(name="Catalog Only")
         assert not root.root_domains.exists()
 
-    def test_new_root_mints_a_domain_per_distinct_host(self):
+    def test_new_root_mints_a_domain_per_distinct_host(self, actor):
         """One root owns many domains — a node may declare several at once."""
         ensure_root_source(
             _node(
@@ -115,6 +131,7 @@ class TestRootDomainMinting:
                     _homepage("https://new-name.example/"),
                 ],
             ),
+            actor=actor,
             warnings=[],
         )
         root = CitationSource.objects.get(name="Rebrand")
@@ -125,14 +142,17 @@ class TestRootDomainMinting:
 
 
 class TestSourceUpsertDedup:
-    def test_redeclare_by_name_with_new_host_adds_domain_no_duplicate(self):
+    def test_redeclare_by_name_with_new_host_adds_domain_no_duplicate(self, actor):
         """A same-named root gaining a new homepage host is found, not duplicated."""
         ensure_root_source(
-            _node("TWIP", links=[_homepage("https://twip.example/")]), warnings=[]
+            _node("TWIP", links=[_homepage("https://twip.example/")]),
+            actor=actor,
+            warnings=[],
         )
         warnings: list[str] = []
         result = ensure_root_source(
             _node("TWIP", links=[_homepage("https://blog.twip.example/")]),
+            actor=actor,
             warnings=warnings,
         )
         assert not result.source_created
@@ -143,16 +163,18 @@ class TestSourceUpsertDedup:
             "blog.twip.example",
         }
 
-    def test_dedup_by_host_under_a_new_name(self):
+    def test_dedup_by_host_under_a_new_name(self, actor):
         """Re-declaring the same host under a different name reuses the host owner."""
         ensure_root_source(
             _node("This Week in Pinball", links=[_homepage("https://twip.example/")]),
+            actor=actor,
             warnings=[],
         )
         before = CitationSource.objects.count()
         warnings: list[str] = []
         result = ensure_root_source(
             _node("TWiP (alt name)", links=[_homepage("https://twip.example/")]),
+            actor=actor,
             warnings=warnings,
         )
         assert not result.source_created
@@ -164,7 +186,7 @@ class TestSourceUpsertDedup:
             "recognition host" in w and "This Week in Pinball" in w for w in warnings
         )
 
-    def test_one_host_owned_plus_one_unowned_mints_only_the_new(self):
+    def test_one_host_owned_plus_one_unowned_mints_only_the_new(self, actor):
         """A single owning root + an unowned host → reuse the root, add the host."""
         root = CitationSource.objects.create(name="Owner", source_type="web")
         CitationSourceRootDomain.objects.create(source=root, host="owned.example")
@@ -176,6 +198,7 @@ class TestSourceUpsertDedup:
                     _homepage("https://fresh.example/"),
                 ],
             ),
+            actor=actor,
             warnings=[],
         )
         assert not result.source_created
@@ -184,7 +207,7 @@ class TestSourceUpsertDedup:
             "fresh.example",
         }
 
-    def test_host_owned_by_a_child_warns_and_does_not_wedge(self):
+    def test_host_owned_by_a_child_warns_and_does_not_wedge(self, actor):
         """A host illegitimately held by a child (a clean() bypass) must not raise.
 
         The root-scoped resolver can't see the child's row, so the node resolves
@@ -201,6 +224,7 @@ class TestSourceUpsertDedup:
         warnings: list[str] = []
         result = ensure_root_source(  # must not raise
             _node("Fresh Root", links=[_homepage("https://squatted.example/")]),
+            actor=actor,
             warnings=warnings,
         )
         # The source was still created; only the taken host was skipped.
@@ -209,7 +233,7 @@ class TestSourceUpsertDedup:
         assert not new_root.root_domains.exists()
         assert any("already owned" in w for w in warnings)
 
-    def test_hosts_spanning_two_roots_warns_and_skips_with_no_writes(self):
+    def test_hosts_spanning_two_roots_warns_and_skips_with_no_writes(self, actor):
         a = CitationSource.objects.create(name="Root A", source_type="web")
         CitationSourceRootDomain.objects.create(source=a, host="a.example")
         b = CitationSource.objects.create(name="Root B", source_type="web")
@@ -226,6 +250,7 @@ class TestSourceUpsertDedup:
                     _homepage("https://b.example/"),
                 ],
             ),
+            actor=actor,
             warnings=warnings,
         )
         assert result.source_created is False
@@ -260,10 +285,10 @@ class TestDeclaredDomainsHosts:
 
 
 class TestDeclaredDomainsMinting:
-    def test_subdomain_is_minted_verbatim_no_rounding(self):
+    def test_subdomain_is_minted_verbatim_no_rounding(self, actor):
         """A declared subdomain stays its own host — declare does not round."""
         result = ensure_root_source(
-            _node("TWIP", domains=["twip.kineticist.com"]), warnings=[]
+            _node("TWIP", domains=["twip.kineticist.com"]), actor=actor, warnings=[]
         )
         assert result.source_created
         root = CitationSource.objects.get(name="TWIP")
@@ -271,13 +296,14 @@ class TestDeclaredDomainsMinting:
             "twip.kineticist.com"
         ]
 
-    def test_homepage_and_domains_union_onto_one_root(self):
+    def test_homepage_and_domains_union_onto_one_root(self, actor):
         ensure_root_source(
             _node(
                 "Pinball Now",
                 links=[_homepage("https://pinballnow.com/")],
                 domains=["oldpin.com"],
             ),
+            actor=actor,
             warnings=[],
         )
         root = CitationSource.objects.get(name="Pinball Now")
@@ -286,16 +312,18 @@ class TestDeclaredDomainsMinting:
             "oldpin.com",
         }
 
-    def test_url_form_domain_normalizes_like_bare_form(self):
+    def test_url_form_domain_normalizes_like_bare_form(self, actor):
         ensure_root_source(
-            _node("Pinball Now", domains=["https://OldPin.com/"]), warnings=[]
+            _node("Pinball Now", domains=["https://OldPin.com/"]),
+            actor=actor,
+            warnings=[],
         )
         root = CitationSource.objects.get(name="Pinball Now")
         assert root.root_domains.filter(host="oldpin.com").exists()
 
 
 class TestRebrandResolution:
-    def test_rebrand_resolves_to_existing_root_via_domains_no_second_root(self):
+    def test_rebrand_resolves_to_existing_root_via_domains_no_second_root(self, actor):
         """``domains:`` declares the old host; the new homepage adds, not forks.
 
         The canonical rebrand: an existing root owns ``oldpin.com``; a node with
@@ -313,6 +341,7 @@ class TestRebrandResolution:
                 links=[_homepage("https://pinballnow.com/")],
                 domains=["oldpin.com"],
             ),
+            actor=actor,
             warnings=[],
         )
         assert not result.source_created
@@ -324,7 +353,7 @@ class TestRebrandResolution:
             "pinballnow.com",
         }
 
-    def test_domains_host_held_by_a_child_warn_skips_no_integrity_error(self):
+    def test_domains_host_held_by_a_child_warn_skips_no_integrity_error(self, actor):
         """A declared domain a *child* squats must warn-skip at mint, not raise.
 
         The root-scoped resolver can't see the child's row, so the node resolves
@@ -341,6 +370,7 @@ class TestRebrandResolution:
         warnings: list[str] = []
         result = ensure_root_source(  # must not raise
             _node("Fresh", domains=["squatted.example", "free.example"]),
+            actor=actor,
             warnings=warnings,
         )
         assert result.source_created
@@ -350,7 +380,7 @@ class TestRebrandResolution:
         ]
         assert any("already owned" in w for w in warnings)
 
-    def test_domains_spanning_two_roots_skips_naming_both(self):
+    def test_domains_spanning_two_roots_skips_naming_both(self, actor):
         a = CitationSource.objects.create(name="Root A", source_type="web")
         CitationSourceRootDomain.objects.create(source=a, host="a.example")
         b = CitationSource.objects.create(name="Root B", source_type="web")
@@ -359,6 +389,7 @@ class TestRebrandResolution:
         warnings: list[str] = []
         result = ensure_root_source(
             _node("Spans Two", domains=["a.example", "b.example"]),
+            actor=actor,
             warnings=warnings,
         )
         assert result.source_created is False
@@ -429,3 +460,32 @@ class TestDetectHostCollision:
 
     def test_unowned_hosts_are_not_a_collision(self):
         assert detect_host_collision(_node("X", domains=["fresh.example"])) is None
+
+
+class TestSourceUpsertAttribution:
+    """Every row a `sources:` upsert creates is attributed to the patch actor.
+
+    Exercises the three create branches in one pass: ``_create_source`` (the
+    root), ``_create_link`` (its homepage link) and ``_ensure_root_domains``
+    (its recognition domain).
+    """
+
+    def test_created_rows_carry_the_actor(self, actor):
+        result = ensure_root_source(
+            _node(
+                "Attributed Site",
+                links=[_homepage("https://attributed.example/")],
+            ),
+            actor=actor,
+            warnings=[],
+        )
+        assert result.source_created
+        root = CitationSource.objects.get(name="Attributed Site")
+        assert root.created_by == actor
+        assert root.updated_by == actor
+        link = root.links.get()
+        assert link.created_by == actor
+        assert link.updated_by == actor
+        domain = root.root_domains.get()
+        assert domain.created_by == actor
+        assert domain.updated_by == actor

--- a/backend/apps/claim_ingest/apply/orchestrate.py
+++ b/backend/apps/claim_ingest/apply/orchestrate.py
@@ -91,7 +91,7 @@ def apply_plan(plan: IngestPlan, *, dry_run: bool = False) -> RunReport:
             # to minted slugs *before* claims are built/validated, so the standard
             # markdown conversion in _validate_fail_fast resolves them to storage
             # form. Existing-slug markers self-resolve and aren't touched here.
-            _materialize_inline_citations(plan.assertions)
+            _materialize_inline_citations(plan.assertions, plan.source.actor)
             # Per-claim provenance (note/citation) carried by the plan, collected
             # once now that handles are resolved (so every assertion carries its
             # real ct/obj). Kept out of _build_claims so that helper's signature —
@@ -128,7 +128,7 @@ def apply_plan(plan: IngestPlan, *, dry_run: bool = False) -> RunReport:
                 entry_notes,
                 claim_entry_index,
             )
-            _attach_plan_citations(to_create, claim_citations)
+            _attach_plan_citations(to_create, claim_citations, plan.source.actor)
             _resolve(to_create, retract_entries, plan.changed_relationship_fields)
 
             # SUCCESS flip inside the transaction — see note above. The

--- a/backend/apps/claim_ingest/apply/persist.py
+++ b/backend/apps/claim_ingest/apply/persist.py
@@ -25,6 +25,7 @@ from typing import assert_never, cast
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 
+from apps.actors.models import Actor
 from apps.claim_ingest.apply.claims import (
     RetractEntry,
     _reject_empty_diff_provenance,
@@ -252,7 +253,9 @@ def _cite_resolution_error(ref: CitationRef, exc: Exception) -> str:
     return f"cite {descriptor}: {detail}"
 
 
-def _resolve_cite_source_id(ref: CitationRef, cache: dict[CitationRef, int]) -> int:
+def _resolve_cite_source_id(
+    ref: CitationRef, cache: dict[CitationRef, int], *, actor: Actor
+) -> int:
     """Resolve a ``CitationRef`` to a ``CitationSource`` pk, memoized via ``cache``.
 
     Shared by the field-level ``cite:`` path (:func:`_attach_plan_citations`) and
@@ -260,7 +263,9 @@ def _resolve_cite_source_id(ref: CitationRef, cache: dict[CitationRef, int]) -> 
     same ``get_or_create_*`` resolvers, so source dedup, web-root matching and
     ``{url, archive}`` backfill come free. Created sources are *uncounted* — the
     resolvers return a bare ``CitationSource``, not created-ness — matching the
-    field-``cite:`` stance (only the ``sources:`` block bumps the counters).
+    field-``cite:`` stance (only the ``sources:`` block bumps the counters). A
+    cite that mints a new source attributes it to ``actor`` (the patch's
+    ``Source`` actor), like the ``sources:`` block.
 
     The resolvers fail three ways — a malformed URL/identifier (``ValidationError``
     from the leaves' ``full_clean``), an unknown scheme or bad identifier
@@ -281,9 +286,13 @@ def _resolve_cite_source_id(ref: CitationRef, cache: dict[CitationRef, int]) -> 
         try:
             match ref:
                 case WebCitationRef(url=url, archive_url=archive_url):
-                    source_id = get_or_create_web_source(url, archive_url).pk
+                    source_id = get_or_create_web_source(
+                        url, archive_url, created_by=actor
+                    ).pk
                 case SchemeCitationRef(scheme=scheme, identifier=identifier):
-                    source_id = get_or_create_external_source(scheme, identifier).pk
+                    source_id = get_or_create_external_source(
+                        scheme, identifier, created_by=actor
+                    ).pk
                 case _:
                     assert_never(ref)
         except (ValidationError, ValueError, ObjectDoesNotExist) as exc:
@@ -295,6 +304,7 @@ def _resolve_cite_source_id(ref: CitationRef, cache: dict[CitationRef, int]) -> 
 def _attach_plan_citations(
     to_create: list[Claim],
     claim_citations: ClaimCitations,
+    actor: Actor,
 ) -> None:
     """Materialize per-claim ``CitationRef``s as ``CitationInstance`` rows.
 
@@ -302,6 +312,9 @@ def _attach_plan_citations(
     a *newly written* claim: a value that diffs as unchanged produces no
     ``to_create`` entry, so re-asserting an already-correct value purely to
     add a ``cite:`` is a documented no-op (see docs/DataPatches.md).
+
+    ``actor`` is the patch's ``Source`` actor — a ``cite:`` URL that mints a new
+    citation source attributes it to the patch, like the ``sources:`` block.
     """
     if not claim_citations:
         return
@@ -315,13 +328,15 @@ def _attach_plan_citations(
         )
         if ref is None:
             continue
-        source_id = _resolve_cite_source_id(ref, source_cache)
+        source_id = _resolve_cite_source_id(ref, source_cache, actor=actor)
         instances.append(CitationInstance(citation_source_id=source_id, claim=claim))
     if instances:
         CitationInstance.objects.mint_many(instances)
 
 
-def _materialize_inline_citations(assertions: list[PlannedClaimAssert]) -> None:
+def _materialize_inline_citations(
+    assertions: list[PlannedClaimAssert], actor: Actor
+) -> None:
     """Mint floating ``CitationInstance`` rows for *new* inline citations.
 
     For each assertion carrying ``inline_cites`` (a ``{numeric-handle:
@@ -356,7 +371,7 @@ def _materialize_inline_citations(assertions: list[PlannedClaimAssert]) -> None:
     owners: list[tuple[PlannedClaimAssert, CiteHandle]] = []
     for pca in cited:
         for handle, ref in pca.inline_cites.items():
-            source_id = _resolve_cite_source_id(ref, source_cache)
+            source_id = _resolve_cite_source_id(ref, source_cache, actor=actor)
             instances.append(CitationInstance(citation_source_id=source_id, claim=None))
             owners.append((pca, handle))
     CitationInstance.objects.mint_many(instances)  # assigns each ``.slug`` in place

--- a/backend/apps/claim_ingest/patches/planning.py
+++ b/backend/apps/claim_ingest/patches/planning.py
@@ -20,6 +20,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
 
+from apps.actors.models import Actor
 from apps.citation.source_node import SourceNode
 from apps.citation.source_upsert import (
     detect_host_collision,
@@ -900,7 +901,7 @@ def _plan_citation_sources(plan: IngestPlan, sources: list[SourceNode]) -> None:
             raise PatchError(
                 f"sources[{i}] ({node['name']!r}): {_format_validation_error(exc)}"
             ) from exc
-    plan.pre_write_hooks.append(_make_sources_hook(sources))
+    plan.pre_write_hooks.append(_make_sources_hook(sources, plan.source.actor))
     plan.dry_run_preview_hooks.append(_make_sources_preview_hook(sources))
 
 
@@ -915,18 +916,19 @@ def _format_validation_error(exc: ValidationError) -> str:
     )
 
 
-def _make_sources_hook(sources: list[SourceNode]) -> PreWriteHook:
+def _make_sources_hook(sources: list[SourceNode], actor: Actor) -> PreWriteHook:
     """Build the pre-write hook that upserts a patch's citation sources.
 
     The closure owns the catalog-side accounting: ``ensure_root_source`` is
     source-agnostic (plain ``list[str]`` sink + a result tuple), and the hook
     folds its result into the ``RunReport`` — keeping the catalog ``RunReport``
-    type out of the citation app.
+    type out of the citation app. ``actor`` is the patch's ``Source`` actor, so
+    the citation rows a patch creates are attributed to it.
     """
 
     def hook(report: RunReport) -> None:
         for node in sources:
-            result = ensure_root_source(node, warnings=report.warnings)
+            result = ensure_root_source(node, actor=actor, warnings=report.warnings)
             if result.source_created:
                 report.sources_created += 1
             else:

--- a/backend/apps/core/models/__init__.py
+++ b/backend/apps/core/models/__init__.py
@@ -2,7 +2,7 @@
 
 Implementation lives in submodules:
 
-- ``mixins`` — abstract bases (TimeStampedModel, AttributedModel,
+- ``mixins`` — abstract bases (TimeStampedModel,
   LastUpdatedModel,
   SluggedModel, LifecycleStatusModel, IdentifiableModel, LabeledModel,
   LabeledIdentityModel, LinkableModel, SitemappedModel), the EntityStatus
@@ -28,7 +28,6 @@ from .fields import BoundedTextField, MarkdownField
 from .license import License
 from .mixins import (
     LIFECYCLE_STATUS_FIELD,
-    AttributedModel,
     DescribedModel,
     EntityStatus,
     IdentifiableModel,
@@ -50,7 +49,6 @@ from .mixins import (
 from .references import RecordReference, register_reference_cleanup
 
 __all__ = [
-    "AttributedModel",
     "BoundedTextField",
     "DescribedModel",
     "EntityStatus",

--- a/backend/apps/core/models/mixins.py
+++ b/backend/apps/core/models/mixins.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable, Mapping
 from datetime import datetime
 from typing import ClassVar, Self, TypeVar, cast
 
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.expressions import Combinable
@@ -21,45 +20,6 @@ class TimeStampedModel(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True, db_default=Now())
     updated_at = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        abstract = True
-
-
-class AttributedModel(models.Model):
-    """Abstract base adding editorial attribution: who created / last updated.
-
-    Two nullable FKs to the user model (``created_by`` / ``updated_by``), both
-    ``SET_NULL`` so deleting a user never cascades away the rows they touched,
-    and ``related_name="+"`` because no reverse "things this user authored"
-    accessor is wanted. ``null`` because a row may be authored by no user — an
-    ingest/patch write has no acting user, leaving both null (ingest provenance
-    rides the ``ingest_run`` FK, not these columns).
-
-    This is *editorial* attribution for directly-edited, non-claims-controlled
-    models (the citation-source family). It is **not** the claims/provenance
-    system — claim-controlled catalog fields record authorship through
-    ``ChangeSet``/``Claim``, not here.
-
-    Callers set the fields explicitly (admin ``save_model``/``save_formset``,
-    the interactive API create paths); the base only declares the columns so the
-    two FK blocks aren't copy-pasted per model.
-    """
-
-    created_by = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        null=True,
-        blank=True,
-        on_delete=models.SET_NULL,
-        related_name="+",
-    )
-    updated_by = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        null=True,
-        blank=True,
-        on_delete=models.SET_NULL,
-        related_name="+",
-    )
 
     class Meta:
         abstract = True


### PR DESCRIPTION
## Summary

Repoint the citation-source family's editorial attribution (`created_by`/`updated_by`) from a FK to `User` to a FK to `Actor`, so data patches — and any future ingest/bot — attribute the citation sources they create instead of landing them with null authorship (the reason a backlog of patches was held off prod).

- Replace `core.AttributedModel` with `actors.ActorAttributedModel` (`created_by`/`updated_by` FK to `Actor`, `PROTECT`, nullable).
- Stamp the patch's `Source` actor through the `sources:` upsert and the inline `cite:` resolver; the interactive API and admin stamp `user.actor`.
- Staged expand/backfill/contract migrations move the FK target, then a backfill attributes legacy seed-ingest rows to the `flipcommons-catalog` source.
- `MigrationExecutor` round-trip tests guard the data move in both directions (including the reverse that clears source-backed attribution so a rollback below `provenance.0012` isn't blocked by the `PROTECT` FKs).

Note: tightening the columns to `NOT NULL` is a planned follow-up commit on this branch before shipping.

## Test plan

- [ ] `make test` — backend suite green, including the new attribution tests and migration round-trips
- [ ] Restore a pre-fix DB snapshot, run migrations, ingest the data patches, and confirm created citation rows attribute to the patch's `Source` actor (verified locally: restored `db.pre-0009`, migrated, ingested `flippatch/patches` → all 539 sources / 578 links / 59 domains attributed, 0 null)
