### PR TITLE
refactor(backend): name more latent types

### DIFF
--- a/backend/apps/accounts/api/profile_schemas.py
+++ b/backend/apps/accounts/api/profile_schemas.py
@@ -18,7 +18,7 @@ from django.db.models import Model
 from ninja import Schema
 from pydantic import Field
 
-from apps.core.authz import Activity
+from apps.core.authz import Activity, PolicyActivities
 from apps.core.schemas import EntityLinkSchema
 from apps.provenance.models import ChangeSet
 
@@ -36,7 +36,7 @@ class UserChangeSetSchema(Schema):
     entity: EntityLinkSchema
     capabilities: dict[Activity, bool] = Field(default_factory=dict)
 
-    policy_activities: ClassVar[tuple[Activity, ...]] = (Activity.CHANGESET_UNDO,)
+    policy_activities: ClassVar[PolicyActivities] = (Activity.CHANGESET_UNDO,)
     policy_target_model: ClassVar[type[Model]] = ChangeSet
 
 

--- a/backend/apps/accounts/backends.py
+++ b/backend/apps/accounts/backends.py
@@ -14,6 +14,8 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
 from django.http import HttpRequest
 
+from apps.core.types import UserId
+
 User = get_user_model()
 
 
@@ -25,7 +27,7 @@ class WorkOSBackend:
     ) -> None:
         return None
 
-    def get_user(self, user_id: int) -> AbstractBaseUser | None:
+    def get_user(self, user_id: UserId) -> AbstractBaseUser | None:
         # is_active filter: a disabled user stops being authenticated on the
         # very next request via AuthenticationMiddleware, no session flush
         # needed. UserBanning.md will tighten this with banned_at__isnull.

--- a/backend/apps/citation/api.py
+++ b/backend/apps/citation/api.py
@@ -26,6 +26,7 @@ from apps.core.api_helpers import authed_user
 from apps.core.authz.markers import requires
 from apps.core.authz.types import Activity
 from apps.core.schemas import ErrorDetailSchema
+from apps.core.types import CitationSourceId
 
 from .extraction import classify_input, extract_isbn, normalize_isbn
 from .extractors import (
@@ -320,7 +321,7 @@ def create_citation_source(
 
 
 def _mint_web_child(
-    parent_id: int, url: str, page_name: str, actor: Actor
+    parent_id: CitationSourceId, url: str, page_name: str, actor: Actor
 ) -> CitationSource:
     """Mint a page child via ``create_web_child``, mapping its error to a 422.
 

--- a/backend/apps/citation/extractors.py
+++ b/backend/apps/citation/extractors.py
@@ -33,6 +33,7 @@ from apps.citation.models import (
     CitationSourceLink,
     CitationSourceRootDomain,
 )
+from apps.core.types import CitationSourceId
 
 if TYPE_CHECKING:
     from apps.actors.models import Actor
@@ -108,7 +109,7 @@ class RecognitionChild:
     per-field ``None`` checks.
     """
 
-    id: int
+    id: CitationSourceId
     name: str
     skip_locator: bool = False
 
@@ -117,7 +118,7 @@ class RecognitionChild:
 class Recognition:
     """Result of recognizing a pasted URL."""
 
-    parent_id: int
+    parent_id: CitationSourceId
     parent_name: str
     child: RecognitionChild | None = None
     identifier: str | None = None
@@ -308,7 +309,7 @@ def web_child_name(url: str, name: str = "") -> str:
 
 
 def create_web_child(
-    parent_id: int,
+    parent_id: CitationSourceId,
     url: str,
     name: str = "",
     *,

--- a/backend/apps/claim_ingest/apply/claims.py
+++ b/backend/apps/claim_ingest/apply/claims.py
@@ -30,6 +30,7 @@ from apps.claim_ingest.plan import (
 from apps.core.models import LIFECYCLE_STATUS_FIELD
 from apps.core.types import ClaimIdentity
 from apps.provenance.models import Claim, ExistingClaimRow, Source
+from apps.provenance.types import ClaimId
 from apps.provenance.validation import validate_claims_batch
 
 
@@ -112,7 +113,7 @@ def _validate_and_collect_errors(
 def _diff_claims(
     valid_claims: list[Claim],
     source: Source,
-) -> tuple[list[Claim], list[int]]:
+) -> tuple[list[Claim], list[ClaimId]]:
     """Compare valid claims against existing active claims from the source.
 
     Returns ``(to_create, superseded_ids)`` where *superseded_ids* are PKs
@@ -145,7 +146,7 @@ def _diff_claims(
             )
 
     to_create: list[Claim] = []
-    superseded_ids: list[int] = []
+    superseded_ids: list[ClaimId] = []
 
     for claim in valid_claims:
         key = ClaimIdentity(claim.content_type_id, claim.object_id, claim.claim_key)

--- a/backend/apps/claim_ingest/apply/persist.py
+++ b/backend/apps/claim_ingest/apply/persist.py
@@ -31,6 +31,7 @@ from apps.claim_ingest.apply.claims import (
     _reject_empty_diff_provenance,
 )
 from apps.claim_ingest.plan import (
+    ChangedRelationshipFields,
     CitationRef,
     CiteHandle,
     EntryIndex,
@@ -41,22 +42,42 @@ from apps.claim_ingest.plan import (
     SchemeCitationRef,
     WebCitationRef,
 )
-from apps.core.types import ClaimIdentity, ContentTypeId, EntityKey
+from apps.core.types import (
+    CitationSourceId,
+    ClaimIdentity,
+    ContentTypeId,
+    EntityKey,
+)
 from apps.provenance.models import ChangeSet, Claim, ClaimControlledModel, IngestRun
+from apps.provenance.types import ClaimId
 
-# Per-entry / per-claim provenance maps produced by ``_collect_plan_provenance``
-# and consumed by ``_persist`` / ``_attach_plan_citations``. ``EntryNotes`` keys
-# each entry's note by its ``EntryIndex`` (one ChangeSet, one note per patch
-# entry); ``ClaimEntryIndex`` resolves a built claim back to its entry for
-# per-entry ChangeSet grouping; ``ClaimCitations`` keys per claim identity.
 type EntryNotes = dict[EntryIndex, str]
+"""Each patch entry's note keyed by its ``EntryIndex`` — one ChangeSet, one note
+per entry. Produced by ``_collect_plan_provenance``, consumed by ``_persist``."""
+
 type ClaimCitations = dict[ClaimIdentity, CitationRef]
+"""Per-claim ``CitationRef`` keyed by claim identity — never per entry, so a
+citation never bleeds onto unrelated claims sharing the entity. Produced by
+``_collect_plan_provenance``, consumed by ``_attach_plan_citations``."""
+
 type ClaimEntryIndex = dict[ClaimIdentity, EntryIndex]
+"""Resolves a built claim back to its authoring entry, for per-entry ChangeSet
+grouping. Produced by ``_collect_plan_provenance``, consumed by ``_persist``."""
+
+type CiteSourceCache = dict[CitationRef, CitationSourceId]
+"""Memoizes ``CitationRef`` → resolved ``CitationSource`` pk within one apply, so a
+cite reused across claims/footnotes resolves (and dedups) once. Threaded through
+``_resolve_cite_source_id`` by both the field-``cite:`` and inline-footnote paths."""
+
+type HandleMap = dict[Handle, EntityKey]
+"""Resolves each ``create:``'s temporary ``Handle`` to its real ``EntityKey``
+(ct_id, pk) after bulk-create. Produced by ``_create_entities``, threaded into
+``_patch_handles`` to patch handle-targeted assertions and identity refs."""
 
 
 def _create_entities(
     entities: list[PlannedEntityCreate],
-) -> dict[Handle, EntityKey]:
+) -> HandleMap:
     """Bulk-create entities.  Returns ``{handle: EntityKey(ct_id, pk)}``.
 
     Processes entities in list order, batching consecutive entries of the
@@ -70,7 +91,7 @@ def _create_entities(
     if not entities:
         return {}
 
-    handle_map: dict[Handle, EntityKey] = {}
+    handle_map: HandleMap = {}
 
     # Group consecutive entities of the same model class into batches.
     # A batch is flushed when the model class changes OR when an entity's
@@ -114,7 +135,7 @@ def _create_entities(
 
 def _patch_handles(
     assertions: list[PlannedClaimAssert],
-    handle_map: dict[Handle, EntityKey],
+    handle_map: HandleMap,
 ) -> None:
     """Resolve temporary handles to real PKs after entity creation.
 
@@ -254,8 +275,8 @@ def _cite_resolution_error(ref: CitationRef, exc: Exception) -> str:
 
 
 def _resolve_cite_source_id(
-    ref: CitationRef, cache: dict[CitationRef, int], *, actor: Actor
-) -> int:
+    ref: CitationRef, cache: CiteSourceCache, *, actor: Actor
+) -> CitationSourceId:
     """Resolve a ``CitationRef`` to a ``CitationSource`` pk, memoized via ``cache``.
 
     Shared by the field-level ``cite:`` path (:func:`_attach_plan_citations`) and
@@ -320,7 +341,7 @@ def _attach_plan_citations(
         return
     from apps.provenance.models import CitationInstance
 
-    source_cache: dict[CitationRef, int] = {}
+    source_cache: CiteSourceCache = {}
     instances: list[CitationInstance] = []
     for claim in to_create:
         ref = claim_citations.get(
@@ -366,7 +387,7 @@ def _materialize_inline_citations(
     # fields of one entry would mint one instance per field — the design's
     # per-field footnote semantics, not a shared one. Moot while every entity has
     # a single markdown field; intentional if that ever changes.
-    source_cache: dict[CitationRef, int] = {}
+    source_cache: CiteSourceCache = {}
     instances: list[CitationInstance] = []
     owners: list[tuple[PlannedClaimAssert, CiteHandle]] = []
     for pca in cited:
@@ -386,7 +407,7 @@ def _materialize_inline_citations(
 def _persist(
     run: IngestRun,
     to_create: list[Claim],
-    superseded_ids: list[int],
+    superseded_ids: list[ClaimId],
     retract_entries: list[RetractEntry],
     entry_notes: EntryNotes,
     claim_entry_index: ClaimEntryIndex,
@@ -489,7 +510,7 @@ def _persist_per_entry(
 def _resolve(
     to_create: list[Claim],
     retract_entries: list[RetractEntry],
-    changed_relationship_fields: dict[ContentTypeId, frozenset[str]],
+    changed_relationship_fields: ChangedRelationshipFields,
 ) -> None:
     """Materialise resolved values on affected entities.
 

--- a/backend/apps/claim_ingest/patches/emit.py
+++ b/backend/apps/claim_ingest/patches/emit.py
@@ -63,6 +63,12 @@ from apps.provenance.models import (
 )
 from apps.provenance.validation import get_relationship_schema
 
+type RelFieldsByModel = dict[type[LinkableClaimModel], set[Namespace]]
+"""Mutable accumulator of relationship namespaces touched per model class, built
+up across a patch's entries during emission. Keyed by model (not ``ContentTypeId``)
+because emission works in model space; ``build_plan`` converts it to the ct_id-keyed
+``ChangedRelationshipFields`` it stamps on the ``IngestPlan``."""
+
 
 class _RemovalResult(NamedTuple):
     """Outcome of ``_add_removals`` for one entry.
@@ -838,7 +844,7 @@ def _add_removals(
     ct_id: int,
     source: Source,
     rel_namespaces: frozenset[Namespace],
-    rel_fields_by_model: dict[type[LinkableClaimModel], set[str]],
+    rel_fields_by_model: RelFieldsByModel,
     *,
     note: str = "",
     citation_ref: CitationRef | None = None,

--- a/backend/apps/claim_ingest/patches/planning.py
+++ b/backend/apps/claim_ingest/patches/planning.py
@@ -33,6 +33,7 @@ from apps.claim_ingest.patches._types import (
     _Target,
 )
 from apps.claim_ingest.patches.emit import (
+    RelFieldsByModel,
     _add_create,
     _add_delete,
     _add_removals,
@@ -143,7 +144,7 @@ def build_plan(doc: PatchDoc, *, source: Source, patch_id: str) -> IngestPlan:
         records_parsed=len(doc.claims),
     )
     rel_namespaces = get_relationship_namespaces()
-    rel_fields_by_model: dict[type[LinkableClaimModel], set[str]] = defaultdict(set)
+    rel_fields_by_model: RelFieldsByModel = defaultdict(set)
     # The patch's symbol table: what entity each reference names — a committed
     # entity, a same-patch create, or neither. Replaces the three reference-
     # resolution paths the front end used to thread separately (a create→handle
@@ -423,7 +424,7 @@ def _process_entry(
     *,
     source: Source,
     rel_namespaces: frozenset[Namespace],
-    rel_fields_by_model: dict[type[LinkableClaimModel], set[str]],
+    rel_fields_by_model: RelFieldsByModel,
     registry: PatchEntityRegistry,
     all_created_ids: AbstractSet[_CreatedKey],
 ) -> _EntryResult:

--- a/backend/apps/claim_ingest/plan.py
+++ b/backend/apps/claim_ingest/plan.py
@@ -134,6 +134,12 @@ type Handle = str
 # ``frozenset[str]`` of valid namespaces.
 type Namespace = str
 
+# Per-content-type set of relationship namespaces a plan touched, keyed by the
+# affected entity's ``ContentTypeId``. The apply engine's ``_resolve`` hands each
+# set to the provenance bulk resolver to scope the relationship re-resolution pass
+# (scalars/FKs re-resolve regardless). Namespaces only — never scalar field names.
+type ChangedRelationshipFields = dict[ContentTypeId, frozenset[Namespace]]
+
 
 @dataclass
 class PlannedEntityCreate:
@@ -243,14 +249,7 @@ class IngestPlan:
     retractions: list[PlannedClaimRetract] = field(default_factory=list)
     records_parsed: int = 0
     records_matched: int = 0
-    # Per-content-type changed relationship namespaces, consumed by the apply
-    # engine's ``_resolve``: it dispatches each affected model to the provenance
-    # bulk resolver, passing this set so only the relationships a patch touched
-    # re-resolve (scalars re-resolve regardless). Relationship namespaces only —
-    # the bulk resolver rejects a scalar field name.
-    changed_relationship_fields: dict[ContentTypeId, frozenset[str]] = field(
-        default_factory=dict
-    )
+    changed_relationship_fields: ChangedRelationshipFields = field(default_factory=dict)
     # Side writes run first inside the apply transaction (before any entity
     # create), each handed the RunReport. Patch-only: citation source upserts.
     pre_write_hooks: list[PreWriteHook] = field(default_factory=list)

--- a/backend/apps/core/authz/__init__.py
+++ b/backend/apps/core/authz/__init__.py
@@ -11,6 +11,7 @@ from .types import (
     Decision,
     DenialCode,
     Deny,
+    PolicyActivities,
     PolicyContext,
     PolicyUser,
 )
@@ -22,6 +23,7 @@ __all__ = [
     "Decision",
     "DenialCode",
     "Deny",
+    "PolicyActivities",
     "PolicyContext",
     "PolicyDeniedError",
     "PolicyUser",

--- a/backend/apps/core/authz/checks.py
+++ b/backend/apps/core/authz/checks.py
@@ -5,7 +5,7 @@ mispairing crashes early instead of producing a wrong verdict on the
 wire — which is the worst place for it.
 
 A schema declares the target-aware activities whose verdicts it embeds
-via a ``ClassVar[tuple[Activity, ...]]`` named ``policy_activities``
+via a ``ClassVar[PolicyActivities]`` named ``policy_activities``
 (``list`` is also accepted, but ``tuple`` is the convention — the
 declaration is static and immutable in spirit). This check walks every
 ninja ``Schema`` subclass and asserts:

--- a/backend/apps/core/authz/types.py
+++ b/backend/apps/core/authz/types.py
@@ -42,6 +42,13 @@ class Activity(StrEnum):
     VIEW_ADMIN_AREA = "admin_area.view"
 
 
+type PolicyActivities = tuple[Activity, ...]
+"""The target-aware activities a Ninja Schema embeds row verdicts for, declared
+as its ``policy_activities`` ClassVar. Validated at ``manage.py check`` (see
+``apps.core.authz.checks``). A ClassVar, never a serialized field — so naming it
+stays off the wire."""
+
+
 class DenialCode(StrEnum):
     """Stable wire identifiers for denial reasons.
 

--- a/backend/apps/core/types.py
+++ b/backend/apps/core/types.py
@@ -78,6 +78,11 @@ type CitationSourceId = int
 """The primary key of a Citation Source — a citable work (book, web page) to
 which evidence (aka Citation Instances) attach."""
 
+type UserId = int
+"""The primary key of a User — the human account behind an interactive action.
+Distinct from an ``Actor`` (the provenance attribution); a claim's author is a
+User, but ingest-authored claims have a null one."""
+
 
 # ---------------------------------------------------------------------------
 # Identity tuples

--- a/backend/apps/media/api.py
+++ b/backend/apps/media/api.py
@@ -26,6 +26,7 @@ from apps.core.authz.types import Activity
 from apps.core.entity_types import get_linkable_model
 from apps.core.exceptions import StructuredValidationError
 from apps.core.schemas import ErrorDetailSchema, ValidationErrorSchema
+from apps.core.types import UserId
 from apps.media.constants import (
     ALLOWED_IMAGE_EXTENSIONS,
     DISPLAY_MAX_DIMENSION,
@@ -111,7 +112,7 @@ def _delete_media_storage_after_commit(storage_keys: list[str]) -> None:
         logger.exception("Storage cleanup failed for %d keys", len(storage_keys))
 
 
-def _check_rate_limit(user_id: int) -> None:
+def _check_rate_limit(user_id: UserId) -> None:
     """Best-effort per-user upload rate limiting via cache.
 
     Only checks the limit — does not increment. Call _incr_rate_limit()
@@ -123,7 +124,7 @@ def _check_rate_limit(user_id: int) -> None:
         raise HttpError(429, "Upload limit exceeded. Try again later.")
 
 
-def _incr_rate_limit(user_id: int) -> None:
+def _incr_rate_limit(user_id: UserId) -> None:
     """Increment the upload counter after a successful upload."""
     key = f"media_upload_count:{user_id}"
     try:

--- a/backend/apps/provenance/models/citation_instance.py
+++ b/backend/apps/provenance/models/citation_instance.py
@@ -13,6 +13,8 @@ from django.utils.crypto import get_random_string
 from apps.core.types import CitationSourceId
 from apps.core.validators import validate_no_mojibake
 
+from ..types import ClaimId
+
 CITATION_INSTANCE_LOCATOR_MAX_LENGTH = 200
 
 # Slug alphabet: lowercase consonants only (vowels dropped). Digit-free so a
@@ -111,7 +113,7 @@ class CitationInstance(models.Model):
     """
 
     citation_source_id: CitationSourceId
-    claim_id: int | None
+    claim_id: ClaimId | None
 
     slug = models.CharField(max_length=CITATION_SLUG_LENGTH, unique=True)
     citation_source = models.ForeignKey(

--- a/backend/apps/provenance/page_endpoints.py
+++ b/backend/apps/provenance/page_endpoints.py
@@ -23,7 +23,12 @@ from ninja import Field, Router, Schema
 from ninja.decorators import decorate_view
 from ninja.responses import Status
 
-from apps.core.authz import Activity, compute_row_capabilities, policy_user
+from apps.core.authz import (
+    Activity,
+    PolicyActivities,
+    compute_row_capabilities,
+    policy_user,
+)
 from apps.core.entity_types import get_linkable_model
 from apps.core.schemas import EntityLinkSchema
 from apps.core.types import EntityKey
@@ -63,7 +68,7 @@ class ChangeSetSummarySchema(ChangeSetWithEntitySchema):
     retractions_count: int
     capabilities: dict[Activity, bool] = Field(default_factory=dict)
 
-    policy_activities: ClassVar[tuple[Activity, ...]] = (Activity.CHANGESET_UNDO,)
+    policy_activities: ClassVar[PolicyActivities] = (Activity.CHANGESET_UNDO,)
     policy_target_model: ClassVar[type[Model]] = ChangeSet
 
 
@@ -77,7 +82,7 @@ class ChangeSetDetailSchema(ChangeSetWithEntitySchema):
     retractions: list[RetractionSchema]
     capabilities: dict[Activity, bool] = Field(default_factory=dict)
 
-    policy_activities: ClassVar[tuple[Activity, ...]] = (Activity.CHANGESET_UNDO,)
+    policy_activities: ClassVar[PolicyActivities] = (Activity.CHANGESET_UNDO,)
     policy_target_model: ClassVar[type[Model]] = ChangeSet
 
 
@@ -95,7 +100,7 @@ class CitedChangeSetSchema(ChangeSetBaseSchema):
     citations: list[CitedChangeSetCitationSchema]
     capabilities: dict[Activity, bool] = Field(default_factory=dict)
 
-    policy_activities: ClassVar[tuple[Activity, ...]] = (Activity.CHANGESET_UNDO,)
+    policy_activities: ClassVar[PolicyActivities] = (Activity.CHANGESET_UNDO,)
     policy_target_model: ClassVar[type[Model]] = ChangeSet
 
 

--- a/backend/apps/provenance/rate_limits.py
+++ b/backend/apps/provenance/rate_limits.py
@@ -47,7 +47,7 @@ from django.core.cache import cache
 
 from apps.core.authz import Activity, Allow, check, policy_user
 from apps.core.exceptions import StructuredApiError
-from apps.core.types import JsonBody
+from apps.core.types import JsonBody, UserId
 
 from .constants import (
     CREATE_RATE_LIMIT,
@@ -121,7 +121,7 @@ DELETE_RATE_LIMIT_SPEC = RateLimitSpec(
 )
 
 
-def _cache_key(user_id: int, bucket: str) -> str:
+def _cache_key(user_id: UserId, bucket: str) -> str:
     return f"ratelimit:{bucket}:user:{user_id}"
 
 

--- a/backend/apps/provenance/revert.py
+++ b/backend/apps/provenance/revert.py
@@ -31,6 +31,7 @@ from .changeset_writer import record_changeset
 from .constants import REVERT_OTHERS_MIN_EDITS
 from .models import ChangeSet, ChangeSetAction, Claim, ClaimControlledModel
 from .resolution import resolve_after_mutation
+from .types import ClaimId
 
 
 class RevertError(Exception):
@@ -46,7 +47,7 @@ class RevertError(Exception):
 
 
 def execute_revert(
-    entity: ClaimControlledModel, *, claim_id: int, user: User, note: str
+    entity: ClaimControlledModel, *, claim_id: ClaimId, user: User, note: str
 ) -> None:
     """Deactivate a single user claim and re-resolve the entity.
 

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -17,7 +17,7 @@ from typing import Annotated, ClassVar, Literal
 from django.db.models import Model
 from ninja import Field, Schema
 
-from apps.core.authz import Activity
+from apps.core.authz import Activity, PolicyActivities
 
 from .models import (
     CHANGESET_NOTE_MAX_LENGTH,
@@ -296,7 +296,7 @@ class ChangeSetSchema(ChangeSetBaseSchema):
     # Declared on each concrete row variant (not on the base) — the
     # ``authz.E101–E106`` system check reads these from ``__dict__``, so
     # inherited declarations don't trigger the structural check.
-    policy_activities: ClassVar[tuple[Activity, ...]] = (Activity.CHANGESET_UNDO,)
+    policy_activities: ClassVar[PolicyActivities] = (Activity.CHANGESET_UNDO,)
     policy_target_model: ClassVar[type[Model]] = ChangeSet
 
 

--- a/backend/apps/provenance/types.py
+++ b/backend/apps/provenance/types.py
@@ -21,6 +21,11 @@ type ChangeSetId = int
 """The primary key of a ChangeSet — the atomic, attributed edit in which a
 claim was written or retracted."""
 
+type ClaimId = int
+"""The primary key of a Claim row — one assertion's identity in the provenance
+ledger. Distinct from ``ClaimSubjectId`` (the entity the claim is *about*) and
+``ClaimKey`` (the slot it asserts); this names the assertion record itself."""
+
 type IngestRunId = int
 """The primary key of an IngestRun — the bulk import to which a change belongs,
 which marks it as ingested rather than interactively created by a human."""


### PR DESCRIPTION
## Summary

Replace repeated bare `int` / `dict` / `tuple` shapes across the citation, provenance and claim_ingest paths with named scalar aliases and compound types that document intent — while keeping aliases off the Ninja wire so they never surface as OpenAPI components.

- New scalar aliases: `ClaimId` (`provenance/types`), `UserId` (`core/types`), `PolicyActivities` (`authz/types`); applied `CitationSourceId` where it was still bare `int`.
- New compound types in the ingest apply path: `CiteSourceCache`, `HandleMap`, `ChangedRelationshipFields`, `RelFieldsByModel`.
- Each model pk alias lives in its owning app's `types.py` (or `core/types.py` for apps without one), per existing convention.
- Wire surfaces stay bare: route params and serialized `Schema` fields keep `int`/`str` (per docs/Python.md); only ClassVars and internal Python signatures take the alias. `capabilities: dict[Activity, bool]` left bare on the wire.

## Test plan

- [x] `make mypy` clean (507 files)
- [x] `ruff check` clean
- [x] `manage.py check` passes (validates `policy_activities` declarations)
- [x] `apps/core/tests/test_openapi_boundaries.py` passes — confirms no alias leaks into the generated OpenAPI schema
- [x] backend pytest passes (pre-commit)