### PR TITLE
refactor(citation): make editorial attribution non-null

### DIFF
--- a/backend/apps/accounts/test_factories.py
+++ b/backend/apps/accounts/test_factories.py
@@ -12,9 +12,14 @@ the literal value is what the test asserts on.
 from __future__ import annotations
 
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .models import User
+
+if TYPE_CHECKING:
+    from apps.actors.models import Actor
+
+_DEFAULT_ATTRIBUTOR = "test-attributor"  # <= 20 chars (username limit)
 
 
 def make_user(
@@ -35,3 +40,20 @@ def make_user(
         username = f"editor-{uuid.uuid4().hex[:8]}"
     overrides.setdefault("email_verified", True)
     return User.objects.create_user(email=email, username=username, **overrides)
+
+
+def default_actor() -> Actor:
+    """A shared default attribution ``Actor`` for tests needing an attributor.
+
+    Backed by one get-or-created default ``User`` — editorial attribution is
+    normally a person, and ``User`` is the actor backing the citation factories
+    can reach (``apps.provenance.Source`` sits a tier above them). Reused so
+    default test attribution funnels through one actor; tests asserting on real
+    attribution pass their own ``created_by`` instead.
+    """
+    user = User.objects.filter(username=_DEFAULT_ATTRIBUTOR).first()
+    if user is None:
+        user = make_user(
+            username=_DEFAULT_ATTRIBUTOR, email=f"{_DEFAULT_ATTRIBUTOR}@example.com"
+        )
+    return user.actor

--- a/backend/apps/actors/models/attributed.py
+++ b/backend/apps/actors/models/attributed.py
@@ -8,12 +8,13 @@ from django.db import models
 class ActorAttributedModel(models.Model):
     """Abstract base adding editorial attribution: who created / last updated.
 
-    Two nullable FKs to :class:`~apps.actors.models.actor.Actor`
+    Two required FKs to :class:`~apps.actors.models.actor.Actor`
     (``created_by`` / ``updated_by``), both ``PROTECT`` so the durable
     attribution anchor outlives the rows that reference it, and
     ``related_name="+"`` because no reverse "things this actor authored"
-    accessor is wanted. ``null`` because a row may be authored by no one — an
-    extractor-minted source can stay unattributed.
+    accessor is wanted. Non-null: every write path supplies an actor — the
+    interactive API and admin stamp ``user.actor``, and ingest stamps the
+    patch's ``source.actor`` — so a citation row always records its author.
 
     This is *editorial* attribution for directly-edited, non-claims-controlled
     models (the citation-source family). It is **not** the claims/provenance
@@ -30,15 +31,11 @@ class ActorAttributedModel(models.Model):
 
     created_by = models.ForeignKey(
         "actors.Actor",
-        null=True,
-        blank=True,
         on_delete=models.PROTECT,
         related_name="+",
     )
     updated_by = models.ForeignKey(
         "actors.Actor",
-        null=True,
-        blank=True,
         on_delete=models.PROTECT,
         related_name="+",
     )

--- a/backend/apps/catalog/tests/conftest.py
+++ b/backend/apps/catalog/tests/conftest.py
@@ -12,7 +12,11 @@ from apps.catalog.models import (
     Theme,
     Title,
 )
-from apps.citation.models import CitationSource
+from apps.citation.test_factories import (
+    make_citation_link,
+    make_citation_root_domain,
+    make_citation_source,
+)
 from apps.provenance.models import ClaimControlledModel, Source
 from apps.provenance.test_factories import make_claim
 
@@ -121,7 +125,7 @@ def source(db):
 @pytest.fixture
 def ipdb_root(db):
     """The root CitationSource for the ipdb scheme (children hang under it)."""
-    return CitationSource.objects.create(
+    return make_citation_source(
         name="Internet Pinball Database",
         source_type="web",
         identifier_key="ipdb",
@@ -131,9 +135,11 @@ def ipdb_root(db):
 @pytest.fixture
 def kineticist_root(db):
     """A non-scheme root web source with a homepage link, for domain matching."""
-    root = CitationSource.objects.create(name="Kineticist", source_type="web")
-    root.links.create(link_type="homepage", url="https://kineticist.com/")
-    root.root_domains.create(host="kineticist.com")  # the recognition signal
+    root = make_citation_source(name="Kineticist", source_type="web")
+    make_citation_link(
+        citation_source=root, link_type="homepage", url="https://kineticist.com/"
+    )
+    make_citation_root_domain(source=root, host="kineticist.com")  # recognition signal
     return root
 
 

--- a/backend/apps/catalog/tests/test_api_claims_additional_entities.py
+++ b/backend/apps/catalog/tests/test_api_claims_additional_entities.py
@@ -28,7 +28,7 @@ from apps.catalog.models import (
     Title,
 )
 from apps.catalog.tests.conftest import make_machine_model
-from apps.citation.models import CitationSource
+from apps.citation.test_factories import make_citation_source
 from apps.core.types import JsonBody
 from apps.provenance.attribution import actor_user
 from apps.provenance.models import ChangeSet, CitationInstance, Source
@@ -39,7 +39,7 @@ User = get_user_model()
 
 @pytest.fixture
 def citation_source(db):
-    return CitationSource.objects.create(
+    return make_citation_source(
         name="Replay Flyer",
         source_type="book",
         author="Staff",

--- a/backend/apps/catalog/tests/test_api_claims_model_relationships.py
+++ b/backend/apps/catalog/tests/test_api_claims_model_relationships.py
@@ -18,7 +18,7 @@ from apps.catalog.models import (
     TitleAbbreviation,
 )
 from apps.catalog.tests.conftest import make_machine_model
-from apps.citation.models import CitationSource
+from apps.citation.test_factories import make_citation_source
 from apps.provenance.models import ChangeSet
 from apps.provenance.test_factories import make_claim, user_changeset
 
@@ -82,7 +82,7 @@ def people(db):
 
 @pytest.fixture
 def citation_source(db):
-    return CitationSource.objects.create(name="Williams Flyer", source_type="web")
+    return make_citation_source(name="Williams Flyer", source_type="web")
 
 
 def _patch(client, slug, body):

--- a/backend/apps/catalog/tests/test_api_claims_title.py
+++ b/backend/apps/catalog/tests/test_api_claims_title.py
@@ -9,7 +9,7 @@ from django.contrib.auth import get_user_model
 
 from apps.catalog.models import Franchise, Title
 from apps.catalog.resolve import resolve_all_entities, resolve_relationship
-from apps.citation.models import CitationSource
+from apps.citation.test_factories import make_citation_source
 from apps.core.types import JsonBody
 from apps.provenance.claims import build_relationship_claim
 from apps.provenance.models import ChangeSet, Claim, Source
@@ -46,7 +46,7 @@ def source(db):
 
 @pytest.fixture
 def citation_source(db):
-    return CitationSource.objects.create(name="Williams Flyer", source_type="web")
+    return make_citation_source(name="Williams Flyer", source_type="web")
 
 
 def _patch(client, slug: str, body: JsonBody):

--- a/backend/apps/catalog/tests/test_api_export.py
+++ b/backend/apps/catalog/tests/test_api_export.py
@@ -14,6 +14,7 @@ from apps.catalog.api.export import (
 from apps.catalog.cache import invalidate_response_cache
 from apps.catalog.engine.aliases import discover_alias_types
 from apps.catalog.models import MachineModel
+from apps.citation.test_factories import make_citation_source
 from apps.provenance.test_factories import make_claim
 
 from .conftest import SAMPLE_IMAGES
@@ -119,10 +120,9 @@ class TestExportStripsInlineCitations:
         # Guards the export_inline=False decoupling: after cite became a
         # public-id type, the strip must still drop its [[cite:id:N]] storage
         # marker from the public dump (not leak it, not emit a resolved cite).
-        from apps.citation.models import CitationSource
         from apps.provenance.models import CitationInstance
 
-        src = CitationSource.objects.create(name="Book", source_type="book")
+        src = make_citation_source(name="Book", source_type="book")
         ci = CitationInstance.objects.create(citation_source=src)
         machine_model.description = f"A fact.[[cite:id:{ci.pk}]] More."
         machine_model.save()

--- a/backend/apps/catalog/tests/test_description_html.py
+++ b/backend/apps/catalog/tests/test_description_html.py
@@ -3,6 +3,7 @@
 import pytest
 
 from apps.catalog.models import Location, Manufacturer, System
+from apps.citation.test_factories import make_citation_link, make_citation_source
 from apps.core.models import RecordReference
 from apps.provenance.test_factories import make_claim
 
@@ -160,16 +161,15 @@ class TestDescriptionCitations:
     """API responses include inline citation metadata alongside rendered HTML."""
 
     def test_citations_present_in_response(self, client, db):
-        from apps.citation.models import CitationSource, CitationSourceLink
         from apps.provenance.models import CitationInstance
 
-        src = CitationSource.objects.create(
+        src = make_citation_source(
             name="The Complete Pinball Book",
             source_type="book",
             author="Marco Rossignoli",
             year=2002,
         )
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=src,
             url="https://example.com/book",
             label="Publisher",

--- a/backend/apps/catalog/tests/test_dump_patch_entry.py
+++ b/backend/apps/catalog/tests/test_dump_patch_entry.py
@@ -19,7 +19,7 @@ from django.core.management.base import CommandError
 
 from apps.catalog.models import MachineModel
 from apps.catalog.tests.conftest import make_machine_model
-from apps.citation.models import CitationSource
+from apps.citation.test_factories import make_citation_source
 from apps.claim_ingest.apply import apply_plan
 from apps.claim_ingest.patches import EditEntry, build_plan, load_patch
 from apps.core.markdown import convert_authoring_to_storage
@@ -78,9 +78,7 @@ def test_round_trip_byte_identity_with_adversarial_text(flipcommons_catalog):
     Byte-identity is style-independent, so correctness survives the readability
     cliff.
     """
-    src = CitationSource.objects.create(
-        name="IPDB", source_type="web", identifier_key="ipdb"
-    )
+    src = make_citation_source(name="IPDB", source_type="web", identifier_key="ipdb")
     ci1 = CitationInstance.objects.create(citation_source=src, claim=None)
     ci2 = CitationInstance.objects.create(citation_source=src, claim=None)
 

--- a/backend/apps/catalog/tests/test_patch_provenance.py
+++ b/backend/apps/catalog/tests/test_patch_provenance.py
@@ -15,6 +15,7 @@ from django.core.exceptions import ValidationError
 from apps.catalog.models import MachineModel, Manufacturer, Tag
 from apps.catalog.tests.conftest import make_machine_model
 from apps.citation.models import CitationSource
+from apps.citation.test_factories import make_citation_link, make_citation_source
 from apps.claim_ingest.apply import apply_plan
 from apps.claim_ingest.patches import (
     EditEntry,
@@ -716,10 +717,10 @@ def test_url_cite_reuses_preexisting_source(flipcommons_catalog, kineticist_root
     # web source is abstract and never a citation target) — re-citing its URL
     # resolves back to it via the children-only exact-link match.
     url = "https://kineticist.com/reviews/medieval-madness"
-    existing = CitationSource.objects.create(
+    existing = make_citation_source(
         name="Curated", source_type="web", parent=kineticist_root
     )
-    existing.links.create(link_type="reference", url=url)
+    make_citation_link(citation_source=existing, link_type="reference", url=url)
     text = (
         "attribution: flipcommons-catalog\n"
         "claims:\n"

--- a/backend/apps/catalog/tests/test_patches.py
+++ b/backend/apps/catalog/tests/test_patches.py
@@ -32,6 +32,11 @@ from apps.citation.models import (
     CitationSourceLink,
     CitationSourceRootDomain,
 )
+from apps.citation.test_factories import (
+    make_citation_link,
+    make_citation_root_domain,
+    make_citation_source,
+)
 from apps.claim_ingest.apply import apply_plan
 from apps.claim_ingest.patches import (
     EditEntry,
@@ -2615,10 +2620,10 @@ def _spanning_two_roots_patch() -> str:
     """Create two roots owning a.example / b.example and return a patch whose
     node's domains span both — the spans-two-roots collision precondition. NB:
     mutates the DB (the two roots) in addition to returning the patch text."""
-    a = CitationSource.objects.create(name="Root A", source_type="web")
-    CitationSourceRootDomain.objects.create(source=a, host="a.example")
-    b = CitationSource.objects.create(name="Root B", source_type="web")
-    CitationSourceRootDomain.objects.create(source=b, host="b.example")
+    a = make_citation_source(name="Root A", source_type="web")
+    make_citation_root_domain(source=a, host="a.example")
+    b = make_citation_source(name="Root B", source_type="web")
+    make_citation_root_domain(source=b, host="b.example")
     return (
         "attribution: flipcommons-catalog\n"
         "sources:\n"
@@ -2705,10 +2710,10 @@ def test_sources_reapply_identical_is_noop():
 
 def test_sources_preexisting_user_source_left_untouched():
     # A user-created collision must never fail or be overwritten.
-    user = CitationSource.objects.create(
+    user = make_citation_source(
         name="Wikipedia", source_type="web", description="user wrote this"
     )
-    CitationSourceLink.objects.create(
+    make_citation_link(
         citation_source=user,
         url="https://en.wikipedia.org/",
         label="Wikipedia",
@@ -2724,7 +2729,7 @@ def test_sources_preexisting_user_source_left_untouched():
 
 def test_sources_missing_link_backfilled_additively():
     # A bare existing root gets its declared homepage link added (additive).
-    CitationSource.objects.create(name="Wikipedia", source_type="web")
+    make_citation_source(name="Wikipedia", source_type="web")
     report = _apply(_WIKIPEDIA, patch_id="0001-backfill")
     assert report.sources_created == 0
     assert report.source_links_created == 1
@@ -2733,8 +2738,8 @@ def test_sources_missing_link_backfilled_additively():
 
 
 def test_sources_divergent_existing_link_left_and_warned():
-    src = CitationSource.objects.create(name="Wikipedia", source_type="web")
-    CitationSourceLink.objects.create(
+    src = make_citation_source(name="Wikipedia", source_type="web")
+    make_citation_link(
         citation_source=src,
         url="https://en.wikipedia.org/",
         label="Different label",
@@ -2749,8 +2754,8 @@ def test_sources_divergent_existing_link_left_and_warned():
 
 
 def test_sources_ambiguous_match_uses_first_and_warns():
-    CitationSource.objects.create(name="Wikipedia", source_type="web")
-    CitationSource.objects.create(name="Wikipedia", source_type="web")
+    make_citation_source(name="Wikipedia", source_type="web")
+    make_citation_source(name="Wikipedia", source_type="web")
     report = _apply(_WIKIPEDIA, patch_id="0001-ambig")
     assert report.sources_created == 0
     assert any("matched 2 rows" in w for w in report.warnings)
@@ -2761,10 +2766,8 @@ def test_sources_same_named_child_does_not_shadow_root():
     # A child sharing (name, source_type) with the declared root must NOT be
     # adopted: the patch creates the parentless root so later cites can nest
     # (recognize_url only sees homepage links on parentless sources).
-    farm = CitationSource.objects.create(name="Wiki Farm", source_type="web")
-    child = CitationSource.objects.create(
-        name="Wikipedia", source_type="web", parent=farm
-    )
+    farm = make_citation_source(name="Wiki Farm", source_type="web")
+    child = make_citation_source(name="Wikipedia", source_type="web", parent=farm)
     report = _apply(_WIKIPEDIA, patch_id="0001-no-shadow")
     assert report.sources_created == 1
     root = CitationSource.objects.get(
@@ -2778,8 +2781,8 @@ def test_sources_same_named_child_does_not_shadow_root():
 def test_sources_existing_row_passes_read_phase_validation():
     # Guards the validate_unique=False / exclude=citation_source exclusions:
     # a node matching an existing row + an in-memory link must NOT false-reject.
-    src = CitationSource.objects.create(name="Wikipedia", source_type="web")
-    CitationSourceLink.objects.create(
+    src = make_citation_source(name="Wikipedia", source_type="web")
+    make_citation_link(
         citation_source=src,
         url="https://en.wikipedia.org/",
         label="Wikipedia",
@@ -2827,7 +2830,7 @@ def test_sources_only_run_audit_not_zero():
 
 
 def test_link_only_backfill_audit_not_zero():
-    CitationSource.objects.create(name="Wikipedia", source_type="web")
+    make_citation_source(name="Wikipedia", source_type="web")
     _apply(_WIKIPEDIA, patch_id="0001-link-audit")
     run = IngestRun.objects.get(patch_id="0001-link-audit")
     assert run.status == IngestRun.Status.SUCCESS

--- a/backend/apps/citation/extractors.py
+++ b/backend/apps/citation/extractors.py
@@ -313,7 +313,7 @@ def create_web_child(
     url: str,
     name: str = "",
     *,
-    created_by: Actor | None = None,
+    created_by: Actor,
 ) -> CitationSource:
     """Mint a validated web-page child under *parent_id*, linked at *url*.
 
@@ -321,9 +321,9 @@ def create_web_child(
     malformed *url* is rejected by the ``URLField`` format check rather than
     silently stored. The display name follows the ``web_child_name`` rule.
 
-    ``created_by`` attributes both rows; ``None`` leaves ``created_by`` /
-    ``updated_by`` null. Raises ``ValidationError`` on invalid input. Atomic, so
-    a link that fails validation leaves no orphaned child behind.
+    ``created_by`` attributes both rows (required — citation attribution is
+    non-null). Raises ``ValidationError`` on invalid input. Atomic, so a link
+    that fails validation leaves no orphaned child behind.
     """
     with transaction.atomic():
         child = CitationSource(
@@ -351,7 +351,7 @@ def get_or_create_scheme_child(
     root: CitationSource,
     identifier: str,
     *,
-    created_by: Actor | None = None,
+    created_by: Actor,
 ) -> CitationSource:
     """Get-or-create the ``(root, identifier)`` scheme child under *root*.
 
@@ -360,9 +360,9 @@ def get_or_create_scheme_child(
     reuses its child. The child carries the ``{root.name} #{id}`` name and a
     canonical ``reference`` link, ``full_clean``d on first create.
 
-    ``created_by`` attributes the child; ``None`` leaves it null. Raises
-    ``ValueError`` if *root* carries no known ``identifier_key`` scheme or the
-    identifier is invalid for it.
+    ``created_by`` attributes the child (required — citation attribution is
+    non-null). Raises ``ValueError`` if *root* carries no known
+    ``identifier_key`` scheme or the identifier is invalid for it.
     """
     extractor = EXTRACTORS.get(root.identifier_key)
     if extractor is None:
@@ -414,7 +414,7 @@ def get_or_create_scheme_child(
 
 
 def get_or_create_external_source(
-    scheme: str, identifier: str, *, created_by: Actor | None = None
+    scheme: str, identifier: str, *, created_by: Actor
 ) -> CitationSource:
     """Get-or-create the child ``CitationSource`` for ``scheme:identifier``.
 
@@ -422,9 +422,10 @@ def get_or_create_external_source(
     get-or-creates the ``(root, identifier)`` child under it via
     ``get_or_create_scheme_child``.
 
-    ``created_by`` attributes a newly minted child; ``None`` leaves it null.
-    Raises ``CitationSource.DoesNotExist`` if no root for *scheme* is seeded,
-    and ``ValueError`` if the scheme or identifier is invalid.
+    ``created_by`` attributes a newly minted child (required — citation
+    attribution is non-null). Raises ``CitationSource.DoesNotExist`` if no root
+    for *scheme* is seeded, and ``ValueError`` if the scheme or identifier is
+    invalid.
     """
     if scheme not in EXTRACTORS:
         raise ValueError(f"Unknown citation scheme {scheme!r}")
@@ -444,7 +445,7 @@ def get_or_create_external_source(
 
 
 def get_or_create_web_source(
-    url: str, archive_url: str = "", *, created_by: Actor | None = None
+    url: str, archive_url: str = "", *, created_by: Actor
 ) -> CitationSource:
     """Get-or-create the web ``CitationSource`` a raw ``url`` cites.
 
@@ -487,7 +488,7 @@ def get_or_create_web_source(
     scheme path.
 
     ``created_by`` attributes a newly minted child and archive link (the citing
-    patch's Source actor); ``None`` leaves them null.
+    patch's Source actor; required — citation attribution is non-null).
     """
     with transaction.atomic():
         # Children only: a root's own homepage link can equal the cited URL, but

--- a/backend/apps/citation/migrations/0012_tighten_attribution_not_null.py
+++ b/backend/apps/citation/migrations/0012_tighten_attribution_not_null.py
@@ -1,0 +1,40 @@
+"""Tighten: make editorial attribution non-null.
+
+Every write path now stamps an actor (interactive API/admin -> user.actor,
+ingest -> source.actor) and 0011 attributed the legacy seed-ingest rows to the
+flipcommons-catalog source, so no null ``created_by``/``updated_by`` remain.
+Enforce that at the schema level — a citation row must record its author.
+
+Hand-authored: ``makemigrations`` prompts for a one-off default on the
+nullable -> non-null change, which 0011 has already made unnecessary; this is
+the plain ``AlterField`` it would otherwise emit.
+"""
+
+from __future__ import annotations
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def _non_null_actor_fk():
+    return models.ForeignKey(
+        on_delete=django.db.models.deletion.PROTECT,
+        related_name="+",
+        to="actors.actor",
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("citation", "0011_attribute_seed_citation_sources"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name=model,
+            name=field,
+            field=_non_null_actor_fk(),
+        )
+        for model in ("citationsource", "citationsourcelink", "citationsourcerootdomain")
+        for field in ("created_by", "updated_by")
+    ]

--- a/backend/apps/citation/source_upsert.py
+++ b/backend/apps/citation/source_upsert.py
@@ -324,8 +324,12 @@ def validate_root_source(node: SourceNode) -> None:
         CitationSourceRootDomain,
     )
 
+    # Validate field/host shape only — ``created_by``/``updated_by`` are stamped
+    # at write time (``ensure_root_source``), not on these throwaway instances,
+    # so exclude them from the non-null check alongside the unset parent FK.
+    attribution = ["created_by", "updated_by"]
     source = CitationSource(**_source_fields(node))
-    source.full_clean(validate_unique=False)
+    source.full_clean(exclude=attribution, validate_unique=False)
 
     seen_urls: set[str] = set()
     for link in node.get("links", []):
@@ -338,11 +342,11 @@ def validate_root_source(node: SourceNode) -> None:
             label=link.get("label", ""),
             link_type=link["link_type"],
         )
-        obj.full_clean(exclude=["citation_source"], validate_unique=False)
+        obj.full_clean(exclude=["citation_source", *attribution], validate_unique=False)
 
     for host in _declared_recognition_hosts(node):
         domain = CitationSourceRootDomain(host=host)
-        domain.full_clean(exclude=["source"], validate_unique=False)
+        domain.full_clean(exclude=["source", *attribution], validate_unique=False)
 
 
 def detect_host_collision(node: SourceNode) -> str | None:

--- a/backend/apps/citation/test_factories.py
+++ b/backend/apps/citation/test_factories.py
@@ -1,0 +1,93 @@
+"""Test-only factories for the citation-source family.
+
+Kept outside ``tests/`` so test helpers can be imported across apps without
+circular dependencies or duplicated conftest fixtures.
+
+Use these instead of constructing the models directly. ``created_by`` /
+``updated_by`` are non-null (``ActorAttributedModel``), so each factory stamps
+:func:`default_actor` by default — encoding the attribution invariant in one
+place so a forgotten actor can't slip into ``.objects.create``. Pass
+``created_by=`` to attribute to a specific actor. Required FKs/fields default to
+disposable values (mirroring ``make_machine_model``), so a bare
+``make_citation_*()`` is a valid row.
+
+The attribution fields are typed (``Actor``); the long-tail model fields ride
+through ``**overrides`` typed by the model itself (its columns are the source of
+truth — re-declaring them in a ``TypedDict`` here would only drift from it).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from apps.accounts.test_factories import default_actor
+from apps.actors.models import Actor
+from apps.citation.models import (
+    CitationSource,
+    CitationSourceLink,
+    CitationSourceRootDomain,
+)
+
+
+def make_citation_source(
+    *,
+    name: str = "Test Citation Source",
+    source_type: str = CitationSource.SourceType.WEB,
+    created_by: Actor | None = None,
+    updated_by: Actor | None = None,
+    **overrides: Any,  # noqa: ANN401 - long-tail CitationSource fields, typed by the model.
+) -> CitationSource:
+    """Create a ``CitationSource`` for tests, defaulting name/source_type/actor."""
+    created_by = created_by or default_actor()
+    return CitationSource.objects.create(
+        name=name,
+        source_type=source_type,
+        created_by=created_by,
+        updated_by=updated_by or created_by,
+        **overrides,
+    )
+
+
+def make_citation_link(
+    *,
+    citation_source: CitationSource | None = None,
+    url: str | None = None,
+    link_type: str = CitationSourceLink.LinkType.HOMEPAGE,
+    created_by: Actor | None = None,
+    updated_by: Actor | None = None,
+    **overrides: Any,  # noqa: ANN401 - long-tail CitationSourceLink fields, typed by the model.
+) -> CitationSourceLink:
+    """Create a ``CitationSourceLink`` for tests, auto-providing a source and url."""
+    created_by = created_by or default_actor()
+    if url is None:  # default only when omitted — an explicit "" tests the constraint
+        url = f"https://example.com/{uuid.uuid4().hex[:8]}"
+    return CitationSourceLink.objects.create(
+        citation_source=citation_source or make_citation_source(),
+        url=url,
+        link_type=link_type,
+        created_by=created_by,
+        updated_by=updated_by or created_by,
+        **overrides,
+    )
+
+
+def make_citation_root_domain(
+    *,
+    source: CitationSource | None = None,
+    host: str | None = None,
+    created_by: Actor | None = None,
+    updated_by: Actor | None = None,
+    **overrides: Any,  # noqa: ANN401 - long-tail CitationSourceRootDomain fields, typed by the model.
+) -> CitationSourceRootDomain:
+    """Create a ``CitationSourceRootDomain`` for tests, auto-providing a root and host."""
+    created_by = created_by or default_actor()
+    if host is None:  # default only when omitted — an explicit "" tests the constraint
+        host = f"example-{uuid.uuid4().hex[:8]}.com"
+    return CitationSourceRootDomain.objects.create(
+        source=source or make_citation_source(),
+        host=host,
+        created_by=created_by,
+        updated_by=updated_by or created_by,
+        **overrides,
+    )

--- a/backend/apps/citation/tests/conftest.py
+++ b/backend/apps/citation/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client
 
-from apps.citation.models import CitationSource, CitationSourceLink
+from apps.citation.test_factories import make_citation_link, make_citation_source
 
 User = get_user_model()
 
@@ -15,7 +15,7 @@ def client():
 @pytest.fixture
 def citation_source(db):
     """Minimal CitationSource — name + source_type only."""
-    return CitationSource.objects.create(
+    return make_citation_source(
         name="The Encyclopedia of Pinball",
         source_type="book",
     )
@@ -24,7 +24,7 @@ def citation_source(db):
 @pytest.fixture
 def citation_source_full(db):
     """CitationSource with all optional fields populated."""
-    return CitationSource.objects.create(
+    return make_citation_source(
         name="The Encyclopedia of Pinball - Edition 1",
         source_type="book",
         author="Richard Bueschel",
@@ -41,7 +41,7 @@ def citation_source_full(db):
 @pytest.fixture
 def citation_source_with_parent(db, citation_source):
     """A child CitationSource with parent set."""
-    return CitationSource.objects.create(
+    return make_citation_source(
         name="The Encyclopedia of Pinball - Edition 1",
         source_type="book",
         parent=citation_source,
@@ -51,7 +51,7 @@ def citation_source_with_parent(db, citation_source):
 @pytest.fixture
 def citation_source_link(db, citation_source):
     """CitationSourceLink on citation_source."""
-    return CitationSourceLink.objects.create(
+    return make_citation_link(
         citation_source=citation_source,
         link_type="homepage",
         url="https://archive.org/details/encyclopedia-of-pinball",

--- a/backend/apps/citation/tests/test_admin.py
+++ b/backend/apps/citation/tests/test_admin.py
@@ -7,6 +7,7 @@ from django.contrib import admin
 from django.forms import inlineformset_factory
 from django.test import RequestFactory
 
+from apps.accounts.test_factories import default_actor
 from apps.citation.admin import (
     CitationSourceAdmin,
     CitationSourceRootDomainInline,
@@ -16,6 +17,7 @@ from apps.citation.models import (
     CitationSourceLink,
     CitationSourceRootDomain,
 )
+from apps.citation.test_factories import make_citation_link, make_citation_root_domain
 
 LinkFormSetCreate: Any = inlineformset_factory(
     CitationSource,
@@ -123,8 +125,8 @@ class TestCitationSourceAdminAttribution:
         request.user = superuser
         admin_instance.save_model(request, citation_source, form=None, change=True)
         assert citation_source.updated_by == superuser.actor
-        # created_by should not be overwritten on change
-        assert citation_source.created_by is None
+        # created_by should not be overwritten on change — stays the fixture's actor
+        assert citation_source.created_by == default_actor()
 
 
 class TestCitationSourceLinkInlineAttribution:
@@ -154,13 +156,13 @@ class TestCitationSourceLinkInlineAttribution:
     def test_updated_by_set_on_existing_link(
         self, admin_instance, request_factory, superuser, citation_source
     ):
-        link = CitationSourceLink.objects.create(
+        link = make_citation_link(
             citation_source=citation_source,
             link_type="homepage",
             url="https://example.com",
             label="Old Label",
         )
-        assert link.created_by is None
+        assert link.created_by == default_actor()
 
         data = {
             "links-TOTAL_FORMS": "1",
@@ -179,8 +181,8 @@ class TestCitationSourceLinkInlineAttribution:
 
         link.refresh_from_db()
         assert link.updated_by == superuser.actor
-        # created_by should NOT be set on update of existing record
-        assert link.created_by is None
+        # created_by should NOT be overwritten on update — stays the fixture's actor
+        assert link.created_by == default_actor()
 
 
 class TestCitationSourceRootDomainInline:
@@ -216,9 +218,7 @@ class TestCitationSourceRootDomainInline:
     ):
         # Removing an alias is a first-class use of this inline; exercise the
         # formset.deleted_objects path end to end.
-        domain = CitationSourceRootDomain.objects.create(
-            source=citation_source, host="example.com"
-        )
+        domain = make_citation_root_domain(source=citation_source, host="example.com")
         data = {
             "root_domains-TOTAL_FORMS": "1",
             "root_domains-INITIAL_FORMS": "1",

--- a/backend/apps/citation/tests/test_api.py
+++ b/backend/apps/citation/tests/test_api.py
@@ -17,6 +17,11 @@ from apps.citation.models import (
     CitationSourceLink,
     CitationSourceRootDomain,
 )
+from apps.citation.test_factories import (
+    make_citation_link,
+    make_citation_root_domain,
+    make_citation_source,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -97,7 +102,7 @@ class TestSearchCitationSources:
 
     def test_search_max_20_results(self, client, user, db):
         for i in range(25):
-            CitationSource.objects.create(name=f"Test Source {i}", source_type="book")
+            make_citation_source(name=f"Test Source {i}", source_type="book")
         client.force_login(user)
         resp = client.get("/api/citation-sources/search/?q=Test Source")
         assert resp.status_code == 200
@@ -126,7 +131,7 @@ class TestSearchCitationSources:
 
     def test_search_returns_identifier_key(self, client, user, db):
         """Search results include identifier_key when set on the source."""
-        CitationSource.objects.create(
+        make_citation_source(
             name="Internet Pinball Database",
             source_type="web",
             identifier_key="ipdb",
@@ -151,16 +156,16 @@ class TestSearchRecognition:
 
     def test_ipdb_url_recognized_with_existing_child(self, client, user, db):
         """Pasting an IPDB URL finds the parent and existing child."""
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="IPDB #4443",
             source_type="web",
             parent=parent,
             identifier="4443",
         )
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=child,
             link_type="homepage",
             url="https://www.ipdb.org/machine.cgi?id=4443",
@@ -179,9 +184,7 @@ class TestSearchRecognition:
 
     def test_ipdb_url_recognized_no_child(self, client, user, db):
         """Pasting an IPDB URL for a non-existent child returns parent + identifier."""
-        CitationSource.objects.create(
-            name="IPDB", source_type="web", identifier_key="ipdb"
-        )
+        make_citation_source(name="IPDB", source_type="web", identifier_key="ipdb")
         client.force_login(user)
         resp = client.get(
             "/api/citation-sources/search/?q=https://www.ipdb.org/machine.cgi?id=9999"
@@ -195,12 +198,8 @@ class TestSearchRecognition:
 
     def test_domain_match_jjp_url(self, client, user, db):
         """Pasting a JJP URL domain-matches to the Jersey Jack parent."""
-        jjp = CitationSource.objects.create(
-            name="Jersey Jack Pinball", source_type="web"
-        )
-        CitationSourceRootDomain.objects.create(
-            source=jjp, host="jerseyjackpinball.com"
-        )
+        jjp = make_citation_source(name="Jersey Jack Pinball", source_type="web")
+        make_citation_root_domain(source=jjp, host="jerseyjackpinball.com")
         client.force_login(user)
         resp = client.get(
             "/api/citation-sources/search/"
@@ -215,21 +214,17 @@ class TestSearchRecognition:
 
     def test_full_url_matches_existing_child_link(self, client, user, db):
         """Re-pasting a URL that matches an existing child's link returns it."""
-        parent = CitationSource.objects.create(
-            name="Jersey Jack Pinball", source_type="web"
-        )
-        CitationSourceLink.objects.create(
+        parent = make_citation_source(name="Jersey Jack Pinball", source_type="web")
+        make_citation_link(
             citation_source=parent,
             link_type="homepage",
             url="https://www.jerseyjackpinball.com/",
         )
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="Elton John Pinball", source_type="web", parent=parent
         )
         url = "https://jerseyjackpinball.com/products/elton-john"
-        CitationSourceLink.objects.create(
-            citation_source=child, link_type="homepage", url=url
-        )
+        make_citation_link(citation_source=child, link_type="homepage", url=url)
         client.force_login(user)
         resp = client.get(f"/api/citation-sources/search/?q={url}")
         data = resp.json()
@@ -250,10 +245,8 @@ class TestSearchRecognition:
         """A malformed host whose ancestor suffix matches a seeded root still
         yields no recognition — /search/ must not surface a confident-but-wrong
         page for garbage input (the read surface has no write-time URL guard)."""
-        root = CitationSource.objects.create(name="American Pinball", source_type="web")
-        CitationSourceRootDomain.objects.create(
-            source=root, host="american-pinball.com"
-        )
+        root = make_citation_source(name="American Pinball", source_type="web")
+        make_citation_root_domain(source=root, host="american-pinball.com")
         client.force_login(user)
         resp = client.get(
             "/api/citation-sources/search/?q=https://www..american-pinball.com/m.pdf"
@@ -270,12 +263,10 @@ class TestSearchRecognition:
 
     def test_subdomain_resolves_to_most_specific_root(self, client, user, db):
         """twip.kineticist.com resolves to the TWiP root, not kineticist.com."""
-        kineticist = CitationSource.objects.create(name="Kineticist", source_type="web")
-        CitationSourceRootDomain.objects.create(
-            source=kineticist, host="kineticist.com"
-        )
-        twip = CitationSource.objects.create(name="TWiP", source_type="web")
-        CitationSourceRootDomain.objects.create(source=twip, host="twip.kineticist.com")
+        kineticist = make_citation_source(name="Kineticist", source_type="web")
+        make_citation_root_domain(source=kineticist, host="kineticist.com")
+        twip = make_citation_source(name="TWiP", source_type="web")
+        make_citation_root_domain(source=twip, host="twip.kineticist.com")
         client.force_login(user)
         resp = client.get(
             "/api/citation-sources/search/?q=https://twip.kineticist.com/some-article"
@@ -289,8 +280,8 @@ class TestSearchRecognition:
 
         A source with only a reference link (no root-domain row) is not matched.
         """
-        source = CitationSource.objects.create(name="Some Source", source_type="web")
-        CitationSourceLink.objects.create(
+        source = make_citation_source(name="Some Source", source_type="web")
+        make_citation_link(
             citation_source=source,
             link_type="reference",
             url="https://en.wikipedia.org/wiki/Pinball",
@@ -307,7 +298,7 @@ class TestSearchComputedFields:
 
     def test_root_book_no_children(self, client, user, db):
         """A standalone book: not abstract, needs locator."""
-        CitationSource.objects.create(name="Solo Book", source_type="book")
+        make_citation_source(name="Solo Book", source_type="book")
         client.force_login(user)
         resp = client.get("/api/citation-sources/search/?q=Solo Book")
         data = resp.json()["results"][0]
@@ -316,10 +307,8 @@ class TestSearchComputedFields:
 
     def test_root_book_with_children(self, client, user, db):
         """A book with editions: abstract."""
-        parent = CitationSource.objects.create(name="Big Book", source_type="book")
-        CitationSource.objects.create(
-            name="Big Book Ed. 1", source_type="book", parent=parent
-        )
+        parent = make_citation_source(name="Big Book", source_type="book")
+        make_citation_source(name="Big Book Ed. 1", source_type="book", parent=parent)
         client.force_login(user)
         resp = client.get("/api/citation-sources/search/?q=Big Book")
         results = {r["id"]: r for r in resp.json()["results"]}
@@ -329,7 +318,7 @@ class TestSearchComputedFields:
 
     def test_root_web_source(self, client, user, db):
         """A root web source (e.g. IPDB): abstract."""
-        CitationSource.objects.create(
+        make_citation_source(
             name="Internet Pinball Database",
             source_type="web",
             identifier_key="ipdb",
@@ -342,7 +331,7 @@ class TestSearchComputedFields:
 
     def test_root_web_source_without_identifier_key(self, client, user, db):
         """A root web source without an identifier scheme: abstract."""
-        CitationSource.objects.create(name="Jersey Jack Pinball", source_type="web")
+        make_citation_source(name="Jersey Jack Pinball", source_type="web")
         client.force_login(user)
         resp = client.get("/api/citation-sources/search/?q=Jersey Jack")
         data = resp.json()["results"][0]
@@ -351,10 +340,10 @@ class TestSearchComputedFields:
 
     def test_child_web_source(self, client, user, db):
         """A child web source (e.g. IPDB machine page): skip locator."""
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="Internet Pinball Database", source_type="web"
         )
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="IPDB Machine 4836", source_type="web", parent=parent
         )
         client.force_login(user)
@@ -366,7 +355,7 @@ class TestSearchComputedFields:
 
     def test_root_magazine(self, client, user, db):
         """A root magazine: abstract."""
-        CitationSource.objects.create(name="Pinball Magazine", source_type="magazine")
+        make_citation_source(name="Pinball Magazine", source_type="magazine")
         client.force_login(user)
         resp = client.get("/api/citation-sources/search/?q=Pinball Magazine")
         data = resp.json()["results"][0]
@@ -724,8 +713,8 @@ class TestCiteUrl:
 
     def test_domain_match_nests_child_and_ignores_site_fields(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(name="Existing", source_type="web")
-        CitationSourceRootDomain.objects.create(source=root, host="existing.example")
+        root = make_citation_source(name="Existing", source_type="web")
+        make_citation_root_domain(source=root, host="existing.example")
         resp = _post(
             client,
             self.URL,
@@ -759,10 +748,8 @@ class TestCiteUrl:
         # root, so the cite nests a child *under* american-pinball.com rather
         # than minting a second root.
         client.force_login(user)
-        root = CitationSource.objects.create(name="American Pinball", source_type="web")
-        CitationSourceRootDomain.objects.create(
-            source=root, host="american-pinball.com"
-        )
+        root = make_citation_source(name="American Pinball", source_type="web")
+        make_citation_root_domain(source=root, host="american-pinball.com")
         resp = _post(
             client,
             self.URL,
@@ -778,12 +765,10 @@ class TestCiteUrl:
 
     def test_exact_child_is_reused(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(name="Existing", source_type="web")
-        CitationSourceRootDomain.objects.create(source=root, host="existing.example")
-        child = CitationSource.objects.create(
-            name="Page", source_type="web", parent=root
-        )
-        CitationSourceLink.objects.create(
+        root = make_citation_source(name="Existing", source_type="web")
+        make_citation_root_domain(source=root, host="existing.example")
+        child = make_citation_source(name="Page", source_type="web", parent=root)
+        make_citation_link(
             citation_source=child,
             link_type="reference",
             url="https://existing.example/page",
@@ -796,9 +781,7 @@ class TestCiteUrl:
 
     def test_scheme_url_returns_422(self, client, user):
         client.force_login(user)
-        CitationSource.objects.create(
-            name="IPDB", source_type="web", identifier_key="ipdb"
-        )
+        make_citation_source(name="IPDB", source_type="web", identifier_key="ipdb")
         resp = _post(
             client,
             self.URL,
@@ -816,13 +799,13 @@ class TestCiteUrl:
         ``scheme:identifier`` — not silently reuse the child.
         """
         client.force_login(user)
-        root = CitationSource.objects.create(
+        root = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="IPDB #4443", source_type="web", parent=root, identifier="4443"
         )
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=child,
             link_type="reference",
             url="https://www.ipdb.org/machine.cgi?id=4443",
@@ -871,7 +854,7 @@ class TestCiteUrl:
         the racer committed.
         """
         client.force_login(user)
-        racer = CitationSource.objects.create(name="Racer", source_type="web")
+        racer = make_citation_source(name="Racer", source_type="web")
 
         def raise_integrity(self, *args, **kwargs):
             raise IntegrityError("duplicate key value violates unique constraint")
@@ -938,10 +921,10 @@ class TestGetCitationSourceDetail:
 
     def test_detail_includes_skip_locator(self, client, user, db):
         """Detail response includes skip_locator field."""
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="Internet Pinball Database", source_type="web"
         )
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="IPDB Machine 1000", source_type="web", parent=parent
         )
         client.force_login(user)
@@ -958,12 +941,10 @@ class TestGetCitationSourceDetail:
 
     def test_detail_children_include_skip_locator(self, client, user, db):
         """Children in detail response include skip_locator."""
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="Internet Pinball Database", source_type="web"
         )
-        CitationSource.objects.create(
-            name="IPDB Machine 2000", source_type="web", parent=parent
-        )
+        make_citation_source(name="IPDB Machine 2000", source_type="web", parent=parent)
         client.force_login(user)
         resp = client.get(f"/api/citation-sources/{parent.pk}/")
         data = resp.json()
@@ -972,13 +953,13 @@ class TestGetCitationSourceDetail:
 
     def test_detail_children_include_urls(self, client, user, db):
         """Children in detail response include their link URLs."""
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="Internet Pinball Database", source_type="web"
         )
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="IPDB Machine 3000", source_type="web", parent=parent
         )
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=child,
             link_type="homepage",
             url="https://www.ipdb.org/machine.cgi?id=3000",
@@ -993,10 +974,8 @@ class TestGetCitationSourceDetail:
 
     def test_detail_children_urls_empty_when_no_links(self, client, user, db):
         """Children with no links have an empty urls list."""
-        parent = CitationSource.objects.create(name="Big Book", source_type="book")
-        CitationSource.objects.create(
-            name="Edition 1", source_type="book", parent=parent
-        )
+        parent = make_citation_source(name="Big Book", source_type="book")
+        make_citation_source(name="Edition 1", source_type="book", parent=parent)
         client.force_login(user)
         resp = client.get(f"/api/citation-sources/{parent.pk}/")
         data = resp.json()
@@ -1017,27 +996,23 @@ class TestListChildren:
         assert resp.status_code in (401, 403)
 
     def test_empty_q_returns_empty_list(self, client, user, db):
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="Internet Pinball Database", source_type="web"
         )
-        CitationSource.objects.create(
-            name="IPDB Machine 1000", source_type="web", parent=parent
-        )
+        make_citation_source(name="IPDB Machine 1000", source_type="web", parent=parent)
         client.force_login(user)
         resp = client.get(f"/api/citation-sources/{parent.pk}/children/?q=")
         assert resp.status_code == 200
         assert resp.json() == []
 
     def test_filter_by_child_name(self, client, user, db):
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="Internet Pinball Database", source_type="web"
         )
-        match = CitationSource.objects.create(
+        match = make_citation_source(
             name="IPDB Machine 4836", source_type="web", parent=parent
         )
-        CitationSource.objects.create(
-            name="IPDB Machine 9999", source_type="web", parent=parent
-        )
+        make_citation_source(name="IPDB Machine 9999", source_type="web", parent=parent)
         client.force_login(user)
         resp = client.get(f"/api/citation-sources/{parent.pk}/children/?q=4836")
         assert resp.status_code == 200
@@ -1046,20 +1021,18 @@ class TestListChildren:
         assert results[0]["id"] == match.pk
 
     def test_filter_by_child_url(self, client, user, db):
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="Internet Pinball Database", source_type="web"
         )
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="IPDB Machine 4836", source_type="web", parent=parent
         )
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=child,
             link_type="homepage",
             url="https://www.ipdb.org/machine.cgi?id=4836",
         )
-        CitationSource.objects.create(
-            name="IPDB Machine 9999", source_type="web", parent=parent
-        )
+        make_citation_source(name="IPDB Machine 9999", source_type="web", parent=parent)
         client.force_login(user)
         resp = client.get(
             f"/api/citation-sources/{parent.pk}/children/?q=ipdb.org/machine.cgi?id=4836"
@@ -1071,13 +1044,13 @@ class TestListChildren:
         assert results[0]["urls"] == ["https://www.ipdb.org/machine.cgi?id=4836"]
 
     def test_response_shape_matches_child_schema(self, client, user, db):
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="Internet Pinball Database", source_type="web"
         )
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="IPDB Machine 5000", source_type="web", parent=parent, year=2020
         )
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=child,
             link_type="homepage",
             url="https://www.ipdb.org/machine.cgi?id=5000",
@@ -1096,11 +1069,11 @@ class TestListChildren:
         }
 
     def test_max_20_results(self, client, user, db):
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="Internet Pinball Database", source_type="web"
         )
         for i in range(25):
-            CitationSource.objects.create(
+            make_citation_source(
                 name=f"IPDB Machine {i}", source_type="web", parent=parent
             )
         client.force_login(user)
@@ -1213,7 +1186,7 @@ class TestUpdateCitationSource:
         assert resp.json()["author"] == ""
 
     def test_duplicate_isbn_returns_422(self, client, user, citation_source_full):
-        other = CitationSource.objects.create(
+        other = make_citation_source(
             name="Other", source_type="book", isbn="9999999999"
         )
         client.force_login(user)
@@ -1238,9 +1211,7 @@ class TestUpdateCitationSource:
 
     def test_day_without_month_after_merge_returns_422(self, client, user):
         """PATCH day on a source with year but no month should fail."""
-        source = CitationSource.objects.create(
-            name="Test", source_type="book", year=1996
-        )
+        source = make_citation_source(name="Test", source_type="book", year=1996)
         client.force_login(user)
         resp = _patch(
             client,
@@ -1367,7 +1338,7 @@ class TestUpdateCitationSourceLink:
         assert citation_source_link.updated_by == user.actor
 
     def test_link_on_wrong_source_returns_404(self, client, user, citation_source_link):
-        other_source = CitationSource.objects.create(name="Other", source_type="web")
+        other_source = make_citation_source(name="Other", source_type="web")
         client.force_login(user)
         resp = _patch(
             client,
@@ -1390,7 +1361,7 @@ class TestUpdateCitationSourceLink:
     def test_duplicate_url_returns_422(
         self, client, user, citation_source, citation_source_link
     ):
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=citation_source,
             link_type="homepage",
             url="https://other.com",
@@ -1445,7 +1416,7 @@ class TestExtractEndpoint:
 
     def test_extract_finds_existing_source(self, client, user):
         client.force_login(user)
-        src = CitationSource.objects.create(
+        src = make_citation_source(
             name="Learning Python", source_type="book", isbn="9780596517748"
         )
         resp = _post(client, EXTRACT_URL, {"input": "9780596517748"})
@@ -1468,7 +1439,7 @@ class TestExtractEndpoint:
     def test_extract_rate_limit(self, client, user):
         cache.clear()
         client.force_login(user)
-        CitationSource.objects.create(
+        make_citation_source(
             name="Learning Python", source_type="book", isbn="9780596517748"
         )
 
@@ -1560,7 +1531,7 @@ class TestCreateCitationSourcePage:
         return f"/api/citation-sources/{parent_id}/pages/"
 
     def test_anonymous_gets_401(self, client):
-        root = CitationSource.objects.create(name="Site", source_type="web")
+        root = make_citation_source(name="Site", source_type="web")
         resp = _post(client, self._url(root.pk), {"url": "https://site.example/p"})
         assert resp.status_code in (401, 403)
 
@@ -1568,7 +1539,7 @@ class TestCreateCitationSourcePage:
         # pages/ files directly under the chosen parent — no recognition, so the
         # root needs no recognition domain.
         client.force_login(user)
-        root = CitationSource.objects.create(name="Site", source_type="web")
+        root = make_citation_source(name="Site", source_type="web")
         resp = _post(
             client,
             self._url(root.pk),
@@ -1589,7 +1560,7 @@ class TestCreateCitationSourcePage:
 
     def test_blank_page_name_falls_back_to_url(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(name="Site", source_type="web")
+        root = make_citation_source(name="Site", source_type="web")
         resp = _post(client, self._url(root.pk), {"url": "https://site.example/x"})
         assert resp.status_code == 201
         child = CitationSource.objects.get(pk=resp.json()["id"])
@@ -1600,9 +1571,7 @@ class TestCreateCitationSourcePage:
         # magazine/book root is intended (the live "Pinball Magazine" magazine
         # root has web children). Pin it so a future "web-only" guard can't land.
         client.force_login(user)
-        root = CitationSource.objects.create(
-            name="Pinball Magazine", source_type="magazine"
-        )
+        root = make_citation_source(name="Pinball Magazine", source_type="magazine")
         resp = _post(
             client,
             self._url(root.pk),
@@ -1622,22 +1591,20 @@ class TestCreateCitationSourcePage:
         # The web-flatness guard: a web child's parent must be a root, so a
         # page nested under a web child (a grandchild) is rejected by clean().
         client.force_login(user)
-        root = CitationSource.objects.create(name="Site", source_type="web")
-        child = CitationSource.objects.create(
-            name="Page", source_type="web", parent=root
-        )
+        root = make_citation_source(name="Site", source_type="web")
+        child = make_citation_source(name="Page", source_type="web", parent=root)
         resp = _post(client, self._url(child.pk), {"url": "https://site.example/deep"})
         assert resp.status_code == 422
 
     def test_malformed_url_returns_422(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(name="Site", source_type="web")
+        root = make_citation_source(name="Site", source_type="web")
         resp = _post(client, self._url(root.pk), {"url": "not-a-url"})
         assert resp.status_code == 422
 
     def test_extra_field_returns_422(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(name="Site", source_type="web")
+        root = make_citation_source(name="Site", source_type="web")
         resp = _post(
             client,
             self._url(root.pk),
@@ -1654,7 +1621,7 @@ class TestCreateCitationSourceRecord:
         return f"/api/citation-sources/{parent_id}/records/"
 
     def test_anonymous_gets_401(self, client):
-        root = CitationSource.objects.create(
+        root = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
         resp = _post(client, self._url(root.pk), {"identifier": "4443"})
@@ -1662,7 +1629,7 @@ class TestCreateCitationSourceRecord:
 
     def test_mints_validated_attributed_child(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(
+        root = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
         resp = _post(client, self._url(root.pk), {"identifier": "4443"})
@@ -1678,7 +1645,7 @@ class TestCreateCitationSourceRecord:
 
     def test_recite_existing_identifier_reuses_child(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(
+        root = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
         first = _post(client, self._url(root.pk), {"identifier": "4443"})
@@ -1690,7 +1657,7 @@ class TestCreateCitationSourceRecord:
 
     def test_pasted_url_normalized_to_bare_id(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(
+        root = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
         resp = _post(
@@ -1711,13 +1678,13 @@ class TestCreateCitationSourceRecord:
         # A parent root that carries no identifier_key has no scheme; the leaf
         # raises ValueError, which must surface as a 422 (not a 500).
         client.force_login(user)
-        root = CitationSource.objects.create(name="Some Site", source_type="web")
+        root = make_citation_source(name="Some Site", source_type="web")
         resp = _post(client, self._url(root.pk), {"identifier": "4443"})
         assert resp.status_code == 422
 
     def test_invalid_identifier_returns_422(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(
+        root = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
         resp = _post(client, self._url(root.pk), {"identifier": "abc"})
@@ -1726,7 +1693,7 @@ class TestCreateCitationSourceRecord:
     def test_random_url_as_identifier_returns_422(self, client, user):
         # A non-IPDB URL doesn't match the extractor's format → rejected.
         client.force_login(user)
-        root = CitationSource.objects.create(
+        root = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
         resp = _post(
@@ -1738,7 +1705,7 @@ class TestCreateCitationSourceRecord:
         # A max-length root name + identifier overflows the generated child name;
         # the leaf's full_clean ValidationError must map to a 422, not a 500.
         client.force_login(user)
-        root = CitationSource.objects.create(
+        root = make_citation_source(
             name="X" * 500, source_type="web", identifier_key="ipdb"
         )
         resp = _post(client, self._url(root.pk), {"identifier": "1"})
@@ -1746,7 +1713,7 @@ class TestCreateCitationSourceRecord:
 
     def test_extra_field_returns_422(self, client, user):
         client.force_login(user)
-        root = CitationSource.objects.create(
+        root = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
         resp = _post(

--- a/backend/apps/citation/tests/test_db_constraints.py
+++ b/backend/apps/citation/tests/test_db_constraints.py
@@ -9,10 +9,15 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection
 
+from apps.accounts.test_factories import default_actor
 from apps.citation.models import (
     CitationSource,
-    CitationSourceLink,
     CitationSourceRootDomain,
+)
+from apps.citation.test_factories import (
+    make_citation_link,
+    make_citation_root_domain,
+    make_citation_source,
 )
 
 
@@ -34,11 +39,11 @@ def _raw_update(model, pk, **fields):
 class TestCitationSourceNonBlank:
     def test_empty_name_rejected(self, db):
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(name="", source_type="book")
+            make_citation_source(name="", source_type="book")
 
     def test_empty_source_type_rejected(self, db):
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(name="Test", source_type="")
+            make_citation_source(name="Test", source_type="")
 
 
 # ---------------------------------------------------------------------------
@@ -49,11 +54,11 @@ class TestCitationSourceNonBlank:
 class TestCitationSourceType:
     def test_invalid_source_type_rejected(self, db):
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(name="Test", source_type="invalid")
+            make_citation_source(name="Test", source_type="invalid")
 
     @pytest.mark.parametrize("source_type", ["book", "magazine", "web"])
     def test_valid_source_type_accepted(self, db, source_type):
-        cs = CitationSource.objects.create(name="Test", source_type=source_type)
+        cs = make_citation_source(name="Test", source_type=source_type)
         assert cs.pk is not None
 
 
@@ -65,19 +70,15 @@ class TestCitationSourceType:
 class TestCitationSourceIdentifierKey:
     def test_invalid_identifier_key_rejected(self, db):
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(
-                name="Test", source_type="web", identifier_key="bogus"
-            )
+            make_citation_source(name="Test", source_type="web", identifier_key="bogus")
 
     def test_empty_identifier_key_accepted(self, db):
-        cs = CitationSource.objects.create(name="Test", source_type="web")
+        cs = make_citation_source(name="Test", source_type="web")
         assert cs.identifier_key == ""
 
     @pytest.mark.parametrize("key", ["ipdb", "opdb", "youtube"])
     def test_valid_identifier_key_accepted(self, db, key):
-        cs = CitationSource.objects.create(
-            name="Test", source_type="web", identifier_key=key
-        )
+        cs = make_citation_source(name="Test", source_type="web", identifier_key=key)
         assert cs.identifier_key == key
 
 
@@ -94,13 +95,13 @@ class TestCitationSourceParent:
             )
 
     def test_valid_parent_accepted(self, citation_source):
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="Child", source_type="book", parent=citation_source
         )
         assert child.parent_id == citation_source.pk
 
     def test_null_parent_accepted(self, db):
-        cs = CitationSource.objects.create(name="Root", source_type="book")
+        cs = make_citation_source(name="Root", source_type="book")
         assert cs.parent_id is None
 
 
@@ -112,7 +113,7 @@ class TestCitationSourceParent:
 class TestCitationSourceDateRanges:
     @pytest.fixture
     def source(self, db):
-        return CitationSource.objects.create(
+        return make_citation_source(
             name="Test", source_type="book", year=1992, month=6, day=15
         )
 
@@ -159,29 +160,25 @@ class TestCitationSourceDateRanges:
 class TestCitationSourceDateChains:
     def test_month_without_year_rejected(self, db):
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(
-                name="Test", source_type="book", month=6, year=None
-            )
+            make_citation_source(name="Test", source_type="book", month=6, year=None)
 
     def test_day_without_month_rejected(self, db):
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(
+            make_citation_source(
                 name="Test", source_type="book", year=1992, day=15, month=None
             )
 
     def test_year_only_accepted(self, db):
-        cs = CitationSource.objects.create(name="Test", source_type="book", year=1992)
+        cs = make_citation_source(name="Test", source_type="book", year=1992)
         assert cs.month is None
         assert cs.day is None
 
     def test_year_month_accepted(self, db):
-        cs = CitationSource.objects.create(
-            name="Test", source_type="book", year=1992, month=6
-        )
+        cs = make_citation_source(name="Test", source_type="book", year=1992, month=6)
         assert cs.day is None
 
     def test_year_month_day_accepted(self, db):
-        cs = CitationSource.objects.create(
+        cs = make_citation_source(
             name="Test", source_type="book", year=1992, month=6, day=15
         )
         assert cs.pk is not None
@@ -194,24 +191,18 @@ class TestCitationSourceDateChains:
 
 class TestCitationSourceISBN:
     def test_empty_isbn_rejected(self, db):
-        cs = CitationSource.objects.create(
-            name="Test", source_type="book", isbn="1234567890"
-        )
+        cs = make_citation_source(name="Test", source_type="book", isbn="1234567890")
         with pytest.raises(IntegrityError):
             _raw_update(CitationSource, cs.pk, isbn="")
 
     def test_null_isbn_accepted(self, db):
-        cs = CitationSource.objects.create(name="Test", source_type="book")
+        cs = make_citation_source(name="Test", source_type="book")
         assert cs.isbn is None
 
     def test_duplicate_isbn_rejected(self, db):
-        CitationSource.objects.create(
-            name="Book A", source_type="book", isbn="1234567890"
-        )
+        make_citation_source(name="Book A", source_type="book", isbn="1234567890")
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(
-                name="Book B", source_type="book", isbn="1234567890"
-            )
+            make_citation_source(name="Book B", source_type="book", isbn="1234567890")
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +212,7 @@ class TestCitationSourceISBN:
 
 class TestCitationSourceLinkConstraints:
     def test_valid_link(self, citation_source):
-        link = CitationSourceLink.objects.create(
+        link = make_citation_link(
             citation_source=citation_source,
             link_type="homepage",
             url="https://example.com",
@@ -229,7 +220,7 @@ class TestCitationSourceLinkConstraints:
         assert link.pk is not None
 
     def test_valid_link_with_label(self, citation_source):
-        link = CitationSourceLink.objects.create(
+        link = make_citation_link(
             citation_source=citation_source,
             link_type="homepage",
             url="https://example.com",
@@ -239,33 +230,33 @@ class TestCitationSourceLinkConstraints:
 
     def test_empty_url_rejected(self, citation_source):
         with pytest.raises(IntegrityError):
-            CitationSourceLink.objects.create(
+            make_citation_link(
                 citation_source=citation_source,
                 link_type="homepage",
                 url="",
             )
 
     def test_duplicate_url_same_source_rejected(self, citation_source):
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=citation_source,
             link_type="homepage",
             url="https://example.com",
         )
         with pytest.raises(IntegrityError):
-            CitationSourceLink.objects.create(
+            make_citation_link(
                 citation_source=citation_source,
                 link_type="homepage",
                 url="https://example.com",
             )
 
     def test_duplicate_url_different_source_accepted(self, citation_source):
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=citation_source,
             link_type="homepage",
             url="https://example.com",
         )
-        other = CitationSource.objects.create(name="Other", source_type="web")
-        link = CitationSourceLink.objects.create(
+        other = make_citation_source(name="Other", source_type="web")
+        link = make_citation_link(
             citation_source=other,
             link_type="homepage",
             url="https://example.com",
@@ -276,7 +267,7 @@ class TestCitationSourceLinkConstraints:
         "link_type", ["homepage", "catalog", "publisher", "reference", "archive"]
     )
     def test_valid_link_types_accepted(self, citation_source, link_type):
-        link = CitationSourceLink.objects.create(
+        link = make_citation_link(
             citation_source=citation_source,
             link_type=link_type,
             url=f"https://example.com/{link_type}",
@@ -285,7 +276,7 @@ class TestCitationSourceLinkConstraints:
 
     def test_invalid_link_type_rejected(self, citation_source):
         with pytest.raises(IntegrityError):
-            CitationSourceLink.objects.create(
+            make_citation_link(
                 citation_source=citation_source,
                 link_type="bogus",
                 url="https://example.com",
@@ -293,7 +284,7 @@ class TestCitationSourceLinkConstraints:
 
     def test_empty_link_type_rejected(self, citation_source):
         with pytest.raises(IntegrityError):
-            CitationSourceLink.objects.create(
+            make_citation_link(
                 citation_source=citation_source,
                 link_type="",
                 url="https://example.com",
@@ -311,27 +302,25 @@ class TestIdentifierConstraints:
     def test_identifier_requires_parent(self, db):
         """Root sources cannot have a non-empty identifier."""
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(
-                name="Orphan", source_type="web", identifier="4443"
-            )
+            make_citation_source(name="Orphan", source_type="web", identifier="4443")
 
     def test_identifier_on_child_accepted(self, db):
         """Child sources can have an identifier."""
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="IPDB #4443", source_type="web", parent=parent, identifier="4443"
         )
         assert child.pk is not None
 
     def test_identifier_key_requires_root(self, db):
         """Child sources cannot have identifier_key."""
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(
+            make_citation_source(
                 name="Bad Child",
                 source_type="web",
                 parent=parent,
@@ -341,13 +330,13 @@ class TestIdentifierConstraints:
     def test_identifier_key_requires_web(self, db):
         """Non-web sources cannot have identifier_key."""
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(
+            make_citation_source(
                 name="Bad Book", source_type="book", identifier_key="ipdb"
             )
 
     def test_identifier_key_and_identifier_mutually_exclusive(self, db):
         """A source cannot be both a scheme-holder and value-holder."""
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
         # Try via raw SQL to bypass ORM checks
@@ -361,14 +350,14 @@ class TestIdentifierConstraints:
 
     def test_unique_child_identifier(self, db):
         """Two children of the same parent cannot share an identifier."""
-        parent = CitationSource.objects.create(
+        parent = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
-        CitationSource.objects.create(
+        make_citation_source(
             name="IPDB #4443", source_type="web", parent=parent, identifier="4443"
         )
         with pytest.raises(IntegrityError):
-            CitationSource.objects.create(
+            make_citation_source(
                 name="IPDB #4443 dup",
                 source_type="web",
                 parent=parent,
@@ -377,16 +366,16 @@ class TestIdentifierConstraints:
 
     def test_same_identifier_different_parents_accepted(self, db):
         """Different parents can have children with the same identifier."""
-        ipdb = CitationSource.objects.create(
+        ipdb = make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
-        opdb = CitationSource.objects.create(
+        opdb = make_citation_source(
             name="OPDB", source_type="web", identifier_key="opdb"
         )
-        c1 = CitationSource.objects.create(
+        c1 = make_citation_source(
             name="IPDB #100", source_type="web", parent=ipdb, identifier="100"
         )
-        c2 = CitationSource.objects.create(
+        c2 = make_citation_source(
             name="OPDB #100", source_type="web", parent=opdb, identifier="100"
         )
         assert c1.pk is not None
@@ -394,13 +383,9 @@ class TestIdentifierConstraints:
 
     def test_empty_identifier_not_unique_constrained(self, db):
         """Multiple children with empty identifier are allowed (no constraint fires)."""
-        parent = CitationSource.objects.create(name="Jersey Jack", source_type="web")
-        c1 = CitationSource.objects.create(
-            name="Page 1", source_type="web", parent=parent
-        )
-        c2 = CitationSource.objects.create(
-            name="Page 2", source_type="web", parent=parent
-        )
+        parent = make_citation_source(name="Jersey Jack", source_type="web")
+        c1 = make_citation_source(name="Page 1", source_type="web", parent=parent)
+        c2 = make_citation_source(name="Page 2", source_type="web", parent=parent)
         assert c1.pk is not None
         assert c2.pk is not None
 
@@ -414,89 +399,130 @@ class TestCitationSourceRootDomain:
     """Host uniqueness/shape (DB) and the root-only rule (``clean()``)."""
 
     def test_valid_domain_on_root(self, db):
-        root = CitationSource.objects.create(name="American Pinball", source_type="web")
-        rd = CitationSourceRootDomain.objects.create(
-            source=root, host="american-pinball.com"
-        )
+        root = make_citation_source(name="American Pinball", source_type="web")
+        rd = make_citation_root_domain(source=root, host="american-pinball.com")
         assert rd.pk is not None
 
     def test_domain_on_non_web_root_accepted(self, db):
         """Any-root, not web-only: a book/magazine root may own a host too."""
-        root = CitationSource.objects.create(name="A Pinball Book", source_type="book")
-        rd = CitationSourceRootDomain(source=root, host="pinball-book.example")
+        root = make_citation_source(name="A Pinball Book", source_type="book")
+        rd = CitationSourceRootDomain(
+            source=root,
+            host="pinball-book.example",
+            created_by=default_actor(),
+            updated_by=default_actor(),
+        )
         rd.full_clean()  # no source_type restriction
         rd.save()
         assert rd.pk is not None
 
     def test_empty_host_rejected(self, db):
-        root = CitationSource.objects.create(name="Root", source_type="web")
+        root = make_citation_source(name="Root", source_type="web")
         with pytest.raises(IntegrityError):
-            CitationSourceRootDomain.objects.create(source=root, host="")
+            make_citation_root_domain(source=root, host="")
 
     def test_duplicate_host_rejected(self, db):
-        a = CitationSource.objects.create(name="A", source_type="web")
-        b = CitationSource.objects.create(name="B", source_type="web")
-        CitationSourceRootDomain.objects.create(source=a, host="example.com")
+        a = make_citation_source(name="A", source_type="web")
+        b = make_citation_source(name="B", source_type="web")
+        make_citation_root_domain(source=a, host="example.com")
         with pytest.raises(IntegrityError):
-            CitationSourceRootDomain.objects.create(source=b, host="example.com")
+            make_citation_root_domain(source=b, host="example.com")
 
     def test_uppercase_host_rejected_at_db(self, db):
         """The lowercase CHECK fires even when ``clean()`` is bypassed."""
-        root = CitationSource.objects.create(name="Root", source_type="web")
+        root = make_citation_source(name="Root", source_type="web")
         with pytest.raises(IntegrityError):
-            CitationSourceRootDomain.objects.create(source=root, host="Example.com")
+            make_citation_root_domain(source=root, host="Example.com")
 
     def test_clean_rejects_domain_on_child(self, db):
-        parent = CitationSource.objects.create(name="Root", source_type="web")
-        child = CitationSource.objects.create(
-            name="Child", source_type="web", parent=parent
+        parent = make_citation_source(name="Root", source_type="web")
+        child = make_citation_source(name="Child", source_type="web", parent=parent)
+        rd = CitationSourceRootDomain(
+            source=child,
+            host="example.com",
+            created_by=default_actor(),
+            updated_by=default_actor(),
         )
-        rd = CitationSourceRootDomain(source=child, host="example.com")
         with pytest.raises(ValidationError):
             rd.full_clean()
 
     def test_clean_accepts_domain_on_root(self, db):
-        root = CitationSource.objects.create(name="Root", source_type="web")
-        rd = CitationSourceRootDomain(source=root, host="example.com")
+        root = make_citation_source(name="Root", source_type="web")
+        rd = CitationSourceRootDomain(
+            source=root,
+            host="example.com",
+            created_by=default_actor(),
+            updated_by=default_actor(),
+        )
         rd.full_clean()  # must not raise
 
     def test_clean_rejects_public_suffix_host(self, db):
         """A bare public suffix must never be stored: under longest-suffix
         matching it would over-match every unrelated site beneath it."""
-        root = CitationSource.objects.create(name="Root", source_type="web")
+        root = make_citation_source(name="Root", source_type="web")
         for host in ("gov.uk", "co.uk"):
-            rd = CitationSourceRootDomain(source=root, host=host)
+            rd = CitationSourceRootDomain(
+                source=root,
+                host=host,
+                created_by=default_actor(),
+                updated_by=default_actor(),
+            )
             with pytest.raises(ValidationError):
                 rd.full_clean()
 
     def test_clean_rejects_non_dns_host(self, db):
         """An IP literal is not a syntactic DNS recognition host."""
-        root = CitationSource.objects.create(name="Root", source_type="web")
-        rd = CitationSourceRootDomain(source=root, host="127.0.0.1")
+        root = make_citation_source(name="Root", source_type="web")
+        rd = CitationSourceRootDomain(
+            source=root,
+            host="127.0.0.1",
+            created_by=default_actor(),
+            updated_by=default_actor(),
+        )
         with pytest.raises(ValidationError):
             rd.full_clean()
 
     def test_clean_accepts_subdomain_and_registrable(self, db):
         """A curator may declare a subdomain verbatim; a registrable domain is
         the ordinary case. Neither is a public suffix."""
-        root = CitationSource.objects.create(name="Root", source_type="web")
+        root = make_citation_source(name="Root", source_type="web")
         for host in ("twip.kineticist.com", "american-pinball.com"):
-            rd = CitationSourceRootDomain(source=root, host=host)
+            rd = CitationSourceRootDomain(
+                source=root,
+                host=host,
+                created_by=default_actor(),
+                updated_by=default_actor(),
+            )
             rd.full_clean()  # must not raise
 
     def test_clean_github_io_canary(self, db):
         """PRIVATE-section boundary at the model edge: ``github.io`` is itself a
         public suffix (rejected), ``foo.github.io`` is one whole site (accepted)."""
-        root = CitationSource.objects.create(name="Root", source_type="web")
+        root = make_citation_source(name="Root", source_type="web")
         with pytest.raises(ValidationError):
-            CitationSourceRootDomain(source=root, host="github.io").full_clean()
+            CitationSourceRootDomain(
+                source=root,
+                host="github.io",
+                created_by=default_actor(),
+                updated_by=default_actor(),
+            ).full_clean()
         # A whole site under the PRIVATE suffix — must not raise.
-        CitationSourceRootDomain(source=root, host="foo.github.io").full_clean()
+        CitationSourceRootDomain(
+            source=root,
+            host="foo.github.io",
+            created_by=default_actor(),
+            updated_by=default_actor(),
+        ).full_clean()
 
     def test_clean_normalizes_host(self, db):
         """clean() canonicalizes the owned value: lower, www-strip, trailing dot."""
-        root = CitationSource.objects.create(name="Root", source_type="web")
-        rd = CitationSourceRootDomain(source=root, host="  WWW.Example.com.  ")
+        root = make_citation_source(name="Root", source_type="web")
+        rd = CitationSourceRootDomain(
+            source=root,
+            host="  WWW.Example.com.  ",
+            created_by=default_actor(),
+            updated_by=default_actor(),
+        )
         rd.full_clean()
         assert rd.host == "example.com"
 
@@ -507,14 +533,19 @@ class TestCitationSourceRootDomain:
         without normalization it would be a dead recognition row (recognition
         looks up ``example.com``). clean() strips it to the matchable host.
         """
-        root = CitationSource.objects.create(name="Root", source_type="web")
-        rd = CitationSourceRootDomain(source=root, host="www.example.com")
+        root = make_citation_source(name="Root", source_type="web")
+        rd = CitationSourceRootDomain(
+            source=root,
+            host="www.example.com",
+            created_by=default_actor(),
+            updated_by=default_actor(),
+        )
         rd.full_clean()
         rd.save()
         assert rd.host == "example.com"
 
     def test_cascade_delete_with_root(self, db):
-        root = CitationSource.objects.create(name="Root", source_type="web")
-        CitationSourceRootDomain.objects.create(source=root, host="example.com")
+        root = make_citation_source(name="Root", source_type="web")
+        make_citation_root_domain(source=root, host="example.com")
         root.delete()
         assert not CitationSourceRootDomain.objects.filter(host="example.com").exists()

--- a/backend/apps/citation/tests/test_extraction.py
+++ b/backend/apps/citation/tests/test_extraction.py
@@ -17,7 +17,7 @@ from apps.citation.extraction import (
     extract_isbn,
     normalize_isbn,
 )
-from apps.citation.models import CitationSource
+from apps.citation.test_factories import make_citation_source
 
 pytestmark = pytest.mark.django_db
 
@@ -160,7 +160,7 @@ AUTHOR_DATA = {
 class TestExtractIsbnHappyPaths:
     def test_existing_match(self):
         """DB has a source with that ISBN → returns match, no HTTP."""
-        src = CitationSource.objects.create(
+        src = make_citation_source(
             name="Learning Python",
             source_type="book",
             isbn="9780596517748",

--- a/backend/apps/citation/tests/test_extractors.py
+++ b/backend/apps/citation/tests/test_extractors.py
@@ -7,6 +7,7 @@ the regex collapsing them all to one canonical 11-char id is the risky part.
 import pytest
 from django.core.exceptions import ValidationError
 
+from apps.accounts.test_factories import default_actor
 from apps.citation.extractors import (
     EXTRACTORS,
     create_web_child,
@@ -20,6 +21,11 @@ from apps.citation.models import (
     CitationSourceLink,
     CitationSourceRootDomain,
 )
+from apps.citation.test_factories import (
+    make_citation_link,
+    make_citation_root_domain,
+    make_citation_source,
+)
 
 # A real-looking 11-char video id (Rick Astley, "Never Gonna Give You Up").
 VID = "dQw4w9WgXcQ"
@@ -27,7 +33,7 @@ VID = "dQw4w9WgXcQ"
 
 @pytest.fixture
 def youtube_root(db):
-    return CitationSource.objects.create(
+    return make_citation_source(
         name="YouTube", source_type="web", identifier_key="youtube"
     )
 
@@ -92,7 +98,7 @@ class TestYouTubeRecognition:
         assert rec.child is None
 
     def test_url_recognized_with_existing_child(self, youtube_root):
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name=f"YouTube #{VID}",
             source_type="web",
             parent=youtube_root,
@@ -114,10 +120,8 @@ class TestYouTubeRecognition:
         # seeded youtube.com recognition host still resolves it (parent only, no
         # identifier). A flatten that returned at the first pattern hit would
         # regress this to None.
-        host_root = CitationSource.objects.create(
-            name="YouTube (web root)", source_type="web"
-        )
-        CitationSourceRootDomain.objects.create(source=host_root, host="youtube.com")
+        host_root = make_citation_source(name="YouTube (web root)", source_type="web")
+        make_citation_root_domain(source=host_root, host="youtube.com")
         rec = recognize_url(f"https://www.youtube.com/watch?v={VID}")
         assert rec is not None
         assert rec.parent_id == host_root.id
@@ -133,8 +137,8 @@ class TestRootDomainRecognition:
     """
 
     def _root(self, name: str, host: str) -> CitationSource:
-        root = CitationSource.objects.create(name=name, source_type="web")
-        CitationSourceRootDomain.objects.create(source=root, host=host)
+        root = make_citation_source(name=name, source_type="web")
+        make_citation_root_domain(source=root, host=host)
         return root
 
     def test_subdomain_resolves_to_registrable_root(self, db):
@@ -170,9 +174,15 @@ class TestRootDomainRecognition:
         # would let a bare public-suffix host swallow every site beneath it — but
         # clean() forbids declaring one, so that root can't exist. Declaring "co.uk"
         # is rejected, and an unrelated *.co.uk cite stays unrecognized.
-        root = CitationSource.objects.create(name="Bad", source_type="web")
+        root = make_citation_source(name="Bad", source_type="web")
+        # Attribute it so full_clean's only complaint is the public-suffix host.
         with pytest.raises(ValidationError):
-            CitationSourceRootDomain(source=root, host="co.uk").full_clean()
+            CitationSourceRootDomain(
+                source=root,
+                host="co.uk",
+                created_by=default_actor(),
+                updated_by=default_actor(),
+            ).full_clean()
         assert recognize_url("https://example.co.uk/page") is None
 
     def test_www_prefixed_input_matches(self, db):
@@ -212,11 +222,9 @@ class TestRootDomainRecognition:
         # The source__parent__isnull filter is defense-in-depth for the clean()
         # root-only rule: a domain attached to a child via a bypass (raw create)
         # never drives recognition.
-        parent = CitationSource.objects.create(name="Parent", source_type="web")
-        child = CitationSource.objects.create(
-            name="Child", source_type="web", parent=parent
-        )
-        CitationSourceRootDomain.objects.create(source=child, host="child.example.com")
+        parent = make_citation_source(name="Parent", source_type="web")
+        child = make_citation_source(name="Child", source_type="web", parent=parent)
+        make_citation_root_domain(source=child, host="child.example.com")
         assert recognize_url("https://child.example.com/page") is None
 
 
@@ -225,10 +233,12 @@ class TestCreateWebChild:
 
     @pytest.fixture
     def root(self, db):
-        return CitationSource.objects.create(name="Kineticist", source_type="web")
+        return make_citation_source(name="Kineticist", source_type="web")
 
     def test_mints_validated_child_and_reference_link(self, root):
-        child = create_web_child(root.pk, "https://kineticist.com/article")
+        child = create_web_child(
+            root.pk, "https://kineticist.com/article", created_by=default_actor()
+        )
         assert child.parent_id == root.pk
         assert child.source_type == "web"
         link = child.links.get()
@@ -239,7 +249,7 @@ class TestCreateWebChild:
         # The link's URLField validates only in full_clean — the leaf's whole
         # point (closing the .objects.create bypass). Atomic: no orphaned child.
         with pytest.raises(ValidationError):
-            create_web_child(root.pk, "not a url")
+            create_web_child(root.pk, "not a url", created_by=default_actor())
         assert not CitationSource.objects.children().exists()
 
     def test_attribution_follows_created_by(self, root, user):
@@ -249,22 +259,18 @@ class TestCreateWebChild:
         assert attributed.created_by_id == user.actor_id
         assert attributed.links.get().created_by_id == user.actor_id
 
-        anon = create_web_child(root.pk, "https://kineticist.com/b")
-        assert anon.created_by_id is None
-        assert anon.links.get().created_by_id is None
-
 
 class TestGetOrCreateSchemeChild:
     """The shared scheme-child leaf: one name rule, idempotent, attributed."""
 
     @pytest.fixture
     def root(self, db):
-        return CitationSource.objects.create(
+        return make_citation_source(
             name="IPDB", source_type="web", identifier_key="ipdb"
         )
 
     def test_mints_named_child_with_canonical_link(self, root):
-        child = get_or_create_scheme_child(root, "4443")
+        child = get_or_create_scheme_child(root, "4443", created_by=default_actor())
         assert child.name == "IPDB #4443"
         assert child.identifier == "4443"
         link = child.links.get()
@@ -272,27 +278,27 @@ class TestGetOrCreateSchemeChild:
         assert link.link_type == "reference"
 
     def test_reuses_on_recite_across_url_shapes(self, root):
-        first = get_or_create_scheme_child(root, "4443")
+        first = get_or_create_scheme_child(root, "4443", created_by=default_actor())
         second = get_or_create_scheme_child(
-            root, "https://www.ipdb.org/machine.cgi?id=4443"
+            root, "https://www.ipdb.org/machine.cgi?id=4443", created_by=default_actor()
         )
         assert first.pk == second.pk
         assert first.links.count() == 1
 
     def test_rejects_an_invalid_identifier(self, root):
         with pytest.raises(ValueError, match="Invalid ipdb identifier"):
-            get_or_create_scheme_child(root, "not-an-id")
+            get_or_create_scheme_child(root, "not-an-id", created_by=default_actor())
 
     def test_rejects_a_root_without_a_scheme(self, db):
-        plain = CitationSource.objects.create(name="No scheme", source_type="web")
+        plain = make_citation_source(name="No scheme", source_type="web")
         with pytest.raises(ValueError, match="no known identifier scheme"):
-            get_or_create_scheme_child(plain, "4443")
+            get_or_create_scheme_child(plain, "4443", created_by=default_actor())
 
     def test_rejects_an_over_long_identifier(self, root):
         # The ``\d+`` id regex has no length cap, so an over-long identifier must
         # be caught by field validation, not silently stored or DB-errored.
         with pytest.raises(ValidationError):
-            get_or_create_scheme_child(root, "1" * 250)
+            get_or_create_scheme_child(root, "1" * 250, created_by=default_actor())
         assert not CitationSource.objects.children().exists()
 
     def test_attribution_follows_created_by(self, root, user):
@@ -303,8 +309,10 @@ class TestGetOrCreateSchemeChild:
     def test_external_source_helper_resolves_the_same_child(self, root):
         # The patch helper (scheme→root lookup) and the leaf mint one child —
         # convergence on a single scheme-child home.
-        via_helper = get_or_create_external_source("ipdb", "4443")
-        via_leaf = get_or_create_scheme_child(root, "4443")
+        via_helper = get_or_create_external_source(
+            "ipdb", "4443", created_by=default_actor()
+        )
+        via_leaf = get_or_create_scheme_child(root, "4443", created_by=default_actor())
         assert via_helper.pk == via_leaf.pk
 
 
@@ -312,16 +320,22 @@ class TestYouTubeGetOrCreate:
     """``get_or_create_external_source`` is idempotent and builds canonical URLs."""
 
     def test_creates_child_with_canonical_link(self, youtube_root):
-        child = get_or_create_external_source("youtube", f"https://youtu.be/{VID}")
+        child = get_or_create_external_source(
+            "youtube", f"https://youtu.be/{VID}", created_by=default_actor()
+        )
         assert child.parent_id == youtube_root.id
         assert child.identifier == VID
         link = CitationSourceLink.objects.get(citation_source=child)
         assert link.url == f"https://www.youtube.com/watch?v={VID}"
 
     def test_idempotent_across_url_shapes(self, youtube_root):
-        first = get_or_create_external_source("youtube", f"https://youtu.be/{VID}")
+        first = get_or_create_external_source(
+            "youtube", f"https://youtu.be/{VID}", created_by=default_actor()
+        )
         second = get_or_create_external_source(
-            "youtube", f"https://www.youtube.com/watch?v={VID}&t=10s"
+            "youtube",
+            f"https://www.youtube.com/watch?v={VID}&t=10s",
+            created_by=default_actor(),
         )
         assert first.id == second.id
 
@@ -338,9 +352,9 @@ class TestGetOrCreateWebSourceRootHomepage:
     HOMEPAGE = "https://american-pinball.com/"
 
     def _root(self, db) -> CitationSource:
-        root = CitationSource.objects.create(name="American Pinball", source_type="web")
-        CitationSourceRootDomain.objects.create(source=root, host=self.HOST)
-        CitationSourceLink.objects.create(
+        root = make_citation_source(name="American Pinball", source_type="web")
+        make_citation_root_domain(source=root, host=self.HOST)
+        make_citation_link(
             citation_source=root,
             link_type=CitationSourceLink.LinkType.HOMEPAGE,
             url=self.HOMEPAGE,
@@ -349,14 +363,14 @@ class TestGetOrCreateWebSourceRootHomepage:
 
     def test_citing_root_homepage_creates_child_not_root(self, db):
         root = self._root(db)
-        source = get_or_create_web_source(self.HOMEPAGE)
+        source = get_or_create_web_source(self.HOMEPAGE, created_by=default_actor())
         assert source.id != root.id
         assert source.parent_id == root.id
 
     def test_citing_root_homepage_is_idempotent(self, db):
         self._root(db)
-        first = get_or_create_web_source(self.HOMEPAGE)
-        second = get_or_create_web_source(self.HOMEPAGE)
+        first = get_or_create_web_source(self.HOMEPAGE, created_by=default_actor())
+        second = get_or_create_web_source(self.HOMEPAGE, created_by=default_actor())
         assert first.id == second.id
 
     def test_rejects_a_malformed_archive_url(self, db):
@@ -365,7 +379,9 @@ class TestGetOrCreateWebSourceRootHomepage:
         self._root(db)
         page = "https://american-pinball.com/news/launch"
         with pytest.raises(ValidationError):
-            get_or_create_web_source(page, archive_url="not a url")
+            get_or_create_web_source(
+                page, archive_url="not a url", created_by=default_actor()
+            )
         assert not CitationSource.objects.children().exists()
 
     def test_malformed_subdomain_host_not_recognized_nor_nested(self, db):
@@ -374,5 +390,8 @@ class TestGetOrCreateWebSourceRootHomepage:
         # the URL resolves to no root and nests nothing under the matched domain.
         root = self._root(db)
         with pytest.raises(CitationSource.DoesNotExist):
-            get_or_create_web_source("https://www..american-pinball.com/manual.pdf")
+            get_or_create_web_source(
+                "https://www..american-pinball.com/manual.pdf",
+                created_by=default_actor(),
+            )
         assert not CitationSource.objects.filter(parent=root).exists()

--- a/backend/apps/citation/tests/test_migration_backfill_root_domains.py
+++ b/backend/apps/citation/tests/test_migration_backfill_root_domains.py
@@ -1,24 +1,22 @@
 """Tests for the root-domain backfill data migration.
 
-The migration is exercised by calling its ``RunPython`` callables directly
-against the live app registry (no ``django_test_migrations`` dependency). Each
-test builds its own citation rows, so it does not rely on production data.
-
-Note these run against the live models, not the frozen migration-state models,
-so a future required field on ``CitationSourceRootDomain`` could pass here yet
-break the real (historical-model) migration.
+The 0005 backfill predates editorial attribution, so it is exercised against the
+frozen migration-state models at citation 0006 — *before* the ``created_by`` /
+``updated_by`` columns were added (0007) and made non-null (0012). Running it
+against the live models would fail on the recognition rows the backfill itself
+creates, which now require an actor the historical migration never set. Each
+test builds its own citation rows at that state, so it relies on no production
+data.
 """
 
 import importlib
 
 import pytest
-from django.apps import apps as django_apps
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
 
-from apps.citation.models import (
-    CitationSource,
-    CitationSourceLink,
-    CitationSourceRootDomain,
-)
+# State just before ``created_by``/``updated_by`` land on the citation models.
+_AT = [("citation", "0006_alter_citationsourcerootdomain_host")]
 
 _migration = importlib.import_module(
     "apps.citation.migrations.0005_backfill_citation_root_domains"
@@ -26,8 +24,39 @@ _migration = importlib.import_module(
 backfill_root_domains = _migration.backfill_root_domains
 remove_root_domains = _migration.remove_root_domains
 
+pytestmark = pytest.mark.django_db(transaction=True)
 
-def _root(name: str, host: str, *, scheme: str = "https") -> CitationSource:
+
+@pytest.fixture
+def state():
+    """Historical app registry at citation 0006 (no attribution columns yet).
+
+    Rewinds the citation app to 0006, yields that frozen ``apps`` (the backfill
+    reads its models through it), then restores to the latest schema so later
+    tests see the real models.
+    """
+    executor = MigrationExecutor(connection)
+    try:
+        executor.migrate(_AT)
+        executor.loader.build_graph()
+        yield executor.loader.project_state(_AT).apps
+    finally:
+        # Drop the rows built at 0006 before restoring to leaf: the leaf includes
+        # 0011, whose fail-fast assertion rejects null-attribution rows (these
+        # have no actor, and no flipcommons-catalog source exists to claim them).
+        # Children first (the parent FK is PROTECT); deleting cascades to links
+        # and recognition domains.
+        apps = executor.loader.project_state(_AT).apps
+        CitationSource = apps.get_model("citation", "CitationSource")
+        CitationSource.objects.filter(parent__isnull=False).delete()
+        CitationSource.objects.all().delete()
+        executor.loader.build_graph()
+        executor.migrate(executor.loader.graph.leaf_nodes())
+
+
+def _root(apps, name: str, host: str, *, scheme: str = "https"):
+    CitationSource = apps.get_model("citation", "CitationSource")
+    CitationSourceLink = apps.get_model("citation", "CitationSourceLink")
     root = CitationSource.objects.create(name=name, source_type="web")
     CitationSourceLink.objects.create(
         citation_source=root, link_type="homepage", url=f"{scheme}://{host}/"
@@ -35,35 +64,44 @@ def _root(name: str, host: str, *, scheme: str = "https") -> CitationSource:
     return root
 
 
-@pytest.mark.django_db
 class TestBackfill:
-    def test_creates_one_row_per_root_homepage_host(self):
-        a = _root("American Pinball", "www.american-pinball.com")
-        b = _root("Kineticist", "kineticist.com")
+    def test_creates_one_row_per_root_homepage_host(self, state):
+        a = _root(state, "American Pinball", "www.american-pinball.com")
+        b = _root(state, "Kineticist", "kineticist.com")
 
-        backfill_root_domains(django_apps, None)
+        backfill_root_domains(state, None)
 
+        CitationSourceRootDomain = state.get_model(
+            "citation", "CitationSourceRootDomain"
+        )
         rows = {rd.host: rd.source_id for rd in CitationSourceRootDomain.objects.all()}
         # www. is stripped on the way in.
         assert rows == {"american-pinball.com": a.id, "kineticist.com": b.id}
 
     @pytest.mark.parametrize("source_type", ["web", "book", "magazine"])
-    def test_backfills_any_root_type(self, source_type):
+    def test_backfills_any_root_type(self, state, source_type):
         # The any-root decision: a host on a non-web root is a recognition row
         # too (the query has no source_type filter).
+        CitationSource = state.get_model("citation", "CitationSource")
+        CitationSourceLink = state.get_model("citation", "CitationSourceLink")
         root = CitationSource.objects.create(name="A Root", source_type=source_type)
         CitationSourceLink.objects.create(
             citation_source=root, link_type="homepage", url="https://example.test/"
         )
 
-        backfill_root_domains(django_apps, None)
+        backfill_root_domains(state, None)
 
+        CitationSourceRootDomain = state.get_model(
+            "citation", "CitationSourceRootDomain"
+        )
         assert CitationSourceRootDomain.objects.filter(
             host="example.test", source_id=root.id
         ).exists()
 
-    def test_skips_child_homepage_links(self):
-        root = _root("American Pinball", "american-pinball.com")
+    def test_skips_child_homepage_links(self, state):
+        root = _root(state, "American Pinball", "american-pinball.com")
+        CitationSource = state.get_model("citation", "CitationSource")
+        CitationSourceLink = state.get_model("citation", "CitationSourceLink")
         child = CitationSource.objects.create(
             name="A page", source_type="web", parent=root
         )
@@ -74,14 +112,18 @@ class TestBackfill:
             url="https://child.american-pinball.com/",
         )
 
-        backfill_root_domains(django_apps, None)
+        backfill_root_domains(state, None)
 
+        CitationSourceRootDomain = state.get_model(
+            "citation", "CitationSourceRootDomain"
+        )
         assert list(
             CitationSourceRootDomain.objects.values_list("host", flat=True)
         ) == ["american-pinball.com"]
 
-    def test_same_root_declaring_a_host_twice_is_not_a_collision(self):
-        root = _root("American Pinball", "american-pinball.com", scheme="https")
+    def test_same_root_declaring_a_host_twice_is_not_a_collision(self, state):
+        root = _root(state, "American Pinball", "american-pinball.com", scheme="https")
+        CitationSourceLink = state.get_model("citation", "CitationSourceLink")
         # Same host, second link (http) on the *same* root.
         CitationSourceLink.objects.create(
             citation_source=root,
@@ -89,41 +131,52 @@ class TestBackfill:
             url="http://american-pinball.com/",
         )
 
-        backfill_root_domains(django_apps, None)
+        backfill_root_domains(state, None)
 
+        CitationSourceRootDomain = state.get_model(
+            "citation", "CitationSourceRootDomain"
+        )
         rd = CitationSourceRootDomain.objects.get(host="american-pinball.com")
         assert rd.source_id == root.id
 
-    def test_audit_raises_on_host_owned_by_two_roots(self):
+    def test_audit_raises_on_host_owned_by_two_roots(self, state):
         # The pre-condition the manual TWiP-duplicate delete satisfies: two roots
         # claiming one host fail loud, before any insert.
-        _root("Site One", "shared.example")
-        _root("Site Two", "shared.example")
+        _root(state, "Site One", "shared.example")
+        _root(state, "Site Two", "shared.example")
 
         with pytest.raises(RuntimeError, match="more than one root"):
-            backfill_root_domains(django_apps, None)
+            backfill_root_domains(state, None)
 
+        CitationSourceRootDomain = state.get_model(
+            "citation", "CitationSourceRootDomain"
+        )
         assert not CitationSourceRootDomain.objects.exists()
 
 
-@pytest.mark.django_db
 class TestReverse:
-    def test_empties_the_table(self):
-        _root("Kineticist", "kineticist.com")
-        backfill_root_domains(django_apps, None)
+    def test_empties_the_table(self, state):
+        _root(state, "Kineticist", "kineticist.com")
+        backfill_root_domains(state, None)
+        CitationSourceRootDomain = state.get_model(
+            "citation", "CitationSourceRootDomain"
+        )
         assert CitationSourceRootDomain.objects.exists()
 
-        remove_root_domains(django_apps, None)
+        remove_root_domains(state, None)
 
         assert not CitationSourceRootDomain.objects.exists()
 
-    def test_reverse_then_reapply_rebuilds_rows(self):
+    def test_reverse_then_reapply_rebuilds_rows(self, state):
         # Reapply-safety: reverse empties the table so a forward re-run can't trip
         # the host unique.
-        _root("Kineticist", "kineticist.com")
-        backfill_root_domains(django_apps, None)
-        remove_root_domains(django_apps, None)
+        _root(state, "Kineticist", "kineticist.com")
+        backfill_root_domains(state, None)
+        remove_root_domains(state, None)
 
-        backfill_root_domains(django_apps, None)
+        backfill_root_domains(state, None)
 
+        CitationSourceRootDomain = state.get_model(
+            "citation", "CitationSourceRootDomain"
+        )
         assert CitationSourceRootDomain.objects.filter(host="kineticist.com").exists()

--- a/backend/apps/citation/tests/test_models.py
+++ b/backend/apps/citation/tests/test_models.py
@@ -4,22 +4,24 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
 
+from apps.accounts.test_factories import default_actor
 from apps.citation.models import CitationSource, CitationSourceLink
+from apps.citation.test_factories import make_citation_link, make_citation_source
 
 
 class TestCitationSourceStr:
     def test_name_only(self, db):
-        cs = CitationSource.objects.create(name="IPDB", source_type="web")
+        cs = make_citation_source(name="IPDB", source_type="web")
         assert str(cs) == "IPDB"
 
     def test_name_and_year(self, db):
-        cs = CitationSource.objects.create(
+        cs = make_citation_source(
             name="The Encyclopedia of Pinball", source_type="book", year=1996
         )
         assert str(cs) == "The Encyclopedia of Pinball (1996)"
 
     def test_name_author_year(self, db):
-        cs = CitationSource.objects.create(
+        cs = make_citation_source(
             name="The Encyclopedia of Pinball",
             source_type="book",
             author="Richard Bueschel",
@@ -72,40 +74,62 @@ class TestWebFlatnessGuard:
     """A web source nests one level — root → child, no grandchildren."""
 
     def test_rejects_a_web_grandchild(self, db):
-        root = CitationSource.objects.create(name="Site", source_type="web")
-        child = CitationSource.objects.create(
-            name="Page", source_type="web", parent=root
+        root = make_citation_source(name="Site", source_type="web")
+        child = make_citation_source(name="Page", source_type="web", parent=root)
+        grandchild = CitationSource(
+            name="Sub-page",
+            source_type="web",
+            parent=child,
+            created_by=default_actor(),
+            updated_by=default_actor(),
         )
-        grandchild = CitationSource(name="Sub-page", source_type="web", parent=child)
         with pytest.raises(ValidationError, match="nests only one level"):
             grandchild.full_clean()
 
     def test_accepts_a_web_child_under_a_root(self, db):
-        root = CitationSource.objects.create(name="Site", source_type="web")
-        child = CitationSource(name="Page", source_type="web", parent=root)
+        root = make_citation_source(name="Site", source_type="web")
+        child = CitationSource(
+            name="Page",
+            source_type="web",
+            parent=root,
+            created_by=default_actor(),
+            updated_by=default_actor(),
+        )
         child.full_clean()  # does not raise
 
     def test_dangling_parent_id_defers_to_the_fk_validator(self, db):
         # The guard must not mask the FK field validator: a non-existent
         # parent_id is a ValidationError (the FK field's job), never a raw
         # DoesNotExist leaking out of clean().
-        orphan = CitationSource(name="x", source_type="web", parent_id=999999)
+        orphan = CitationSource(
+            name="x",
+            source_type="web",
+            parent_id=999999,
+            created_by=default_actor(),
+            updated_by=default_actor(),
+        )
         with pytest.raises(ValidationError):
             orphan.full_clean()
 
     def test_accepts_book_three_level_nesting(self, db):
         # Book is not a flat-hierarchy type, so deep nesting stays valid.
-        root = CitationSource.objects.create(name="Book", source_type="book")
-        edition = CitationSource.objects.create(
+        root = make_citation_source(name="Book", source_type="book")
+        edition = make_citation_source(
             name="2nd Edition", source_type="book", parent=root
         )
-        page = CitationSource(name="Page 42", source_type="book", parent=edition)
+        page = CitationSource(
+            name="Page 42",
+            source_type="book",
+            parent=edition,
+            created_by=default_actor(),
+            updated_by=default_actor(),
+        )
         page.full_clean()  # does not raise
 
 
 class TestCitationSourceRelationships:
     def test_children_relationship(self, citation_source):
-        child = CitationSource.objects.create(
+        child = make_citation_source(
             name="Child", source_type="book", parent=citation_source
         )
         assert child in citation_source.children.all()
@@ -131,7 +155,7 @@ class TestCitationSourceLinkStr:
         )
 
     def test_without_label(self, citation_source):
-        link = CitationSourceLink.objects.create(
+        link = make_citation_link(
             citation_source=citation_source,
             link_type="homepage",
             url="https://example.com",

--- a/backend/apps/citation/tests/test_source_upsert.py
+++ b/backend/apps/citation/tests/test_source_upsert.py
@@ -20,6 +20,7 @@ from apps.citation.source_upsert import (
     ensure_root_source,
     validate_root_source,
 )
+from apps.citation.test_factories import make_citation_root_domain, make_citation_source
 
 pytestmark = pytest.mark.django_db
 
@@ -188,8 +189,8 @@ class TestSourceUpsertDedup:
 
     def test_one_host_owned_plus_one_unowned_mints_only_the_new(self, actor):
         """A single owning root + an unowned host → reuse the root, add the host."""
-        root = CitationSource.objects.create(name="Owner", source_type="web")
-        CitationSourceRootDomain.objects.create(source=root, host="owned.example")
+        root = make_citation_source(name="Owner", source_type="web")
+        make_citation_root_domain(source=root, host="owned.example")
         result = ensure_root_source(
             _node(
                 "Owner",
@@ -214,12 +215,10 @@ class TestSourceUpsertDedup:
         by name and reaches the mint — which must warn-and-skip the taken host,
         never trip the ``host`` unique and abort the patch run.
         """
-        parent = CitationSource.objects.create(name="A Root", source_type="web")
-        child = CitationSource.objects.create(
-            name="A Child", source_type="web", parent=parent
-        )
+        parent = make_citation_source(name="A Root", source_type="web")
+        child = make_citation_source(name="A Child", source_type="web", parent=parent)
         # Bypass clean() to plant the pathological child-owned row.
-        CitationSourceRootDomain.objects.create(source=child, host="squatted.example")
+        make_citation_root_domain(source=child, host="squatted.example")
 
         warnings: list[str] = []
         result = ensure_root_source(  # must not raise
@@ -234,10 +233,10 @@ class TestSourceUpsertDedup:
         assert any("already owned" in w for w in warnings)
 
     def test_hosts_spanning_two_roots_warns_and_skips_with_no_writes(self, actor):
-        a = CitationSource.objects.create(name="Root A", source_type="web")
-        CitationSourceRootDomain.objects.create(source=a, host="a.example")
-        b = CitationSource.objects.create(name="Root B", source_type="web")
-        CitationSourceRootDomain.objects.create(source=b, host="b.example")
+        a = make_citation_source(name="Root A", source_type="web")
+        make_citation_root_domain(source=a, host="a.example")
+        b = make_citation_source(name="Root B", source_type="web")
+        make_citation_root_domain(source=b, host="b.example")
 
         sources_before = CitationSource.objects.count()
         domains_before = CitationSourceRootDomain.objects.count()
@@ -331,8 +330,8 @@ class TestRebrandResolution:
         root** (because the unified set feeds resolution) and add the new host —
         never mint a second root.
         """
-        existing = CitationSource.objects.create(name="OldPin", source_type="web")
-        CitationSourceRootDomain.objects.create(source=existing, host="oldpin.com")
+        existing = make_citation_source(name="OldPin", source_type="web")
+        make_citation_root_domain(source=existing, host="oldpin.com")
         before = CitationSource.objects.count()
 
         result = ensure_root_source(
@@ -360,12 +359,10 @@ class TestRebrandResolution:
         by name and reaches the mint; the unified host set flows through the same
         warn-skip the homepage path uses, never tripping the ``host`` unique.
         """
-        parent = CitationSource.objects.create(name="A Root", source_type="web")
-        child = CitationSource.objects.create(
-            name="A Child", source_type="web", parent=parent
-        )
+        parent = make_citation_source(name="A Root", source_type="web")
+        child = make_citation_source(name="A Child", source_type="web", parent=parent)
         # Bypass clean() to plant the pathological child-owned row.
-        CitationSourceRootDomain.objects.create(source=child, host="squatted.example")
+        make_citation_root_domain(source=child, host="squatted.example")
 
         warnings: list[str] = []
         result = ensure_root_source(  # must not raise
@@ -381,10 +378,10 @@ class TestRebrandResolution:
         assert any("already owned" in w for w in warnings)
 
     def test_domains_spanning_two_roots_skips_naming_both(self, actor):
-        a = CitationSource.objects.create(name="Root A", source_type="web")
-        CitationSourceRootDomain.objects.create(source=a, host="a.example")
-        b = CitationSource.objects.create(name="Root B", source_type="web")
-        CitationSourceRootDomain.objects.create(source=b, host="b.example")
+        a = make_citation_source(name="Root A", source_type="web")
+        make_citation_root_domain(source=a, host="a.example")
+        b = make_citation_source(name="Root B", source_type="web")
+        make_citation_root_domain(source=b, host="b.example")
 
         warnings: list[str] = []
         result = ensure_root_source(
@@ -435,10 +432,10 @@ class TestDetectHostCollision:
     """The committed-state collision preview the dry-run path emits."""
 
     def test_hosts_spanning_two_roots_returns_warning_naming_both(self):
-        a = CitationSource.objects.create(name="Root A", source_type="web")
-        CitationSourceRootDomain.objects.create(source=a, host="a.example")
-        b = CitationSource.objects.create(name="Root B", source_type="web")
-        CitationSourceRootDomain.objects.create(source=b, host="b.example")
+        a = make_citation_source(name="Root A", source_type="web")
+        make_citation_root_domain(source=a, host="a.example")
+        b = make_citation_source(name="Root B", source_type="web")
+        make_citation_root_domain(source=b, host="b.example")
 
         warning = detect_host_collision(
             _node("Spans Two", domains=["a.example", "b.example"])
@@ -449,8 +446,8 @@ class TestDetectHostCollision:
 
     def test_single_owning_root_is_not_a_collision(self):
         """One owner means the node resolves to it — normal dedup, no warning."""
-        owner = CitationSource.objects.create(name="Owner", source_type="web")
-        CitationSourceRootDomain.objects.create(source=owner, host="owned.example")
+        owner = make_citation_source(name="Owner", source_type="web")
+        make_citation_root_domain(source=owner, host="owned.example")
         assert (
             detect_host_collision(
                 _node("X", domains=["owned.example", "fresh.example"])

--- a/backend/apps/core/tests/test_markdown.py
+++ b/backend/apps/core/tests/test_markdown.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 from django.core.exceptions import ValidationError
 
+from apps.citation.test_factories import make_citation_link, make_citation_source
 from apps.core.markdown import (
     convert_authoring_to_storage,
     convert_storage_to_authoring,
@@ -35,9 +36,8 @@ def system(db, manufacturer):
 
 @pytest.fixture
 def citation_source(db):
-    from apps.citation.models import CitationSource
 
-    return CitationSource.objects.create(
+    return make_citation_source(
         name="The Encyclopedia of Pinball",
         source_type="book",
         author="Jeff Lawton",
@@ -47,9 +47,8 @@ def citation_source(db):
 
 @pytest.fixture
 def citation_source_with_links(citation_source):
-    from apps.citation.models import CitationSourceLink
 
-    CitationSourceLink.objects.create(
+    make_citation_link(
         citation_source=citation_source,
         url="https://example.com/archive",
         label="Archive scan",
@@ -140,10 +139,9 @@ class TestRenderMarkdownHtml:
 
     @pytest.mark.django_db
     def test_metadata_out_collects_citations(self):
-        from apps.citation.models import CitationSource
         from apps.provenance.models import CitationInstance
 
-        src = CitationSource.objects.create(
+        src = make_citation_source(
             name="Source Book", source_type="book", author="A. Author"
         )
         ci = CitationInstance.objects.create(citation_source=src, locator="ch. 3")
@@ -193,10 +191,9 @@ class TestRenderMarkdownFields:
     @pytest.mark.django_db
     def test_citations_key_included(self):
         from apps.catalog.models import Manufacturer
-        from apps.citation.models import CitationSource
         from apps.provenance.models import CitationInstance
 
-        src = CitationSource.objects.create(name="Book", source_type="book")
+        src = make_citation_source(name="Book", source_type="book")
         ci = CitationInstance.objects.create(citation_source=src, locator="p. 1")
         mfr = Manufacturer(
             name="Test", slug="test", description=f"Info.[[cite:id:{ci.pk}]]"

--- a/backend/apps/provenance/tests/test_api_citation_instances.py
+++ b/backend/apps/provenance/tests/test_api_citation_instances.py
@@ -6,7 +6,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client
 
-from apps.citation.models import CitationSource
+from apps.citation.test_factories import make_citation_link, make_citation_source
 from apps.provenance.models import CitationInstance
 from apps.provenance.test_factories import make_claim
 
@@ -22,7 +22,7 @@ def client():
 
 @pytest.fixture
 def citation_source(db):
-    return CitationSource.objects.create(
+    return make_citation_source(
         name="The Encyclopedia of Pinball",
         source_type="book",
     )
@@ -101,12 +101,11 @@ class TestListCitationInstances:
 
 class TestBatchCitationInstances:
     def test_returns_instances_with_source_details(self, client, citation_source):
-        from apps.citation.models import CitationSourceLink
 
         ci = CitationInstance.objects.create(
             citation_source=citation_source, locator="p. 30"
         )
-        CitationSourceLink.objects.create(
+        make_citation_link(
             citation_source=citation_source,
             link_type="archive",
             url="https://archive.org/details/example",

--- a/backend/apps/provenance/tests/test_api_evidence.py
+++ b/backend/apps/provenance/tests/test_api_evidence.py
@@ -6,7 +6,7 @@ import pytest
 from django.contrib.auth import get_user_model
 
 from apps.catalog.models import Title
-from apps.citation.models import CitationSource, CitationSourceLink
+from apps.citation.test_factories import make_citation_link, make_citation_source
 from apps.provenance.models import CitationInstance
 from apps.provenance.test_factories import make_claim, user_changeset
 
@@ -22,8 +22,8 @@ def title(db, bootstrap_source):
 
 @pytest.fixture
 def citation_source(db):
-    source = CitationSource.objects.create(name="Williams Flyer", source_type="web")
-    CitationSourceLink.objects.create(
+    source = make_citation_source(name="Williams Flyer", source_type="web")
+    make_citation_link(
         citation_source=source,
         link_type="homepage",
         url="https://example.com/flyer",

--- a/backend/apps/provenance/tests/test_capabilities_embed.py
+++ b/backend/apps/provenance/tests/test_capabilities_embed.py
@@ -21,7 +21,7 @@ from django.test.utils import CaptureQueriesContext
 from apps.accounts.test_factories import make_user
 from apps.catalog.models import Title
 from apps.catalog.tests.conftest import make_machine_model
-from apps.citation.models import CitationSource
+from apps.citation.test_factories import make_citation_source
 from apps.provenance.models import CitationInstance
 from apps.provenance.test_factories import make_claim, user_changeset
 
@@ -120,7 +120,7 @@ def test_sources_page_capabilities_does_not_scale_queries(client, bootstrap_sour
     user = make_user()
     title = Title.objects.create(name="MM3", slug="mm-z")
     make_claim(title, "name", "MM3", source=bootstrap_source)
-    citation_source = CitationSource.objects.create(name="Flyer", source_type="web")
+    citation_source = make_citation_source(name="Flyer", source_type="web")
 
     _seed_cited_changesets(user, title, citation_source, 2)
     base = _q(lambda: client.get("/api/pages/sources/title/mm-z/"))

--- a/backend/apps/provenance/tests/test_citation_instance.py
+++ b/backend/apps/provenance/tests/test_citation_instance.py
@@ -6,6 +6,7 @@ from django.db.models import ProtectedError
 from django.test import RequestFactory
 
 from apps.citation.models import CitationSource
+from apps.citation.test_factories import make_citation_source
 from apps.provenance.admin import CitationInstanceAdmin
 from apps.provenance.models import CitationInstance, Claim, Source
 from apps.provenance.test_factories import source_changeset
@@ -13,9 +14,7 @@ from apps.provenance.test_factories import source_changeset
 
 @pytest.fixture
 def citation_source(db):
-    return CitationSource.objects.create(
-        name="The Encyclopedia of Pinball", source_type="book"
-    )
+    return make_citation_source(name="The Encyclopedia of Pinball", source_type="book")
 
 
 @pytest.fixture
@@ -33,7 +32,7 @@ def claim(db, provenance_source):
     # isn't claim-controlled, so we create the row directly (not via make_claim);
     # actor + changeset are NOT NULL, so supply a source changeset and its actor.
     ct = ContentType.objects.get_for_model(CitationSource)
-    cs = CitationSource.objects.create(name="Target", source_type="web")
+    cs = make_citation_source(name="Target", source_type="web")
     changeset = source_changeset(provenance_source)
     return Claim.objects.create(
         content_type=ct,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -388,7 +388,14 @@ source_modules = [
     "apps.kiosk",
 ]
 forbidden_modules = ["apps.accounts.test_factories"]
-ignore_imports = ["apps.*.tests.** -> apps.accounts.test_factories"]
+# Tests import it freely; the second ignore lets another test factory reuse it
+# (citation's default_actor() delegates here) — both are test-only helpers, not
+# production code. apps.provenance.Source sits a tier above citation, so a
+# user-backed default actor is the one the citation factory can reach.
+ignore_imports = [
+    "apps.*.tests.** -> apps.accounts.test_factories",
+    "apps.**.test_factories -> apps.accounts.test_factories",
+]
 
 [[tool.importlinter.contracts]]
 name = "Production code does not import provenance test factories"
@@ -570,7 +577,7 @@ forbidden_modules = [
 name = "Citation app internal stack"
 type = "layers"
 exhaustive = true # so new submodule left unplaced fails build
-exhaustive_ignores = ["apps", "migrations", "tests", "management"]
+exhaustive_ignores = ["apps", "migrations", "tests", "management", "test_factories"]
 containers = ["apps.citation"]
 layers = [
     "api | admin",

--- a/backend/tests/test_bounded_text_fields.py
+++ b/backend/tests/test_bounded_text_fields.py
@@ -112,9 +112,9 @@ def test_citation_instance_locator_rejects_overlong_in_full_clean() -> None:
     """``full_clean()`` enforces CharField max_length via Django validators."""
     from django.core.exceptions import ValidationError as DjangoValidationError
 
-    from apps.citation.models import CitationSource
+    from apps.citation.test_factories import make_citation_source
 
-    src = CitationSource.objects.create(name="X", source_type="book")
+    src = make_citation_source(name="X", source_type="book")
     inst = CitationInstance(
         citation_source=src,
         locator="x" * (CITATION_INSTANCE_LOCATOR_MAX_LENGTH + 1),

--- a/docs/plans/citations/Citations.md
+++ b/docs/plans/citations/Citations.md
@@ -1,9 +1,0 @@
-# Citations
-
-This directory now keeps only the durable planning docs for the citation system:
-
-- [CitationDecisions.md](CitationDecisions.md): the decision process, major tradeoffs, and the conclusions that survived implementation.
-- [CitationsDesign.md](CitationsDesign.md): the current high-level product and system design.
-- [CitationAutogenerationDesign.md](CitationAutogenerationDesign.md): the planned backend extraction layer for turning pasted evidence into source drafts.
-
-The older working notes, refactor plans, and implementation sketches were intentionally consolidated away. They were useful while designing and building the feature, but they were no longer a good long-term explanation of how this project thinks about citations.


### PR DESCRIPTION
## Summary

Tighten citation editorial attribution to non-null: every `CitationSource`/`Link`/`RootDomain` now must record the actor that created/updated it, enforced at the schema level. Builds on the merged User→Actor change (#587) and the prior legacy backfill.

Two commits, reviewable on their boundaries:

- **`test(citation)`** — add `make_citation_source/link/root_domain` factories plus a shared user-backed `default_actor()`, and route every test that builds a citation row through them so each row carries an attributing actor. Pure test refactor; green on its own.
- **`refactor(citation)`** — drop `null/blank` on `ActorAttributedModel.created_by/updated_by`, migration `0012` `AlterField`s the three models to `NOT NULL`, require `created_by` on the extractor helpers, and exclude the attribution fields from `validate_root_source`'s shape-only `full_clean`.

Notable details:
- `default_actor()` lives in `accounts/test_factories` (user-backed) — `provenance.Source` sits a tier above citation, so the citation factory can't reach it; import-linter contracts updated to let test factories delegate.
- The root-domain backfill migration test now runs against frozen `0006` models (it predates the attribution columns).

## Test plan

- [ ] `make test` — full backend suite green (factory churn + the migration round-trips)
- [ ] `make mypy`, `uv run lint-imports`, `make lint` — type/layer/lint gates pass
- [ ] `manage.py makemigrations --check` — no drift (model matches `0012`)
- [ ] Confirm a citation row can no longer be created without an actor (e.g. `CitationSource.objects.create(name="x", source_type="web")` raises `IntegrityError`)
