### PR TITLE
feat(provenance): backfill citation quotes out of ChangeSet notes

### DIFF
--- a/backend/apps/catalog/tests/test_note_quote_equivalence.py
+++ b/backend/apps/catalog/tests/test_note_quote_equivalence.py
@@ -1,0 +1,251 @@
+"""The note-quote backfill's equivalence oracle and migration behavior.
+
+The oracle: ``rewrite-then-ingest ≡ ingest-then-migrate``. A patch whose
+quote was moved onto the ``cite:`` mapping at the source (flippatch's rewrite
+script) and a patch ingested in its legacy ``note:``-scaffolding form and then
+run through the backfill migrations must reach the **identical** end state —
+same quote on the instance, same residual note. This is the property that
+catches any divergence between the two consumers of the recognizer (the
+rewrite script in flippatch, the migrations here), including a drift between
+the two byte-identical recognizer copies.
+
+The migration halves are exercised through their real ``_forward`` functions
+(imported via ``importlib`` — migration module names start with a digit).
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+import pytest
+from django.apps import apps as django_apps
+
+from apps.catalog.tests.conftest import make_machine_model
+from apps.claim_ingest.apply import apply_plan
+from apps.claim_ingest.patches import build_plan, load_patch
+from apps.provenance.models import ChangeSet, Source
+
+_populate = import_module("apps.provenance.migrations.0023_populate_citation_quotes")
+_strip = import_module("apps.provenance.migrations.0024_strip_note_quote_scaffolding")
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def models(db, flipcommons_catalog):
+    return {
+        "legacy": make_machine_model(name="Legacy MM", slug="legacy-mm", year=1997),
+        "rewritten": make_machine_model(
+            name="Rewritten MM", slug="rewritten-mm", year=1997
+        ),
+    }
+
+
+def _apply(text: str, *, patch_id: str) -> None:
+    doc = load_patch(text)
+    source = Source.objects.get(slug=doc.attribution)
+    plan = build_plan(doc, source=source, patch_id=patch_id)
+    apply_plan(plan)
+
+
+def _run_backfill() -> None:
+    _populate._forward(django_apps, None)
+    _strip._forward(django_apps, None)
+
+
+def _year_changeset(model) -> ChangeSet:
+    claim = model.claims.get(field_name="year", is_active=True)
+    changeset = claim.changeset
+    assert isinstance(changeset, ChangeSet)
+    return changeset
+
+
+def _evidence(model) -> set[tuple[str, str, str]]:
+    claim = model.claims.get(field_name="year", is_active=True)
+    return {
+        (inst.citation_source.name, inst.locator, inst.quote)
+        for inst in claim.citation_instances.select_related("citation_source")
+    }
+
+
+class TestEquivalenceOracle:
+    def test_pure_quote_note(self, models, ipdb_root):
+        # Legacy path: the note carries the quote as scaffolding.
+        _apply(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.legacy-mm:\n"
+            "      note: 'IPDB says \"This game was never produced\".'\n"
+            "      cite: ipdb:4443\n"
+            "      year: 1998\n",
+            patch_id="0001-legacy",
+        )
+        # Rewritten path: what flippatch's rewrite script emits for that note.
+        _apply(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.rewritten-mm:\n"
+            "      cite:\n"
+            "        ref: ipdb:4443\n"
+            "        quote: 'This game was never produced'\n"
+            "      year: 1998\n",
+            patch_id="0002-rewritten",
+        )
+
+        _run_backfill()
+
+        assert _year_changeset(models["legacy"]).note == ""
+        assert _year_changeset(models["rewritten"]).note == ""
+        assert _evidence(models["legacy"]) == _evidence(models["rewritten"])
+        assert _evidence(models["legacy"]) == {
+            ("Internet Pinball Database #4443", "", "This game was never produced")
+        }
+
+    def test_mixed_note_keeps_residual(self, models, ipdb_root):
+        _apply(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.legacy-mm:\n"
+            "      note: 'IPDB says \"This is a re-themed game.\"; IPDB records 1 unit.'\n"
+            "      cite: ipdb:4443\n"
+            "      year: 1998\n",
+            patch_id="0001-legacy",
+        )
+        _apply(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.rewritten-mm:\n"
+            "      note: 'IPDB records 1 unit.'\n"
+            "      cite:\n"
+            "        ref: ipdb:4443\n"
+            "        quote: 'This is a re-themed game.'\n"
+            "      year: 1998\n",
+            patch_id="0002-rewritten",
+        )
+
+        _run_backfill()
+
+        assert _year_changeset(models["legacy"]).note == "IPDB records 1 unit."
+        assert _year_changeset(models["rewritten"]).note == "IPDB records 1 unit."
+        assert _evidence(models["legacy"]) == _evidence(models["rewritten"])
+
+    def test_unrecognized_note_is_untouched_on_both_paths(self, models, ipdb_root):
+        # The rewrite script skips what the recognizer refuses, so the
+        # "rewritten" file carries the identical note — and the migration
+        # must leave the ingested row equally alone.
+        note = (
+            'note: \'The name includes "Prototype", which indicates that this '
+            "is a prototype that never reached commercial production.'\n"
+        )
+        _apply(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.legacy-mm:\n"
+            f"      {note}"
+            "      cite: ipdb:4443\n"
+            "      year: 1998\n",
+            patch_id="0001-legacy",
+        )
+        _apply(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.rewritten-mm:\n"
+            f"      {note}"
+            "      cite: ipdb:4443\n"
+            "      year: 1998\n",
+            patch_id="0002-rewritten",
+        )
+
+        _run_backfill()
+
+        expected = (
+            'The name includes "Prototype", which indicates that this is a '
+            "prototype that never reached commercial production."
+        )
+        assert _year_changeset(models["legacy"]).note == expected
+        assert _year_changeset(models["rewritten"]).note == expected
+        assert _evidence(models["legacy"]) == _evidence(models["rewritten"])
+        assert all(quote == "" for _, _, quote in _evidence(models["legacy"]))
+
+
+class TestBackfillMigration:
+    def test_multi_claim_changeset_shares_the_quote(self, models, ipdb_root):
+        _apply(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.legacy-mm:\n"
+            "      note: 'IPDB says \"never produced\".'\n"
+            "      cite: ipdb:4443\n"
+            "      year: 1998\n"
+            "      production_quantity: 4000\n",
+            patch_id="0001-legacy",
+        )
+        _run_backfill()
+
+        year = models["legacy"].claims.get(field_name="year", is_active=True)
+        qty = models["legacy"].claims.get(
+            field_name="production_quantity", is_active=True
+        )
+        year_inst = year.citation_instances.get()
+        assert year_inst.quote == "never produced"
+        assert qty.citation_instances.get().pk == year_inst.pk
+
+    def test_quote_note_without_citation_reported_not_migrated(
+        self, models, flipcommons_catalog, capsys
+    ):
+        from apps.provenance.test_factories import make_claim, source_changeset
+
+        changeset = source_changeset(flipcommons_catalog)
+        changeset.note = 'IPDB says "never produced".'
+        changeset.save(update_fields=["note"])
+        make_claim(models["legacy"], "year", 1998, changeset=changeset)
+
+        _run_backfill()
+
+        changeset.refresh_from_db()
+        assert changeset.note == 'IPDB says "never produced".'  # untouched
+        assert "no citation instances" in capsys.readouterr().out
+
+    def test_seed_import_notes_blanked(self, models, flipcommons_catalog):
+        from apps.provenance.test_factories import make_claim, source_changeset
+
+        changeset = source_changeset(flipcommons_catalog)
+        changeset.note = "Seed import (backfilled)."
+        changeset.save(update_fields=["note"])
+        make_claim(models["legacy"], "year", 1998, changeset=changeset)
+
+        _run_backfill()
+
+        changeset.refresh_from_db()
+        assert changeset.note == ""
+
+    def test_populate_reverse_blanks_only_migrated_quotes(self, models, ipdb_root):
+        _apply(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.legacy-mm:\n"
+            "      note: 'IPDB says \"never produced\".'\n"
+            "      cite: ipdb:4443\n"
+            "      year: 1998\n",
+            patch_id="0001-legacy",
+        )
+        _apply(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.rewritten-mm:\n"
+            "      cite:\n"
+            "        ref: ipdb:4443\n"
+            "        quote: 'authored at ingest'\n"
+            "      year: 1998\n",
+            patch_id="0002-rewritten",
+        )
+        _populate._forward(django_apps, None)
+        assert _evidence(models["legacy"]) != set()
+
+        _populate._reverse(django_apps, None)
+
+        # The migrated quote is blanked; the ingest-authored one survives.
+        assert {q for _, _, q in _evidence(models["legacy"])} == {""}
+        assert {q for _, _, q in _evidence(models["rewritten"])} == {
+            "authored at ingest"
+        }

--- a/backend/apps/provenance/migrations/0023_populate_citation_quotes.py
+++ b/backend/apps/provenance/migrations/0023_populate_citation_quotes.py
@@ -1,0 +1,82 @@
+"""Populate ``CitationInstance.quote`` from quote-shaped ``ChangeSet.note``s.
+
+Step one of the two-migration note-quote backfill (docs/plans/citations/
+CitationInstanceQuotes.md): write the quotes, don't touch the notes. The strip
+(``0024``) blanks the migrated notes to their residual only where this
+migration verifiably landed the quote, so the two are safe to review between.
+
+For each changeset whose note the recognizer matches, the quote lands on the
+changeset's field-level instances via the ``ClaimCitationInstance`` join —
+inline description instances carry no join rows, so they're naturally
+excluded. An instance is shared only within a changeset (verified: no instance
+spans two changesets), so the write is unambiguous; the walk in
+``note_quote_backfill`` still asserts that per changeset rather than assuming
+it, and REPORTS everything it can't migrate rather than silently dropping it.
+
+``QuerySet.update()``, not ``save()`` — ``CitationInstance`` is immutable and
+its ``save()`` rejects a row that already has a pk. Retro-filling a
+newly-added column on immutable rows is the one sanctioned exception;
+superseding instances instead would break their slugs and inline markers.
+
+Reverse blanks exactly the quotes the forward would write (recomputed — the
+transform is deterministic), so reverse-then-forward is clean.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+
+from apps.provenance.note_quote_backfill import quote_candidates
+
+
+def _forward(apps, schema_editor):
+    CitationInstance = apps.get_model("citation", "CitationInstance")
+    migrated = 0
+    reports: list[str] = []
+    for candidate in quote_candidates(apps):
+        if candidate.reason is not None:
+            reports.append(
+                f"changeset {candidate.changeset.pk}: {candidate.reason}: "
+                f"{candidate.changeset.note[:80]}"
+            )
+            continue
+        assert candidate.instances is not None and candidate.extracted is not None
+        pending = [
+            inst.pk
+            for inst in candidate.instances
+            if inst.quote != candidate.extracted.quote
+        ]
+        if pending:
+            CitationInstance.objects.filter(pk__in=pending).update(
+                quote=candidate.extracted.quote
+            )
+        migrated += 1
+    print(f"\n  populated quotes for {migrated} changesets")
+    for line in reports:
+        print(f"  SKIP {line}")
+
+
+def _reverse(apps, schema_editor):
+    CitationInstance = apps.get_model("citation", "CitationInstance")
+    for candidate in quote_candidates(apps):
+        if candidate.reason is not None or candidate.instances is None:
+            continue
+        assert candidate.extracted is not None
+        CitationInstance.objects.filter(
+            pk__in=[inst.pk for inst in candidate.instances],
+            quote=candidate.extracted.quote,
+        ).update(quote="")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "provenance",
+            "0022_remove_claim_provenance_claim_citation_max_length_and_more",
+        ),
+        ("citation", "0014_citationinstance_quote_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(_forward, _reverse),
+    ]

--- a/backend/apps/provenance/migrations/0024_strip_note_quote_scaffolding.py
+++ b/backend/apps/provenance/migrations/0024_strip_note_quote_scaffolding.py
@@ -1,0 +1,65 @@
+"""Strip migrated quote-notes to their residual; blank seed-import boilerplate.
+
+Step two of the note-quote backfill (docs/plans/citations/
+CitationInstanceQuotes.md): with the quotes verifiably on their
+``CitationInstance`` rows (``0023``), the ``<source> says "…"`` scaffolding
+comes off the notes. A pure-quote note blanks; a mixed note keeps its
+editorial residual. The strip is what makes the equivalence oracle hold — a
+rewritten-then-ingested patch yields an empty note, so the migrated
+historical note must reach the same state.
+
+Self-verifying: a note is stripped only when every one of its changeset's
+field-level instances carries exactly the extracted quote — i.e. only where
+``0023`` (or an ingest of the rewritten patch) actually landed it. Anything
+else is left untouched and reported.
+
+Also blanks the ~16,834 ``Seed import (backfilled).`` notes —
+``provenance/0011`` backfill boilerplate, redundant with the changeset's
+ingest-run linkage. The recognizer never sees them (not quote-shaped); they
+go by exact-match update.
+
+Reverse is a no-op: the original scaffolding is not reconstructible (nor
+meant to be — both migrations land before public launch, while the entire
+corpus is still Flipcommons-authored bootstrapping data).
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+
+from apps.provenance.note_quote_backfill import SEED_NOTE, quote_candidates
+
+
+def _forward(apps, schema_editor):
+    ChangeSet = apps.get_model("provenance", "ChangeSet")
+
+    stripped = 0
+    for candidate in quote_candidates(apps):
+        if candidate.reason is not None or candidate.instances is None:
+            continue
+        assert candidate.extracted is not None
+        if any(
+            inst.quote != candidate.extracted.quote for inst in candidate.instances
+        ):
+            print(
+                f"  SKIP changeset {candidate.changeset.pk}: quote not populated: "
+                f"{candidate.changeset.note[:80]}"
+            )
+            continue
+        ChangeSet.objects.filter(pk=candidate.changeset.pk).update(
+            note=candidate.extracted.residual
+        )
+        stripped += 1
+
+    seed = ChangeSet.objects.filter(note=SEED_NOTE).update(note="")
+    print(f"\n  stripped {stripped} quote-notes; blanked {seed} seed-import notes")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("provenance", "0023_populate_citation_quotes"),
+    ]
+
+    operations = [
+        migrations.RunPython(_forward, migrations.RunPython.noop),
+    ]

--- a/backend/apps/provenance/note_quote_backfill.py
+++ b/backend/apps/provenance/note_quote_backfill.py
@@ -1,0 +1,130 @@
+"""Shared machinery for the note-quote backfill migrations.
+
+One definition of "migratable" for both halves of the backfill —
+``provenance/0023`` (populate quotes) and ``provenance/0024`` (strip notes) —
+so the strip can never touch a note the populate didn't verifiably land.
+The pure text transform lives in :mod:`apps.provenance.note_quotes`; this
+module adds the DB walk around it.
+
+Imported by migrations ``provenance/0023`` and ``provenance/0024``: do NOT
+delete this module or change its semantics — migration replays on fresh
+databases depend on it behaving exactly as it did when they shipped.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, NamedTuple
+
+from apps.provenance.note_quotes import ExtractedQuote, extract_quote
+
+# The provenance/0011 backfill boilerplate; never quote-shaped, skipped fast.
+SEED_NOTE = "Seed import (backfilled)."
+
+# The note's source phrase implies acceptable source-name substrings for the
+# sources we can check (abbreviation and full name both count). A miss means
+# the note quotes one source while the changeset cites another — writing the
+# quote would mis-attribute it, so the row is skipped and reported for hand
+# review.
+SOURCE_NAME_HINTS: dict[str, tuple[str, ...]] = {
+    "ipdb": ("ipdb", "internet pinball database"),
+    "opdb": ("opdb", "open pinball database"),
+    "wikipedia": ("wikipedia",),
+    "kineticist": ("kineticist",),
+    "eremeka": ("eremeka",),
+    "early arcades japan": ("early arcades japan",),
+}
+
+
+class QuoteCandidate(NamedTuple):
+    """One non-empty note's disposition in the backfill.
+
+    ``instances`` is the list of historical ``CitationInstance`` rows the
+    quote belongs on, and is only set when ``reason`` is ``None``; a skipped
+    row instead carries the human-readable ``reason`` for the report.
+    """
+
+    changeset: Any  # historical ChangeSet model instance
+    extracted: ExtractedQuote | None
+    instances: list[Any] | None  # historical CitationInstance rows
+    reason: str | None
+
+
+def _source_names(instance: Any) -> str:  # noqa: ANN401 - historical model
+    """The instance's source name plus its parent's, lowered, for hint checks."""
+    source = instance.citation_source
+    names = str(source.name)
+    if source.parent_id is not None:
+        names += " " + source.parent.name
+    return names.lower()
+
+
+def _instances_match_source(instances: list[Any], source_phrase: str) -> bool:
+    """False only when the note names a checkable source the cite disagrees with."""
+    phrase = source_phrase.lower()
+    for token, name_tokens in SOURCE_NAME_HINTS.items():
+        if token in phrase:
+            return all(
+                any(name_token in _source_names(inst) for name_token in name_tokens)
+                for inst in instances
+            )
+    return True
+
+
+# ``apps`` is a migration StateApps registry — typed ``Any`` because the
+# historical models it yields have no importable static type.
+def quote_candidates(apps: Any) -> Iterator[QuoteCandidate]:  # noqa: ANN401
+    """Yield every non-seed note's backfill disposition, in changeset order.
+
+    Shared by 0023's forward (write quotes) and reverse (blank them) and
+    0024's strip guard. A recognized note is migratable only when its
+    changeset has field-level instances (via the ``ClaimCitationInstance``
+    join — inline instances have no join rows), they all cite one source,
+    that source agrees with the note's named source and no instance already
+    carries a different quote.
+    """
+    ChangeSet = apps.get_model("provenance", "ChangeSet")
+    CitationInstance = apps.get_model("citation", "CitationInstance")
+
+    notes = (
+        ChangeSet.objects.exclude(note="")
+        .exclude(note=SEED_NOTE)
+        .only("id", "note")
+        .order_by("id")
+    )
+    for changeset in notes.iterator():
+        extracted = extract_quote(changeset.note)
+        if extracted is None:
+            if '"' in changeset.note:
+                yield QuoteCandidate(
+                    changeset, None, None, "unrecognized quote-shaped note"
+                )
+            continue
+        instances = list(
+            CitationInstance.objects.filter(claims__changeset=changeset)
+            .distinct()
+            .select_related("citation_source", "citation_source__parent")
+        )
+        if not instances:
+            yield QuoteCandidate(changeset, extracted, None, "no citation instances")
+            continue
+        if len({inst.citation_source_id for inst in instances}) > 1:
+            yield QuoteCandidate(
+                changeset, extracted, None, "instances span several sources"
+            )
+            continue
+        if not _instances_match_source(instances, extracted.source):
+            yield QuoteCandidate(
+                changeset,
+                extracted,
+                None,
+                f"note quotes {extracted.source!r} but instances cite "
+                f"{instances[0].citation_source.name!r}",
+            )
+            continue
+        if any(inst.quote and inst.quote != extracted.quote for inst in instances):
+            yield QuoteCandidate(
+                changeset, extracted, None, "instance already carries a quote"
+            )
+            continue
+        yield QuoteCandidate(changeset, extracted, instances, None)

--- a/backend/apps/provenance/note_quotes.py
+++ b/backend/apps/provenance/note_quotes.py
@@ -1,0 +1,183 @@
+"""The quote recognizer: pull a verbatim source quote out of a legacy note.
+
+Legacy ``ChangeSet.note``s carry evidence as ``<source> says "<quote>"``
+scaffolding; the quote now belongs on the citation (``CitationInstance.quote``).
+This module is the pure transform both migration consumers share: flippatch's
+patch-rewrite script (``scripts/quote_rewrite/extract_quote.py`` there — a
+byte-identical twin below the module docstring; the repos share no runtime
+dependency) and the provenance data migrations here. Change one, change both —
+the ``rewrite-then-ingest ≡ ingest-then-migrate`` property test catches
+divergence.
+
+Deliberately conservative: only the confidently-shaped notes match; anything
+with substantive prose outside the quoted spans returns ``None`` and is fixed
+by hand. Every proposed rewrite gets human review via a before/after diff, so
+the recognizer optimizes for "never mangles" over "always matches".
+
+Imported by migrations ``provenance/0023`` and ``provenance/0024``: do NOT
+delete this module or change its semantics — migration replays on fresh
+databases depend on it behaving exactly as it did when they shipped.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import NamedTuple
+
+
+class ExtractedQuote(NamedTuple):
+    """A recognized quote-note, decomposed.
+
+    ``quote`` is the verbatim excerpt (multi-span joined by ``[...]``);
+    ``residual`` is what remains for the note (always ``""`` today — a note
+    with substantive leftover prose fails recognition instead); ``source``
+    is the note's source phrase (``IPDB``, ``The eremeka catalog``), returned
+    so consumers can flag a note whose named source disagrees with the unit's
+    ``cite:`` — moving such a quote would mis-attribute it.
+    """
+
+    quote: str
+    residual: str
+    source: str
+
+
+# Typography the authoring convention already mandates straightening: smart
+# quotes become straight ones and a real ellipsis character becomes the
+# explicit-omission marker. Applied before parsing so grandfathered pre-0039
+# notes (exempt from the note-typography lint) parse identically.
+_TYPOGRAPHY = {
+    "“": '"',
+    "”": '"',
+    "‘": "'",
+    "’": "'",
+    "…": "[...]",
+}
+
+# The verb phrases that introduce a quote without adding meaning of their own
+# ("this" refers to the entity the claim is about). Anything else between the
+# source name and the first quote — a subject, a dative object, a clause — is
+# substantive prose and fails recognition.
+_VERBS = ("says", "lists", "states", "reports", "reported", "dates this")
+
+# ``<source> <verb> ["that"] "`` or ``<source>: "`` — the source phrase is
+# short and quote-free. 60 chars accommodates the longest real prefix ("The
+# Canadian Trademarks Database lists") without inviting whole-sentence
+# prefixes.
+_PREFIX_RE = re.compile(
+    rf"^(?P<source>[^\"]{{1,60}}?)(?:\s+(?:{'|'.join(_VERBS)})\s+(?:that\s+)?|:\s+)(?=\")"
+)
+
+# Connectives allowed between two quoted spans: pure glue that ``[...]``
+# preserves. Anything longer is paraphrase, which fails recognition.
+_CONNECTIVE_RE = re.compile(r"(?:,?\s+and\s+|,\s+|;\s+|\s+)")
+
+# What may trail the final span: nothing, or a lone terminal period.
+_TERMINATOR_RE = re.compile(r"^\.?$")
+
+# A trailing residual after the final span: editorial rationale set off by a
+# comma, semicolon or dash ("..., identifying this as an aftermarket
+# re-theme..."). It stays behind as the note. Must itself be quote-free —
+# a quoted residual means the span split is ambiguous, so recognition fails.
+_RESIDUAL_RE = re.compile(r"^(?:,|;|\s+--|\s+—)\s+(?P<residual>[^\"]{4,})$", re.DOTALL)
+
+
+def _normalize(text: str) -> str:
+    for smart, straight in _TYPOGRAPHY.items():
+        text = text.replace(smart, straight)
+    return text
+
+
+class _ParsedTail(NamedTuple):
+    """The tail of a quote-note: its quoted spans and any trailing residual."""
+
+    spans: list[str]
+    residual: str
+
+
+def _parse_spans(tail: str) -> _ParsedTail | None:
+    """Parse *tail* as quoted spans joined by pure connectives, or ``None``.
+
+    Non-greedy span matching: an inner unescaped quote makes this parse fail
+    (the text after the early closing quote isn't a connective), which is what
+    lets the greedy fallback in :func:`extract_quote` read it as one outer
+    span instead. A trailing ``_RESIDUAL_RE`` fragment after the final span is
+    allowed and returned.
+    """
+    spans: list[str] = []
+    pos = 0
+    while True:
+        if pos >= len(tail) or tail[pos] != '"':
+            return None
+        end = tail.find('"', pos + 1)
+        if end == -1:
+            return None
+        spans.append(tail[pos + 1 : end])
+        pos = end + 1
+        rest = tail[pos:]
+        if _TERMINATOR_RE.match(rest):
+            return _ParsedTail(spans, "")
+        residual = _RESIDUAL_RE.match(rest)
+        if residual is not None:
+            return _ParsedTail(spans, residual.group("residual").strip())
+        connective = _CONNECTIVE_RE.match(rest)
+        if connective is None:
+            return None
+        pos += connective.end()
+
+
+# The greedy single-span reading: everything between the first quote and the
+# LAST quote in the tail is the span (inner unescaped quotes belong to the
+# source text), followed by a terminator or a trailing residual.
+_GREEDY_SPAN_RE = re.compile(r'^"(?P<span>.+)"(?P<after>[^\"]*)$', re.DOTALL)
+
+# Sentence punctuation immediately before an inner quote char is the tell-tale
+# of a disguised span boundary ("A," and that "B.") — a genuinely nested phrase
+# closes on a word character (a "flasher type" slot machine). Refusing these
+# keeps the greedy reading from splicing connective prose into a "verbatim"
+# quote; the rare source text that really quotes dialogue this way falls to
+# hand review instead.
+_DISGUISED_BOUNDARY_RE = re.compile(r'[.,;!?]"')
+
+
+def extract_quote(note: str) -> ExtractedQuote | None:
+    """Recognize a ``<source> says "<quote>"`` note; ``None`` on any doubt.
+
+    On a match the quote is the verbatim span text — multiple spans joined by
+    ``[...]`` in source order — with the convention's typography normalization
+    applied (straight quotes, ``…`` → ``[...]``). The scaffolding (``<source>
+    says``) is dropped: the citation already names the source. Trailing
+    editorial rationale set off from the final span survives as ``residual``.
+    A note whose prose doesn't otherwise reduce to scaffolding + spans + glue
+    is not recognized.
+    """
+    text = _normalize(note.strip())
+    prefix = _PREFIX_RE.match(text)
+    if prefix is None:
+        return None
+    tail = text[prefix.end() :]
+
+    # Prefer the multi-span reading; fall back to one greedy outer span so a
+    # nested unescaped quote ("Also called a "flasher type" slot machine.")
+    # matches to the outermost closing quote.
+    parsed = _parse_spans(tail)
+    if parsed is None:
+        greedy = _GREEDY_SPAN_RE.match(tail)
+        if greedy is None or _DISGUISED_BOUNDARY_RE.search(greedy.group("span")):
+            return None
+        after = greedy.group("after")
+        if _TERMINATOR_RE.match(after):
+            residual = ""
+        else:
+            residual_match = _RESIDUAL_RE.match(after)
+            if residual_match is None:
+                return None
+            residual = residual_match.group("residual").strip()
+        parsed = _ParsedTail([greedy.group("span")], residual)
+    if not all(span.strip() for span in parsed.spans):
+        return None
+
+    return ExtractedQuote(
+        quote=" [...] ".join(span.strip() for span in parsed.spans),
+        residual=parsed.residual,
+        source=prefix.group("source"),
+    )

--- a/backend/apps/provenance/tests/test_note_quotes.py
+++ b/backend/apps/provenance/tests/test_note_quotes.py
@@ -1,0 +1,223 @@
+"""Unit tests for the quote recognizer twin (apps.provenance.note_quotes).
+
+A mirror of flippatch's tests/test_extract_quote.py against the twin copy —
+each case is drawn from the real note corpus the recognizer was honed on.
+Keep the two suites in sync like the recognizers themselves; the equivalence
+test in apps/catalog/tests/test_note_quote_equivalence.py is what catches a
+behavioral divergence between the repos.
+"""
+
+from __future__ import annotations
+
+from apps.provenance.note_quotes import extract_quote
+
+# --- The canonical shapes -----------------------------------------------
+
+
+def test_simple_says_note():
+    result = extract_quote('IPDB says "This is Not A Pinball."')
+    assert result is not None
+    assert result.quote == "This is Not A Pinball."
+    assert result.residual == ""
+    assert result.source == "IPDB"
+
+
+def test_trailing_period_outside_quote_dropped():
+    result = extract_quote('IPDB says "Never went into production".')
+    assert result is not None
+    assert result.quote == "Never went into production"
+    assert result.residual == ""
+
+
+def test_lists_verb():
+    result = extract_quote('The eremeka catalog lists "1976 Advantage by Sankyo".')
+    assert result is not None
+    assert result.quote == "1976 Advantage by Sankyo"
+    assert result.source == "The eremeka catalog"
+
+
+def test_says_that():
+    result = extract_quote('Wikipedia says that "the company was renamed".')
+    assert result is not None
+    assert result.quote == "the company was renamed"
+
+
+def test_colon_form():
+    result = extract_quote(
+        'This Week in Pinball: "I stumbled upon a trademark filing."'
+    )
+    assert result is not None
+    assert result.quote == "I stumbled upon a trademark filing."
+    assert result.source == "This Week in Pinball"
+
+
+def test_dates_this_verb():
+    result = extract_quote(
+        'Early Arcades Japan dates this "1973 つり天狗 (Fishing Tengu) by 三共 (Sankyo)".'
+    )
+    assert result is not None
+    assert result.quote == "1973 つり天狗 (Fishing Tengu) by 三共 (Sankyo)"
+
+
+# --- Nested unescaped quotes match to the outermost closing quote --------
+
+
+def test_nested_unescaped_quotes_greedy():
+    result = extract_quote('IPDB says "Also called a "flasher type" slot machine."')
+    assert result is not None
+    assert result.quote == 'Also called a "flasher type" slot machine.'
+    assert result.residual == ""
+
+
+def test_nested_quotes_inside_long_span():
+    result = extract_quote(
+        'IPDB says "Although Bally also referred to this game as "an upright '
+        'pin-game", a disc is used instead of a ball and therefore we classify '
+        'it as Not A Pinball."'
+    )
+    assert result is not None
+    assert result.quote.startswith("Although Bally also referred")
+    assert '"an upright pin-game"' in result.quote
+
+
+# --- Multi-span notes join with [...] ------------------------------------
+
+
+def test_two_spans_joined():
+    result = extract_quote('IPDB says "never produced" and "prototype only".')
+    assert result is not None
+    assert result.quote == "never produced [...] prototype only"
+
+
+# --- Typography normalization ---------------------------------------------
+
+
+def test_smart_quotes_straightened():
+    result = extract_quote("IPDB says “This game was never produced.”")
+    assert result is not None
+    assert result.quote == "This game was never produced."
+
+
+def test_ellipsis_character_becomes_marker():
+    result = extract_quote('IPDB says "was selected… but never made".')
+    assert result is not None
+    assert result.quote == "was selected[...] but never made"
+
+
+def test_smart_apostrophe_straightened():
+    result = extract_quote("IPDB says “It used to be Williams’ 1948 ‘Rainbow’.”")
+    assert result is not None
+    assert result.quote == "It used to be Williams' 1948 'Rainbow'."
+
+
+# --- Trailing residuals ----------------------------------------------------
+
+
+def test_comma_residual_survives_as_note():
+    result = extract_quote(
+        'IPDB says "This is a re-themed game.", identifying this as an '
+        "aftermarket re-theme of an existing machine."
+    )
+    assert result is not None
+    assert result.quote == "This is a re-themed game."
+    assert result.residual == (
+        "identifying this as an aftermarket re-theme of an existing machine."
+    )
+
+
+def test_semicolon_residual():
+    result = extract_quote(
+        "IPDB says \"'Goin' Nuts' was never placed into production\"; "
+        "IPDB records 10 units."
+    )
+    assert result is not None
+    assert result.quote == "'Goin' Nuts' was never placed into production"
+    assert result.residual == "IPDB records 10 units."
+
+
+def test_dash_residual():
+    result = extract_quote(
+        'The Museum of the Game lists "Williams Electronics, Inc. (1967-1985)" '
+        "-- the span the name was active."
+    )
+    assert result is not None
+    assert result.quote == "Williams Electronics, Inc. (1967-1985)"
+    assert result.residual == "the span the name was active."
+
+
+def test_quoted_residual_refused():
+    # A residual containing a quote means the span split is ambiguous.
+    assert (
+        extract_quote(
+            'The eremeka catalog lists "1970 Jumbo Kick"; flipcommons held it '
+            'with no maker (IPDB: "Unknown Manufacturer").'
+        )
+        is None
+    )
+
+
+# --- Refusals: substantive prose outside the spans ------------------------
+
+
+def test_own_data_note_refused():
+    assert (
+        extract_quote(
+            'The name includes "Prototype", which indicates that this is a '
+            "prototype that never reached commercial production."
+        )
+        is None
+    )
+
+
+def test_subject_between_verb_and_quote_refused():
+    # The quote alone would lose its subject ("Midway").
+    assert (
+        extract_quote(
+            'Wikipedia says Midway "moved its headquarters from Franklin Park, '
+            "Illinois, to Williams's then-headquarters in Chicago.\""
+        )
+        is None
+    )
+
+
+def test_meaning_bearing_trailing_text_refused():
+    # " in 1988" isn't set off by punctuation — it belongs to the claim.
+    assert (
+        extract_quote('Wikipedia says "moved its headquarters to Chicago" in 1988.')
+        is None
+    )
+
+
+def test_translation_gloss_inline_refused():
+    # The gloss between subject and quote is interpretation, not scaffolding.
+    assert (
+        extract_quote(
+            'Weblio says サンワイズ (Sunwise) "1998年3月6日に倒産した" '
+            "(went bankrupt on 6 March 1998); it was based in Mitaka, Tokyo."
+        )
+        is None
+    )
+
+
+def test_multi_span_with_substantive_connective_refused():
+    assert (
+        extract_quote(
+            'Wikipedia says the company "manufactured other machines," was '
+            '"founded by Ode D. Jennings," and that "Jennings & Company was '
+            'incorporated in Illinois."'
+        )
+        is None
+    )
+
+
+def test_plain_rationale_note_refused():
+    assert extract_quote("Corrected the year per the flyer.") is None
+
+
+def test_empty_and_quoteless_refused():
+    assert extract_quote("") is None
+    assert extract_quote("On The Flip museum's list of unreleased prototypes") is None
+
+
+def test_empty_span_refused():
+    assert extract_quote('IPDB says ""') is None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -544,7 +544,10 @@ layers = [
     "changeset_writer",
     "validation | schemas | claim_ranking_in_db | licensing | resolution | rate_limits",
     "attribution",
-    "models | claim_presence | constants | entity_links | pagination | authz",
+    # note_quote_backfill is migration support (provenance/0023-0024): it walks
+    # historical models through the apps registry, so its only static import is
+    # the pure recognizer below.
+    "models | claim_presence | constants | entity_links | pagination | authz | note_quote_backfill",
     # The abstract claim-control bases every claim-controlled model inherits.
     # Pinned to the bottom so it can't reach UP into the provenance domain
     # (Claim, ChangeSet, Source). Its core-only-leaf guarantee — no cross-app
@@ -552,7 +555,9 @@ layers = [
     # since the global tiers would otherwise let it import down into citation /
     # accounts. Together they keep the package lift-out-ready (below citation).
     "model_bases",
-    "types",
+    # note_quotes is the pure quote recognizer (byte-identical twin of
+    # flippatch's) — imports nothing, so it lives at the bottom beside types.
+    "types | note_quotes",
 ]
 
 [[tool.importlinter.contracts]]

--- a/docs/DataPatchAuthoring.md
+++ b/docs/DataPatchAuthoring.md
@@ -35,7 +35,7 @@ These principles apply whether you hand-author or generate.
 
 ### Attribution of the overall patch
 
-**Attribute the overall patch to the `flipcommons-catalog` source by default.** It's Flipcommons' own attribution for values we research, scrape and classify ourselves, and it owns the overwhelming majority of patches. Anything web-scraped where we apply editorial judgment is `flipcommons-catalog`; scraping a fact off IPDB or Kineticist does **not** mean attributing the patch to them. Deriving a structured value by classifying a source's free text (parsing IPDB notes into a `game_format`, say) is this same default case, not an exception: `flipcommons-catalog`, with `cite:` to the source text as evidence and `note:` quoting it — there's no source claim to supersede, because the source never had that field.
+**Attribute the overall patch to the `flipcommons-catalog` source by default.** It's Flipcommons' own attribution for values we research, scrape and classify ourselves, and it owns the overwhelming majority of patches. Anything web-scraped where we apply editorial judgment is `flipcommons-catalog`; scraping a fact off IPDB or Kineticist does **not** mean attributing the patch to them. Deriving a structured value by classifying a source's free text (parsing IPDB notes into a `game_format`, say) is this same default case, not an exception: `flipcommons-catalog`, with `cite:` to the source text as evidence, its `quote:` carrying the excerpt you classified — there's no source claim to supersede, because the source never had that field.
 
 Reach for a different attribution only in these cases:
 
@@ -48,15 +48,19 @@ Reach for a different attribution only in these cases:
 
 **Each entry targets exactly one record.** By default keep that record's fields together in the one entry under a single `note`/`cite`. When the fields have **distinct evidence**, you may instead split them across several entries on the same record — each its own `ChangeSet` with its own `note`/`cite`, as long as the fields are disjoint (see [DataPatches.md](DataPatches.md#notes--citations)).
 
-### Note every entry
+### Quote the evidence on the cite
 
-**Explain every change with `note:`**, written as `<source> says "<verbatim quote>"`. Quote the source _verbatim_ and mark your own omissions with `[...]`. **Preserve the source's own characters**, including non-ASCII letters in foreign-language quotes (e.g. `Günter`, `gegründet`) — notes are stored as UTF-8, so don't strip or transliterate them. Only normalize stray _typography_ that's a copy-paste artifact rather than part of the quote: straighten smart quotes (`“ ”` → `"`) and spell out an ellipsis `…` as `[...]`.
+**Put the verbatim source excerpt in `quote:` on the `cite:` mapping** — see the mapping form in [DataPatches.md](DataPatches.md#notes--citations). Quote the source _verbatim_ and mark your own omissions with `[...]`; when quoting several passages, join the spans with `[...]` in source order. **Preserve the source's own characters**, including non-ASCII letters in foreign-language quotes (e.g. `Günter`, `gegründet`) — quotes are stored as UTF-8, so don't strip or transliterate them. Only normalize stray _typography_ that's a copy-paste artifact rather than part of the quote: straighten smart quotes (`“ ”` → `"`) and spell out an ellipsis `…` as `[...]`. A reviewer should be able to follow the citation and ctrl-F find each span.
+
+### Note only when there's something to explain
+
+**`note:` is the edit summary — rationale beyond the evidence.** Uncertainty, cleanup comments, merge explanations, disambiguations and paraphrased source facts ("what the source states, in my words, and why the value follows") belong here; a verbatim excerpt does NOT — that's the `quote:`. A cite with a quote usually needs no note at all. Do not write the legacy `<source> says "<quote>"` scaffolding: the citation already names the source and the quote carries the evidence.
 
 ### Cite most entries
 
 **Cite external evidence with `cite:` on every substantive claim.** Skip the cite only when the evidence _is_ the entity's own data — then state it in the `note:` instead ("Its name contains the word 'prototype'"). The other exemptions are scaffolding entries (below) and aliases/abbreviations (see [Aliases and abbreviations](#aliases-and-abbreviations)).
 
-**Pick the cite form by source:** `scheme:identifier` for IPDB/OPDB records, or a raw `http(s)://` URL for any other web page (a forum thread, an archive scan, a manufacturer's page). Reach for the scheme form whenever one exists; the URL form is the escape hatch for sources without a scheme. A URL cite needs its **website root seeded first** — see [Citation sources](#citation-sources).
+**Pick the cite ref form by source:** `scheme:identifier` for IPDB/OPDB records, or a raw `http(s)://` URL for any other web page (a forum thread, an archive scan, a manufacturer's page). Reach for the scheme form whenever one exists; the URL form is the escape hatch for sources without a scheme. A URL cite needs its **website root seeded first** — see [Citation sources](#citation-sources).
 
 **The cite can target a different record than the claim.** When the evidence lives in a _different_ record's note (a cross-reference — "‹other game› is not a pinball"), `cite:` the record that contains the statement.
 

--- a/frontend/src/lib/components/input/citation/NotesAndCitationsDetails.svelte
+++ b/frontend/src/lib/components/input/citation/NotesAndCitationsDetails.svelte
@@ -17,8 +17,8 @@
     citation = $bindable(null),
     showCitation = true,
     showMixedEditWarning = false,
-    noteLabel = 'Edit note',
-    notePlaceholder = 'Why are you making this change?',
+    noteLabel = 'Edit summary',
+    notePlaceholder = 'Optional: rationale beyond the evidence — put source quotes on the citation',
   }: Props = $props();
 </script>
 

--- a/frontend/src/lib/components/pages/record/edit/SectionEditorForm.dom.test.ts
+++ b/frontend/src/lib/components/pages/record/edit/SectionEditorForm.dom.test.ts
@@ -38,7 +38,7 @@ describe('SectionEditorForm', () => {
 
     await user.click(screen.getByText('Notes & Citations'));
 
-    const noteInput = screen.getByLabelText(/Edit note/);
+    const noteInput = screen.getByLabelText(/Edit summary/);
     await user.type(noteInput, 'Corrected per IPDB');
 
     await user.click(screen.getByRole('button', { name: 'Save' }));

--- a/frontend/src/lib/components/pages/record/edit/SectionEditorModal.dom.test.ts
+++ b/frontend/src/lib/components/pages/record/edit/SectionEditorModal.dom.test.ts
@@ -142,7 +142,7 @@ describe('SectionEditorModal', () => {
     await user.click(screen.getByText('Notes & Citations'));
 
     // Type a note
-    const noteInput = screen.getByLabelText(/Edit note/);
+    const noteInput = screen.getByLabelText(/Edit summary/);
     await user.type(noteInput, 'Corrected per IPDB');
 
     await user.click(screen.getByRole('button', { name: 'Save' }));
@@ -157,14 +157,14 @@ describe('SectionEditorModal', () => {
     // Open, type a note, close without saving
     await user.click(screen.getByRole('button', { name: 'Open editor' }));
     await user.click(screen.getByText('Notes & Citations'));
-    const noteInput = screen.getByLabelText(/Edit note/);
+    const noteInput = screen.getByLabelText(/Edit summary/);
     await user.type(noteInput, 'some note');
     await user.keyboard('{Escape}');
 
     // Reopen — note should be empty
     await user.click(screen.getByRole('button', { name: 'Open editor' }));
     await user.click(screen.getByText('Notes & Citations'));
-    expect(screen.getByLabelText(/Edit note/)).toHaveValue('');
+    expect(screen.getByLabelText(/Edit summary/)).toHaveValue('');
   });
 
   it('renders the section switcher in the modal header and switches sections', async () => {


### PR DESCRIPTION
## Summary

Steps 3–4 of [CitationInstanceQuotes.md](https://github.com/The-Flip/flipcommons/blob/main/docs/plans/citations/CitationInstanceQuotes.md): the two-migration backfill that moves verbatim quotes out of `ChangeSet.note` onto `CitationInstance.quote`, plus the retirement of note-as-quote in docs and the editor. **Stacked on #599 and #598** (merge those first — the migration graph depends on both; this PR's base is the #599 branch and it contains a merge of #598).

- `provenance/0023` populates quotes from every recognizer-matched note via the join table (`QuerySet.update()` on the immutable rows), reporting every skip: unrecognized quote-shaped notes, no-instance notes, multi-source changesets, note-source/cite-source mismatches
- `provenance/0024` strips migrated notes to their editorial residual — only where every instance verifiably carries the extracted quote — and blanks the 16,834 `Seed import (backfilled).` notes
- The recognizer (`note_quotes.py`) is a byte-identical twin of flippatch's `scripts/quote_rewrite/extract_quote.py`; conservative by design (refuses subjects-between-verb-and-quote, substantive connectives, translation glosses, disguised span boundaries)
- The **equivalence oracle** test locks `rewrite-then-ingest ≡ ingest-then-migrate` — same quote, same residual note from either path
- Editor note relabels to 'Edit summary'; DataPatchAuthoring.md moves the verbatim-excerpt conventions onto `cite.quote`

## Test plan

- [x] Full backend suite incl. the oracle and migration behavior tests; recognizer twin has a 24-case characterization suite mirrored from flippatch
- [x] Rehearsed on the `db.pre-0039` prod snapshot: full migration replay populated + stripped 367 quote-notes, blanked all seed notes, and the rewritten flippatch patches ingested cleanly on top (391 quoted instances from both paths)
- [ ] Human review of the 367-row before/after rewrite report (generated during rehearsal) before this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)