### PR TITLE
Upgrade super-sitemap 1.0.12 → 2.0.4 (adopt v2 adapter API)

### DIFF
--- a/docs/plans/seo/Sitemap.md
+++ b/docs/plans/seo/Sitemap.md
@@ -289,11 +289,11 @@ The sitemap endpoint reads `STATIC_LASTMOD` directly (see §3) and emits one `<u
 
 ## 3. Frontend — super-sitemap
 
-The frontend uses [`super-sitemap`](https://github.com/jasongitmail/super-sitemap) for XML rendering. It handles escaping, `lastmod` formatting, and sitemap-index splitting (when total URLs cross 50k, an index document points at `/sitemap1.xml`, `/sitemap2.xml`, etc. — which only works if the route file is named `sitemap[[page=integer]].xml` and passes `page: params.page`, per the super-sitemap README). Pin to `super-sitemap@^1.0.12` — zero runtime dependencies, healthy maintenance (~40k downloads/month, single-maintainer with consistent cadence over 18+ months).
+The frontend uses [`super-sitemap`](https://github.com/jasongitmail/super-sitemap) for XML rendering. It handles escaping, `lastmod` formatting, and sitemap-index splitting (when total URLs cross 50k, an index document points at `/sitemap1.xml`, `/sitemap2.xml`, etc. — which only works if the route file is named `sitemap[[page=integer]].xml` and passes `page: params.page`, per the super-sitemap README). Pin to `super-sitemap@^2.0.4`, imported through its SvelteKit adapter subpath (`super-sitemap/sveltekit`) — v2 dropped the bare package entry point in favor of per-framework adapters. Still zero runtime dependencies, healthy maintenance (~40k downloads/month, single-maintainer with consistent cadence over 18+ months).
 
 ### Route file: `sitemap[[page=integer]].xml`
 
-The route lives at `frontend/src/routes/sitemap[[page=integer]].xml/+server.ts` from day one, even though today's URL count is well under 50k. The optional `[[page=integer]]` rest-param lets the same endpoint serve `/sitemap.xml` (the index or single urlset) and `/sitemap1.xml`, `/sitemap2.xml`, etc. (per-page urlsets) without a second file. Renaming later when we cross 50k would mean either breaking the canonical `/sitemap.xml` URL or adding a redirect — both avoidable by getting the route shape right upfront. The `=integer` matcher (in `src/params/integer.ts`, pattern `^[1-9]\d*$` to match super-sitemap's own page validation at sitemap.js:105) keeps `/sitemapfoo.xml`, `/sitemap0.xml`, and `/sitemap007.xml` 404ing at the router instead of routing through and getting 400 from super-sitemap.
+The route lives at `frontend/src/routes/sitemap[[page=integer]].xml/+server.ts` from day one, even though today's URL count is well under 50k. The optional `[[page=integer]]` rest-param lets the same endpoint serve `/sitemap.xml` (the index or single urlset) and `/sitemap1.xml`, `/sitemap2.xml`, etc. (per-page urlsets) without a second file. Renaming later when we cross 50k would mean either breaking the canonical `/sitemap.xml` URL or adding a redirect — both avoidable by getting the route shape right upfront. The `=integer` matcher (in `src/params/integer.ts`, pattern `^[1-9]\d*$` to match super-sitemap's own page validation, `/^[1-9]\d*$/` in `core/internal/pagination.js`) keeps `/sitemapfoo.xml`, `/sitemap0.xml`, and `/sitemap007.xml` 404ing at the router instead of routing through and getting 400 from super-sitemap.
 
 ### Listed-indexable routes that consume a catalog entity's slug
 
@@ -314,7 +314,7 @@ The `satisfies` clause forces every key to be a real route ID and every value to
 
 ```ts
 // frontend/src/routes/sitemap[[page=integer]].xml/+server.ts
-import * as sitemap from "super-sitemap";
+import * as sitemap from "super-sitemap/sveltekit";
 import { SITE_ORIGIN } from "$env/static/private";
 import {
   allRoutes,
@@ -413,9 +413,11 @@ export const GET = async ({ fetch, url, request, params }) => {
 
 That's the whole endpoint. Adding a new entity type requires zero changes here — `GET /api/sitemap/` reports the new feed, `catalogRoutesByEntity()` finds its route IDs, the loop wires them into `paramValues`. Adding a new static page requires one line: an entry in `STATIC_LASTMOD`. Adding a new listed-indexable route that consumes a catalog entity's slug requires one line in `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE`.
 
+**super-sitemap v2 deltas (the shipped `+server.ts` is authoritative; this sketch is a simplified skeleton).** The v2 upgrade tightened several rules the sketch above glosses over, all handled in the real endpoint: (a) import from `super-sitemap/sveltekit`, not the bare package; (b) `excludeRoutePatterns` takes `RegExp` objects, not strings (see `routeIdToRegex` below); (c) v2 rejects a `paramValues` key on a param-less route, so the `directRoutesByEntity` predicate also drops `catalog-listing` routes (`/titles`, `/cabinets`, … stay static-discovered, with `<lastmod>` attached via a `listingLastmodByUrl` map keyed off each feed's `max_lastmod`); (d) v2 rejects both a missing key AND an empty array for a discovered dynamic route, so the loop sets `paramValues` only for routes that have entries and adds every zero-entry indexable dynamic route to `excludeRoutePatterns` for that request instead of seeding an empty array.
+
 ### Rest-param routes (`Location`)
 
-`Location.public_id_field = "location_path"` — a slash-separated path like `"manufacturer/title/region/site"` — and its SvelteKit route is `/locations/[...path]` (rest segment). The frontend passes `values: [e.slug]` to super-sitemap regardless of whether the route uses `[slug]` or `[...path]`. Verified against super-sitemap@1.0.12: the library substitutes via `String.prototype.replace` with no URL-encoding, so `values: ["a/b/c"]` produces `/locations/a/b/c` (literal slashes). No per-route shape branch is needed. A targeted regression test (Location with multi-segment path → expect `/locations/foo/bar`, not `/locations/foo%2Fbar`) belongs in §7 to catch a future library change.
+`Location.public_id_field = "location_path"` — a slash-separated path like `"manufacturer/title/region/site"` — and its SvelteKit route is `/locations/[...path]` (rest segment). The frontend passes `values: [e.slug]` to super-sitemap regardless of whether the route uses `[slug]` or `[...path]`. Verified against super-sitemap@2.0.4: the library substitutes without URL-encoding, so `values: ["a/b/c"]` produces `/locations/a/b/c` (literal slashes). No per-route shape branch is needed. A targeted regression test (Location with multi-segment path → expect `/locations/foo/bar`, not `/locations/foo%2Fbar`) belongs in §7 to catch a future library change.
 
 ### Tolerating unclassified routes
 
@@ -439,7 +441,7 @@ and call `safeIsIndexable` at both sites. Returning `false` is the safer default
 
 ### `routeIdToRegex` helper
 
-`excludeRoutePatterns` expects regex strings. SvelteKit route IDs include `[slug]`, `[...path]`, `[[optional]]`, and `(group)` shapes. super-sitemap matches `excludeRoutePatterns` against URLs (not route IDs), so the helper must (a) escape `/`, `.`, `[`, `]` literals, (b) translate dynamic segments to wildcard patterns, and (c) **strip `(group)` segments entirely** — the same transform `stripRouteGroups` applies when building `STATIC_LASTMOD_BY_URL`. Both consumers must agree on group handling, or a static route's exclusion regex won't line up with the URL super-sitemap emits for it from auto-discovery. Unit-test the helper directly with each shape and against the full `allRoutes()` snapshot — accidentally over- or under-matching here silently drops correct URLs from the sitemap or leaks non-indexable ones in.
+`excludeRoutePatterns` expects an array of `RegExp` objects — super-sitemap@2 throws on plain strings. SvelteKit route IDs include `[slug]`, `[...path]`, `[[optional]]`, and `(group)` shapes. Crucially, v2 matches `excludeRoutePatterns` against the route **key** — after `(group)` segments are stripped but _before_ dynamic params are interpolated — not against resolved URLs (this changed from v1). So the helper (a) **strips `(group)` segments** (the same `stripRouteGroups` transform used to build `STATIC_LASTMOD_BY_URL`), then (b) escapes regex metacharacters and (c) anchors both ends, leaving `[slug]`/`[...path]` literal — no wildcard translation, because super-sitemap feeds the un-interpolated key. Both consumers must agree on group handling, or a static route's exclusion pattern won't line up with the key super-sitemap emits for it from auto-discovery. Unit-test the helper directly with each shape and against the full `allRoutes()` snapshot (matching against `stripRouteGroups(id)`, as super-sitemap does) — accidentally over- or under-matching here silently drops correct URLs from the sitemap or leaks non-indexable ones in. (One gap: optional-param `[[x]]` routes are expanded into variants by super-sitemap before filtering, which `routeIdToRegex` does not mirror; harmless today because the only `[[…]]` route is this `+server` endpoint, which super-sitemap never discovers.)
 
 ### Why super-sitemap
 
@@ -449,7 +451,7 @@ and call `safeIsIndexable` at both sites. Returning `false` is the safer default
 
 ### Response caching
 
-The SvelteKit `/sitemap.xml` response sets `Cache-Control: public, max-age=3600` by passing explicit `headers` to `sitemap.response()` — super-sitemap@1.0.12's default is `max-age=0, s-maxage=3600` (sitemap.js:117), which we override because (a) we want clients/crawlers to actually cache, not re-validate every hit, and (b) `s-maxage` is a no-op today (Caddy isn't a caching reverse proxy and there's no CDN in front of it). The Django `/api/sitemap/` response sets the same TTL and is also cached in-process for an hour, so the staleness budget is bounded by the longer-lived layer. The two cache lifetimes don't compose multiplicatively — both are wall-clock from the moment each layer warms — but they make repeated crawler hits cheap regardless of layer.
+The SvelteKit `/sitemap.xml` response sets `Cache-Control: public, max-age=3600` by passing explicit `headers` to `sitemap.response()` — super-sitemap's default is `max-age=0, s-maxage=3600` (`getHeaders` in `core/internal/sitemap.js`), which we override because (a) we want clients/crawlers to actually cache, not re-validate every hit, and (b) `s-maxage` is a no-op today (Caddy isn't a caching reverse proxy and there's no CDN in front of it). The Django `/api/sitemap/` response sets the same TTL and is also cached in-process for an hour, so the staleness budget is bounded by the longer-lived layer. The two cache lifetimes don't compose multiplicatively — both are wall-clock from the moment each layer warms — but they make repeated crawler hits cheap regardless of layer.
 
 Add `s-maxage` back the same diff that introduces a shared cache layer.
 
@@ -559,7 +561,7 @@ Sitemap frontend endpoint + robots line (Commit D steps). `LISTED_INDEXABLE_ENTI
 #### Commit D — sitemap endpoint + robots line
 
 1. `frontend/src/lib/route-metadata.server.ts` — add `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE` with `/manufacturers/[slug]/systems → manufacturer`. Add parity test (key ∈ `SEARCH_ENGINE_INDEXABLE_ROUTE_IDS`; value ∈ `CatalogEntityKey`; key NOT a `catalog-*` route).
-2. `pnpm add super-sitemap@~1.0.12`.
+2. `pnpm add super-sitemap@~2.0.4` (import via the `super-sitemap/sveltekit` adapter subpath).
 3. `frontend/src/routes/sitemap[[page=integer]].xml/+server.ts` — note the optional-param route shape (sitemap-index support from day one). Wire super-sitemap to `/api/sitemap/` via `createServerClient` for catalog URLs, expand to route IDs via `catalogRoutesByEntity()` + `LISTED_INDEXABLE_ENTITY_SLUG_SOURCE`, apply `detail_excluded_slugs` only to `catalog-detail` classifications, attach static `lastmod` via `processPaths` reading `STATIC_LASTMOD_BY_URL`. Pass `page: params.page` to `sitemap.response()`. Use `safeIsIndexable` (per §3 "Tolerating unclassified routes"). Set `Cache-Control` on responses. Gate on `ALLOW_SEARCH_ENGINE_INDEXING` via `isDeploymentSearchEngineIndexable()`. Return 502 if the Django client returns an error.
 4. Implement and unit-test the `routeIdToRegex` helper plus `stripRouteGroups` (per §3).
 5. Append the `Sitemap:` line to `frontend/src/routes/robots.txt/+server.ts` (indexable-mode only, pointing to `${SITE_ORIGIN}/sitemap.xml` — the canonical entry point even with the `[[page]]` route shape). Extend the existing robots test.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "openapi-fetch": "^0.17.0",
     "postcss-jit-props": "^1.0.16",
     "posthog-js": "^1.396.2",
-    "super-sitemap": "~1.0.12"
+    "super-sitemap": "~2.0.4"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^1.396.2
         version: 1.396.2
       super-sitemap:
-        specifier: ~1.0.12
-        version: 1.0.12(svelte@5.56.4(@typescript-eslint/types@8.62.1))
+        specifier: ~2.0.4
+        version: 2.0.4
     devDependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.5.7
@@ -2958,10 +2958,8 @@ packages:
     engines: {node: '>=20.19.0'}
     hasBin: true
 
-  super-sitemap@1.0.12:
-    resolution: {integrity: sha512-C3gfAS1RZxL5bbZGtgnIOitMhfqAt8RmhW8AWTia6c8n9RW3Zx7f/SxVeFWZD0I1nUAx2pkxuWazVtev0Nmb5w==}
-    peerDependencies:
-      svelte: '>=4.0.0 <6.0.0'
+  super-sitemap@2.0.4:
+    resolution: {integrity: sha512-GVoa8ZcORd4jjDWl9Tz3MRMXYBnM4q5jX9vaK9LAoWrdXLWjYLB3e5innjul1RS/Ih5+x5vBpIf8bCyoW20yJQ==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -6102,9 +6100,7 @@ snapshots:
       - supports-color
       - typescript
 
-  super-sitemap@1.0.12(svelte@5.56.4(@typescript-eslint/types@8.62.1)):
-    dependencies:
-      svelte: 5.56.4(@typescript-eslint/types@8.62.1)
+  super-sitemap@2.0.4: {}
 
   supports-color@10.2.2: {}
 

--- a/frontend/src/lib/sitemap-helpers.test.ts
+++ b/frontend/src/lib/sitemap-helpers.test.ts
@@ -22,10 +22,10 @@ describe('stripRouteGroups', () => {
 });
 
 describe('routeIdToRegex', () => {
-  // super-sitemap applies excludeRoutePatterns to route-ID form (with
-  // `[slug]`, `[...path]`, and `(group)` still present), so the regex
-  // should match the route ID literally — no wildcard expansion of
-  // dynamic segments. These anchor tests pin both directions.
+  // super-sitemap@2 matches excludeRoutePatterns against the route key with
+  // `(group)` segments stripped but dynamic params (`[slug]`, `[...path]`)
+  // still present — no wildcard expansion of dynamic segments. These anchor
+  // tests pin both directions.
   it.each<[RouteId, string, boolean]>([
     ['/login', '/login', true],
     ['/login', '/login/', false],
@@ -34,20 +34,20 @@ describe('routeIdToRegex', () => {
     ['/titles/[slug]/edit', '/titles/foo/edit', false],
     ['/locations/[...path]/edit', '/locations/[...path]/edit', true],
     ['/locations/[...path]/edit', '/locations/a/b/edit', false],
-    ['/(legal)/privacy', '/(legal)/privacy', true],
-    ['/(legal)/privacy', '/privacy', false],
+    // Groups are stripped before matching, mirroring super-sitemap v2.
+    ['/(legal)/privacy', '/privacy', true],
+    ['/(legal)/privacy', '/(legal)/privacy', false],
     // Optional param — literal, not expanded.
     ['/sitemap[[page=integer]].xml', '/sitemap[[page=integer]].xml', true],
   ])('regex for %s matches %s = %s', (id, candidate, expected) => {
-    const re = new RegExp(routeIdToRegex(id));
-    expect(re.test(candidate)).toBe(expected);
+    expect(routeIdToRegex(id).test(candidate)).toBe(expected);
   });
 
   // Snapshot: the exclude set should be exactly the non-indexable routes,
-  // matched literally against the route-ID-with-groups form that
-  // super-sitemap's filterRoutes() feeds in. A regression that over- or
-  // under-matched here would silently drop correct URLs from the sitemap
-  // or leak non-indexable ones in.
+  // matched against the group-stripped route key that super-sitemap v2's
+  // exclusion filter feeds in. A regression that over- or under-matched here
+  // would silently drop correct URLs from the sitemap or leak non-indexable
+  // ones in.
   it('excludes exactly the non-indexable routes', () => {
     const excludePatterns = allRoutes()
       .filter((id) => {
@@ -57,8 +57,7 @@ describe('routeIdToRegex', () => {
           return false;
         }
       })
-      .map(routeIdToRegex)
-      .map((p) => new RegExp(p));
+      .map(routeIdToRegex);
 
     for (const id of allRoutes()) {
       let isIndexable: boolean;
@@ -67,7 +66,8 @@ describe('routeIdToRegex', () => {
       } catch {
         isIndexable = false;
       }
-      const matched = excludePatterns.some((re) => re.test(id));
+      const routeKey = stripRouteGroups(id);
+      const matched = excludePatterns.some((re) => re.test(routeKey));
       expect(matched, `expected ${id} matched=${matched} for indexable=${isIndexable}`).toBe(
         !isIndexable,
       );

--- a/frontend/src/lib/sitemap-helpers.ts
+++ b/frontend/src/lib/sitemap-helpers.ts
@@ -10,9 +10,11 @@
  * `STATIC_LASTMOD` (which uses route-ID form, with groups) by URL form
  * (which is what super-sitemap's `processPaths` callback receives).
  *
- * Mirrors super-sitemap's own group-stripping pattern (sitemap.js:267) so
- * the two stay in lockstep — a divergence would mean a static route's
- * lookup misses and its `<lastmod>` silently disappears from the sitemap.
+ * Mirrors super-sitemap's own group-stripping pattern
+ * (`removeSvelteKitRouteGroups` in
+ * `super-sitemap/dist/adapters/sveltekit/internal/routes.js`) so the two stay
+ * in lockstep — a divergence would mean a static route's lookup misses and
+ * its `<lastmod>` silently disappears from the sitemap.
  */
 export function stripRouteGroups(routeId: string): string {
   const stripped = routeId.replaceAll(/\/\([^)]+\)/g, '');
@@ -20,16 +22,30 @@ export function stripRouteGroups(routeId: string): string {
 }
 
 /**
- * Convert a SvelteKit route ID into a regex string for super-sitemap's
+ * Convert a SvelteKit route ID into a `RegExp` for super-sitemap's
  * `excludeRoutePatterns`.
  *
- * Key invariant: super-sitemap applies `excludeRoutePatterns` against
- * route-ID form (with `[slug]`, `[...path]`, and `(group)` still present)
- * — NOT against resolved URLs. See `filterRoutes` in `super-sitemap/dist/sitemap.js`:
- * the patterns run BEFORE the `(group)` strip. So the regex must match the
- * literal route-ID form, which means we just escape regex metacharacters
- * and anchor both ends — no `[slug]` → wildcard rewriting needed.
+ * Key invariant: super-sitemap@2 matches `excludeRoutePatterns` against the
+ * route key AFTER `(group)` segments are stripped, but BEFORE dynamic params
+ * are interpolated — see `createSvelteKitNormalizedRoutes` in
+ * `super-sitemap/dist/adapters/sveltekit/internal/routes.js`, where the
+ * exclusion `.filter()` runs after `removeSvelteKitRouteGroups()`. (This
+ * changed from v1, which matched the raw route ID with groups still present.)
+ * So we strip groups first, then escape regex metacharacters and anchor both
+ * ends — `[slug]` / `[...path]` stay literal, matching super-sitemap's own
+ * un-interpolated route key.
+ *
+ * v2 also requires `excludeRoutePatterns` entries to be actual `RegExp`
+ * objects — passing regex strings now throws (`route-exclusion.js`).
+ *
+ * Limitation: optional params (`[[x]]`) are not expanded here. super-sitemap
+ * expands a route's optional-segment variants BEFORE filtering, so a pattern
+ * built from the un-expanded route ID would only match one variant. This is
+ * fine today because the only `[[…]]` route is the sitemap `+server` endpoint,
+ * which super-sitemap never discovers (it walks `+page*` files only). Revisit
+ * if a non-indexable optional-param page route is ever added.
  */
-export function routeIdToRegex(routeId: string): string {
-  return '^' + routeId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '$';
+export function routeIdToRegex(routeId: string): RegExp {
+  const stripped = stripRouteGroups(routeId);
+  return new RegExp('^' + stripped.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '$');
 }

--- a/frontend/src/params/integer.ts
+++ b/frontend/src/params/integer.ts
@@ -6,9 +6,9 @@ import type { ParamMatcher } from '@sveltejs/kit';
  * matcher, the optional `[[page]]` rest segment would accept arbitrary
  * strings (e.g. `/sitemapfoo.xml`), which super-sitemap can't render.
  *
- * Pattern mirrors super-sitemap's own page-validation regex (sitemap.js:105):
- * `/sitemap0.xml` and `/sitemap007.xml` should 404 at the router (route
- * doesn't exist) rather than route through and get rejected with 400
- * downstream.
+ * Pattern mirrors super-sitemap's own page-validation regex (`/^[1-9]\d*$/`
+ * in `core/internal/pagination.js`): `/sitemap0.xml` and `/sitemap007.xml`
+ * should 404 at the router (route doesn't exist) rather than route through
+ * and get rejected with 400 downstream.
  */
 export const match: ParamMatcher = (param) => /^[1-9]\d*$/.test(param);

--- a/frontend/src/routes/sitemap[[page=integer]].xml/+server.ts
+++ b/frontend/src/routes/sitemap[[page=integer]].xml/+server.ts
@@ -14,7 +14,7 @@
  */
 
 import { env } from '$env/dynamic/private';
-import * as sitemap from 'super-sitemap';
+import * as sitemap from 'super-sitemap/sveltekit';
 import type { RequestHandler } from './$types';
 import type { RouteId } from '$app/types';
 import {
@@ -64,17 +64,23 @@ function safeIsIndexable(id: RouteId): boolean {
 // requests. Compute the derived structures once at module load rather than
 // rebuilding inside every GET.
 
-// Route IDs that super-sitemap auto-discovers but must NOT emit. Matched
-// against route-ID form (with `[slug]` / `(group)` still present) per
-// super-sitemap's `filterRoutes` semantics — NOT URL form.
-const EXCLUDE_ROUTE_PATTERNS: readonly string[] = allRoutes()
+// Route IDs that super-sitemap auto-discovers but must NOT emit. In v2 these
+// are matched against the route key with `(group)` segments stripped but
+// dynamic params (`[slug]` / `[...path]`) still present — `routeIdToRegex`
+// builds a `RegExp` in exactly that shape. NOT URL form.
+const EXCLUDE_ROUTE_PATTERNS: readonly RegExp[] = allRoutes()
   .filter((id) => !safeIsIndexable(id))
   .map(routeIdToRegex);
 
 // catalog-* detail/edit-history/sources route IDs, grouped by entity.
-// `safeIsIndexable` filters to exactly the indexable catalog kinds.
+// `safeIsIndexable` filters to the indexable catalog kinds; the `catalog-listing`
+// exclusion drops the param-less listing routes (`/cabinets`, `/titles`, …) —
+// they carry no `[slug]`, so they belong in super-sitemap's static-route
+// auto-discovery, not `paramValues`. (super-sitemap@2 throws on a `paramValues`
+// key for a route that expects no params; v1 silently ignored it.) Listing
+// `<lastmod>` is still attached separately via `listingLastmodByUrl` below.
 const DIRECT_ROUTES_BY_ENTITY: ReadonlyMap<CatalogEntityKey, readonly RouteId[]> =
-  catalogRoutesByEntity((_cls, id) => safeIsIndexable(id));
+  catalogRoutesByEntity((cls, id) => cls.kind !== 'catalog-listing' && safeIsIndexable(id));
 
 // LISTED_INDEXABLE_ENTITY_SLUG_SOURCE inverted: kind → route IDs.
 const LISTED_ROUTES_BY_ENTITY: ReadonlyMap<CatalogEntityKey, readonly RouteId[]> = (() => {
@@ -97,6 +103,18 @@ const STATIC_LASTMOD_BY_URL: ReadonlyMap<string, string> = new Map(
   Object.entries(STATIC_LASTMOD).map(([routeId, lastmod]) => [stripRouteGroups(routeId), lastmod]),
 );
 
+// Every indexable dynamic catalog route (detail/edit-history/sources plus the
+// listed-slug-source routes), flattened. super-sitemap@2 requires each
+// discovered dynamic route to carry ≥1 `paramValue` — so any route in this set
+// that a given request produces no entries for must be excluded from discovery
+// instead (see GET). This is the complete set of indexable dynamic routes: the
+// static `EXCLUDE_ROUTE_PATTERNS` removes every non-indexable route, so any
+// dynamic route super-sitemap still discovers is one of these.
+const ALL_INDEXABLE_DYNAMIC_ROUTES: readonly RouteId[] = [
+  ...DIRECT_ROUTES_BY_ENTITY.values(),
+  ...LISTED_ROUTES_BY_ENTITY.values(),
+].flat();
+
 // ----------------------------------------------------------------------------
 
 export const GET: RequestHandler = async ({ fetch, url, request, params }) => {
@@ -110,19 +128,12 @@ export const GET: RequestHandler = async ({ fetch, url, request, params }) => {
     return new Response('Sitemap unavailable', { status: 502 });
   }
 
-  // Initialize every indexable dynamic route to an empty paramValues entry
-  // FIRST, then overlay feed data. super-sitemap throws on any dynamic route
-  // it discovers in the file tree that lacks a paramValues key — and a
-  // catalog kind with zero active rows produces no Django feed (the backend
-  // skips empty feeds), so the route would otherwise crash the response.
-  // Empty arrays are accepted and produce zero URLs.
+  // Populate `paramValues` from the feed, one entry per slug. super-sitemap@2
+  // rejects both a missing key AND an empty array for any dynamic route it
+  // discovers — so a route with zero entries this request (entity absent from
+  // the feed, or every slug excluded) is left OUT of `paramValues` here and
+  // excluded from discovery below, rather than seeded with an empty array.
   const paramValues: sitemap.ParamValues = {};
-  for (const routes of DIRECT_ROUTES_BY_ENTITY.values()) {
-    for (const id of routes) paramValues[id] = [];
-  }
-  for (const routes of LISTED_ROUTES_BY_ENTITY.values()) {
-    for (const id of routes) paramValues[id] = [];
-  }
 
   // Catalog listing pages (`/titles`, `/manufacturers`, …) are static routes,
   // so super-sitemap auto-discovers them but can't know their freshness. Key
@@ -149,12 +160,22 @@ export const GET: RequestHandler = async ({ fetch, url, request, params }) => {
         isDetail && excluded.size
           ? feed.entries.filter((e) => !excluded.has(e.slug))
           : feed.entries;
+      // Leave zero-entry routes unset; they're excluded from discovery below.
+      if (entries.length === 0) continue;
       paramValues[id] = entries.map((e) => ({
         values: [e.slug],
         lastmod: e.lastmod,
       }));
     }
   }
+
+  // super-sitemap@2 throws on any discovered dynamic route without a
+  // (non-empty) `paramValue`. Every indexable dynamic route we didn't populate
+  // has zero URLs this request, so exclude it from discovery — matched, like
+  // EXCLUDE_ROUTE_PATTERNS, against the group-stripped route key.
+  const emptyRouteExclusions: RegExp[] = ALL_INDEXABLE_DYNAMIC_ROUTES.filter(
+    (id) => !(id in paramValues),
+  ).map(routeIdToRegex);
 
   // Same fallback pattern as `frontend/src/lib/api/server.ts`. Railway
   // builds enforce SITE_ORIGIN at build time via svelte.config.js; the
@@ -164,7 +185,7 @@ export const GET: RequestHandler = async ({ fetch, url, request, params }) => {
   return sitemap.response({
     origin,
     page: params.page,
-    excludeRoutePatterns: [...EXCLUDE_ROUTE_PATTERNS],
+    excludeRoutePatterns: [...EXCLUDE_ROUTE_PATTERNS, ...emptyRouteExclusions],
     paramValues,
     // Static routes are auto-discovered by super-sitemap walking the routes
     // tree; `processPaths` attaches `<lastmod>` to each one from
@@ -175,7 +196,7 @@ export const GET: RequestHandler = async ({ fetch, url, request, params }) => {
         const lastmod = listingLastmodByUrl.get(p.path) ?? STATIC_LASTMOD_BY_URL.get(p.path);
         return lastmod ? { ...p, lastmod } : p;
       }),
-    // super-sitemap@1.0.12 defaults to `max-age=0, s-maxage=3600`. We
+    // super-sitemap defaults to `max-age=0, s-maxage=3600`. We
     // override because (a) there is no shared cache today (Caddy isn't a
     // caching reverse proxy, no CDN), so `s-maxage` is a no-op; (b) we want
     // clients/crawlers to actually cache the response for the TTL.


### PR DESCRIPTION
## Why

super-sitemap v2 restructured into per-framework adapters and dropped the bare package entry point, so `import * as sitemap from 'super-sitemap'` no longer resolves. That's what broke Dependabot PR #596 (failed `frontend` vitest, `api-types` svelte-check, and `ci`). This PR does the upgrade properly by adopting the v2 API rather than pinning back.

## What changed

The upgrade is more than an import swap — v2 introduces several breaking behaviors the sitemap endpoint relied on. This adopts all of them:

- **Adapter subpath import.** Import from `super-sitemap/sveltekit` (the SvelteKit adapter subpath) — the only way to reach `response` / `ParamValues` / `PathObj` in v2.
- **`excludeRoutePatterns` now requires real `RegExp` objects** (strings throw) and is matched against the route key *after* `(group)` stripping. `routeIdToRegex` now group-strips first and returns a `RegExp`.
- **No `paramValues` key on param-less routes.** v2 rejects a `paramValues` entry for a route with no params, so the static `catalog-listing` routes are dropped from `DIRECT_ROUTES_BY_ENTITY` (their `<lastmod>` is already attached via `listingLastmodByUrl`).
- **No empty-array init for dynamic routes.** v2 rejects both a missing key *and* an empty array for a discovered dynamic route. The old empty-init strategy is gone: `paramValues` is populated only for routes with entries, and zero-entry indexable dynamic routes are excluded from discovery per request.

## Docs / comments

Synced the docs and comments that still described the v1 contract: `docs/plans/seo/Sitemap.md` (version pin, adapter import, the `excludeRoutePatterns` contract, internal-file refs) and the stale `sitemap.js` line reference in `frontend/src/params/integer.ts`.

## Tests

Updated `sitemap-helpers` tests to the v2 group-stripped matching semantics. Full frontend test suite (1686) and svelte-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZ7g2zHd9vPv7wGpEDRw6F

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZ7g2zHd9vPv7wGpEDRw6F)_