### PR TITLE
feat(locations): add canonical/meta tags and exclude empty locations from sitemap

### DIFF
--- a/backend/apps/catalog/api/locations.py
+++ b/backend/apps/catalog/api/locations.py
@@ -140,15 +140,13 @@ def _get_location_tree() -> _LocationTree:
     )
 
     # Accumulate manufacturer PKs at each location and all its ancestors.
+    # Every active CorporateEntity contributes: ``manufacturer`` is a
+    # non-null FK, so a corporate entity at a location implies a
+    # manufacturer (same invariant ``Location.sitemap_queryset()`` relies on).
     mfr_pks_by_path: dict[str, set[int]] = {}
-    for cel in (
-        CorporateEntityLocation.objects.select_related(
-            "location__parent__parent__parent__parent",
-            "corporate_entity__manufacturer",
-        )
-        .filter(corporate_entity__manufacturer__isnull=False)
-        .filter(active_status_q("corporate_entity"))
-    ):
+    for cel in CorporateEntityLocation.objects.select_related(
+        "location__parent__parent__parent__parent", "corporate_entity"
+    ).filter(active_status_q("corporate_entity")):
         mfr_pk = cel.corporate_entity.manufacturer_id
         cur: Location | None = cel.location
         while cur is not None:

--- a/backend/apps/catalog/models/location.py
+++ b/backend/apps/catalog/models/location.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import ClassVar
+from typing import ClassVar, Self
 
 from django.db import models
-from django.db.models.functions import Lower
+from django.db.models import Exists, OuterRef, Q, Value
+from django.db.models.functions import Concat, Lower
 
 from apps.core.models import (
     TimeStampedModel,
+    active_status_q,
     field_lowercase,
     field_not_blank,
     status_valid,
@@ -148,6 +150,28 @@ class Location(CatalogModel, TimeStampedModel):
 
     def __str__(self) -> str:
         return self.name or self.location_path
+
+    @classmethod
+    def sitemap_queryset(cls) -> models.QuerySet[Self]:
+        # Narrow sitemap membership to locations with at least one
+        # manufacturer at or below them. A location page's primary content is
+        # its aggregated manufacturer grid (manufacturers propagate up the
+        # ancestor chain — see ``apps.catalog.api.locations``), so a
+        # zero-manufacturer location renders an empty page that search
+        # engines cluster as duplicate content. An active CorporateEntity at
+        # a location implies a manufacturer (non-null FK). "At or below" is a
+        # ``location_path`` prefix match: the path encodes the full ancestry,
+        # and the trailing ``/`` keeps a shared string prefix (``nl`` vs
+        # ``nl2``) from counting as ancestry.
+        has_manufacturer_at_or_below = CorporateEntityLocation.objects.filter(
+            Q(location__location_path=OuterRef("location_path"))
+            | Q(
+                location__location_path__startswith=Concat(
+                    OuterRef("location_path"), Value("/")
+                )
+            )
+        ).filter(active_status_q("corporate_entity"))
+        return super().sitemap_queryset().filter(Exists(has_manufacturer_at_or_below))
 
     @classmethod
     def compose_public_id(cls, authored_fields: Mapping[str, object]) -> str:

--- a/backend/apps/catalog/tests/test_location_sitemap.py
+++ b/backend/apps/catalog/tests/test_location_sitemap.py
@@ -1,0 +1,113 @@
+"""Tests for ``Location.sitemap_queryset()`` — sitemap membership is narrowed
+to locations with at least one manufacturer at or below them.
+
+A location page's primary content is its aggregated manufacturer grid
+(manufacturers propagate up the ancestor chain), so a zero-manufacturer
+location renders an empty page that search engines cluster as duplicate
+content. Such locations are excluded from the sitemap entirely (detail,
+``/edit-history``, and ``/sources`` URLs).
+
+Fixtures use Location + CorporateEntityLocation directly (bypassing claims)
+for speed, mirroring ``test_api_locations.py``.
+"""
+
+import pytest
+
+from apps.catalog.models import (
+    CorporateEntity,
+    CorporateEntityLocation,
+    Location,
+    Manufacturer,
+)
+from apps.core.sitemap import all_sitemap_feeds
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_location(location_path, name, parent=None):
+    slug = location_path.rsplit("/", 1)[-1]
+    return Location.objects.create(
+        location_path=location_path,
+        slug=slug,
+        name=name,
+        location_type="country" if parent is None else "city",
+        parent=parent,
+    )
+
+
+def _make_mfr_at(name, slug, location, entity_status="active"):
+    mfr = Manufacturer.objects.create(name=name, slug=slug)
+    entity = CorporateEntity.objects.create(
+        name=name, slug=slug, manufacturer=mfr, status=entity_status
+    )
+    CorporateEntityLocation.objects.create(corporate_entity=entity, location=location)
+    return mfr
+
+
+def _sitemap_paths() -> set[str]:
+    return set(Location.sitemap_queryset().values_list("location_path", flat=True))
+
+
+class TestLocationSitemapQueryset:
+    def test_location_with_direct_manufacturer_included(self):
+        usa = _make_location("usa", "USA")
+        vt = _make_location("usa/vt", "Vermont", parent=usa)
+        _make_mfr_at("Richard Mfg", "richard-mfg", vt)
+
+        assert "usa/vt" in _sitemap_paths()
+
+    def test_ancestors_of_manufacturer_bearing_location_included(self):
+        """Manufacturers aggregate up the chain, so every ancestor page has
+        content and stays in the sitemap."""
+        usa = _make_location("usa", "USA")
+        vt = _make_location("usa/vt", "Vermont", parent=usa)
+        winooski = _make_location("usa/vt/winooski", "Winooski", parent=vt)
+        _make_mfr_at("Richard Mfg", "richard-mfg", winooski)
+
+        assert _sitemap_paths() == {"usa", "usa/vt", "usa/vt/winooski"}
+
+    def test_zero_manufacturer_location_excluded(self):
+        usa = _make_location("usa", "USA")
+        il = _make_location("usa/il", "Illinois", parent=usa)
+        chicago = _make_location("usa/il/chicago", "Chicago", parent=il)
+        _make_mfr_at("Williams", "williams", chicago)
+        _make_location("usa/hi", "Hawaii", parent=usa)
+
+        paths = _sitemap_paths()
+        assert "usa/hi" not in paths
+        assert "usa/il" in paths
+
+    def test_empty_branch_excluded_entirely(self):
+        nl = _make_location("netherlands", "Netherlands")
+        _make_location("netherlands/reuver", "Reuver", parent=nl)
+
+        assert _sitemap_paths() == set()
+
+    def test_shared_path_prefix_is_not_ancestry(self):
+        """``nl`` must not inherit content from ``nl2`` just because
+        ``"nl2".startswith("nl")`` — descendant matching requires a full
+        path segment."""
+        _make_location("nl", "Netherlands")
+        nl2 = _make_location("nl2", "Not Netherlands")
+        _make_mfr_at("Dutch Pinball", "dutch-pinball", nl2)
+
+        assert _sitemap_paths() == {"nl2"}
+
+    def test_soft_deleted_corporate_entity_does_not_count(self):
+        usa = _make_location("usa", "USA")
+        _make_mfr_at("Ghost Pinball", "ghost-pinball", usa, entity_status="deleted")
+
+        assert _sitemap_paths() == set()
+
+    def test_feed_drops_excluded_locations(self):
+        """The exclusion flows through ``all_sitemap_feeds()`` — a
+        zero-manufacturer location emits no URLs at all (detail,
+        /edit-history, /sources)."""
+        usa = _make_location("usa", "USA")
+        vt = _make_location("usa/vt", "Vermont", parent=usa)
+        _make_mfr_at("Richard Mfg", "richard-mfg", vt)
+        _make_location("usa/hi", "Hawaii", parent=usa)
+
+        feeds = {f.kind: f for f in all_sitemap_feeds()}
+        slugs = {e.slug for e in feeds["location"].entries}
+        assert slugs == {"usa", "usa/vt"}

--- a/docs/plans/seo/Sitemap.md
+++ b/docs/plans/seo/Sitemap.md
@@ -109,7 +109,7 @@ class SitemappedModel(LinkableModel, LastUpdatedModel):
         return ()
 ```
 
-The two overrides today:
+The overrides today:
 
 ```python
 # apps/catalog/models/machine_model.py
@@ -153,6 +153,26 @@ class Title(CatalogModel, ...):
                 F("updated_at"),
             ),
         )
+```
+
+```python
+# apps/catalog/models/location.py
+class Location(CatalogModel, ...):
+    @classmethod
+    def sitemap_queryset(cls):
+        # Membership-narrowing override (the documented "narrow membership"
+        # case): only locations with ≥1 manufacturer at or below them. A
+        # location page's primary content is its aggregated manufacturer grid
+        # (manufacturers propagate up the ancestor chain), so a
+        # zero-manufacturer location renders an empty page that search
+        # engines cluster as duplicate content ("Duplicate without
+        # user-selected canonical" in Search Console). Excluded rows drop ALL
+        # their URLs (detail, /edit-history, /sources) — unlike
+        # `non_canonical_detail_slugs()`, which is for canonical-URL reasons
+        # and keeps the ancillary pages. Implemented as an `Exists` over
+        # CorporateEntityLocation with a `location_path` prefix match; see
+        # the model for the shipped queryset.
+        ...
 ```
 
 Note `machine_models` (not `models`) — that's the `related_name` on `MachineModel.title` and `MachineModel.title` is the only FK from `MachineModel` to `Title`. `active_status_q("relation")` (from `apps/core/models/mixins.py`) builds the active-or-null `Q` filter for child rows reached through a relation, mirroring `LifecycleQuerySet.active()`'s null-inclusive shape for ingest compatibility. Read directly off `type[LinkableModel]` — no `getattr` fallback (per the [field-on-model antipattern](../model_driven_metadata/ModelDrivenMetadata.md#antipattern-field-on-model)).
@@ -485,6 +505,7 @@ One-line additive change. Update the existing robots vitest to assert the line i
 - Anything auth-gated — recognized by `requireCapability` in the layout chain; non-indexable routes are excluded by `isSearchEngineIndexable(routeId)`; never enumerated by hand.
 - Soft-deleted catalog rows (`status='deleted'`) — excluded by `.active()` at every queryset entry point.
 - The `catalog-detail` URL for Models whose parent Title has exactly one active Model (see above); their `/edit-history` and `/sources` URLs are still in.
+- Locations with zero manufacturers at or below them — excluded entirely (detail, `/edit-history`, and `/sources`) via `Location.sitemap_queryset()`, since their pages render an empty manufacturer grid that search engines cluster as duplicate content.
 
 ## 6. `SITE_ORIGIN` build + deploy checks
 

--- a/frontend/src/routes/locations/[...path]/+layout.svelte
+++ b/frontend/src/routes/locations/[...path]/+layout.svelte
@@ -3,7 +3,9 @@
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { auth } from '$lib/auth.svelte';
-  import { WIDE_BREAKPOINT, pageTitle } from '$lib/constants';
+  import { WIDE_BREAKPOINT } from '$lib/constants';
+  import MetaTags from '$lib/components/layout/page/head/MetaTags.svelte';
+  import { metaDescriptionFor } from '$lib/components/layout/page/head/meta-tags';
   import PageActionBar from '$lib/components/layout/page/PageActionBar.svelte';
   import RecordDetailShell from '$lib/components/pages/record/detail/RecordDetailShell.svelte';
   import SectionEditorHost from '$lib/components/pages/record/edit/SectionEditorHost.svelte';
@@ -33,6 +35,15 @@
   let isRoot = $derived(profile.location_type === null);
   let path = $derived(profile.public_id);
   let displayName = $derived(profile.name || 'Locations');
+
+  let metaDescription = $derived.by(() => {
+    if (isRoot) return 'Browse pinball manufacturers by country, region, and city.';
+    // Geographic fallback lists ancestors nearest-first ("Chicago, Illinois,
+    // United States") so near-identical sibling/parent pages still get
+    // distinct descriptions.
+    const place = [profile.name, ...profile.ancestors.map((a) => a.name).reverse()].join(', ');
+    return metaDescriptionFor(profile, `Pinball manufacturers in ${place}.`);
+  });
 
   let breadcrumbs = $derived<Crumb[] | null>(
     isRoot
@@ -135,9 +146,12 @@
   locationEditActionContext.set(editAction);
 </script>
 
-<svelte:head>
-  <title>{pageTitle(displayName)}</title>
-</svelte:head>
+<MetaTags
+  title={displayName}
+  description={metaDescription}
+  url={page.url.href}
+  ogType={isRoot ? 'website' : 'article'}
+/>
 
 {#snippet actionBar()}
   {#if isRoot}

--- a/frontend/src/routes/locations/[...path]/locations.dom.test.ts
+++ b/frontend/src/routes/locations/[...path]/locations.dom.test.ts
@@ -1,17 +1,20 @@
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { authMock } = vi.hoisted(() => ({
+const { authMock, pageState } = vi.hoisted(() => ({
   authMock: { isAuthenticated: true, load: () => Promise.resolve() },
+  pageState: { url: new URL('http://localhost/locations') },
 }));
 
 vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
-vi.mock('$app/paths', () => ({ resolve: (p: string) => p }));
+vi.mock('$app/paths', () => ({ resolve: (p: string) => p, asset: (p: string) => p }));
 vi.mock('$app/state', () => ({
   page: {
     params: {},
-    url: new URL('http://localhost/locations'),
+    get url() {
+      return pageState.url;
+    },
   },
 }));
 vi.mock('$lib/auth.svelte', () => ({ auth: authMock }));
@@ -39,11 +42,14 @@ type Profile = {
   slug: string;
   public_id: string;
   location_type: string | null;
+  description: { text: string; html: string; plain: string };
   manufacturer_count: number;
   ancestors: AncestorRef[];
   children: ChildRef[];
   manufacturers: Manufacturer[];
 };
+
+const EMPTY_DESCRIPTION = { text: '', html: '', plain: '' };
 
 function renderLayout(profile: Profile) {
   render(Layout, {
@@ -57,6 +63,7 @@ const ROOT: Profile = {
   slug: '',
   public_id: '',
   location_type: null,
+  description: EMPTY_DESCRIPTION,
   manufacturer_count: 4,
   ancestors: [],
   children: [
@@ -81,6 +88,7 @@ const COUNTRY: Profile = {
   slug: 'usa',
   public_id: 'usa',
   location_type: 'country',
+  description: EMPTY_DESCRIPTION,
   manufacturer_count: 3,
   ancestors: [],
   children: [
@@ -99,6 +107,7 @@ const CITY: Profile = {
   slug: 'chicago',
   public_id: 'usa/il/chicago',
   location_type: 'city',
+  description: EMPTY_DESCRIPTION,
   manufacturer_count: 2,
   ancestors: [
     { name: 'United States', public_id: 'usa' },
@@ -180,6 +189,67 @@ describe('locations layout — country', () => {
     expect(screen.getByRole('link', { name: 'History' })).toHaveAttribute(
       'href',
       '/locations/usa/edit-history',
+    );
+  });
+});
+
+describe('locations layout — meta tags', () => {
+  const defaultUrl = pageState.url;
+
+  afterEach(() => {
+    pageState.url = defaultUrl;
+  });
+
+  it('emits canonical, description, and og tags for a location page', () => {
+    pageState.url = new URL('http://localhost/locations/usa/il/chicago');
+    renderLayout(CITY);
+    expect(document.title).toBe('Chicago — Flipcommons Pinball Encyclopedia');
+    expect(document.head.querySelector('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      'http://localhost/locations/usa/il/chicago',
+    );
+    // No entity description on the fixture, so the geographic fallback —
+    // ancestors nearest-first — keeps sibling pages' descriptions distinct.
+    expect(document.head.querySelector('meta[name="description"]')).toHaveAttribute(
+      'content',
+      'Pinball manufacturers in Chicago, Illinois, United States.',
+    );
+    expect(document.head.querySelector('meta[property="og:type"]')).toHaveAttribute(
+      'content',
+      'article',
+    );
+  });
+
+  it('prefers the entity description over the geographic fallback', () => {
+    pageState.url = new URL('http://localhost/locations/usa/il/chicago');
+    renderLayout({
+      ...CITY,
+      description: {
+        text: 'Home of pinball.',
+        html: '<p>Home of pinball.</p>',
+        plain: 'Home of pinball.',
+      },
+    });
+    expect(document.head.querySelector('meta[name="description"]')).toHaveAttribute(
+      'content',
+      'Home of pinball.',
+    );
+  });
+
+  it('emits listing-flavored tags at the global root', () => {
+    renderLayout(ROOT);
+    expect(document.title).toBe('Locations — Flipcommons Pinball Encyclopedia');
+    expect(document.head.querySelector('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      'http://localhost/locations',
+    );
+    expect(document.head.querySelector('meta[property="og:type"]')).toHaveAttribute(
+      'content',
+      'website',
+    );
+    expect(document.head.querySelector('meta[name="description"]')).toHaveAttribute(
+      'content',
+      'Browse pinball manufacturers by country, region, and city.',
     );
   });
 });


### PR DESCRIPTION
## Summary

Address Google Search Console's "Duplicate without user-selected canonical" report (~35 location pages, first detected 2026-07-01) by giving location pages the meta tags every other entity page already has, and by excluding zero-manufacturer locations from the sitemap.

- Root cause, not the super-sitemap v2 upgrade (which landed July 3, after first detection): the locations route was the only entity route without `MetaTags` — no `<link rel="canonical">`, no meta description, no OG tags — and the pages are near-duplicates (manufacturers propagate up the ancestor chain, so single-branch parents render the same grid as their only child; zero-manufacturer divisions like `/locations/usa/hi` are ~93% text-identical to each other). With no declared canonical, Google clustered them and picked winners itself.
- Locations layout now renders `MetaTags`: self-referencing canonical, meta description (geographic fallback listing ancestors nearest-first, e.g. "Pinball manufacturers in Chicago, Illinois, United States.", so near-identical pages get distinct copy), OG/Twitter tags; `/locations` root gets listing copy with `og:type=website`.
- `Location.sitemap_queryset()` (the documented membership-narrowing channel) now includes only locations with ≥1 active corporate entity at or below them, matched by `location_path` prefix with a trailing `/` so string prefixes (`nl` vs `nl2`) don't count as ancestry. Excluded rows drop all their URLs (detail, `/edit-history`, `/sources`). No frontend change needed.
- Cleanup: dropped the tree builder's dead `corporate_entity__manufacturer__isnull=False` filter (`CorporateEntity.manufacturer` is a non-null FK since the initial migration) and narrowed its `select_related` to `corporate_entity` (the loop reads only `manufacturer_id`). Updated `docs/plans/seo/Sitemap.md`.
- Deferred by design: cross-canonicalizing single-branch parent/child pairs and content differentiation of division pages. If GSC later shows "Duplicate, Google chose different canonical than user," revisit.

## Test plan

- [x] TDD per repo policy: failing tests written first for both fixes
- [x] 3 new DOM tests (canonical/description/og:type on a location page, entity-description priority, root listing tags); all 12 locations DOM tests pass
- [x] 7 new backend tests in `apps/catalog/tests/test_location_sitemap.py` (direct attachment, ancestor propagation, empty branch, prefix-vs-ancestry, soft-deleted corporate entity, feed integration)
- [x] Verified SSR end-to-end against the dev server: `/locations` serves canonical + description + og:type in initial HTML
- [x] Pre-commit hooks green: full backend + frontend suites, mypy, svelte-check, ruff, eslint, import-linter
- [ ] After deploy: spot-check a live location page for the canonical tag, confirm `/sitemap.xml` no longer lists `/locations/usa/hi`, then hit "Validate Fix" in Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDQAgQYRtDGcGTqQT2yQuV