### PR TITLE
chore(build): split pre-commit/pre-push and parallelize backend tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,11 @@
+# Wire both hook types on `pre-commit install`. `default_stages` keeps every
+# hook below on the commit stage unless it opts into pre-push explicitly, so
+# nothing runs twice: fast checks gate each commit, the full test suite gates
+# each push. After pulling this change, run `pre-commit install` once to
+# register the pre-push hook.
+default_install_hook_types: [pre-commit, pre-push]
+default_stages: [pre-commit]
+
 repos:
   # Security + basic file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -123,9 +131,22 @@ repos:
         language: system
         files: ^frontend/
         pass_filenames: false
+      # Backend tests, split across two git stages:
+      #   commit -> fast set (excludes the `migration` marker); parallelized by
+      #             `-n auto` in backend/pytest.ini. Keeps each commit quick.
+      #   push   -> full suite, including the migration-machinery tests that
+      #             rewind + replay migrations (seconds apiece). The safety net
+      #             runs once per push instead of on every commit.
       - id: backend-test
-        name: backend tests
+        name: backend tests (fast; excludes migration tests)
+        entry: uv run --directory backend pytest -m "not migration"
+        language: system
+        files: ^backend/
+        pass_filenames: false
+      - id: backend-test-full
+        name: backend tests (full, incl. migrations)
         entry: uv run --directory backend pytest
         language: system
         files: ^backend/
         pass_filenames: false
+        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,7 +112,13 @@ repos:
         files: ^(CLAUDE|AGENTS)\.md$
         pass_filenames: false
 
-      # Frontend lint + type check
+      # Frontend, split across two git stages like the backend tests:
+      #   commit -> lint only. It autofixes formatting/style (prettier --write),
+      #             which is exactly what you want applied before a commit.
+      #   push   -> type check + vitest. svelte-check has no daemon (unlike
+      #             backend mypy/dmypy) so it's a ~40s cold check, and vitest's
+      #             jsdom setup dominates the ~85s suite. Both are expensive
+      #             comprehensive verification -> run once per push, not per commit.
       - id: frontend-lint
         name: frontend lint
         entry: bash -c 'cd frontend && pnpm lint'
@@ -125,12 +131,14 @@ repos:
         language: system
         files: ^frontend/
         pass_filenames: false
+        stages: [pre-push]
       - id: frontend-test
         name: frontend tests
         entry: bash -c 'cd frontend && pnpm test'
         language: system
         files: ^frontend/
         pass_filenames: false
+        stages: [pre-push]
       # Backend tests, split across two git stages:
       #   commit -> fast set (excludes the `migration` marker); parallelized by
       #             `-n auto` in backend/pytest.ini. Keeps each commit quick.

--- a/backend/apps/actors/tests/test_actor_backfill_migration.py
+++ b/backend/apps/actors/tests/test_actor_backfill_migration.py
@@ -18,6 +18,8 @@ import pytest
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 
+pytestmark = pytest.mark.migration
+
 _BEFORE = [
     ("accounts", "0003_alter_user_username"),
     ("provenance", "0011_backfill_seed_changesets"),

--- a/backend/apps/citation/tests/test_migration_attribution_actor.py
+++ b/backend/apps/citation/tests/test_migration_attribution_actor.py
@@ -15,6 +15,8 @@ import pytest
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 
+pytestmark = pytest.mark.migration
+
 # Pin accounts/actors at their leaves so ``project_state`` materializes those
 # apps too — citation 0007 predates the actors dependency (added in 0008), so a
 # citation-only target would leave ``actors``/``accounts`` out of the state.

--- a/backend/apps/citation/tests/test_migration_backfill_root_domains.py
+++ b/backend/apps/citation/tests/test_migration_backfill_root_domains.py
@@ -24,7 +24,7 @@ _migration = importlib.import_module(
 backfill_root_domains = _migration.backfill_root_domains
 remove_root_domains = _migration.remove_root_domains
 
-pytestmark = pytest.mark.django_db(transaction=True)
+pytestmark = [pytest.mark.django_db(transaction=True), pytest.mark.migration]
 
 
 @pytest.fixture

--- a/backend/apps/provenance/tests/test_actor_fk_backfill.py
+++ b/backend/apps/provenance/tests/test_actor_fk_backfill.py
@@ -22,6 +22,8 @@ import pytest
 
 from apps.provenance.test_migration_state import historical_apps
 
+pytestmark = pytest.mark.migration
+
 _migration = importlib.import_module(
     "apps.provenance.migrations.0013_backfill_actor_fks"
 )

--- a/backend/apps/provenance/tests/test_citation_join_backfill.py
+++ b/backend/apps/provenance/tests/test_citation_join_backfill.py
@@ -22,6 +22,8 @@ import pytest
 
 from apps.provenance.test_migration_state import historical_apps
 
+pytestmark = pytest.mark.migration
+
 _migration = importlib.import_module(
     "apps.provenance.migrations.0018_backfill_scalar_citation_joins"
 )

--- a/backend/apps/provenance/tests/test_seed_changeset_backfill.py
+++ b/backend/apps/provenance/tests/test_seed_changeset_backfill.py
@@ -31,6 +31,8 @@ import pytest
 
 from apps.provenance.test_migration_state import historical_apps
 
+pytestmark = pytest.mark.migration
+
 _migration = importlib.import_module(
     "apps.provenance.migrations.0011_backfill_seed_changesets"
 )

--- a/backend/apps/provenance/tests/test_seed_ingest_run_backfill.py
+++ b/backend/apps/provenance/tests/test_seed_ingest_run_backfill.py
@@ -27,6 +27,8 @@ import pytest
 
 from apps.provenance.test_migration_state import historical_apps
 
+pytestmark = pytest.mark.migration
+
 _migration = importlib.import_module(
     "apps.provenance.migrations.0010_backfill_seed_ingest_runs"
 )

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,6 +1,14 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = config.settings
+# -n auto: run across all cores via pytest-xdist. The suite is DB-bound and
+# single-process runtime had grown past the pre-commit timeout; parallelizing
+# is the biggest lever and needs no test changes.
+addopts = -n auto
 python_files = tests.py test_*.py *_tests.py
+markers =
+    migration: exercises Django data/schema migrations by rewinding + replaying
+        them (seconds each). Deselected from the fast pre-commit run via
+        `-m "not migration"`; still run on pre-push and in CI.
 filterwarnings =
     error
     ignore:No directory at:UserWarning

--- a/scripts/test-backend
+++ b/scripts/test-backend
@@ -3,4 +3,5 @@ set -e
 cd "$(dirname "$0")/../backend"
 
 echo "==> Backend tests..."
-uv run pytest -n auto
+# -n auto lives in backend/pytest.ini addopts, so a bare invocation is parallel.
+uv run pytest


### PR DESCRIPTION
## What

Speeds up `git commit` by moving comprehensive checks off the pre-commit hook, leaving fast checks to gate each commit and the full verification to gate each push.

**Backend tests split by git stage:**
- **commit** → fast set (`-m "not migration"`), parallelized with `-n auto` (pytest-xdist)
- **push** → full suite, including the migration-machinery tests that rewind + replay migrations

**Frontend split the same way:**
- **commit** → lint only (`prettier --write` + eslint/stylelint)
- **push** → `svelte-check` type check + vitest

## Why — measured

The 48 migration tests are ~1% of the suite but the dominant cost: they rewind + replay migrations and don't parallelize across xdist workers well. On the current suite (4,469 tests):

| Run | Wall |
| --- | --- |
| Full backend suite (old pre-commit) | ~82s |
| Fast subset `-m "not migration"` (new pre-commit) | ~22s |
| Migration tests alone (48) | ~41s |

`-n auto` is an independent ~1.6x on the fast subset (~33s → ~20s single→parallel).

Frontend `svelte-check` is a ~40s cold check (no daemon) and vitest's jsdom setup dominates its ~85s — both are comprehensive checks with no incremental mode, so they belong on push, not per-commit.

## Safety net unchanged

CI still runs the full `pytest`, `pnpm test` and `pnpm check` (svelte-check) on every PR. Pre-push is fast local feedback; CI remains the authoritative merge gate. Nothing that left pre-commit is ungated at merge.

## Heads-up for existing contributors

This branch adds `default_install_hook_types: [pre-commit, pre-push]`, so the pre-push hook only registers after you reinstall hooks. **Run `make bootstrap` or `pre-commit install` after pulling** to pick up the pre-push hook. New clones get it automatically via `make bootstrap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
