### PR TITLE
chore(build): run migration tests on pre-push only when migrations change

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,22 +139,37 @@ repos:
         files: ^frontend/
         pass_filenames: false
         stages: [pre-push]
-      # Backend tests, split across two git stages:
+      # Backend tests, split across git stages and file scope:
       #   commit -> fast set (excludes the `migration` marker); parallelized by
       #             `-n auto` in backend/pytest.ini. Keeps each commit quick.
-      #   push   -> full suite, including the migration-machinery tests that
-      #             rewind + replay migrations (seconds apiece). The safety net
-      #             runs once per push instead of on every commit.
+      #   push   -> same fast set again, as the comprehensive gate for the code
+      #             being pushed (pre-commit-stage hooks don't re-run on push).
+      #   push, but ONLY when a migration or migration-test file changed ->
+      #             the migration-machinery tests. They rewind + replay
+      #             migrations (seconds apiece) and pin already-shipped, frozen
+      #             migrations, so ordinary code can't break them -- only
+      #             editing/adding a migration can, and that's always a
+      #             `migrations/` (or migration-test) file change. Scoping them
+      #             here keeps ~40s of rewind churn off the vast majority of
+      #             pushes. CI still runs the full suite (incl. migrations)
+      #             unconditionally, so nothing is ungated at merge.
       - id: backend-test
         name: backend tests (fast; excludes migration tests)
         entry: uv run --directory backend pytest -m "not migration"
         language: system
         files: ^backend/
         pass_filenames: false
-      - id: backend-test-full
-        name: backend tests (full, incl. migrations)
-        entry: uv run --directory backend pytest
+      - id: backend-test-push
+        name: backend tests (excludes migration tests)
+        entry: uv run --directory backend pytest -m "not migration"
         language: system
         files: ^backend/
+        pass_filenames: false
+        stages: [pre-push]
+      - id: backend-test-migrations
+        name: backend migration tests (only when migrations change)
+        entry: uv run --directory backend pytest -m migration
+        language: system
+        files: ^backend/.*(migration|_backfill).*\.py$
         pass_filenames: false
         stages: [pre-push]

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -7,8 +7,9 @@ addopts = -n auto
 python_files = tests.py test_*.py *_tests.py
 markers =
     migration: exercises Django data/schema migrations by rewinding + replaying
-        them (seconds each). Deselected from the fast pre-commit run via
-        `-m "not migration"`; still run on pre-push and in CI.
+        them (seconds each). Deselected from the commit/push test runs via
+        `-m "not migration"`; run on pre-push only when a migration or
+        migration-test file changed, and unconditionally in CI.
 filterwarnings =
     error
     ignore:No directory at:UserWarning


### PR DESCRIPTION
## What

Follow-up to #608. The 48 `migration`-marked backend tests now run on pre-push **only when a migration or migration-test file changed** — not on every push.

## Why

Those tests drive `MigrationExecutor` to rewind the DB to a historical node, build rows the current schema can't hold, run the backfill under test, then replay all migrations forward to restore. With `transaction=True` it all physically commits, so each test pays a full rewind + restore cycle. Measured: ~40s of wall time even parallelized (single-process ~98s), dominating the pre-push backend run — and it's largely redundant, since every test in a file rewinds to the same node.

Crucially, these tests pin **already-shipped, frozen migrations**. Ordinary code changes can't break them; only editing or adding a migration can, and that is always a `migrations/` (or migration-test) file change. So gating them on that file scope keeps the safety net exactly where it matters and off the ~95% of pushes that don't touch migrations.

## How

Split the single unconditional pre-push backend run into two hooks:

- `backend-test-push` — the non-migration suite (`-m "not migration"`), `files: ^backend/`. Still gates **every** push.
- `backend-test-migrations` — the migration suite (`-m migration`), `files: ^backend/.*(migration|_backfill).*\.py$`, so it fires only when a migration or migration-test file is in the push.

CI still runs the full suite (incl. migrations) unconditionally, so nothing is ungated at merge.

## Verification

- `pre-commit validate-config` passes.
- Regex checked against all 7 marked test files + the `test_migration_state.py` helper + real migration files (match) and representative non-migration files (no match).
- End-to-end via `pre-commit run backend-test-migrations --hook-stage pre-push`:
  - non-migration file → **Skipped**
  - `migrations/0011_backfill_seed_changesets.py` → runs the 48 tests, **Passed**

## Contributor note

Adds a new hook id. **Run `pre-commit install` after pulling** to register it (or `make bootstrap`, which does it for you).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
