### PR TITLE
docs(hooks): clarify svelte-check cost and give per-machine timings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,9 +116,14 @@ repos:
       #   commit -> lint only. It autofixes formatting/style (prettier --write),
       #             which is exactly what you want applied before a commit.
       #   push   -> type check + vitest. svelte-check has no daemon (unlike
-      #             backend mypy/dmypy) so it's a ~40s cold check, and vitest's
-      #             jsdom setup dominates the ~85s suite. Both are expensive
-      #             comprehensive verification -> run once per push, not per commit.
+      #             backend mypy/dmypy), so it rebuilds the whole TS program
+      #             (our ~1080 src files + generated route/API types + the
+      #             node_modules .d.ts it references) on every run -- cost
+      #             tracks that type graph, not the component count. ~40s on a
+      #             4-core cloud box, ~14s on a MacBook Air M3. vitest's jsdom
+      #             setup dominates its ~85s suite (cloud box). Both are
+      #             expensive comprehensive verification -> run once per push,
+      #             not per commit.
       - id: frontend-lint
         name: frontend lint
         entry: bash -c 'cd frontend && pnpm lint'


### PR DESCRIPTION
Comment-only follow-up to #609. The frontend hook comment claimed svelte-check is a "~40s cold check" with no context.

**What changed:** the comment now explains svelte-check's time tracks the **TypeScript program** it rebuilds on every run — our ~1080 `src` files + generated route/API types + the referenced node_modules `.d.ts` — not the component count. A project with far fewer components on the same framework would pay most of the same cost.

**Timings, now attributed to their machines:** ~40s on the 4-core cloud box, ~14s on a MacBook Air M3.

While confirming, verified `skipLibCheck: true` is already set in `frontend/tsconfig.json`, so svelte-check isn't deep-checking dependency `.d.ts` bodies — no cheap lever left there; the remaining cost is inherent to building + strict-checking the program.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)