### PR TITLE
feat(provenance): show inline citations on edit history

### DIFF
--- a/backend/apps/catalog/tests/test_patch_provenance.py
+++ b/backend/apps/catalog/tests/test_patch_provenance.py
@@ -1138,14 +1138,17 @@ def test_url_cite_surfaced_in_edit_history(
     year_change = next(c for c in cs["changes"] if c["field_name"] == "year")
     (citation,) = year_change["citations"]
     assert citation["source_name"] == url
-    assert citation["url"] == url
+    (link,) = citation["links"]
+    assert link["url"] == url
+    assert link["link_type"] == "reference"
 
 
 def test_url_cite_with_archive_surfaces_live_link_in_edit_history(
     client, flipcommons_catalog, kineticist_root, pm
 ):
-    # Compact field history shows the live page, NOT its Wayback snapshot — even
-    # though "archive" sorts before "reference" in the default link ordering.
+    # Field history must lead with the live page, NOT its Wayback snapshot.
+    # All links now cross the wire; the client titles the citation with the
+    # ``reference`` link (see citationLinkDisplay), so that's the invariant.
     url = "https://kineticist.com/reviews/mm"
     archive = "https://web.archive.org/web/20240101000000/" + url
     text = (
@@ -1168,7 +1171,9 @@ def test_url_cite_with_archive_surfaces_live_link_in_edit_history(
     )
     year_change = next(c for c in cs["changes"] if c["field_name"] == "year")
     (citation,) = year_change["citations"]
-    assert citation["url"] == url  # the live page, not the archive snapshot
+    by_type = {link["link_type"]: link["url"] for link in citation["links"]}
+    assert by_type["reference"] == url  # the live page leads
+    assert by_type["archive"] == archive  # the snapshot rides along as a chip
 
 
 # ── edit-history surfacing ─────────────────────────────────────────
@@ -1188,7 +1193,9 @@ def test_edit_history_exposes_citation(client, flipcommons_catalog, ipdb_root, p
     year_change = next(c for c in cs["changes"] if c["field_name"] == "year")
     (citation,) = year_change["citations"]
     assert citation["source_name"] == "Internet Pinball Database #4443"
-    assert citation["url"] == "https://www.ipdb.org/machine.cgi?id=4443"
+    assert "https://www.ipdb.org/machine.cgi?id=4443" in [
+        link["url"] for link in citation["links"]
+    ]
 
 
 def test_changeset_detail_exposes_citation(client, flipcommons_catalog, ipdb_root, pm):

--- a/backend/apps/provenance/history.py
+++ b/backend/apps/provenance/history.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from itertools import chain
@@ -10,9 +11,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Prefetch, Q
 
 from apps.citation.deep_links import deep_linked_url
-from apps.citation.models import CitationSourceLink
+from apps.citation.models import CitationInstance
 from apps.core.authz import PolicyUser, compute_row_capabilities
 from apps.core.types import ClaimKey
+from apps.core.wikilinks import get_link_type, get_patterns
 
 from .attribution import actor_user_id
 from .claim_ranking_in_db import ranked_claims
@@ -30,6 +32,7 @@ from .helpers import (
 from .models import ChangeSet, Claim, ClaimControlledModel
 from .schemas import (
     ChangeSetSchema,
+    CitationLinkSchema,
     ClaimAttributionSchema,
     FieldChangeCitationSchema,
     FieldChangeSchema,
@@ -42,40 +45,125 @@ ordered newest-first. A chain yields a field's prior value and the full set of
 values a change is displayed against."""
 
 
-def _field_change_citations(claim: Claim) -> list[FieldChangeCitationSchema]:
-    """Build the compact citation list for a field change's claim.
+class InlineCitationLookup:
+    """Citation instances resolved from ``[[cite:id:N]]`` markers, keyed by pk.
 
-    Requires the claim to have been loaded with citation instances prefetched
-    (``prefetched_citation_instances`` — see ``claims_prefetch`` and the
-    edit-history / changeset-detail querysets). Uses the source's live link as
-    the compact citation URL; the full set of links (incl. an ``archive``
-    snapshot) is exposed by the citation-source detail surface, not here.
+    Built once per response by :func:`resolve_inline_citations`; consulted by
+    :func:`_field_change_citations` so per-change citation building does no
+    DB work. Same encapsulated shape as
+    :class:`apps.core.markdown.field.WikilinkAuthoringLookup`.
     """
-    result: list[FieldChangeCitationSchema] = []
-    for inst in citation_instances(claim):
-        # Prefer the live page over its durable ``archive`` snapshot. The
-        # snapshot is a backup, not the canonical link — and the default link
-        # ordering sorts "archive" before "reference", so ``links[0]`` alone
-        # would surface the Wayback URL. Pick on the prefetched list (no requery).
-        links = list(inst.citation_source.links.all())
-        live = next(
-            (
-                link
-                for link in links
-                if link.link_type != CitationSourceLink.LinkType.ARCHIVE
-            ),
-            links[0] if links else None,
-        )
-        result.append(
-            FieldChangeCitationSchema(
-                source_name=inst.citation_source.name,
-                url=(
-                    deep_linked_url(inst.citation_source, inst.locator, live.url)
-                    if live
-                    else None
-                ),
+
+    __slots__ = ("_instances",)
+
+    def __init__(self) -> None:
+        self._instances: dict[int, CitationInstance] = {}
+
+    def add(self, instance: CitationInstance) -> None:
+        assert instance.pk is not None
+        self._instances[instance.pk] = instance
+
+    def get(self, pk: int) -> CitationInstance | None:
+        return self._instances.get(pk)
+
+
+def _cite_storage_pattern() -> re.Pattern[str] | None:
+    """The compiled ``[[cite:id:N]]`` pattern, or None when the ``cite``
+    link type isn't registered (cleared-registry tests)."""
+    link_type = get_link_type("cite")
+    if link_type is None:
+        return None
+    return get_patterns(link_type)["storage"]
+
+
+def _inline_cite_pks(value: object) -> list[int]:
+    """Citation-instance pks referenced by ``[[cite:id:N]]`` markers in
+    *value*, in document order, deduped keeping the first occurrence."""
+    if not isinstance(value, str) or not value:
+        return []
+    pattern = _cite_storage_pattern()
+    if pattern is None:
+        return []
+    seen: set[int] = set()
+    pks: list[int] = []
+    for match in pattern.finditer(value):
+        pk = int(match.group(1))
+        if pk not in seen:
+            seen.add(pk)
+            pks.append(pk)
+    return pks
+
+
+def resolve_inline_citations(values: Iterable[object]) -> InlineCitationLookup:
+    """Batch-load every citation instance referenced inline across *values*.
+
+    One query (plus the links prefetch), independent of how many values are
+    passed, so callers rendering many claim values stay query-bounded.
+    """
+    pks: set[int] = set()
+    for value in values:
+        pks.update(_inline_cite_pks(value))
+    lookup = InlineCitationLookup()
+    if not pks:
+        return lookup
+    instances = (
+        CitationInstance.objects.filter(pk__in=pks)
+        # The parent ride-along feeds deep_linked_url (scheme lookup via the
+        # root's identifier_key) without a per-cite query.
+        .select_related("citation_source", "citation_source__parent")
+        .prefetch_related("citation_source__links")
+    )
+    for instance in instances:
+        lookup.add(instance)
+    return lookup
+
+
+def _citation_schema(
+    inst: CitationInstance, *, slug: str | None
+) -> FieldChangeCitationSchema:
+    """Serialize one citation instance for a field change."""
+    source = inst.citation_source
+    return FieldChangeCitationSchema(
+        source_name=source.name,
+        source_type=source.source_type,
+        author=source.author,
+        year=source.year,
+        locator=inst.locator,
+        slug=slug,
+        links=[
+            CitationLinkSchema(
+                url=deep_linked_url(source, inst.locator, link.url),
+                link_type=link.link_type,
+                display_name=link.display_name,
             )
-        )
+            for link in source.links.all()
+        ],
+    )
+
+
+def _field_change_citations(
+    claim: Claim, prior: object, inline: InlineCitationLookup
+) -> list[FieldChangeCitationSchema]:
+    """Build the citation list for a field change's claim.
+
+    Attached (join-row) evidence comes first and requires the claim to have
+    been loaded with citation instances prefetched
+    (``prefetched_citation_instances`` — see ``claims_prefetch`` and the
+    edit-history / changeset-detail querysets). Inline citations follow:
+    ``[[cite:id:N]]`` markers from the claim's own value in document order,
+    then markers only the *prior* value carries (removed by this change), so
+    a client rendering a diff can label every marker on either side. Markers
+    whose instance row is gone are skipped, matching the editor's
+    broken-link degrade.
+    """
+    result = [_citation_schema(inst, slug=None) for inst in citation_instances(claim)]
+    pks = _inline_cite_pks(claim.value)
+    own = set(pks)
+    pks += [pk for pk in _inline_cite_pks(prior) if pk not in own]
+    for pk in pks:
+        inst = inline.get(pk)
+        if inst is not None:
+            result.append(_citation_schema(inst, slug=inst.slug))
     return result
 
 
@@ -103,6 +191,7 @@ def build_changes(
     *,
     winning_ids: set[int] | None = None,
     ctx: ClaimDisplayContext | None = None,
+    inline_citations: InlineCitationLookup | None = None,
 ) -> tuple[list[FieldChangeSchema], list[RetractionSchema]]:
     """Build per-field changes and retractions for a changeset.
 
@@ -110,9 +199,10 @@ def build_changes(
     entity, so the model is uniform; it lets display dispatch markdown fields.
 
     No per-row DB lookups during display building: pass a pre-built ``ctx``
-    when the caller already has one (e.g. a multi-changeset response that
-    resolved references across the whole entity); otherwise this builds its
-    own from the union of values referenced here.
+    (and matching ``inline_citations``) when the caller already has them
+    (e.g. a multi-changeset response that resolved references across the
+    whole entity); otherwise this builds its own from the union of values
+    referenced here.
 
     ``winning_ids`` is only meaningful for entity-wide history; omit it for
     single-changeset detail views and ``is_winning`` will be left unset.
@@ -124,6 +214,10 @@ def build_changes(
         ctx = resolve_display_context(
             FieldValue(c.field_name, c.value)
             for c in chain(own, rets, *history_by_key.values())
+        )
+    if inline_citations is None:
+        inline_citations = resolve_inline_citations(
+            c.value for c in chain(own, rets, *history_by_key.values())
         )
 
     changes: list[FieldChangeSchema] = []
@@ -148,7 +242,7 @@ def build_changes(
                     (claim.pk in winning_ids) if winning_ids is not None else None
                 ),
                 is_retracted=claim.retracted_by_changeset_id is not None,
-                citations=_field_change_citations(claim),
+                citations=_field_change_citations(claim, prior, inline_citations),
             )
         )
 
@@ -193,8 +287,9 @@ def build_edit_history(
     Returns ChangeSetSchema rows newest first. Query count is bounded
     independent of changeset count: changesets+prefetches, all claims for
     the entity (for old-value lookup), winning-claim computation, one query
-    per distinct FK target model display needs to resolve, and one per
-    public-id link type for markdown wikilink rendering.
+    per distinct FK target model display needs to resolve, one per
+    public-id link type for markdown wikilink rendering, and one (plus a
+    links prefetch) for inline citation instances.
 
     ``user`` is the caller (boundary-cast via ``policy_user``) and is
     used to populate the per-row ``capabilities`` map.
@@ -257,6 +352,7 @@ def build_edit_history(
     #    claims, retracted claims, and history chains all draw from it), so one
     #    pass suffices.
     ctx = resolve_display_context(FieldValue(c.field_name, c.value) for c in all_claims)
+    inline_citations = resolve_inline_citations(c.value for c in all_claims)
     model = type(entity)
 
     # 5. Build response.
@@ -269,6 +365,7 @@ def build_edit_history(
             history,
             winning_ids=winning_ids,
             ctx=ctx,
+            inline_citations=inline_citations,
         )
         assert cs.pk is not None
         result.append(

--- a/backend/apps/provenance/schemas.py
+++ b/backend/apps/provenance/schemas.py
@@ -148,13 +148,51 @@ class ClaimValueSchema(Schema):
     )
 
 
+class CitationLinkSchema(Schema):
+    """A link attached to a citation source, ready for display."""
+
+    url: str = Field(
+        description="The link's URL, deep-linked to the locator when possible."
+    )
+    link_type: str = Field(
+        description="Kind of link: one of ``homepage``, ``catalog``, ``publisher``, ``reference`` or ``archive``."
+    )
+    display_name: str = Field(
+        description="Human-readable link text — the link's label, or its link-type name when unlabeled. Never blank."
+    )
+
+
 class FieldChangeCitationSchema(Schema):
-    """A citation attached to a single field change's claim."""
+    """A citation backing a single field change's claim.
+
+    Covers both kinds of evidence: instances attached to the claim as
+    supporting evidence (``slug`` is null) and instances referenced by
+    inline ``[[cite:slug]]`` markers in a markdown value (``slug`` set, so
+    clients can match the entry to its marker in the text).
+    """
 
     source_name: str = Field(description="The cited source's display name.")
-    url: str | None = Field(
+    source_type: str = Field(
+        description="Kind of source: one of ``database``, ``wiki``, ``book``, ``editorial`` or ``other``."
+    )
+    author: str = Field(description="Author of the cited source, if recorded.")
+    year: int | None = Field(
+        None, description="Publication year of the source, if known."
+    )
+    locator: str = Field(
+        description="Specific location within the source, such as a page or section."
+    )
+    slug: str | None = Field(
         None,
-        description="A link to the cited source, or null when it has no link.",
+        description=(
+            "The citation instance's authoring slug when the citation is an "
+            "inline ``[[cite:slug]]`` marker in the change's text; null for "
+            "evidence attached directly to the claim."
+        ),
+    )
+    links: list[CitationLinkSchema] = Field(
+        default_factory=list,
+        description="External links for the cited source.",
     )
 
 
@@ -392,20 +430,6 @@ class AttributionSchema(Schema):
         Field(description="Name of the source this content was derived from."),
     ] = None
     source_url: Annotated[str | None, Field(description="URL of that source.")] = None
-
-
-class CitationLinkSchema(Schema):
-    """A link attached to a citation source, ready for display."""
-
-    url: str = Field(
-        description="The link's URL, deep-linked to the locator when possible."
-    )
-    link_type: str = Field(
-        description="Kind of link: one of ``homepage``, ``catalog``, ``publisher``, ``reference`` or ``archive``."
-    )
-    display_name: str = Field(
-        description="Human-readable link text — the link's label, or its link-type name when unlabeled. Never blank."
-    )
 
 
 class InlineCitationSchema(Schema):

--- a/backend/apps/provenance/tests/test_api_edit_history.py
+++ b/backend/apps/provenance/tests/test_api_edit_history.py
@@ -6,7 +6,13 @@ import pytest
 
 from apps.accounts.test_factories import make_user
 from apps.catalog.tests.conftest import make_machine_model
-from apps.provenance.test_factories import make_claim, make_ingest_source
+from apps.citation.test_factories import make_citation_link, make_citation_source
+from apps.provenance.test_factories import (
+    cite_claim,
+    make_citation_instance,
+    make_claim,
+    make_ingest_source,
+)
 
 
 def _user_changesets(resp) -> list[dict[str, Any]]:
@@ -230,6 +236,103 @@ class TestEditHistorySoftDeleted:
         data = _user_changesets(resp)
         assert len(data) == 1
         assert data[0]["changes"][0]["new_value"]["raw"] == 1998
+
+
+@pytest.mark.django_db
+class TestEditHistoryCitations:
+    def test_attached_citation_carries_rich_metadata(self, client, user, pm):
+        """Join-attached (supporting-evidence) citations expose the full
+        source metadata, not just a name and one URL."""
+        claim = make_claim(pm, "year", 1998, user=user)
+        src = make_citation_source(
+            name="The Toy Book",
+            source_type="web",
+            author="Ryan Vincent",
+            year=2024,
+        )
+        make_citation_link(
+            citation_source=src,
+            url="https://toybook.com/wonderland/",
+            link_type="reference",
+        )
+        cite_claim(claim, citation_source=src, locator="para. 2")
+
+        resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
+        assert resp.status_code == 200
+        [cit] = _user_changesets(resp)[0]["changes"][0]["citations"]
+        assert cit["source_name"] == "The Toy Book"
+        assert cit["source_type"] == "web"
+        assert cit["author"] == "Ryan Vincent"
+        assert cit["year"] == 2024
+        assert cit["locator"] == "para. 2"
+        # Attached evidence has no inline marker, so no slug.
+        assert cit["slug"] is None
+        assert [link["url"] for link in cit["links"]] == [
+            "https://toybook.com/wonderland/"
+        ]
+
+    def test_inline_citations_returned_in_document_order(self, client, user, pm):
+        """Inline ``[[cite:id:N]]`` markers in a markdown claim surface as
+        citations on the change, slug-keyed and ordered by first appearance."""
+        src_a = make_citation_source(
+            name="The Toy Book", author="Ryan Vincent", year=2024
+        )
+        make_citation_link(
+            citation_source=src_a,
+            url="https://toybook.com/wonderland/",
+            link_type="reference",
+        )
+        src_b = make_citation_source(name="Kickstarter")
+        inst_a = make_citation_instance(citation_source=src_a)
+        inst_b = make_citation_instance(citation_source=src_b)
+        make_claim(
+            pm,
+            "description",
+            f"Founded by veterans.[[cite:id:{inst_b.pk}]] "
+            f"Debuted at Expo.[[cite:id:{inst_a.pk}]]",
+            user=user,
+        )
+
+        resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
+        assert resp.status_code == 200
+        citations = _user_changesets(resp)[0]["changes"][0]["citations"]
+        assert [c["slug"] for c in citations] == [inst_b.slug, inst_a.slug]
+        assert [c["source_name"] for c in citations] == ["Kickstarter", "The Toy Book"]
+        toy_book = citations[1]
+        assert toy_book["author"] == "Ryan Vincent"
+        assert toy_book["year"] == 2024
+        assert [link["url"] for link in toy_book["links"]] == [
+            "https://toybook.com/wonderland/"
+        ]
+
+    def test_old_value_only_citations_included(self, client, user, pm):
+        """A citation that appears only in the prior text (removed by the
+        edit) still gets metadata, so the diff can label its marker."""
+        inst_old = make_citation_instance(
+            citation_source=make_citation_source(name="Pinside forum")
+        )
+        inst_kept = make_citation_instance(
+            citation_source=make_citation_source(name="Kickstarter")
+        )
+        make_claim(
+            pm,
+            "description",
+            f"Old text.[[cite:id:{inst_old.pk}]] Kept.[[cite:id:{inst_kept.pk}]]",
+            user=user,
+        )
+        make_claim(
+            pm,
+            "description",
+            f"New text. Kept.[[cite:id:{inst_kept.pk}]]",
+            user=user,
+        )
+
+        resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
+        assert resp.status_code == 200
+        newest = _user_changesets(resp)[0]
+        citations = newest["changes"][0]["citations"]
+        # New-text citations first (document order), then old-only ones.
+        assert [c["slug"] for c in citations] == [inst_kept.slug, inst_old.slug]
 
 
 @pytest.mark.django_db

--- a/frontend/src/lib/components/pages/record/edit-history/EditHistory.svelte
+++ b/frontend/src/lib/components/pages/record/edit-history/EditHistory.svelte
@@ -1,3 +1,5 @@
+<!-- @component Changeset-grouped edit history for one entity: per-field diffs
+with revert controls and per-change citation footers. -->
 <script lang="ts">
   import { invalidateAll } from '$app/navigation';
   import client from '$lib/api/client';
@@ -12,7 +14,9 @@
   import FocusContentShell from '$lib/components/layout/page/FocusContentShell.svelte';
   import InlineDiff from '$lib/components/ui/InlineDiff.svelte';
   import ClaimAttribution from '$lib/components/provenance/ClaimAttribution.svelte';
-  import ClaimValue from '$lib/components/provenance/ClaimValue.svelte';
+  import ChangeValue from '$lib/components/provenance/ChangeValue.svelte';
+  import ChangeCitations from '$lib/components/provenance/ChangeCitations.svelte';
+  import CiteMarkedText from '$lib/components/provenance/CiteMarkedText.svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { getEntityContext } from '$lib/entity-context';
   import {
@@ -22,6 +26,10 @@
     isDiffable,
     isUnchanged,
   } from '$lib/components/provenance/change-display';
+  import {
+    citeIndexesForChange,
+    substituteCiteMarkers,
+  } from '$lib/components/provenance/cite-markers';
 
   type ChangeSet = ChangeSetSchema;
   type FieldChange = FieldChangeSchema;
@@ -87,6 +95,9 @@
     return !hasChanges && !hasUnmatchedRetractions;
   }
 
+  /** For value renders with no owning change (unmatched retractions). */
+  const NO_CITE_INDEXES = new Map<string, number>();
+
   function canRevert(change: FieldChange): boolean {
     return (
       auth.isAuthenticated &&
@@ -130,27 +141,16 @@
   }
 </script>
 
-{#snippet oldValue(value: ClaimValueSchema | null | undefined)}
-  <span class="old-value"><ClaimValue {value} /></span>
+{#snippet markedText(text: string)}
+  <CiteMarkedText {text} />
 {/snippet}
 
-{#snippet newValue(value: ClaimValueSchema | null | undefined)}
-  <span class="new-value"><ClaimValue {value} /></span>
+{#snippet oldValue(value: ClaimValueSchema | null | undefined, citeIndexes: Map<string, number>)}
+  <span class="old-value"><ChangeValue {value} {citeIndexes} /></span>
 {/snippet}
 
-{#snippet fieldCitations(change: FieldChange)}
-  {#if change.citations && change.citations.length > 0}
-    <dd class="field-citations">
-      <span class="cite-label">Source:</span>
-      {#each change.citations as cite (cite.source_name)}
-        {#if cite.url}
-          <a class="cite-link" href={cite.url} target="_blank">{cite.source_name}</a>
-        {:else}
-          <span class="cite-link">{cite.source_name}</span>
-        {/if}
-      {/each}
-    </dd>
-  {/if}
+{#snippet newValue(value: ClaimValueSchema | null | undefined, citeIndexes: Map<string, number>)}
+  <span class="new-value"><ChangeValue {value} {citeIndexes} /></span>
 {/snippet}
 
 {#snippet revertControls(change: FieldChange)}
@@ -221,6 +221,8 @@
               {/if}
               <dl class="field-list">
                 {#each cs.changes as change (change.claim_key)}
+                  {@const citeIndexes = citeIndexesForChange(change)}
+                  {@const citeMarked = citeIndexes.size > 0}
                   {#if change.is_retracted}
                     {@const info =
                       change.claim_id != null ? retractionLookup.get(change.claim_id) : undefined}
@@ -237,65 +239,73 @@
                         {/if}
                       </dd>
                       {#if isUnchanged(change)}
-                        <dd>{@render oldValue(change.new_value)}</dd>
+                        <dd>{@render oldValue(change.new_value, citeIndexes)}</dd>
                       {:else if isDiffable(change)}
                         <dd>
                           <InlineDiff
-                            oldValue={diffText(change.old_value)}
-                            newValue={diffText(change.new_value)}
+                            oldValue={substituteCiteMarkers(
+                              diffText(change.old_value),
+                              citeIndexes,
+                            )}
+                            newValue={substituteCiteMarkers(
+                              diffText(change.new_value),
+                              citeIndexes,
+                            )}
+                            renderText={citeMarked ? markedText : undefined}
                           />
                         </dd>
                       {:else}
                         <dd>
                           {#if hasMeaningfulValue(change.old_value?.raw)}
-                            {@render oldValue(change.old_value)}
+                            {@render oldValue(change.old_value, citeIndexes)}
                             <span class="arrow">&rarr;</span>
                           {/if}
-                          {@render oldValue(change.new_value)}
+                          {@render oldValue(change.new_value, citeIndexes)}
                         </dd>
                       {/if}
                     </div>
                   {:else if isUnchanged(change)}
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
-                      <dd>{@render newValue(change.new_value)}</dd>
+                      <dd>{@render newValue(change.new_value, citeIndexes)}</dd>
                       {@render revertControls(change)}
-                      {@render fieldCitations(change)}
+                      <ChangeCitations citations={change.citations ?? []} indexes={citeIndexes} />
                     </div>
                   {:else if isDeletion(change)}
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
                       <dd>
-                        {@render oldValue(change.old_value)}
+                        {@render oldValue(change.old_value, citeIndexes)}
                         <span class="deleted-marker" aria-label="removed">&#x2715;</span>
                       </dd>
                       {@render revertControls(change)}
-                      {@render fieldCitations(change)}
+                      <ChangeCitations citations={change.citations ?? []} indexes={citeIndexes} />
                     </div>
                   {:else if isDiffable(change)}
                     <div class="field-row field-row-diff">
                       <dt>{change.field_name}</dt>
                       <dd>
                         <InlineDiff
-                          oldValue={diffText(change.old_value)}
-                          newValue={diffText(change.new_value)}
+                          oldValue={substituteCiteMarkers(diffText(change.old_value), citeIndexes)}
+                          newValue={substituteCiteMarkers(diffText(change.new_value), citeIndexes)}
+                          renderText={citeMarked ? markedText : undefined}
                         />
                       </dd>
                       {@render revertControls(change)}
-                      {@render fieldCitations(change)}
+                      <ChangeCitations citations={change.citations ?? []} indexes={citeIndexes} />
                     </div>
                   {:else}
                     <div class="field-row">
                       <dt>{change.field_name}</dt>
                       <dd>
                         {#if hasMeaningfulValue(change.old_value?.raw)}
-                          {@render oldValue(change.old_value)}
+                          {@render oldValue(change.old_value, citeIndexes)}
                           <span class="arrow">&rarr;</span>
                         {/if}
-                        {@render newValue(change.new_value)}
+                        {@render newValue(change.new_value, citeIndexes)}
                       </dd>
                       {@render revertControls(change)}
-                      {@render fieldCitations(change)}
+                      <ChangeCitations citations={change.citations ?? []} indexes={citeIndexes} />
                     </div>
                   {/if}
                 {/each}
@@ -306,7 +316,7 @@
                       <dt>{retraction.field_name}</dt>
                       <dd>
                         <span class="reverted-badge">reverted</span>
-                        {@render oldValue(retraction.old_value)}
+                        {@render oldValue(retraction.old_value, NO_CITE_INDEXES)}
                       </dd>
                     </div>
                   {/if}
@@ -406,29 +416,6 @@
   .field-row-diff dd {
     flex-basis: 100%;
     display: block;
-  }
-
-  .field-citations {
-    flex-basis: 100%;
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--size-1);
-    align-items: baseline;
-    font-size: var(--font-size-00, 0.75rem);
-    color: var(--color-text-muted);
-  }
-
-  .cite-label {
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-  }
-
-  .cite-link {
-    color: var(--color-text-muted);
-  }
-
-  a.cite-link {
-    color: var(--color-link);
   }
 
   .old-value {

--- a/frontend/src/lib/components/provenance/ChangeCitations.svelte
+++ b/frontend/src/lib/components/provenance/ChangeCitations.svelte
@@ -1,0 +1,115 @@
+<!-- @component Citations footer for one field change: numbered rows for inline
+[[cite:]] citations (matching the [n] markers in the change's text), unnumbered
+rows for evidence attached directly to the claim. -->
+<script lang="ts">
+  import type { FieldChangeCitationSchema } from '$lib/api/schema';
+  import { displayLocator } from '$lib/citation-types';
+  import { citationLinkDisplay } from '$lib/components/citation/citation-links';
+
+  let {
+    citations,
+    indexes,
+  }: {
+    citations: FieldChangeCitationSchema[];
+    /** Per-change footnote numbers keyed by citation-instance slug (see
+     *  `assignCiteIndexes`); attached citations have no slug and no number. */
+    indexes: Map<string, number>;
+  } = $props();
+
+  interface Entry {
+    citation: FieldChangeCitationSchema;
+    index: number | undefined;
+  }
+
+  /** Numbered (inline) entries in marker order, then unnumbered (attached) ones. */
+  let entries = $derived.by(() => {
+    const numbered: Entry[] = [];
+    const unnumbered: Entry[] = [];
+    for (const citation of citations) {
+      const index = citation.slug != null ? indexes.get(citation.slug) : undefined;
+      (index === undefined ? unnumbered : numbered).push({ citation, index });
+    }
+    numbered.sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+    return [...numbered, ...unnumbered];
+  });
+</script>
+
+{#if entries.length > 0}
+  <dd class="change-citations">
+    {#each entries as { citation, index }, i (citation.slug ?? `attached-${i}`)}
+      {@const links = citationLinkDisplay(citation.links ?? [])}
+      <div class="citation-row">
+        {#if index !== undefined}
+          <span class="marker">{index}.</span>
+        {/if}
+        <span>
+          <strong>
+            {#if links.titleHref}
+              <a href={links.titleHref} target="_blank">{citation.source_name}</a>
+            {:else}
+              {citation.source_name}
+            {/if}
+          </strong>
+          {#if citation.author || citation.year}
+            <span class="meta">
+              &mdash; {[citation.author, citation.year].filter(Boolean).join(', ')}
+            </span>
+          {/if}
+          {#if citation.locator}
+            <span class="meta">({displayLocator(citation.source_type, citation.locator)})</span>
+          {/if}
+          {#each links.chips as link (link.url)}
+            <a class="chip" href={link.url} target="_blank">{link.display_name}</a>
+          {/each}
+        </span>
+      </div>
+    {/each}
+  </dd>
+{/if}
+
+<style>
+  .change-citations {
+    flex-basis: 100%;
+    font-size: var(--font-size-0);
+    line-height: var(--font-lineheight-3);
+    color: var(--color-text-muted);
+  }
+
+  .citation-row {
+    display: flex;
+    gap: var(--size-1);
+    align-items: baseline;
+  }
+
+  .marker {
+    min-width: 1.2em;
+    text-align: right;
+  }
+
+  strong {
+    color: var(--color-text);
+  }
+
+  strong a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  strong a:hover {
+    text-decoration: underline;
+  }
+
+  .meta {
+    color: var(--color-text-muted);
+  }
+
+  .chip {
+    margin-left: var(--size-1);
+    color: var(--color-link);
+    text-decoration: none;
+  }
+
+  .chip:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/frontend/src/lib/components/provenance/ChangeValue.svelte
+++ b/frontend/src/lib/components/provenance/ChangeValue.svelte
@@ -1,0 +1,24 @@
+<!-- @component One side of a field change's value: markdown values with
+inline citations render their [[cite:]] tokens as numbered superscripts;
+everything else falls through to ClaimValue. -->
+<script lang="ts">
+  import type { ClaimValueSchema } from '$lib/api/schema';
+  import ClaimValue from './ClaimValue.svelte';
+  import CiteMarkedText from './CiteMarkedText.svelte';
+  import { substituteCiteMarkers } from './cite-markers';
+
+  let {
+    value,
+    citeIndexes,
+  }: {
+    value: ClaimValueSchema | null | undefined;
+    /** Per-change footnote numbers from `citeIndexesForChange`. */
+    citeIndexes: Map<string, number>;
+  } = $props();
+</script>
+
+{#if value?.display?.kind === 'markdown' && citeIndexes.size > 0}
+  <CiteMarkedText text={substituteCiteMarkers(value.display.text, citeIndexes)} />
+{:else}
+  <ClaimValue {value} />
+{/if}

--- a/frontend/src/lib/components/provenance/CiteMarkedText.svelte
+++ b/frontend/src/lib/components/provenance/CiteMarkedText.svelte
@@ -1,0 +1,19 @@
+<!-- @component Plain text whose [n] / [?] cite markers (from
+substituteCiteMarkers) render as superscripts. -->
+<script lang="ts">
+  import { splitCiteMarkers } from './cite-markers';
+
+  let { text }: { text: string } = $props();
+</script>
+
+{#each splitCiteMarkers(text) as part, i (i)}
+  {#if part.type === 'marker'}<sup class="cite-marker">{part.text}</sup>{:else}{part.text}{/if}
+{/each}
+
+<style>
+  sup.cite-marker {
+    font-size: var(--font-size-00, 0.75rem);
+    color: var(--color-link);
+    line-height: 0;
+  }
+</style>

--- a/frontend/src/lib/components/provenance/cite-markers.test.ts
+++ b/frontend/src/lib/components/provenance/cite-markers.test.ts
@@ -1,0 +1,90 @@
+/** Tests for inline cite-marker helpers used by edit history. */
+
+import { describe, expect, it } from 'vitest';
+import {
+  assignCiteIndexes,
+  extractCiteSlugs,
+  splitCiteMarkers,
+  substituteCiteMarkers,
+} from './cite-markers';
+
+describe('extractCiteSlugs', () => {
+  it('returns slugs in document order, deduped', () => {
+    const text = 'A.[[cite:bbb]] B.[[cite:aaa]] C.[[cite:bbb]]';
+    expect(extractCiteSlugs(text)).toEqual(['bbb', 'aaa']);
+  });
+
+  it('ignores storage-form tokens', () => {
+    expect(extractCiteSlugs('Broken.[[cite:id:42]] Ok.[[cite:xyz]]')).toEqual(['xyz']);
+  });
+
+  it('returns empty for text without tokens', () => {
+    expect(extractCiteSlugs('No citations here.')).toEqual([]);
+  });
+});
+
+describe('assignCiteIndexes', () => {
+  it('numbers by first appearance in the new text', () => {
+    const indexes = assignCiteIndexes('X.[[cite:bbb]] Y.[[cite:aaa]]', '', new Set(['aaa', 'bbb']));
+    expect([...indexes.entries()]).toEqual([
+      ['bbb', 1],
+      ['aaa', 2],
+    ]);
+  });
+
+  it('continues numbering with old-only slugs after new-text ones', () => {
+    const indexes = assignCiteIndexes(
+      'Kept.[[cite:kkk]]',
+      'Removed.[[cite:rrr]] Kept.[[cite:kkk]]',
+      new Set(['kkk', 'rrr']),
+    );
+    expect(indexes.get('kkk')).toBe(1);
+    expect(indexes.get('rrr')).toBe(2);
+  });
+
+  it('skips slugs without citation metadata', () => {
+    const indexes = assignCiteIndexes('A.[[cite:ghost]] B.[[cite:real]]', '', new Set(['real']));
+    expect(indexes.has('ghost')).toBe(false);
+    expect(indexes.get('real')).toBe(1);
+  });
+});
+
+describe('substituteCiteMarkers', () => {
+  it('rewrites tokens to their assigned markers', () => {
+    const indexes = new Map([
+      ['bbb', 1],
+      ['aaa', 2],
+    ]);
+    expect(substituteCiteMarkers('X.[[cite:bbb]] Y.[[cite:aaa]]', indexes)).toBe('X.[1] Y.[2]');
+  });
+
+  it('renders unassigned slugs as [?]', () => {
+    expect(substituteCiteMarkers('X.[[cite:ghost]]', new Map())).toBe('X.[?]');
+  });
+
+  it('leaves storage-form tokens untouched', () => {
+    expect(substituteCiteMarkers('Broken.[[cite:id:42]]', new Map())).toBe('Broken.[[cite:id:42]]');
+  });
+});
+
+describe('splitCiteMarkers', () => {
+  it('splits text runs from markers', () => {
+    expect(splitCiteMarkers('veterans[1] and CEOs.[2]')).toEqual([
+      { type: 'text', text: 'veterans' },
+      { type: 'marker', text: '[1]' },
+      { type: 'text', text: ' and CEOs.' },
+      { type: 'marker', text: '[2]' },
+    ]);
+  });
+
+  it('treats [?] as a marker', () => {
+    expect(splitCiteMarkers('x[?]')).toEqual([
+      { type: 'text', text: 'x' },
+      { type: 'marker', text: '[?]' },
+    ]);
+  });
+
+  it('returns one text part when there are no markers', () => {
+    expect(splitCiteMarkers('plain prose')).toEqual([{ type: 'text', text: 'plain prose' }]);
+  });
+});

--- a/frontend/src/lib/components/provenance/cite-markers.ts
+++ b/frontend/src/lib/components/provenance/cite-markers.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure helpers for inline `[[cite:slug]]` markers in edit-history claim text.
+ *
+ * Edit history shows markdown claim values as authoring-form plain text (the
+ * diff operates on it), so inline citations arrive as literal `[[cite:slug]]`
+ * tokens. These helpers assign each cited slug a per-change footnote number,
+ * rewrite the tokens to compact `[n]` markers *before* the text is diffed
+ * (same slug → same marker on both sides, so unchanged citations diff as
+ * unchanged), and split marked text for superscript rendering.
+ */
+
+import type { FieldChangeSchema } from '$lib/api/schema';
+import { diffText } from './change-display';
+
+/**
+ * Authoring-form inline citation token. Mirrors the backend's authoring
+ * pattern for the `cite` wikilink type: `[[cite:<slug>]]` where the slug is
+ * never the `id:` storage prefix (storage-form tokens are left untouched —
+ * they only survive to display text when the instance row is gone, and render
+ * as-is, matching the editor's broken-link degrade).
+ */
+const CITE_TOKEN = /\[\[cite:(?!id:)([^\]]+)\]\]/g;
+
+/** A cite marker rewritten by {@link substituteCiteMarkers}: `[1]`, `[2]`, or
+ *  `[?]` for a slug with no citation metadata. */
+const CITE_MARKER = /^\[(?:\d+|\?)\]$/;
+
+/** {@link CITE_MARKER} as a capturing split pattern, so `String.split` keeps
+ *  the markers in the output. */
+const CITE_MARKER_SPLIT = /(\[(?:\d+|\?)\])/g;
+
+/** Slugs referenced by `[[cite:slug]]` tokens in `text`, in document order,
+ *  deduped keeping the first occurrence. */
+export function extractCiteSlugs(text: string): string[] {
+  const seen = new Set<string>();
+  const slugs: string[] = [];
+  for (const match of text.matchAll(CITE_TOKEN)) {
+    const slug = match[1];
+    if (!seen.has(slug)) {
+      seen.add(slug);
+      slugs.push(slug);
+    }
+  }
+  return slugs;
+}
+
+/**
+ * Assign 1-based footnote numbers to the cited slugs of one field change.
+ *
+ * Numbering follows first appearance in the new text, then slugs only the
+ * old text cites (removed by the change) continue the sequence. Only slugs
+ * in `knownSlugs` (i.e. with citation metadata to show in the footer) get a
+ * number; unknown tokens later render as `[?]`.
+ */
+export function assignCiteIndexes(
+  newText: string,
+  oldText: string,
+  knownSlugs: ReadonlySet<string>,
+): Map<string, number> {
+  const indexes = new Map<string, number>();
+  for (const slug of [...extractCiteSlugs(newText), ...extractCiteSlugs(oldText)]) {
+    if (knownSlugs.has(slug) && !indexes.has(slug)) {
+      indexes.set(slug, indexes.size + 1);
+    }
+  }
+  return indexes;
+}
+
+/**
+ * Footnote numbers for one field change's inline citations, keyed by
+ * citation-instance slug — assigned from marker order in the change's own
+ * old/new text, so the `[n]` markers and the citations footer agree.
+ */
+export function citeIndexesForChange(change: FieldChangeSchema): Map<string, number> {
+  const known = new Set<string>();
+  for (const citation of change.citations ?? []) {
+    if (citation.slug != null) known.add(citation.slug);
+  }
+  return assignCiteIndexes(diffText(change.new_value), diffText(change.old_value), known);
+}
+
+/** Rewrite `[[cite:slug]]` tokens in `text` to `[n]` markers (or `[?]` when
+ *  the slug has no assigned number). Run on both sides before diffing. */
+export function substituteCiteMarkers(text: string, indexes: Map<string, number>): string {
+  return text.replace(CITE_TOKEN, (_token, slug: string) => {
+    const index = indexes.get(slug);
+    return index === undefined ? '[?]' : `[${index}]`;
+  });
+}
+
+/** One piece of marker-split text: a plain-text run or a `[n]` marker. */
+export interface CiteMarkedPart {
+  type: 'text' | 'marker';
+  text: string;
+}
+
+/**
+ * Split substituted text into plain runs and `[n]` / `[?]` markers so the
+ * markers can render as superscripts. Only apply to text that actually went
+ * through {@link substituteCiteMarkers} — on arbitrary prose a literal
+ * bracketed number would be misread as a marker.
+ */
+export function splitCiteMarkers(text: string): CiteMarkedPart[] {
+  return text
+    .split(CITE_MARKER_SPLIT)
+    .filter((piece) => piece !== '')
+    .map((piece) => ({
+      type: CITE_MARKER.test(piece) ? ('marker' as const) : ('text' as const),
+      text: piece,
+    }));
+}

--- a/frontend/src/lib/components/ui/InlineDiff.svelte
+++ b/frontend/src/lib/components/ui/InlineDiff.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { computeWordDiff } from '$lib/diff';
 
-  let { oldValue, newValue }: { oldValue: string; newValue: string } = $props();
+  let {
+    oldValue,
+    newValue,
+    renderText,
+  }: {
+    oldValue: string;
+    newValue: string;
+    /** Optional renderer for each diff segment's text, so callers can style
+     *  sub-runs (e.g. superscript cite markers) without the diff knowing. */
+    renderText?: Snippet<[string]>;
+  } = $props();
 
   let segments = $derived(computeWordDiff(oldValue, newValue));
 
@@ -20,14 +31,18 @@
   });
 </script>
 
+{#snippet segText(text: string)}
+  {#if renderText}{@render renderText(text)}{:else}{text}{/if}
+{/snippet}
+
 <div class="diff-container" class:collapsed={needsExpansion && !expanded} bind:this={container}>
   {#each segments as seg, i (i)}
     {#if seg.type === 'added'}
-      <ins>{seg.text}</ins>
+      <ins>{@render segText(seg.text)}</ins>
     {:else if seg.type === 'removed'}
-      <del>{seg.text}</del>
+      <del>{@render segText(seg.text)}</del>
     {:else}
-      <span>{seg.text}</span>
+      <span>{@render segText(seg.text)}</span>
     {/if}
   {/each}
 </div>

--- a/frontend/src/routes/cabinets/[slug]/edit-history/edit-history-page.test.ts
+++ b/frontend/src/routes/cabinets/[slug]/edit-history/edit-history-page.test.ts
@@ -38,7 +38,18 @@ describe('cabinet edit-history page (taxonomy representative)', () => {
           citations: [
             {
               source_name: 'Internet Pinball Database #4443',
-              url: 'https://www.ipdb.org/machine.cgi?id=4443',
+              source_type: 'database',
+              author: '',
+              year: null,
+              locator: '',
+              slug: null,
+              links: [
+                {
+                  url: 'https://www.ipdb.org/machine.cgi?id=4443',
+                  link_type: 'reference',
+                  display_name: 'ipdb.org',
+                },
+              ],
             },
           ],
         },

--- a/frontend/src/routes/changesets/+page.svelte
+++ b/frontend/src/routes/changesets/+page.svelte
@@ -6,9 +6,16 @@
   import { resolveHref } from '$lib/utils';
   import ClaimAttribution from '$lib/components/provenance/ClaimAttribution.svelte';
   import ClaimValue from '$lib/components/provenance/ClaimValue.svelte';
+  import ChangeValue from '$lib/components/provenance/ChangeValue.svelte';
+  import ChangeCitations from '$lib/components/provenance/ChangeCitations.svelte';
+  import CiteMarkedText from '$lib/components/provenance/CiteMarkedText.svelte';
   import InlineDiff from '$lib/components/ui/InlineDiff.svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { diffText, isDiffable } from '$lib/components/provenance/change-display';
+  import {
+    citeIndexesForChange,
+    substituteCiteMarkers,
+  } from '$lib/components/provenance/cite-markers';
   import { changesLabel } from './changes';
 
   type ChangeSetSummary = ChangeSetSummarySchema;
@@ -158,6 +165,10 @@
   <title>Changelog &mdash; {SITE_TITLE}</title>
 </svelte:head>
 
+{#snippet markedText(text: string)}
+  <CiteMarkedText {text} />
+{/snippet}
+
 <div class="changes-page">
   <header class="page-header">
     <h1>Changelog</h1>
@@ -232,15 +243,24 @@
               {#if detail.changes.length > 0}
                 <dl class="field-list">
                   {#each detail.changes as change (change.claim_key)}
+                    {@const citeIndexes = citeIndexesForChange(change)}
                     {#if isDiffable(change)}
                       <div class="field-row field-row-diff">
                         <dt>{change.field_name}</dt>
                         <dd>
                           <InlineDiff
-                            oldValue={diffText(change.old_value)}
-                            newValue={diffText(change.new_value)}
+                            oldValue={substituteCiteMarkers(
+                              diffText(change.old_value),
+                              citeIndexes,
+                            )}
+                            newValue={substituteCiteMarkers(
+                              diffText(change.new_value),
+                              citeIndexes,
+                            )}
+                            renderText={citeIndexes.size > 0 ? markedText : undefined}
                           />
                         </dd>
+                        <ChangeCitations citations={change.citations ?? []} indexes={citeIndexes} />
                       </div>
                     {:else}
                       <div class="field-row">
@@ -248,14 +268,15 @@
                         <dd>
                           {#if change.old_value != null}
                             <span class="old-value claim-value-inline"
-                              ><ClaimValue value={change.old_value} /></span
+                              ><ChangeValue value={change.old_value} {citeIndexes} /></span
                             >
                             <span class="arrow">&rarr;</span>
                           {/if}
                           <span class="new-value claim-value-inline"
-                            ><ClaimValue value={change.new_value} /></span
+                            ><ChangeValue value={change.new_value} {citeIndexes} /></span
                           >
                         </dd>
+                        <ChangeCitations citations={change.citations ?? []} indexes={citeIndexes} />
                       </div>
                     {/if}
                   {/each}
@@ -459,6 +480,7 @@
 
   .field-row {
     display: flex;
+    flex-wrap: wrap;
     gap: var(--size-3);
     padding: var(--size-1) 0;
     border-bottom: 1px solid var(--color-border-soft);

--- a/frontend/src/routes/manufacturers/[slug]/edit-history/edit-history-page.test.ts
+++ b/frontend/src/routes/manufacturers/[slug]/edit-history/edit-history-page.test.ts
@@ -1,7 +1,36 @@
 import { render } from 'svelte/server';
 import { describe, expect, it } from 'vitest';
 
+import type { ChangeSetSchema, FieldChangeCitationSchema } from '$lib/api/schema';
 import Harness from './edit-history-page.test-harness.svelte';
+
+function makeCitation(over: Partial<FieldChangeCitationSchema>): FieldChangeCitationSchema {
+  return {
+    source_name: 'Some Source',
+    source_type: 'web',
+    author: '',
+    year: null,
+    locator: '',
+    slug: null,
+    links: [],
+    ...over,
+  };
+}
+
+function makeChangeset(over: Partial<ChangeSetSchema>): ChangeSetSchema {
+  return {
+    id: 1,
+    attribution: {
+      author: { kind: 'user', username: 'kim' },
+      created_at: '2026-07-01T00:00:00+00:00',
+    },
+    note: '',
+    changes: [],
+    retractions: [],
+    capabilities: { 'changeset.undo': false },
+    ...over,
+  };
+}
 
 describe('manufacturer edit-history page', () => {
   it('wraps EditHistory in FocusContentShell with back link to detail and an Edit History heading', () => {
@@ -13,5 +42,95 @@ describe('manufacturer edit-history page', () => {
     expect(body).toContain('Back');
     expect(body).toContain('>Edit History</h1>');
     expect(body.toLowerCase()).toContain('no edit history yet');
+  });
+
+  it('renders inline [[cite:]] tokens as numbered superscripts with a citations footer', () => {
+    const changeset = makeChangeset({
+      changes: [
+        {
+          field_name: 'description',
+          claim_key: 'description',
+          old_value: null,
+          new_value: {
+            raw: 'Founded in 2024.[[cite:id:1]] Debuted at Expo.[[cite:id:2]]',
+            display: {
+              kind: 'markdown',
+              text: 'Founded in 2024.[[cite:bbb]] Debuted at Expo.[[cite:aaa]]',
+            },
+          },
+          claim_id: 10,
+          claim_user_id: 1,
+          is_active: true,
+          is_winning: true,
+          is_retracted: false,
+          citations: [
+            makeCitation({
+              slug: 'aaa',
+              source_name: 'The Toy Book',
+              author: 'Ryan Vincent',
+              year: 2024,
+              links: [
+                {
+                  url: 'https://toybook.com/wonderland/',
+                  link_type: 'reference',
+                  display_name: 'toybook.com',
+                },
+              ],
+            }),
+            makeCitation({ slug: 'bbb', source_name: 'Kickstarter' }),
+          ],
+        },
+      ],
+    });
+
+    const { body } = render(Harness, { props: { data: { changesets: [changeset] } } });
+
+    // Tokens become markers, numbered by document order: bbb first.
+    expect(body).not.toContain('[[cite:');
+    expect(body).toContain('>[1]</sup>');
+    expect(body).toContain('>[2]</sup>');
+    // Footer lists both sources; the numbered Kickstarter row comes first.
+    expect(body).toContain('Kickstarter');
+    expect(body).toContain('The Toy Book');
+    expect(body.indexOf('Kickstarter')).toBeLessThan(body.indexOf('The Toy Book'));
+    expect(body).toContain('Ryan Vincent, 2024');
+    expect(body).toContain('href="https://toybook.com/wonderland/"');
+  });
+
+  it('renders attached (scalar) citations as unnumbered footer rows', () => {
+    const changeset = makeChangeset({
+      changes: [
+        {
+          field_name: 'name',
+          claim_key: 'name',
+          old_value: null,
+          new_value: { raw: 'Wonderland Amusements', display: null },
+          claim_id: 11,
+          claim_user_id: 1,
+          is_active: true,
+          is_winning: true,
+          is_retracted: false,
+          citations: [
+            makeCitation({
+              source_name: 'IPDB entry',
+              source_type: 'database',
+              links: [
+                {
+                  url: 'https://ipdb.org/1',
+                  link_type: 'reference',
+                  display_name: 'ipdb.org',
+                },
+              ],
+            }),
+          ],
+        },
+      ],
+    });
+
+    const { body } = render(Harness, { props: { data: { changesets: [changeset] } } });
+
+    expect(body).toContain('IPDB entry');
+    expect(body).toContain('href="https://ipdb.org/1"');
+    expect(body).not.toContain('</sup>');
   });
 });


### PR DESCRIPTION
## Summary

Inline `[[cite:]]` citations in markdown claims never surfaced on edit-history pages — the per-change citations list only read the `ClaimCitationInstance` join, and the frontend rendered markdown claim text raw, tokens and all. Now the tokens render as numbered `[n]` superscripts inside the (unchanged) word-diff, backed by a per-change citations footer that lists inline citations by marker number and attached scalar evidence unnumbered.

- `FieldChangeCitationSchema` grows the full source shape (`source_type`, `author`, `year`, `locator`, all `links`) plus a `slug` marking inline citations, replacing the single-URL `{source_name, url}` pair
- `build_edit_history` batch-loads instances referenced by `[[cite:id:N]]` markers — including ones only the prior value cites, so diffs can label removed markers — in one query, preserving the bounded-query guarantee; changeset detail shares the path
- `[[cite:slug]]` tokens are rewritten to `[n]` before word-diffing (same slug → same marker, so unchanged citations diff as unchanged, and a swapped citation shows red/green at the exact spot); the diff itself stays plain text — no markdown rendering
- New `ChangeCitations` footer (linked source name, author/year, locator, link chips incl. archive) replaces the old "Source:" row; the `/changesets` changelog gets the same treatment
- The live-page-over-Wayback-snapshot invariant moves to the wire's `reference` link, which the client uses as the title link

## Test plan

- [x] Backend TDD: new `TestEditHistoryCitations` cases written first and confirmed failing (rich attached metadata, inline citations in document order, removed-citation inclusion), then made green
- [x] Full backend suite (4444 passed), mypy, ruff
- [x] Frontend: new `cite-markers` unit tests + SSR render tests for numbered superscripts, footer ordering and unnumbered scalar rows; full vitest suite (1766 passed), eslint, svelte-check
- [ ] Manual: open a manufacturer edit-history page whose description carries `[[cite:]]` markers (e.g. `/manufacturers/wonderland-amusements/edit-history`) and confirm superscript markers plus the citations footer; expand the same changeset on `/changesets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)