### PR TITLE
feat(provenance): support multiple citations per scalar claim

### DIFF
--- a/backend/apps/catalog/tests/test_patch_provenance.py
+++ b/backend/apps/catalog/tests/test_patch_provenance.py
@@ -73,7 +73,7 @@ def test_note_and_cite_parsed_and_excluded_from_fields():
     (entry,) = doc.claims
     assert isinstance(entry, EditEntry)  # no create/delete → an edit
     assert entry.note == "tagged because the name says so"
-    assert entry.cite == "ipdb:4443"
+    assert entry.cite == (("ipdb:4443", "", "", ""),)
     assert entry.fields == {"year": 1990}  # note/cite are not field assertions
 
 
@@ -624,7 +624,7 @@ def test_attach_citations_is_per_claim(flipcommons_catalog, ipdb_root, pm):
             value=1998,
             content_type_id=ct.pk,
             object_id=pm.pk,
-            cite_spec=CiteSpec(ref=SchemeCitationRef("ipdb", "4443")),
+            cite_specs=(CiteSpec(ref=SchemeCitationRef("ipdb", "4443")),),
             entry_index=0,
         )
     )
@@ -649,6 +649,256 @@ def test_attach_citations_is_per_claim(flipcommons_catalog, ipdb_root, pm):
     link = year_claim.citation_links.get()
     assert link.citation_instance_id == year_claim.citation_instances.get().pk
     assert not qty_claim.citation_links.exists()
+
+
+# ── cite: list form — multiple citations per entry ─────────────────
+
+
+def test_cite_list_parsed_and_excluded_from_fields():
+    doc = load_patch(
+        "attribution: flipcommons-catalog\n"
+        "claims:\n"
+        "  - model.x:\n"
+        "      cite:\n"
+        "        - ipdb:4443\n"
+        "        - ref: ipdb:5556\n"
+        "          locator: Notes section\n"
+        "          quote: exists only as a prototype\n"
+        "      year: 1990\n"
+    )
+    (entry,) = doc.claims
+    assert isinstance(entry, EditEntry)
+    assert entry.cite == (
+        ("ipdb:4443", "", "", ""),
+        ("ipdb:5556", "", "Notes section", "exists only as a prototype"),
+    )
+    assert entry.fields == {"year": 1990}
+
+
+def test_cite_list_fans_out_to_all_claims(
+    flipcommons_catalog, ipdb_root, pm, prototype_tag
+):
+    # N cites × M claims: every claim in the entry carries every cite, through
+    # N shared instances per changeset (not M×N clones).
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      cite:
+        - ipdb:4443
+        - ref: ipdb:5556
+          quote: exists only as a prototype
+      year: 1998
+      tag: [prototype]
+"""
+    _apply(text)
+
+    year_claim = pm.claims.get(field_name="year", is_active=True)
+    tag_claim = pm.claims.get(field_name="tag", is_active=True)
+    year_instances = set(year_claim.citation_instances.values_list("pk", flat=True))
+    tag_instances = set(tag_claim.citation_instances.values_list("pk", flat=True))
+    assert len(year_instances) == 2
+    # Shared instances: the tag claim reaches the SAME two rows, not clones.
+    assert tag_instances == year_instances
+    assert CitationInstance.objects.count() == 2
+    sources = {
+        i.citation_source.identifier for i in year_claim.citation_instances.all()
+    }
+    assert sources == {"4443", "5556"}
+    quotes = {i.quote for i in year_claim.citation_instances.all()}
+    assert quotes == {"", "exists only as a prototype"}
+
+
+def test_cite_single_spec_still_parses_as_before(flipcommons_catalog, ipdb_root, pm):
+    # The single-spec form is unchanged wire grammar — a list of one.
+    text = "attribution: flipcommons-catalog\nclaims:\n  - model.medieval-madness:\n      cite: ipdb:4443\n      year: 1998\n"
+    _apply(text)
+    year_claim = pm.claims.get(field_name="year", is_active=True)
+    assert year_claim.citation_instances.get().citation_source.identifier == "4443"
+
+
+def test_cite_empty_list_rejected():
+    with pytest.raises(PatchError, match="non-empty"):
+        load_patch(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.x:\n"
+            "      cite: []\n"
+            "      year: 1990\n"
+        )
+
+
+def test_cite_nested_list_element_rejected():
+    with pytest.raises(PatchError, match="cite"):
+        load_patch(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.x:\n"
+            "      cite:\n"
+            "        - [ipdb:4443]\n"
+            "      year: 1990\n"
+        )
+
+
+def test_cite_list_exact_duplicate_rejected():
+    # Byte-identical specs are caught at parse time.
+    with pytest.raises(PatchError, match="duplicate"):
+        load_patch(
+            "attribution: flipcommons-catalog\n"
+            "claims:\n"
+            "  - model.x:\n"
+            "      cite:\n"
+            "        - ipdb:4443\n"
+            "        - ipdb:4443\n"
+            "      year: 1990\n"
+        )
+
+
+def test_cite_list_normalized_duplicate_rejected(flipcommons_catalog, youtube_root, pm):
+    # The video locators '95' and '1:35' both canonicalize to '1:35' — duplicates
+    # are judged on the parsed, normalized spec, not the raw string.
+    text = (
+        "attribution: flipcommons-catalog\n"
+        "claims:\n"
+        "  - model.medieval-madness:\n"
+        "      cite:\n"
+        "        - ref: youtube:dQw4w9WgXcQ\n"
+        "          locator: '95'\n"
+        "        - ref: youtube:dQw4w9WgXcQ\n"
+        "          locator: '1:35'\n"
+        "      year: 1998\n"
+    )
+    with pytest.raises(PatchError, match="duplicate"):
+        _apply(text)
+
+
+def test_cite_list_string_vs_mapping_duplicate_rejected(
+    flipcommons_catalog, ipdb_root, pm
+):
+    # A bare string and a mapping naming the same ref (with no distinguishing
+    # locator/quote) are the same evidence twice.
+    text = (
+        "attribution: flipcommons-catalog\n"
+        "claims:\n"
+        "  - model.medieval-madness:\n"
+        "      cite:\n"
+        "        - ipdb:4443\n"
+        "        - ref: ipdb:4443\n"
+        "      year: 1998\n"
+    )
+    with pytest.raises(PatchError, match="duplicate"):
+        _apply(text)
+
+
+def test_cite_list_same_ref_different_quote_allowed(flipcommons_catalog, ipdb_root, pm):
+    # Same source, different quote = two distinct pieces of evidence; both
+    # instances attach to the claim.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      cite:
+        - ref: ipdb:4443
+          quote: first excerpt
+        - ref: ipdb:4443
+          quote: second excerpt
+      year: 1998
+"""
+    _apply(text)
+    year_claim = pm.claims.get(field_name="year", is_active=True)
+    assert year_claim.citation_instances.count() == 2
+    assert (
+        CitationSource.objects.filter(parent=ipdb_root, identifier="4443").count() == 1
+    )
+
+
+def test_cite_list_url_bare_and_archived_one_join_row(
+    flipcommons_catalog, kineticist_root, pm
+):
+    # A bare URL and the same URL with an archive: are distinct specs (the
+    # archive rides the ref) but resolve to one (source, locator, quote) — the
+    # claim gets ONE instance and ONE join row, not a unique-constraint error.
+    url = "https://kineticist.com/reviews/medieval-madness"
+    text = (
+        "attribution: flipcommons-catalog\n"
+        "claims:\n"
+        "  - model.medieval-madness:\n"
+        "      cite:\n"
+        f"        - {url}\n"
+        f"        - ref: {url}\n"
+        "          archive: https://web.archive.org/web/2024/https://kineticist.com/reviews/medieval-madness\n"
+        "      year: 1998\n"
+    )
+    _apply(text)
+    year_claim = pm.claims.get(field_name="year", is_active=True)
+    assert year_claim.citation_instances.count() == 1
+    assert year_claim.citation_links.count() == 1
+
+
+def test_cite_list_on_delete_entry(flipcommons_catalog, ipdb_root, pm):
+    # A delete entry's cite list rides the cascade's status claims.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      delete: true
+      note: duplicate record
+      cite:
+        - ipdb:4443
+        - ipdb:5556
+"""
+    _apply(text)
+    status_claim = pm.claims.get(field_name="status", is_active=True)
+    assert status_claim.citation_instances.count() == 2
+
+
+def test_cite_list_with_no_carrier_rejected(flipcommons_catalog, pm):
+    make_claim(pm, "year", 1998, ingest_source=flipcommons_catalog)
+    text = (
+        "attribution: flipcommons-catalog\n"
+        "claims:\n"
+        "  - model.medieval-madness:\n"
+        "      cite:\n"
+        "        - ipdb:4443\n"
+        "        - ipdb:5556\n"
+        "      retract: [year]\n"
+    )
+    with pytest.raises(PatchError, match="cite has no field to attach to"):
+        _apply(text)
+
+
+def test_cite_list_in_changesets_item(flipcommons_catalog, ipdb_root, pm):
+    # A grouped changesets: item carries its own cite list.
+    text = """
+attribution: flipcommons-catalog
+claims:
+  - model.medieval-madness:
+      changesets:
+        - note: two sources agree
+          cite:
+            - ipdb:4443
+            - ipdb:5556
+          year: 1998
+"""
+    _apply(text)
+    year_claim = pm.claims.get(field_name="year", is_active=True)
+    assert year_claim.citation_instances.count() == 2
+
+
+def test_cite_list_idempotent_across_applications(flipcommons_catalog, ipdb_root, pm):
+    base = (
+        "attribution: flipcommons-catalog\n"
+        "claims:\n"
+        "  - model.medieval-madness:\n"
+        "      cite:\n"
+        "        - ipdb:4443\n"
+        "        - ipdb:5556\n"
+        "      year: {year}\n"
+    )
+    _apply(base.format(year=1998), patch_id="0001-a")
+    _apply(base.format(year=1999), patch_id="0002-b")
+    # Re-citing the same ids reuses the two child sources.
+    assert CitationSource.objects.filter(parent=ipdb_root).count() == 2
 
 
 def test_patch_plan_missing_entry_index_raises(flipcommons_catalog, pm):

--- a/backend/apps/claim_ingest/apply/claims.py
+++ b/backend/apps/claim_ingest/apply/claims.py
@@ -242,7 +242,7 @@ def _reject_empty_diff_provenance(plan: IngestPlan, changed: set[EntryIndex]) ->
     for pca in plan.assertions:
         idx = pca.entry_index
         assert idx is not None  # patch assertions are always stamped
-        if pca.note or pca.cite_spec is not None or pca.inline_cites:
+        if pca.note or pca.cite_specs or pca.inline_cites:
             has_provenance.add(idx)
         is_status = pca.field_name == LIFECYCLE_STATUS_FIELD
         only_status[idx] = only_status.get(idx, True) and is_status

--- a/backend/apps/claim_ingest/apply/persist.py
+++ b/backend/apps/claim_ingest/apply/persist.py
@@ -56,8 +56,8 @@ type EntryNotes = dict[EntryIndex, str]
 """Each patch entry's note keyed by its ``EntryIndex`` — one ChangeSet, one note
 per entry. Produced by ``_collect_plan_provenance``, consumed by ``_persist``."""
 
-type ClaimCitations = dict[ClaimIdentity, CiteSpec]
-"""Per-claim ``CiteSpec`` keyed by claim identity — never per entry, so a
+type ClaimCitations = dict[ClaimIdentity, tuple[CiteSpec, ...]]
+"""Per-claim ``CiteSpec``s keyed by claim identity — never per entry, so a
 citation never bleeds onto unrelated claims sharing the entity. Produced by
 ``_collect_plan_provenance``, consumed by ``_attach_plan_citations``."""
 
@@ -172,7 +172,7 @@ def _patch_handles(
 def _collect_plan_provenance(
     plan: IngestPlan,
 ) -> tuple[EntryNotes, ClaimCitations, ClaimEntryIndex]:
-    """Gather per-entry ``note``/``cite_spec`` and the claim→entry grouping map.
+    """Gather per-entry ``note``/``cite_specs`` and the claim→entry grouping map.
 
     Source-agnostic — any plan may set these; today only the patch adapter does
     (from a patch entry's ``note:``/``cite:``). Runs after ``_patch_handles``,
@@ -207,12 +207,12 @@ def _collect_plan_provenance(
         # Every assertion is stamped by the front end's second pass.
         assert pca.entry_index is not None
         claim_entry_index[ident] = pca.entry_index
-        if not pca.note and pca.cite_spec is None:
+        if not pca.note and not pca.cite_specs:
             continue  # the common case: a plain assertion with no note/cite
         if pca.note:
             entry_notes[pca.entry_index] = pca.note
-        if pca.cite_spec is not None:
-            claim_citations[ident] = pca.cite_spec
+        if pca.cite_specs:
+            claim_citations[ident] = pca.cite_specs
     for pcr in plan.retractions:
         if pcr.note:
             assert pcr.entry_index is not None
@@ -359,25 +359,33 @@ def _attach_plan_citations(
 
     # One shared instance per distinct citation per ChangeSet: claims in the
     # same entry citing the same evidence reach one row through join fan-out
-    # rather than minting a clone each.
+    # rather than minting a clone each. Within one claim, two specs that are
+    # distinct as authored can still resolve to one instance content (the same
+    # URL cited bare and with an ``archive:``) — ``seen`` collapses those to
+    # one join row instead of tripping the unique (claim, instance) constraint.
     source_cache: CiteSourceCache = {}
     shared: dict[_SharedCiteKey, CitationInstance] = {}
     cited: list[tuple[Claim, _SharedCiteKey]] = []
     for claim in to_create:
-        spec = claim_citations.get(
-            ClaimIdentity(claim.content_type_id, claim.object_id, claim.claim_key)
+        specs = claim_citations.get(
+            ClaimIdentity(claim.content_type_id, claim.object_id, claim.claim_key), ()
         )
-        if spec is None:
-            continue
-        source_id = _resolve_cite_source_id(spec.ref, source_cache, actor=actor)
-        key = _SharedCiteKey(claim.changeset_id, source_id, spec.locator, spec.quote)
-        if key not in shared:
-            shared[key] = CitationInstance(
-                citation_source_id=source_id,
-                locator=spec.locator,
-                quote=spec.quote,
+        seen: set[_SharedCiteKey] = set()
+        for spec in specs:
+            source_id = _resolve_cite_source_id(spec.ref, source_cache, actor=actor)
+            key = _SharedCiteKey(
+                claim.changeset_id, source_id, spec.locator, spec.quote
             )
-        cited.append((claim, key))
+            if key in seen:
+                continue
+            seen.add(key)
+            if key not in shared:
+                shared[key] = CitationInstance(
+                    citation_source_id=source_id,
+                    locator=spec.locator,
+                    quote=spec.quote,
+                )
+            cited.append((claim, key))
     if shared:
         CitationInstance.objects.mint_many(list(shared.values()))
         ClaimCitationInstance.objects.bulk_create(

--- a/backend/apps/claim_ingest/patches/emit.py
+++ b/backend/apps/claim_ingest/patches/emit.py
@@ -206,7 +206,7 @@ def _emit_assert(
     value: object = None,
     claim_key: ClaimKey = "",
     note: str = "",
-    cite_spec: CiteSpec | None = None,
+    cite_specs: tuple[CiteSpec, ...] = (),
     inline_cites: dict[CiteHandle, CiteSpec] | None = None,
 ) -> None:
     plan.assertions.append(
@@ -215,7 +215,7 @@ def _emit_assert(
             value=value,
             claim_key=claim_key,
             note=note,
-            cite_spec=cite_spec,
+            cite_specs=cite_specs,
             inline_cites=dict(inline_cites) if inline_cites else {},
             content_type_id=target.content_type_id,
             object_id=target.object_id,
@@ -231,7 +231,7 @@ def _emit_direct(
     target: _Target,
     *,
     note: str = "",
-    cite_spec: CiteSpec | None = None,
+    cite_specs: tuple[CiteSpec, ...] = (),
     inline_cites: dict[CiteHandle, CiteSpec] | None = None,
 ) -> None:
     """Emit a scalar or FK claim assertion (FK value is the target public_id).
@@ -246,7 +246,7 @@ def _emit_direct(
         field_name=field_name,
         value=value,
         note=note,
-        cite_spec=cite_spec,
+        cite_specs=cite_specs,
         inline_cites=inline_cites,
     )
 
@@ -691,7 +691,7 @@ def _emit_relationship(
     *,
     registry: PatchEntityRegistry,
     note: str = "",
-    cite_spec: CiteSpec | None = None,
+    cite_specs: tuple[CiteSpec, ...] = (),
 ) -> _MemberEmitResult:
     """Emit ``exists=true`` member assertions; return their clash keys + carrier flag.
 
@@ -761,7 +761,7 @@ def _emit_relationship(
                         identity=resolved.concrete,
                         identity_refs=resolved.refs,
                         note=note,
-                        cite_spec=cite_spec,
+                        cite_specs=cite_specs,
                         content_type_id=target.content_type_id,
                         object_id=target.object_id,
                         handle=target.handle,
@@ -795,7 +795,7 @@ def _emit_relationship(
                         identity=payload,
                         identity_refs={rel_spec.value_key: handle},
                         note=note,
-                        cite_spec=cite_spec,
+                        cite_specs=cite_specs,
                         content_type_id=target.content_type_id,
                         object_id=target.object_id,
                         handle=target.handle,
@@ -824,7 +824,7 @@ def _emit_relationship(
             value=claim_value,
             claim_key=claim_key,
             note=note,
-            cite_spec=cite_spec,
+            cite_specs=cite_specs,
         )
         clash_keys.append(claim_key)
         carrier_written = True
@@ -847,7 +847,7 @@ def _add_removals(
     rel_fields_by_model: RelFieldsByModel,
     *,
     note: str = "",
-    cite_spec: CiteSpec | None = None,
+    cite_specs: tuple[CiteSpec, ...] = (),
 ) -> _RemovalResult:
     """Emit ``exists=false`` member supersedes for each ``remove:`` member.
 
@@ -912,7 +912,7 @@ def _add_removals(
                 value=claim_value,
                 claim_key=claim_key,
                 note=note,
-                cite_spec=cite_spec,
+                cite_specs=cite_specs,
             )
             rel_fields_by_model[model_class].add(namespace)
             carrier_written = True
@@ -1112,7 +1112,7 @@ def _add_delete(
     entry: DeleteEntry,
     *,
     note: str = "",
-    cite_spec: CiteSpec | None = None,
+    cite_specs: tuple[CiteSpec, ...] = (),
 ) -> list[EntityKey]:
     """Emit ``status=deleted`` assertions to soft-delete *existing* and its cascade.
 
@@ -1161,7 +1161,7 @@ def _add_delete(
             field_name=LIFECYCLE_STATUS_FIELD,
             value="deleted",
             note=note,
-            cite_spec=cite_spec,
+            cite_specs=cite_specs,
         )
         affected.append(EntityKey(ct_id, target_entity.pk))
     cascaded = [require_linkable(e) for e in walk.cascade if e.pk != existing.pk]

--- a/backend/apps/claim_ingest/patches/parsing.py
+++ b/backend/apps/claim_ingest/patches/parsing.py
@@ -64,12 +64,12 @@ _SLUG_HANDLE_RE = re.compile(r"^[a-z]+$")
 
 # Keys in a claim entry's value mapping that are directives, not claim fields.
 #
-# Grammar mirror: pindata's `schema/patch.schema.json` is a hand-maintained JSON
-# Schema of this patch *wire* grammar. It's a structural pre-check for authors,
-# living in the repo where patches are written, run by pindata's `make validate`.
-# It's deliberately partial (this parser and planning stay authoritative) and
-# can't see this file, so when you change the wire grammar here, update
-# `patch.schema.json` in pindata to match.
+# Grammar mirror: flippatch's `schema/patch.schema.json` is a hand-maintained
+# JSON Schema of this patch *wire* grammar. It's a structural pre-check for
+# authors, living in the repo where patches are written, run by flippatch's
+# `make validate`. It's deliberately partial (this parser and planning stay
+# authoritative) and can't see this file, so when you change the wire grammar
+# here, update `patch.schema.json` in flippatch to match.
 RESERVED_FIELD_KEYS = frozenset(
     {
         "create",
@@ -250,17 +250,12 @@ class _PatchEntry:
     entity_type: str
     public_id: str
     # Per-entry provenance, common to all kinds. ``note`` becomes the entity's
-    # ChangeSet note; ``cite`` is a raw ``scheme:identifier`` string or a
-    # ``http(s)://`` URL, parsed + validated into a CiteSpec in build_plan.
-    # ``cite_archive`` is an optional durable-snapshot (Wayback) URL that rides
-    # the same citation; only valid alongside a ``http(s)://`` ``cite``.
-    # ``cite_locator``/``cite_quote`` are the minted CitationInstance's fields:
-    # where in the source, and the verbatim excerpt. Empty when unset.
+    # ChangeSet note; ``cite`` is the entry-level citation(s) — one
+    # :class:`_RawCite` per authored spec (a single spec or a list in the
+    # wire grammar), each parsed + validated into a CiteSpec in build_plan.
+    # Every spec fans out to every claim the entry asserts. Empty when unset.
     note: str = ""
-    cite: str = ""
-    cite_archive: str = ""
-    cite_locator: str = ""
-    cite_quote: str = ""
+    cite: tuple[_RawCite, ...] = ()
     # Inline-citation specs for *new* footnotes referenced by numeric-handle
     # ``[[cite:1]]`` markers in this entry's markdown fields, keyed by the
     # patch-local handle (``"1"``). Each value is a parsed CiteSpec minted at
@@ -489,22 +484,16 @@ def _parse_entry_body(ref: str, raw_fields: JsonBody) -> PatchEntry:
     create = _require_bool(raw_fields, "create", ref)
     delete = _require_bool(raw_fields, "delete", ref)
     note = _require_str(raw_fields, "note", ref)
-    cite, cite_archive, cite_locator, cite_quote = _normalize_raw_cite(
-        raw_fields.get("cite", ""), ref
-    )
+    cite = _normalize_raw_cites(raw_fields.get("cite", ""), ref)
     cites = _parse_cites(raw_fields.get("cites", {}), ref)
     # Authored claim fields: everything that isn't a reserved directive key.
     fields = {k: v for k, v in raw_fields.items() if k not in RESERVED_FIELD_KEYS}
-    # ``cites`` is passed per-constructor below rather than spread here — its
-    # ``dict[str, CiteSpec]`` value would widen this all-``str`` mapping.
+    # ``cite``/``cites`` are passed per-constructor below rather than spread
+    # here — their non-``str`` values would widen this all-``str`` mapping.
     common = {
         "entity_type": entity_type,
         "public_id": public_id,
         "note": note,
-        "cite": cite,
-        "cite_archive": cite_archive,
-        "cite_locator": cite_locator,
-        "cite_quote": cite_quote,
     }
 
     if create and delete:
@@ -520,16 +509,17 @@ def _parse_entry_body(ref: str, raw_fields: JsonBody) -> PatchEntry:
                 f"({', '.join(sorted(fields))}) — reassign references in a "
                 f"separate entry, in an earlier patch, before the delete"
             )
-        return DeleteEntry(**common, cites=cites)
+        return DeleteEntry(**common, cite=cite, cites=cites)
 
     if create:
         for key in ("retract", "remove"):
             if key in raw_fields:
                 raise PatchError(f"{ref}: {key!r} is meaningless on a create")
-        return CreateEntry(**common, cites=cites, fields=fields)
+        return CreateEntry(**common, cite=cite, cites=cites, fields=fields)
 
     return EditEntry(
         **common,
+        cite=cite,
         cites=cites,
         retract=_parse_retract(raw_fields, ref),
         remove=_parse_remove(raw_fields, ref),
@@ -694,43 +684,79 @@ def _normalize_raw_cite(raw_cite: object, ref: str) -> _RawCite:
     )
 
 
-def _parse_provenance(entry: PatchEntry) -> tuple[str, CiteSpec | None]:
-    """Validate an entry's ``note``/``cite`` and parse ``cite`` into a CiteSpec.
+def _normalize_raw_cites(raw_cite: object, ref: str) -> tuple[_RawCite, ...]:
+    """Split an entry-level ``cite:`` value into per-spec :class:`_RawCite`\\ s.
+
+    Three authoring forms: absent (``""`` via the ``.get`` default) → empty;
+    a single spec (string or mapping, the original grammar) → one element; a
+    **list** of such specs → one element each. Byte-identical list elements are
+    rejected here as a cheap copy-paste catch; normalized duplicates (same
+    parsed spec through differing spellings) are caught on the parsed
+    ``CiteSpec``\\ s in :func:`_parse_provenance`.
+    """
+    if raw_cite == "":
+        return ()
+    if not isinstance(raw_cite, list):
+        return (_normalize_raw_cite(raw_cite, ref),)
+    if not raw_cite:
+        raise PatchError(
+            f"{ref}: a 'cite' list must be non-empty — omit the key instead"
+        )
+    normalized: list[_RawCite] = []
+    for i, element in enumerate(raw_cite):
+        element_ref = f"{ref} cite[{i}]"
+        if not isinstance(element, str | dict) or element == "":
+            raise PatchError(
+                f"{element_ref}: each 'cite' list element must be a "
+                f"'scheme:identifier'/URL string or a "
+                f"{{ref, archive, locator, quote}} mapping"
+            )
+        raw = _normalize_raw_cite(element, element_ref)
+        if raw in normalized:
+            raise PatchError(f"{element_ref}: duplicate cite {raw.cite!r}")
+        normalized.append(raw)
+    return tuple(normalized)
+
+
+def _parse_provenance(entry: PatchEntry) -> tuple[str, tuple[CiteSpec, ...]]:
+    """Validate an entry's ``note``/``cite`` and parse ``cite`` into CiteSpecs.
 
     Length-checks each value against the DB column it lands in so an overlong
     value fails as a clear :class:`PatchError` here rather than deep in
     persistence — and mojibake-checks ``locator``/``quote``, which the bulk
     mint path (``mint_many`` → ``bulk_create``) would otherwise never validate.
-    ``cite``'s ref is one of two forms:
+    Each cite's ref is one of two forms:
 
     * ``scheme:identifier`` — the scheme must be a registered scheme and the
       identifier must normalize (``ipdb:4443``).
     * a ``http(s)://`` URL — a standalone web source. A URL that matches a
       known scheme's record pattern is rejected: cite it as ``scheme:identifier``
       so it dedups through the scheme path.
+
+    Duplicates are judged on the *parsed* spec — ``ipdb:04443`` and
+    ``ipdb:4443``, or a bare string and a mapping naming the same ref, are the
+    same evidence twice and rejected. The same ref with a differing locator or
+    quote is a distinct piece of evidence and allowed.
     """
     note = entry.note
     if len(note) > CHANGESET_NOTE_MAX_LENGTH:
         raise PatchError(
             f"{entry.ref}: note exceeds {CHANGESET_NOTE_MAX_LENGTH} characters"
         )
-    if entry.cite_archive and not entry.cite.startswith(("http://", "https://")):
-        raise PatchError(
-            f"{entry.ref}: 'cite.archive' is only valid alongside a http(s):// "
-            f"URL cite, not a scheme cite or an empty cite"
+    specs: list[CiteSpec] = []
+    for raw in entry.cite:
+        cite_ref = _parse_cite_value(raw.cite, raw.archive, entry.ref)
+        locator, quote = _validated_cite_instance_fields(
+            cite_ref, raw.locator, raw.quote, entry.ref
         )
-    if not entry.cite:
-        if entry.cite_locator or entry.cite_quote:
+        spec = CiteSpec(ref=cite_ref, locator=locator, quote=quote)
+        if spec in specs:
             raise PatchError(
-                f"{entry.ref}: 'cite.locator'/'cite.quote' need a 'cite.ref' "
-                f"to attach to"
+                f"{entry.ref}: duplicate cite {raw.cite!r} — the same source, "
+                f"locator and quote appear twice in one 'cite' list"
             )
-        return note, None
-    cite_ref = _parse_cite_value(entry.cite, entry.cite_archive, entry.ref)
-    locator, quote = _validated_cite_instance_fields(
-        cite_ref, entry.cite_locator, entry.cite_quote, entry.ref
-    )
-    return note, CiteSpec(ref=cite_ref, locator=locator, quote=quote)
+        specs.append(spec)
+    return note, tuple(specs)
 
 
 def _validated_cite_instance_fields(

--- a/backend/apps/claim_ingest/patches/planning.py
+++ b/backend/apps/claim_ingest/patches/planning.py
@@ -436,7 +436,7 @@ def _process_entry(
     per-entry provenance-carrier check is enforced inline; the returned
     :class:`_EntryResult` carries only what ``_validate_plan_wide`` needs.
     """
-    note, cite_spec = _parse_provenance(entry)
+    note, cite_specs = _parse_provenance(entry)
     model_class = _resolve_model_class(entry)
     ct_id = ContentType.objects.get_for_model(model_class).pk
     existing = registry.lookup_existing(model_class, entry.public_id)
@@ -456,7 +456,7 @@ def _process_entry(
             )
         if existing is None:
             raise PatchError(f"{entry.ref}: no such {entry.entity_type} to delete")
-        affected = _add_delete(plan, existing, entry, note=note, cite_spec=cite_spec)
+        affected = _add_delete(plan, existing, entry, note=note, cite_specs=cite_specs)
         contributions: dict[_TargetKey, _TargetContribution] = {
             tkey: _TargetContribution(
                 ref=entry.ref,
@@ -555,7 +555,7 @@ def _process_entry(
                 value,
                 target,
                 note=note,
-                cite_spec=cite_spec,
+                cite_specs=cite_specs,
                 inline_cites=inline_cites_by_field.get(key, {}),
             )
             carrier_written = True
@@ -570,7 +570,7 @@ def _process_entry(
                 entry,
                 registry=registry,
                 note=note,
-                cite_spec=cite_spec,
+                cite_specs=cite_specs,
             )
             rel_fields_by_model[model_class].add(key)
             hierarchy_edges.extend(emit.hierarchy_edges)
@@ -602,7 +602,7 @@ def _process_entry(
             rel_namespaces,
             rel_fields_by_model,
             note=note,
-            cite_spec=cite_spec,
+            cite_specs=cite_specs,
         )
         removed_members = removal.removed_members
         carrier_written = carrier_written or removal.carrier_written
@@ -610,7 +610,7 @@ def _process_entry(
     _check_provenance_carrier(
         entry,
         note=note,
-        cite_spec=cite_spec,
+        cite_specs=cite_specs,
         carrier_written=carrier_written,
         retracted_any=retracted_any,
     )
@@ -674,7 +674,7 @@ def _check_provenance_carrier(
     entry: CreateEntry | EditEntry,
     *,
     note: str,
-    cite_spec: CiteSpec | None,
+    cite_specs: tuple[CiteSpec, ...],
     carrier_written: bool,
     retracted_any: bool,
 ) -> None:
@@ -691,7 +691,7 @@ def _check_provenance_carrier(
     emits nothing, so ``_persist`` makes no ChangeSet and the note would vanish.
     This keeps note in step with cite, which likewise requires a real carrier.
     """
-    if cite_spec is not None and not carrier_written:
+    if cite_specs and not carrier_written:
         raise PatchError(
             f"{entry.ref}: cite has no field to attach to — cite a field you're "
             f"also asserting (a retraction, a no-op removal, a field-less "

--- a/backend/apps/claim_ingest/plan.py
+++ b/backend/apps/claim_ingest/plan.py
@@ -207,11 +207,13 @@ class PlannedClaimAssert:
     value: Any = None
     claim_key: str = ""
     # Per-entry patch provenance. ``note`` flows to the entity's ChangeSet
-    # note; ``cite_spec`` (set only on explicit-field assertions, never the
-    # create-owned slug/status scaffolding) is materialized as a
-    # CitationInstance on the resulting claim at apply time.
+    # note; ``cite_specs`` (set only on explicit-field assertions, never the
+    # create-owned slug/status scaffolding) is the entry's citation list —
+    # every spec is materialized as a CitationInstance on the resulting claim
+    # at apply time, so N specs on M claims fan out to M×N support edges
+    # through N shared instances.
     note: str = ""
-    cite_spec: CiteSpec | None = None
+    cite_specs: tuple[CiteSpec, ...] = ()
     # Inline-citation footnotes referenced by ``[[cite:<numeric-handle>]]`` markers
     # in a markdown field's value, keyed by the patch-local numeric handle. Each
     # is a *new* citation minted at apply time (a floating CitationInstance
@@ -246,7 +248,7 @@ class PlannedClaimRetract:
     object_id: int
     claim_key: str
     # Per-entry patch note → the entry's ChangeSet note. A retraction has no
-    # new claim, so it carries no ``cite_spec``.
+    # new claim, so it carries no ``cite_specs``.
     note: str = ""
     # The file-order index of the authoring patch entry (see
     # ``PlannedClaimAssert.entry_index``); stamped in the same second pass.

--- a/backend/apps/provenance/tests/test_api_edit_history.py
+++ b/backend/apps/provenance/tests/test_api_edit_history.py
@@ -271,6 +271,25 @@ class TestEditHistoryCitations:
             "https://toybook.com/wonderland/"
         ]
 
+    def test_multiple_attached_citations_all_returned(self, client, user, pm):
+        """A claim backed by several join-attached citations surfaces every
+        one on the change, not just the first."""
+        claim = make_claim(pm, "year", 1998, user=user)
+        book = make_citation_source(name="The Encyclopedia of Pinball")
+        web = make_citation_source(name="The Toy Book", source_type="web")
+        cite_claim(claim, citation_source=book, locator="p. 42")
+        cite_claim(claim, citation_source=web)
+
+        resp = client.get(f"/api/pages/edit-history/model/{pm.slug}/")
+        assert resp.status_code == 200
+        citations = _user_changesets(resp)[0]["changes"][0]["citations"]
+        assert {(c["source_name"], c["locator"]) for c in citations} == {
+            ("The Encyclopedia of Pinball", "p. 42"),
+            ("The Toy Book", ""),
+        }
+        # Attached evidence has no inline markers.
+        assert all(c["slug"] is None for c in citations)
+
     def test_inline_citations_returned_in_document_order(self, client, user, pm):
         """Inline ``[[cite:id:N]]`` markers in a markdown claim surface as
         citations on the change, slug-keyed and ordered by first appearance."""

--- a/docs/DataPatchAuthoring.md
+++ b/docs/DataPatchAuthoring.md
@@ -165,10 +165,7 @@ Creating records (rather than correcting seeded ones) has its own discipline. Pr
 
 Dependencies point one way: **Manufacturer → CorporateEntity → Title → Model**. A FK target must exist in the seed, an earlier patch, or an **earlier entry in the same patch** — forward references within a patch are unsupported, and a Location parent must exist in an _earlier patch_ (same-patch location parents don't resolve). Citation website roots must be seeded in the same or an earlier patch before any URL cite against them.
 
-Two working layouts, both valid:
-
-- **Depth-split series** (0043–0046): one patch per entity depth — all manufacturers, then all corporate entities, then titles, then models. Right for generated sweeps over many makers; the generator emits each layer from one worksheet.
-- **Vertical single-file** (0081): one maker's manufacturer → corporate entity → title(s) → model(s) in one dependency-ordered patch. Right for hand-authored one-maker additions; the whole change reviews as a unit.
+**Prefer the vertical per-manufacturer layout** (0081): one maker's manufacturer → corporate entity → title(s) → model(s) in a single dependency-ordered patch. All the related data reviews as one unit, and a generated sweep emits one such patch per maker. The depth-split series (0043–0046: all manufacturers, then all corporate entities, then titles, then models) predates same-patch dependency support and survives as precedent, not as a layout to copy — reach for a split only where the dependency genuinely spans patches (location parents; citation roots shared by many makers).
 
 ### Fill every field you can — grounded in DomainModel.md
 
@@ -181,6 +178,8 @@ A new record should carry every field the evidence supports, and no field it doe
 
 Required minimums for a `create: true`: every entity needs `name` plus a cite; a Model additionally needs `title` and `corporate_entity`. Everything else is fill-what-the-evidence-supports — a Model with no known year is acceptable (say so in the `note:`), a Model with an invented year is not.
 
+**A Model's `year` (and `month`) is the manufacture date — not the trade-show presentation, not the announcement.** A source dating a different event ("presentato Enada ottobre 1974", a reveal, a flyer date) is not `year` evidence: leave the field to a source that dates manufacture, and keep the presentation/announcement date in the `note:` (with its quote) or the description. When two sources disagree on a year, check first whether they are dating different events before treating it as a conflict.
+
 ### Uncertain values
 
 Assert the best value and record the uncertainty in the `note:` — the model has no "approximate" flag (0042 precedent: eremeka's `~1967` becomes `year: 1967` with the `~` quoted in evidence). A source's `(?)` marker, a year range, or a disputed spelling all follow the same rule: pick the best-supported value, keep the hedge visible in the note and quote. Never invent precision the source doesn't have.
@@ -191,7 +190,7 @@ A value can be hedged; a record cannot. When the source itself is unsure a machi
 
 ### Single-source facts
 
-Corroborate wherever possible — IPDB first (scheme-citable, quotable), then targeted web research — but a fact citable from only one original-research archive (eremeka, tilt.it) is still assertable: these archives are effectively primary for machines documented nowhere else. When corroboration was sought and not found, say so in the `note:` on the create. Descriptions still aim for two distinct root sources; where one root is all that exists, multiple footnotes from it beat no description.
+Corroborate wherever possible — IPDB first (scheme-citable, quotable), then targeted web research — but a fact citable from only one original-research archive (eremeka, tilt.it) is still assertable: these archives are effectively primary for obscure machines. When corroboration was sought and not found, say so in the `note:` on the create — and phrase it as the **authoring act, not a claim about the world**: "corroborating sources were sought at authoring time and none found" stays true forever, while "no other source documents the firm" is falsified by the first new website that mentions it. The same durability rule applies to any note: never write a present-tense absence or uniqueness claim ("the only known…", "documented nowhere else") when a past-tense search statement carries the same information. Descriptions still aim for two distinct root sources; where corroboration hasn't surfaced, multiple footnotes from the one root beat no description.
 
 ### Titles for one-off machines
 
@@ -199,7 +198,7 @@ Every Model gets a Title, even a one-off from a maker with one machine. Disambig
 
 ### Re-releases, kits and conversions across makers
 
-When a machine is another maker's game re-released, rebadged, kitted or converted (common among the Italian firms: Tecnoplay's Devil King re-releases Zaccaria's Mystic Star kit; Bell Games' Fantasy rethemes Bally's Centaur), model the relationship per [DomainModel.md](DomainModel.md): remakes share the original's Title; `variant_of` links cosmetic variants; `converted_from` links cabinet conversions; conversion kits carry the `conversion-kit` tag. The relationship claim needs its own cite — the source line stating the lineage — and when sources disagree about who made what, prefer the better-evidenced attribution and document the disagreement in the `note:`.
+When a machine is another maker's game re-released, rebadged, kitted or converted (common among the Italian firms: Tecnoplay's Devil King re-releases Zaccaria's Mystic Star kit; Bell Games' Fantasy rethemes Bally's Centaur), model the relationship per [DomainModel.md](DomainModel.md): remakes share the original's Title; `variant_of` links cosmetic variants; `converted_from` links cabinet conversions; conversion kits carry the `conversion-kit` tag. A source listing electromechanical and solid-state versions of a game, or 1P/2P/4P editions, describes **separate Models** (the seed's convention — "Wood's Queen (1P/2P/4P)", Combat em/ss — each its own record), not `variant_of` variants: reserve `variant_of` for cosmetic/packaging variants of one product. The relationship claim needs its own cite — the source line stating the lineage — and when sources disagree about who made what, prefer the better-evidenced attribution and document the disagreement in the `note:`.
 
 ## Corporate Entity locations
 

--- a/docs/DataPatches.md
+++ b/docs/DataPatches.md
@@ -292,6 +292,17 @@ cite:
   archive: https://web.archive.org/... # optional: durable snapshot; http(s) refs only
 ```
 
+`cite:` also takes a **list** of such specs (each element a bare string or a mapping) when a fact is backed by several separate sources — the policy for AI-authored patches is to cite as many facts as possible from multiple separate sources. Every citation in the list attaches to every claim the entry asserts, exactly like a single cite:
+
+```yaml
+cite:
+  - ipdb:4443
+  - ref: https://en.wikipedia.org/wiki/Medieval_Madness
+    quote: "was released in 1997"
+```
+
+The same source, locator and quote appearing twice in one list is a hard error — judged on the parsed, normalized spec, so `ref: ipdb:4443` duplicates the bare `ipdb:4443` string form. The same ref with a differing locator or quote is a distinct piece of evidence and fine. An empty list is rejected; omit the key instead.
+
 A `locator:` on a **video** cite (`youtube:<id>`) must be a start time — `95`, `1:35`, `1:02:03` or `1h2m3s` — validated against the video type's timestamp grammar at apply and stored canonical; a malformed one fails the patch loudly. Other types' locators stay freeform.
 
 `quote` is a **verbatim** excerpt: only exact source text and `[...]` ellipses belong in it — a reviewer should be able to follow the citation and ctrl-F find it. Interpretation, translation and rationale go in `note:` instead. Claims in the entry share one citation instance only when the whole citation matches — a differing quote is a distinct piece of evidence even against the same source and locator.

--- a/frontend/src/lib/components/input/citation/CitationInstanceFields.dom.test.ts
+++ b/frontend/src/lib/components/input/citation/CitationInstanceFields.dom.test.ts
@@ -1,0 +1,82 @@
+/** Tests for the shared citation row body: labeled + hinted fields (never
+ *  placeholder-only), the add-locator reveal and the consumer action slots.
+ *  The panel-level behaviors over multiple rows live in
+ *  InlineCitationsPanel.dom.test.ts. */
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import CitationInstanceFields from './CitationInstanceFields.svelte';
+import CitationInstanceFieldsFixture from './CitationInstanceFields.fixture.svelte';
+
+describe('CitationInstanceFields', () => {
+  it('labels the quote and (revealed) locator with persistent hints, not placeholders', async () => {
+    const user = userEvent.setup();
+    render(CitationInstanceFieldsFixture);
+
+    expect(screen.getByRole('textbox', { name: /quote/i })).toBeInTheDocument();
+    expect(screen.getByText('Exact text quoted from the source')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Add a locator' }));
+    const locatorInput = screen.getByRole('textbox', { name: /location in source/i });
+    expect(locatorInput).toHaveFocus();
+    expect(screen.getByText('e.g. p. 42, Chapter 3, a timestamp')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add a locator' })).toBeNull();
+  });
+
+  it('labels the locator per citation type (a video asks for a start time)', () => {
+    render(CitationInstanceFields, {
+      citation: {
+        sourceName: 'YouTube #dQw4w9WgXcQ',
+        sourceType: 'video',
+        locator: '1:35',
+        quote: '',
+      },
+    });
+    expect(screen.getByRole('textbox', { name: /start time/i })).toHaveValue('1:35');
+    expect(screen.queryByRole('button', { name: 'Add a locator' })).toBeNull();
+  });
+
+  it('keeps an opened locator input visible after its text is cleared', async () => {
+    const user = userEvent.setup();
+    render(CitationInstanceFieldsFixture);
+
+    await user.click(screen.getByRole('button', { name: 'Add a locator' }));
+    const locatorInput = screen.getByRole('textbox', { name: /location in source/i });
+    await user.type(locatorInput, 'p. 42');
+    await user.clear(locatorInput);
+
+    expect(screen.getByRole('textbox', { name: /location in source/i })).toBeInTheDocument();
+  });
+
+  it('edits write through to the host citation', async () => {
+    const user = userEvent.setup();
+    render(CitationInstanceFieldsFixture);
+
+    await user.click(screen.getByRole('button', { name: 'Add a locator' }));
+    await user.type(screen.getByRole('textbox', { name: /location in source/i }), 'p. 42');
+    await user.type(screen.getByRole('textbox', { name: /quote/i }), 'Verbatim.');
+
+    expect(screen.getByTestId('citation-json')).toHaveTextContent(
+      JSON.stringify({
+        sourceName: 'The Encyclopedia of Pinball',
+        sourceType: 'book',
+        locator: 'p. 42',
+        quote: 'Verbatim.',
+      }),
+    );
+  });
+
+  it('renders the header Remove button only when onremove is provided, and calls it', async () => {
+    const user = userEvent.setup();
+    render(CitationInstanceFieldsFixture, { withRemove: true });
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+    expect(screen.getByTestId('removed')).toHaveTextContent('true');
+  });
+
+  it('omits the Remove button without onremove and still renders consumer actions', () => {
+    render(CitationInstanceFieldsFixture);
+    expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Change citation' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/components/input/citation/CitationInstanceFields.fixture.svelte
+++ b/frontend/src/lib/components/input/citation/CitationInstanceFields.fixture.svelte
@@ -1,0 +1,25 @@
+<!-- @component Test fixture: hosts CitationInstanceFields over one reactive
+  citation with a remove callback and a consumer actions snippet, mirroring the
+  citation as JSON so tests can assert edits write through. -->
+<script lang="ts">
+  import CitationInstanceFields from './CitationInstanceFields.svelte';
+
+  let { withRemove = false }: { withRemove?: boolean } = $props();
+
+  let citation = $state({
+    sourceName: 'The Encyclopedia of Pinball',
+    sourceType: 'book',
+    locator: '',
+    quote: '',
+  });
+  let removed = $state(false);
+</script>
+
+<CitationInstanceFields {citation} onremove={withRemove ? () => (removed = true) : undefined}>
+  {#snippet actions()}
+    <button type="button">Change citation</button>
+  {/snippet}
+</CitationInstanceFields>
+
+<p data-testid="citation-json">{JSON.stringify(citation)}</p>
+<p data-testid="removed">{String(removed)}</p>

--- a/frontend/src/lib/components/input/citation/CitationInstanceFields.svelte
+++ b/frontend/src/lib/components/input/citation/CitationInstanceFields.svelte
@@ -1,0 +1,133 @@
+<!-- @component Shared row body for one citation being refined until save: the
+  source-name summary plus FieldGroup-labeled locator and quote fields — the
+  label + persistent-hint pattern, never placeholder text as the only guidance
+  — and the "Add a locator" reveal. Consumed by the edit form's citation list
+  (EditCitationField) and the inline-citations panel; consumers pass their own
+  row actions (`onremove` renders a header Remove button, the `actions` snippet
+  lands in the bottom action row). -->
+<script lang="ts">
+  import { tick } from 'svelte';
+  import type { Snippet } from 'svelte';
+  import { citationTypeMeta } from '$lib/citation-types';
+  import FieldGroup from '$lib/components/input/FieldGroup.svelte';
+
+  /** The slice of a pending citation this row edits in place. Structural, so
+   *  both hosts' richer shapes (EditCitationSelection, PendingInlineCitation)
+   *  satisfy it without conversion. */
+  interface CitationFieldsValue {
+    sourceName: string;
+    sourceType: string;
+    locator: string;
+    quote: string;
+  }
+
+  let {
+    citation = $bindable(),
+    onremove,
+    actions,
+  }: {
+    citation: CitationFieldsValue;
+    /** Renders a "Remove" button beside the source name when provided. */
+    onremove?: () => void;
+    /** Extra consumer-specific buttons for the bottom action row. */
+    actions?: Snippet;
+  } = $props();
+
+  // The source's citation type drives the locator prompt (a video asks for a
+  // start time; books and pages stay freeform).
+  let meta = $derived(citationTypeMeta(citation.sourceType));
+
+  // The locator is unprompted but reachable: most cites never need one, so the
+  // field shows only after "Add a locator" — and stays visible once it has
+  // ever held text this session, so a cleared value doesn't yank the field out
+  // from under the contributor.
+  let locatorAdded = $state(false);
+  let locatorInput: HTMLInputElement | undefined = $state();
+  let locatorVisible = $derived(!!citation.locator || locatorAdded);
+
+  async function addLocator() {
+    locatorAdded = true;
+    await tick();
+    locatorInput?.focus();
+  }
+</script>
+
+<div class="citation-row" role="group" aria-label={citation.sourceName}>
+  <div class="citation-header">
+    <div class="citation-summary">{citation.sourceName}</div>
+    {#if onremove}
+      <button type="button" class="row-button" onclick={onremove}>Remove</button>
+    {/if}
+  </div>
+  {#if locatorVisible}
+    <FieldGroup label={meta.locatorLabel} hint={meta.locatorHelp} optional>
+      {#snippet children(inputId, describedBy)}
+        <input
+          bind:this={locatorInput}
+          id={inputId}
+          type="text"
+          aria-describedby={describedBy}
+          maxlength="200"
+          bind:value={citation.locator}
+        />
+      {/snippet}
+    </FieldGroup>
+  {/if}
+  <FieldGroup label="Quote" hint="Exact text quoted from the source" optional>
+    {#snippet children(inputId, describedBy)}
+      <textarea
+        id={inputId}
+        aria-describedby={describedBy}
+        rows="3"
+        maxlength="2000"
+        bind:value={citation.quote}></textarea>
+    {/snippet}
+  </FieldGroup>
+  {#if !locatorVisible || actions}
+    <div class="citation-actions">
+      {#if !locatorVisible}
+        <button type="button" class="row-button" onclick={addLocator}>Add a locator</button>
+      {/if}
+      {#if actions}{@render actions()}{/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .citation-row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-2);
+    padding: var(--size-2) var(--size-3);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-2);
+  }
+
+  .citation-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--size-2);
+  }
+
+  .citation-summary {
+    color: var(--color-text);
+    font-size: var(--font-size-1);
+  }
+
+  .citation-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--size-2);
+  }
+
+  .row-button {
+    padding: var(--size-1) var(--size-3);
+    border: 1px solid var(--color-input-border);
+    border-radius: var(--radius-2);
+    background: var(--color-input-bg);
+    color: var(--color-text-muted);
+    font: inherit;
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/lib/components/input/citation/EditCitationField.dom.test.ts
+++ b/frontend/src/lib/components/input/citation/EditCitationField.dom.test.ts
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import EditCitationField from './EditCitationField.svelte';
+import EditCitationFieldFixture from './EditCitationField.fixture.svelte';
 
 const { GET, POST } = vi.hoisted(() => ({
   GET: vi.fn(),
@@ -17,8 +18,9 @@ function getOpenCitationPickerButton() {
   return screen.getByRole('button', { name: /add citation/i });
 }
 
-function getLocatorInput() {
-  return screen.getByRole('textbox', { name: /citation locator/i });
+/** The row for one attached citation, located by its source-name group label. */
+function row(sourceName: string) {
+  return within(screen.getByRole('group', { name: sourceName }));
 }
 
 describe('EditCitationField', () => {
@@ -63,6 +65,8 @@ describe('EditCitationField', () => {
     render(EditCitationField, { showMixedEditWarning: true });
 
     await user.click(getOpenCitationPickerButton());
+    // The picker replaces the button that summoned it — no dead control above.
+    expect(screen.queryByRole('button', { name: /add citation/i })).not.toBeInTheDocument();
     await user.type(screen.getByRole('combobox', { name: /search sources/i }), 'flyer');
 
     const sourceResult = await screen.findByRole('option', { name: /williams flyer/i });
@@ -70,93 +74,59 @@ describe('EditCitationField', () => {
     await user.type(screen.getByRole('textbox', { name: /location in source/i }), 'p. 2');
     await fireEvent.pointerDown(screen.getByRole('button', { name: 'Insert' }));
 
-    // A locator entered at the picker's own stage lands in the panel's
-    // locator field, editable until save.
+    // A locator entered at the picker's own stage lands in the row's locator
+    // field, editable until save.
     expect(await screen.findByText('Williams Flyer')).toBeInTheDocument();
-    expect(getLocatorInput()).toHaveValue('p. 2');
+    expect(screen.getByRole('textbox', { name: /location in source/i })).toHaveValue('p. 2');
     expect(
       screen.getByText(/This citation will apply to all changed fields in this save/i),
     ).toBeInTheDocument();
+    // The list editor keeps inviting further sources.
+    expect(screen.getByRole('button', { name: 'Add another citation' })).toBeInTheDocument();
   });
 
-  it('removes an existing citation selection', async () => {
-    const user = userEvent.setup();
+  it('stacks one row per citation and pluralizes the mixed-edit warning', () => {
+    render(EditCitationFieldFixture);
 
-    render(EditCitationField, {
-      citation: {
-        citationSourceId: 7,
-        sourceName: 'Williams Flyer',
-        locator: 'p. 2',
-        quote: '',
-      },
-    });
-
-    expect(screen.getByText('Williams Flyer')).toBeInTheDocument();
-    expect(getLocatorInput()).toHaveValue('p. 2');
-    await user.click(screen.getByRole('button', { name: 'Remove citation' }));
-    expect(screen.queryByText('Williams Flyer')).not.toBeInTheDocument();
-    expect(screen.queryByRole('textbox', { name: /citation locator/i })).not.toBeInTheDocument();
-  });
-
-  it('binds the quote textarea to the selected citation', async () => {
-    const user = userEvent.setup();
-    const citation = {
-      citationSourceId: 7,
-      sourceName: 'Williams Flyer',
-      locator: 'p. 2',
-      quote: '',
-    };
-
-    render(EditCitationField, { citation });
-
-    const quoteInput = screen.getByRole('textbox', { name: /quote from the source/i });
-    await user.type(quoteInput, 'Released in 1997.');
-    expect(quoteInput).toHaveValue('Released in 1997.');
-  });
-
-  it('shows no quote textarea before a citation is selected', () => {
-    render(EditCitationField, { citation: null });
+    expect(screen.getByRole('group', { name: 'Williams Flyer' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Pinside thread' })).toBeInTheDocument();
     expect(
-      screen.queryByRole('textbox', { name: /quote from the source/i }),
-    ).not.toBeInTheDocument();
+      screen.getByText(/These citations will apply to all changed fields in this save/i),
+    ).toBeInTheDocument();
   });
 
-  describe('the unprompted locator affordance', () => {
-    const locatorlessCitation = {
-      citationSourceId: 7,
-      sourceName: 'Pinside thread',
-      locator: '',
-      quote: '',
-    };
+  it('removes only the row whose Remove was clicked, writing through to the host', async () => {
+    const user = userEvent.setup();
+    render(EditCitationFieldFixture);
 
-    it('collapses the locator behind "Add a locator" when the pick has none', () => {
-      render(EditCitationField, { citation: { ...locatorlessCitation } });
-      expect(screen.queryByRole('textbox', { name: /citation locator/i })).not.toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /add a locator/i })).toBeInTheDocument();
-    });
+    await user.click(row('Williams Flyer').getByRole('button', { name: 'Remove' }));
 
-    it('expands to a focused freeform input that binds the locator', async () => {
-      const user = userEvent.setup();
-      render(EditCitationField, { citation: { ...locatorlessCitation } });
+    expect(screen.queryByRole('group', { name: 'Williams Flyer' })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Pinside thread' })).toBeInTheDocument();
+    expect(screen.getByTestId('citations-json')).not.toHaveTextContent('Williams Flyer');
+  });
 
-      await user.click(screen.getByRole('button', { name: /add a locator/i }));
-      const input = getLocatorInput();
-      expect(input).toHaveFocus();
-      // The affordance is gone once the field is open.
-      expect(screen.queryByRole('button', { name: /add a locator/i })).not.toBeInTheDocument();
+  it('binds each row quote to its own citation', async () => {
+    const user = userEvent.setup();
+    render(EditCitationFieldFixture);
 
-      await user.type(input, '1:35');
-      expect(input).toHaveValue('1:35');
-    });
+    await user.type(
+      row('Williams Flyer').getByRole('textbox', { name: /quote/i }),
+      'Released in 1997.',
+    );
 
-    it('keeps the field open when its text is cleared mid-edit', async () => {
-      const user = userEvent.setup();
-      render(EditCitationField, { citation: { ...locatorlessCitation } });
+    expect(row('Williams Flyer').getByRole('textbox', { name: /quote/i })).toHaveValue(
+      'Released in 1997.',
+    );
+    expect(row('Pinside thread').getByRole('textbox', { name: /quote/i })).toHaveValue('');
+    expect(screen.getByTestId('citations-json')).toHaveTextContent('Released in 1997.');
+  });
 
-      await user.click(screen.getByRole('button', { name: /add a locator/i }));
-      await user.type(getLocatorInput(), '1:35');
-      await user.clear(getLocatorInput());
-      expect(getLocatorInput()).toBeInTheDocument();
-    });
+  it('shows no rows or warning before a citation is selected', () => {
+    render(EditCitationField, { citations: [], showMixedEditWarning: true });
+    expect(screen.queryByRole('textbox', { name: /quote/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/will apply to all changed fields/i)).not.toBeInTheDocument();
+    // Before any pick, the button doesn't yet say "another".
+    expect(screen.getByRole('button', { name: 'Add citation' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/lib/components/input/citation/EditCitationField.fixture.svelte
+++ b/frontend/src/lib/components/input/citation/EditCitationField.fixture.svelte
@@ -1,0 +1,28 @@
+<!-- @component Test fixture: hosts EditCitationField over reactive two-citation
+  state and mirrors it as JSON, so tests can assert that row edits and removals
+  write through to the host's array. -->
+<script lang="ts">
+  import EditCitationField from './EditCitationField.svelte';
+  import type { EditCitationSelection } from '$lib/edit-citation';
+
+  let citations = $state<EditCitationSelection[]>([
+    {
+      citationSourceId: 7,
+      sourceName: 'Williams Flyer',
+      sourceType: 'web',
+      locator: '',
+      quote: '',
+    },
+    {
+      citationSourceId: 9,
+      sourceName: 'Pinside thread',
+      sourceType: 'web',
+      locator: '',
+      quote: '',
+    },
+  ]);
+</script>
+
+<EditCitationField bind:citations showMixedEditWarning={true} />
+
+<p data-testid="citations-json">{JSON.stringify(citations)}</p>

--- a/frontend/src/lib/components/input/citation/EditCitationField.svelte
+++ b/frontend/src/lib/components/input/citation/EditCitationField.svelte
@@ -1,57 +1,44 @@
-<!-- @component The "Evidence for this edit" panel: pick a citation, then refine its locator and quote until save. -->
+<!-- @component The "Evidence for this edit" panel: a stacked list of citations,
+  each refinable (locator, quote) until save. Rows are the shared
+  CitationInstanceFields body; "Add citation" opens the picker and appends —
+  multiple separate sources backing one edit are first-class. -->
 <script lang="ts">
-  import { tick } from 'svelte';
   import { type EditCitationSelection } from '$lib/edit-citation';
   import FieldGroup from '$lib/components/input/FieldGroup.svelte';
   import CitationAutocomplete from './CitationAutocomplete.svelte';
+  import CitationInstanceFields from './CitationInstanceFields.svelte';
   import type { CompletedCitationDraft } from './citation-types';
 
   let {
-    citation = $bindable<EditCitationSelection | null>(null),
+    citations = $bindable<EditCitationSelection[]>([]),
     showMixedEditWarning = false,
   }: {
-    citation?: EditCitationSelection | null;
+    citations?: EditCitationSelection[];
     showMixedEditWarning?: boolean;
   } = $props();
 
   let pickerOpen = $state(false);
 
-  // The locator is unprompted but reachable: nothing mints until save, so
-  // this panel — not an extra picker stage — is where a skip_locator cite
-  // picks up its rare locator (a video post's 1:35, an article's § heading).
-  // The input stays visible once it has ever held text this session, so a
-  // cleared value doesn't yank the field out from under the contributor.
-  let locatorAdded = $state(false);
-  let locatorInput: HTMLInputElement | undefined = $state();
-  let locatorVisible = $derived(!!citation?.locator || locatorAdded);
-
-  async function addLocator() {
-    locatorAdded = true;
-    await tick();
-    locatorInput?.focus();
-  }
-
   // The picker hands back a content spec, not a minted instance — the spec
-  // rides the save payload and the backend mints the shared instance then.
-  // A quote already typed survives a source re-pick: clearing user-entered
-  // text on "Change citation" would be worse than a stale quote the user can
-  // see and edit.
+  // rides the save payload and the backend mints the shared instances then.
+  // The list updates by reassignment (not push/splice) so the change reaches
+  // the parent's binding regardless of how deep its reactivity goes.
   function handleComplete(draft: CompletedCitationDraft) {
-    citation = {
-      citationSourceId: draft.sourceId,
-      sourceName: draft.sourceName,
-      locator: draft.locator,
-      quote: citation?.quote ?? '',
-    };
-    // Collapse back down for a fresh locator-less pick; a locator entered at
-    // the picker's own stage (book/video) keeps the field open via `derived`.
-    locatorAdded = false;
+    citations = [
+      ...citations,
+      {
+        citationSourceId: draft.sourceId,
+        sourceName: draft.sourceName,
+        sourceType: draft.sourceType,
+        locator: draft.locator,
+        quote: '',
+      },
+    ];
     pickerOpen = false;
   }
 
-  function removeCitation() {
-    citation = null;
-    locatorAdded = false;
+  function removeCitation(index: number) {
+    citations = citations.filter((_, i) => i !== index);
   }
 
   function openPicker() {
@@ -66,60 +53,14 @@
 <FieldGroup label="Evidence for this edit" optional>
   <!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
   {#snippet children(inputId, errorId)}
-    <div class="citation-field">
-      {#if citation}
-        <div id={inputId} class="citation-summary">
-          {citation.sourceName}
-        </div>
-        {#if locatorVisible}
-          <input
-            bind:this={locatorInput}
-            type="text"
-            aria-label="Citation locator"
-            placeholder="Where in the source (p. 42, 1:35)"
-            maxlength="200"
-            bind:value={citation.locator}
-          />
-        {/if}
-        <textarea
-          aria-label="Quote from the source"
-          placeholder="Exact text quoted from the source"
-          rows="3"
-          maxlength="2000"
-          bind:value={citation.quote}></textarea>
-      {/if}
+    <div class="citation-field" id={inputId}>
+      {#each citations as citation, index (citation)}
+        <CitationInstanceFields {citation} onremove={() => removeCitation(index)} />
+      {/each}
 
-      <div class="citation-actions">
-        <button type="button" class="citation-button" onclick={openPicker}>
-          {citation ? 'Change citation' : 'Add citation'}
-        </button>
-        {#if citation && !locatorVisible}
-          <button
-            type="button"
-            class="citation-button citation-button-secondary"
-            onclick={addLocator}
-          >
-            Add a locator
-          </button>
-        {/if}
-        {#if citation}
-          <button
-            type="button"
-            class="citation-button citation-button-secondary"
-            onclick={removeCitation}
-          >
-            Remove citation
-          </button>
-        {/if}
-      </div>
-
-      {#if showMixedEditWarning && citation}
-        <p class="citation-warning">
-          This citation will apply to all changed fields in this save. Split unrelated edits if
-          needed.
-        </p>
-      {/if}
-
+      <!-- The picker replaces the button that summoned it (the same swap as
+           the "Add a locator" reveal): while it's open, the picker IS the
+           add-citation action, so a lingering button would be a dead control. -->
       {#if pickerOpen}
         <div class="citation-picker">
           <CitationAutocomplete
@@ -128,6 +69,19 @@
             onback={closePicker}
           />
         </div>
+      {:else}
+        <div class="citation-actions">
+          <button type="button" class="citation-button" onclick={openPicker}>
+            {citations.length > 0 ? 'Add another citation' : 'Add citation'}
+          </button>
+        </div>
+      {/if}
+
+      {#if showMixedEditWarning && citations.length > 0}
+        <p class="citation-warning">
+          {citations.length === 1 ? 'This citation' : 'These citations'} will apply to all changed fields
+          in this save. Split unrelated edits if needed.
+        </p>
       {/if}
     </div>
   {/snippet}
@@ -138,15 +92,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--size-2);
-  }
-
-  .citation-summary {
-    padding: var(--size-2) var(--size-3);
-    border: 1px solid var(--color-border-soft);
-    border-radius: var(--radius-2);
-    background: var(--color-surface);
-    color: var(--color-text);
-    font-size: var(--font-size-1);
   }
 
   .citation-actions {
@@ -163,10 +108,6 @@
     color: var(--color-text);
     font: inherit;
     cursor: pointer;
-  }
-
-  .citation-button-secondary {
-    color: var(--color-text-muted);
   }
 
   .citation-warning {

--- a/frontend/src/lib/components/input/citation/InlineCitationsPanel.svelte
+++ b/frontend/src/lib/components/input/citation/InlineCitationsPanel.svelte
@@ -3,13 +3,12 @@
   locator and quote editable until save (nothing mints until then). A row
   appears when the picker inserts its marker and disappears when the marker is
   deleted from the text; already-saved cites are immutable and never show.
-  Fields use the same FieldGroup label + persistent hint pattern as the
-  picker's locator stage — never placeholder text as the only guidance. -->
+  Rows are the shared CitationInstanceFields body (FieldGroup label + hint
+  fields, add-locator reveal); a row carries no buttons of its own — deleting
+  the marker is how a pending inline cite is removed. -->
 <script lang="ts">
-  import { tick } from 'svelte';
   import { pendingCitationsInText, type PendingInlineCitation } from '$lib/pending-citations';
-  import { citationTypeMeta } from '$lib/citation-types';
-  import FieldGroup from '$lib/components/input/FieldGroup.svelte';
+  import CitationInstanceFields from './CitationInstanceFields.svelte';
 
   let {
     pending,
@@ -22,70 +21,13 @@
   } = $props();
 
   let visible = $derived(pendingCitationsInText(pending, text));
-
-  // The locator is unprompted but reachable (same rule as EditCitationField):
-  // most cites — a web page pinned by its URL — never need one, so a row shows
-  // only "Add a locator" until the cite carries a locator (entered at the
-  // picker's locator stage) or the contributor opens it here. Once opened it
-  // stays visible for the session, so a cleared value doesn't yank the field
-  // out from under the contributor.
-  let locatorAdded = $state(new Set<string>());
-  let locatorInputs: Record<string, HTMLInputElement | undefined> = $state({});
-
-  function locatorVisible(citation: PendingInlineCitation): boolean {
-    return !!citation.locator || locatorAdded.has(citation.slug);
-  }
-
-  async function addLocator(slug: string) {
-    locatorAdded = new Set([...locatorAdded, slug]);
-    await tick();
-    locatorInputs[slug]?.focus();
-  }
 </script>
 
 {#if visible.length > 0}
   <div class="inline-citations">
     <span class="panel-label">Inline citations</span>
     {#each visible as citation (citation.slug)}
-      {@const meta = citationTypeMeta(citation.sourceType)}
-      <div class="citation-row" role="group" aria-label={citation.sourceName}>
-        <div class="citation-summary">{citation.sourceName}</div>
-        {#if locatorVisible(citation)}
-          <FieldGroup label={meta.locatorLabel} hint={meta.locatorHelp} optional>
-            {#snippet children(inputId, describedBy)}
-              <input
-                bind:this={locatorInputs[citation.slug]}
-                id={inputId}
-                type="text"
-                aria-describedby={describedBy}
-                maxlength="200"
-                bind:value={citation.locator}
-              />
-            {/snippet}
-          </FieldGroup>
-        {/if}
-        <FieldGroup label="Quote" hint="Exact text quoted from the source" optional>
-          {#snippet children(inputId, describedBy)}
-            <textarea
-              id={inputId}
-              aria-describedby={describedBy}
-              rows="3"
-              maxlength="2000"
-              bind:value={citation.quote}></textarea>
-          {/snippet}
-        </FieldGroup>
-        {#if !locatorVisible(citation)}
-          <div>
-            <button
-              type="button"
-              class="add-locator-button"
-              onclick={() => addLocator(citation.slug)}
-            >
-              Add a locator
-            </button>
-          </div>
-        {/if}
-      </div>
+      <CitationInstanceFields {citation} />
     {/each}
   </div>
 {/if}
@@ -101,29 +43,5 @@
     font-size: var(--font-size-0);
     font-weight: var(--font-weight-6);
     color: var(--color-text-muted);
-  }
-
-  .citation-row {
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-2);
-    padding: var(--size-2) var(--size-3);
-    border: 1px solid var(--color-border-soft);
-    border-radius: var(--radius-2);
-  }
-
-  .citation-summary {
-    color: var(--color-text);
-    font-size: var(--font-size-1);
-  }
-
-  .add-locator-button {
-    padding: var(--size-1) var(--size-3);
-    border: 1px solid var(--color-input-border);
-    border-radius: var(--radius-2);
-    background: var(--color-input-bg);
-    color: var(--color-text-muted);
-    font: inherit;
-    cursor: pointer;
   }
 </style>

--- a/frontend/src/lib/components/input/citation/NotesAndCitationsDetails.svelte
+++ b/frontend/src/lib/components/input/citation/NotesAndCitationsDetails.svelte
@@ -1,3 +1,5 @@
+<!-- @component Collapsible "Notes & Citations" panel for edit forms: the edit
+  summary note plus the multi-citation evidence list (EditCitationField). -->
 <script lang="ts">
   import EditCitationField from './EditCitationField.svelte';
   import TextField from '$lib/components/input/TextField.svelte';
@@ -5,29 +7,29 @@
 
   interface Props {
     note?: string;
-    citation?: EditCitationSelection | null;
+    citations?: EditCitationSelection[];
     showCitation?: boolean;
     showMixedEditWarning?: boolean;
     noteLabel?: string;
-    notePlaceholder?: string;
+    noteHint?: string;
   }
 
   let {
     note = $bindable(''),
-    citation = $bindable(null),
+    citations = $bindable([]),
     showCitation = true,
     showMixedEditWarning = false,
     noteLabel = 'Edit summary',
-    notePlaceholder = 'Why are you making this change?',
+    noteHint = 'Why are you making this change?',
   }: Props = $props();
 </script>
 
 <details class="meta-section">
   <summary>{showCitation ? 'Notes & Citations' : 'Notes'}</summary>
   <div class="meta-fields">
-    <TextField label={noteLabel} bind:value={note} placeholder={notePlaceholder} optional />
+    <TextField label={noteLabel} bind:value={note} hint={noteHint} optional />
     {#if showCitation}
-      <EditCitationField bind:citation {showMixedEditWarning} />
+      <EditCitationField bind:citations {showMixedEditWarning} />
     {/if}
   </div>
 </details>

--- a/frontend/src/lib/components/pages/record/create/CreatePage.svelte
+++ b/frontend/src/lib/components/pages/record/create/CreatePage.svelte
@@ -1,3 +1,4 @@
+<!-- @component Generic create-record page: name/slug fields (slug projected from name), extra per-entity fields, creation note + citations. -->
 <script lang="ts" generics="T extends { slug: string; name: string }">
   import type { Snippet } from 'svelte';
   import { goto } from '$app/navigation';
@@ -35,7 +36,7 @@
     cancelHref: string;
     parentBreadcrumb?: { text: string; href: string };
     projectSlug?: (name: string) => string;
-    notePlaceholder?: string;
+    noteHint?: string;
     /**
      * Field keys whose server-side errors should route to the caller
      * (via the `errors` arg on the `extraFields` snippet). Any field
@@ -67,7 +68,7 @@
     cancelHref,
     parentBreadcrumb,
     projectSlug,
-    notePlaceholder,
+    noteHint,
     extraFieldKeys,
     extraFields,
     extraBody,
@@ -86,7 +87,7 @@
   let slug = $state(initialSlug);
   let syncedSlug = $state(initialSlug);
   let note = $state('');
-  let citation = $state<EditCitationSelection | null>(null);
+  let citations = $state<EditCitationSelection[]>([]);
 
   let formError = $state('');
   let nameError = $state('');
@@ -141,7 +142,7 @@
         // never trips.
         slug: slug.trim().toLowerCase(),
         note: note || '',
-        citations: buildEditCitationsRequest(citation),
+        citations: buildEditCitationsRequest(citations),
         ...extras,
       });
 
@@ -216,9 +217,9 @@
 
   <NotesAndCitationsDetails
     bind:note
-    bind:citation
+    bind:citations
     noteLabel="Creation note"
-    notePlaceholder={notePlaceholder ?? `Why are you adding this ${entityLabel.toLowerCase()}?`}
+    noteHint={noteHint ?? `Why are you adding this ${entityLabel.toLowerCase()}?`}
   />
 
   <div class="form-footer">

--- a/frontend/src/lib/components/pages/record/delete/DeletePage.dom.test.ts
+++ b/frontend/src/lib/components/pages/record/delete/DeletePage.dom.test.ts
@@ -22,7 +22,7 @@ vi.mock('$lib/undo-delete', () => ({ submitUndoDelete }));
 type Response = { changeset_id: number };
 type Submit = (
   public_id: string,
-  opts: { note: string; citation: import('$lib/edit-citation').EditCitationSelection | null },
+  opts: { note: string; citations: import('$lib/edit-citation').EditCitationSelection[] },
 ) => Promise<DeleteOutcome<Response>>;
 
 function makeImpact() {

--- a/frontend/src/lib/components/pages/record/delete/DeletePage.svelte
+++ b/frontend/src/lib/components/pages/record/delete/DeletePage.svelte
@@ -1,3 +1,4 @@
+<!-- @component Generic soft-delete confirmation page: impact/blocked preview, deletion note + citations and the undoable delete submit. -->
 <script lang="ts" generics="TResponse extends { changeset_id: number }">
   import { goto } from '$app/navigation';
   import Button from '$lib/components/ui/Button.svelte';
@@ -16,7 +17,7 @@
     public_id: string;
     submit: (
       public_id: string,
-      opts: { note: string; citation: EditCitationSelection | null },
+      opts: { note: string; citations: EditCitationSelection[] },
     ) => Promise<DeleteOutcome<TResponse>>;
     cancelHref: string;
     redirectAfterDelete: string;
@@ -24,7 +25,7 @@
     parentBreadcrumb?: ParentBreadcrumb;
     blocked: BlockedState | null;
     impact: ImpactState;
-    notePlaceholder?: string;
+    noteHint?: string;
   };
 
   let {
@@ -38,26 +39,24 @@
     parentBreadcrumb,
     blocked,
     impact,
-    notePlaceholder,
+    noteHint,
   }: Props = $props();
 
   let note = $state('');
-  let citation = $state<EditCitationSelection | null>(null);
+  let citations = $state<EditCitationSelection[]>([]);
   let formError = $state('');
   let submitting = $state(false);
 
   let isBlocked = $derived(blocked !== null);
   let heading = $derived(isBlocked ? `Can't delete “${entityName}”` : `Delete “${entityName}”?`);
   let headTitle = $derived(isBlocked ? `Can't delete ${entityName}` : `Delete ${entityName}?`);
-  let placeholder = $derived(
-    notePlaceholder ?? `Why are you deleting this ${entityLabel.toLowerCase()}?`,
-  );
+  let hint = $derived(noteHint ?? `Why are you deleting this ${entityLabel.toLowerCase()}?`);
 
   async function handleDelete() {
     formError = '';
     submitting = true;
     try {
-      const outcome = await submit(public_id, { note, citation });
+      const outcome = await submit(public_id, { note, citations });
       switch (outcome.kind) {
         case 'ok': {
           const name = entityName;
@@ -165,12 +164,7 @@
   {/if}
 
   {#if !isBlocked}
-    <NotesAndCitationsDetails
-      bind:note
-      bind:citation
-      noteLabel="Deletion note"
-      notePlaceholder={placeholder}
-    />
+    <NotesAndCitationsDetails bind:note bind:citations noteLabel="Deletion note" noteHint={hint} />
   {/if}
 
   <div class="form-footer">

--- a/frontend/src/lib/components/pages/record/edit/SectionEditorForm.svelte
+++ b/frontend/src/lib/components/pages/record/edit/SectionEditorForm.svelte
@@ -1,3 +1,4 @@
+<!-- @component Shared edit-form chrome: error line, the section editor body, the Notes & Citations panel and the sticky Cancel/Save footer. -->
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { type EditCitationSelection, buildEditCitationsRequest } from '$lib/edit-citation';
@@ -22,17 +23,17 @@
   } = $props();
 
   let note = $state('');
-  let citation = $state<EditCitationSelection | null>(null);
+  let citations = $state<EditCitationSelection[]>([]);
 
   export function resetMeta() {
     note = '';
-    citation = null;
+    citations = [];
   }
 
   function buildMeta(): SaveMeta {
     return {
       note: note || undefined,
-      citations: buildEditCitationsRequest(citation),
+      citations: buildEditCitationsRequest(citations),
     };
   }
 </script>
@@ -43,7 +44,7 @@
 
 {@render children()}
 
-<NotesAndCitationsDetails bind:note bind:citation {showCitation} {showMixedEditWarning} />
+<NotesAndCitationsDetails bind:note bind:citations {showCitation} {showMixedEditWarning} />
 
 <div class="form-footer">
   <Button variant="secondary" onclick={oncancel}>Cancel</Button>

--- a/frontend/src/lib/delete-flow.ts
+++ b/frontend/src/lib/delete-flow.ts
@@ -33,7 +33,7 @@ export type DeleteOutcome<TResponse> =
 
 interface DeleteSubmitOptions {
   note?: string;
-  citation?: EditCitationSelection | null;
+  citations?: EditCitationSelection[];
 }
 
 // Entity-segment union derived from the schema's delete routes.
@@ -67,7 +67,7 @@ export function createDeleteSubmitter<E extends DeleteEntity>(entity: E) {
         params: { path: { public_id } },
         body: {
           note: opts.note ?? '',
-          citations: buildEditCitationsRequest(opts.citation ?? null),
+          citations: buildEditCitationsRequest(opts.citations ?? []),
         },
       } as never,
     );

--- a/frontend/src/lib/edit-citation.test.ts
+++ b/frontend/src/lib/edit-citation.test.ts
@@ -11,26 +11,36 @@ import {
 const citation: EditCitationSelection = {
   citationSourceId: 7,
   sourceName: 'Williams Flyer',
+  sourceType: 'web',
   locator: 'p. 2',
   quote: 'Released in 1997.',
 };
 
+const secondCitation: EditCitationSelection = {
+  citationSourceId: 9,
+  sourceName: 'Internet Pinball Database #4032',
+  sourceType: 'database',
+  locator: '',
+  quote: '',
+};
+
 describe('buildEditCitationsRequest', () => {
-  it('serializes the selected citation as a content spec', () => {
-    expect(buildEditCitationsRequest(citation)).toEqual([
+  it('serializes every selected citation as a content spec, in order', () => {
+    expect(buildEditCitationsRequest([citation, secondCitation])).toEqual([
       { citation_source_id: 7, locator: 'p. 2', quote: 'Released in 1997.' },
+      { citation_source_id: 9, locator: '', quote: '' },
     ]);
   });
 
   it('sends an empty list when none is selected', () => {
-    expect(buildEditCitationsRequest(null)).toEqual([]);
+    expect(buildEditCitationsRequest([])).toEqual([]);
   });
 });
 
 describe('withEditMetadata', () => {
   it('adds trimmed note and citations to an existing patch body', () => {
     expect(
-      withEditMetadata({ fields: { description: 'Updated' } }, '  cleanup  ', citation),
+      withEditMetadata({ fields: { description: 'Updated' } }, '  cleanup  ', [citation]),
     ).toEqual({
       fields: { description: 'Updated' },
       note: 'cleanup',
@@ -39,7 +49,7 @@ describe('withEditMetadata', () => {
   });
 
   it('sends empty citations for bodies without a citation', () => {
-    expect(withEditMetadata({ fields: { description: 'Updated' } }, '', null)).toEqual({
+    expect(withEditMetadata({ fields: { description: 'Updated' } }, '', [])).toEqual({
       fields: { description: 'Updated' },
       note: '',
       citations: [],
@@ -65,24 +75,24 @@ describe('countPendingChanges', () => {
 });
 
 describe('shouldShowMixedEditCitationWarning', () => {
-  it('warns when one citation is attached to multiple pending changes', () => {
+  it('warns when citations are attached to multiple pending changes', () => {
     expect(
       shouldShowMixedEditCitationWarning(
         {
           fields: { year: 1998, description: 'Updated' },
         },
-        citation,
+        [citation, secondCitation],
       ),
     ).toBe(true);
   });
 
-  it('does not warn for a single pending change or no citation', () => {
+  it('does not warn for a single pending change or no citations', () => {
     expect(
       shouldShowMixedEditCitationWarning(
         {
           fields: { description: 'Updated' },
         },
-        citation,
+        [citation],
       ),
     ).toBe(false);
     expect(
@@ -90,7 +100,7 @@ describe('shouldShowMixedEditCitationWarning', () => {
         {
           fields: { description: 'Updated', year: 1998 },
         },
-        null,
+        [],
       ),
     ).toBe(false);
   });

--- a/frontend/src/lib/edit-citation.ts
+++ b/frontend/src/lib/edit-citation.ts
@@ -1,41 +1,42 @@
+/** The edit form's citation selections and the save-payload builders that turn
+ * them into `citations` content specs. */
 import type { CitationInstanceCreateSchema } from '$lib/api/schema';
 
 /** A citation the user attached to an edit: the content spec the save payload
  * sends (source + locator + quote — the backend mints the shared instance at
- * save time) plus the source name for display. */
+ * save time) plus the source name and type for display (`sourceType` keys the
+ * locator label/hint; neither rides the payload). */
 export type EditCitationSelection = {
   citationSourceId: number;
   sourceName: string;
+  sourceType: string;
   locator: string;
   quote: string;
 };
 
 type PatchBody = Record<string, unknown>;
 
-/** Build the save payload's `citations` list from the user's selection
+/** Build the save payload's `citations` list from the user's selections
  * (empty when no citation was attached). */
 export function buildEditCitationsRequest(
-  citation: EditCitationSelection | null,
+  citations: EditCitationSelection[],
 ): CitationInstanceCreateSchema[] {
-  if (!citation) return [];
-  return [
-    {
-      citation_source_id: citation.citationSourceId,
-      locator: citation.locator,
-      quote: citation.quote,
-    },
-  ];
+  return citations.map((citation) => ({
+    citation_source_id: citation.citationSourceId,
+    locator: citation.locator,
+    quote: citation.quote,
+  }));
 }
 
 export function withEditMetadata<T extends PatchBody>(
   body: T,
   note: string,
-  citation: EditCitationSelection | null,
+  citations: EditCitationSelection[],
 ): T & { note: string; citations: CitationInstanceCreateSchema[] } {
   return {
     ...body,
     note: note.trim(),
-    citations: buildEditCitationsRequest(citation),
+    citations: buildEditCitationsRequest(citations),
   };
 }
 
@@ -59,7 +60,7 @@ export function countPendingChanges(body: PatchBody | null): number {
 
 export function shouldShowMixedEditCitationWarning(
   body: PatchBody | null,
-  citation: EditCitationSelection | null,
+  citations: EditCitationSelection[],
 ): boolean {
-  return citation !== null && countPendingChanges(body) > 1;
+  return citations.length > 0 && countPendingChanges(body) > 1;
 }


### PR DESCRIPTION
## Summary

Support attaching multiple citations to a single scalar claim in the edit UI as well as data patches.

The DB already supported this; it models claim-to-citation as many-to-many (`ClaimCitationInstance` join); this wires up the entry points that only handled a single citation.

- **Patch grammar**: `cite:` now also accepts a **list** of specs (each the existing `scheme:id`/URL string or `{ref, locator, quote, archive}` mapping). Every cite fans out to every claim in the entry. Duplicate specs are rejected on the parsed, normalized form; an empty list is rejected. The single-spec form is unchanged, so all existing patches parse identically.
- **Edit form**: `EditCitationField` becomes a stacked-row citation list built on a new shared `CitationInstanceFields` row body extracted from `InlineCitationsPanel`. The "Add citation" button relabels to "Add another citation" after the first and is replaced by the picker while it's open (the same swap as the "Add a locator" reveal). Locator/quote fields use `FieldGroup` labels + persistent hints instead of placeholder-only text; the Edit summary placeholder moved to a hint too.
- **Display**: edit-history and provenance surfaces already rendered citation lists; covered with an N>1 edit-history test.

The interactive save backend already accepted a `citations` list and needed no changes.

## Test plan

- [x] `make test` — backend (4581 passed) + frontend (1792 passed)
- [x] `make quality` and `make mypy` clean
- [x] End-to-end: applied a two-source `cite:` list patch via `ingest_patches`, confirmed 2 shared `CitationInstance` rows + 2 join rows on the claim, both citations rendering stacked on the live edit-history page
- [ ] Reviewer: in the edit form, add two citations to one field, confirm both save and appear in edit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)
