### PR TITLE
feat(catalog): show a lineage link's maker when it differs from the subject

### DIFF
--- a/backend/apps/catalog/api/machine_models.py
+++ b/backend/apps/catalog/api/machine_models.py
@@ -131,27 +131,60 @@ class ModelVariantSchema(Schema):
     public_id: str
     year: int | None = None
     variant_features: list[str] = []
+    # Variants are same-maker cosmetic editions by definition, so this usually
+    # matches the subject and stays hidden — but nothing enforces that, so the
+    # ref carries the maker to disambiguate the anomaly like every other lineage
+    # link rather than being the one surface that structurally can't.
+    manufacturer: EntityRef | None = None
 
 
 class ModelRef(Schema):
-    """A reference to a machine model by its public id, with optional year."""
+    """A reference to a machine model by its public id, with optional year and
+    manufacturer. The manufacturer lets a reader distinguish same-named lineage
+    links (e.g. a game and the bootlegs that copied its name) whose surfaces
+    don't otherwise show a maker."""
 
     name: str
     public_id: str
     year: int | None = None
+    manufacturer: EntityRef | None = None
+
+
+def _manufacturer_ref(pm: MachineModel | None) -> EntityRef | None:
+    """The model's manufacturer as an `EntityRef`, resolved via its corporate
+    entity (the manufacturer is a property of the maker, not the model)."""
+    if pm is None:
+        return None
+    mfr = (
+        pm.corporate_entity.manufacturer
+        if pm.corporate_entity and pm.corporate_entity.manufacturer
+        else None
+    )
+    return EntityRef(name=mfr.name, public_id=mfr.public_id) if mfr else None
 
 
 def _model_ref(pm: MachineModel | None) -> ModelRef | None:
     """Build a `ModelRef` for a nullable related model (e.g. `variant_of`), or `None`."""
     if pm is None:
         return None
-    return ModelRef(name=pm.name, public_id=pm.public_id, year=pm.year)
+    return ModelRef(
+        name=pm.name,
+        public_id=pm.public_id,
+        year=pm.year,
+        manufacturer=_manufacturer_ref(pm),
+    )
 
 
 def _model_refs(models: Iterable[MachineModel]) -> list[ModelRef]:
     """Build `ModelRef`s for a related-model collection (e.g. `conversions`)."""
     return [
-        ModelRef(name=pm.name, public_id=pm.public_id, year=pm.year) for pm in models
+        ModelRef(
+            name=pm.name,
+            public_id=pm.public_id,
+            year=pm.year,
+            manufacturer=_manufacturer_ref(pm),
+        )
+        for pm in models
     ]
 
 
@@ -293,15 +326,10 @@ def _serialize_model_list(
     thumbnail_url, _ = extract_image_urls(
         pm.extra_data or {}, displayed_primary_media(pm), min_rank=min_rank
     )
-    mfr = (
-        pm.corporate_entity.manufacturer
-        if pm.corporate_entity and pm.corporate_entity.manufacturer
-        else None
-    )
     return ModelListItemSchema(
         name=pm.name,
         slug=pm.slug,
-        manufacturer=EntityRef(name=mfr.name, public_id=mfr.public_id) if mfr else None,
+        manufacturer=_manufacturer_ref(pm),
         year=pm.year,
         thumbnail_url=thumbnail_url,
     )
@@ -336,6 +364,7 @@ def _serialize_model_detail(pm: MachineModel) -> ModelDetailSchema:
             public_id=v.public_id,
             year=v.year,
             variant_features=_extract_variant_features(v.extra_data or {}),
+            manufacturer=_manufacturer_ref(v),
         )
         for v in pm.variants.all()
     ]
@@ -351,6 +380,7 @@ def _serialize_model_detail(pm: MachineModel) -> ModelDetailSchema:
                 public_id=sib.public_id,
                 year=sib.year,
                 variant_features=_extract_variant_features(sib.extra_data or {}),
+                manufacturer=_manufacturer_ref(sib),
             )
             for sib in parent.variants.all()
             if sib.pk != pm.pk
@@ -363,19 +393,13 @@ def _serialize_model_detail(pm: MachineModel) -> ModelDetailSchema:
         else None
     )
 
-    mfr = (
-        pm.corporate_entity.manufacturer
-        if pm.corporate_entity and pm.corporate_entity.manufacturer
-        else None
-    )
-
     return ModelDetailSchema(
         name=pm.name,
         public_id=pm.public_id,
         last_modified=pm.last_modified,
         slug=pm.slug,
         description=describe(pm),
-        manufacturer=EntityRef(name=mfr.name, public_id=mfr.public_id) if mfr else None,
+        manufacturer=_manufacturer_ref(pm),
         corporate_entity=(
             EntityRef(
                 name=pm.corporate_entity.name, public_id=pm.corporate_entity.public_id
@@ -521,17 +545,49 @@ def _model_detail_qs() -> QuerySet[MachineModel]:
             "cabinet",
             "game_format",
             "production_status",
-            "variant_of",
-            "converted_from",
-            "remake_of",
-            "bootleg_of",
+            # `__corporate_entity__manufacturer` so the lineage ModelRefs can
+            # carry a maker for disambiguating same-named links (bootlegs etc.)
+            # without an N+1 per related row.
+            "variant_of__corporate_entity__manufacturer",
+            "converted_from__corporate_entity__manufacturer",
+            "remake_of__corporate_entity__manufacturer",
+            "bootleg_of__corporate_entity__manufacturer",
         )
         .prefetch_related(
-            "variants",
-            "variant_of__variants",
-            "conversions",
-            "remakes",
-            "bootlegs",
+            # Variants and sibling variants also carry a maker; select the
+            # manufacturer join so building their refs stays query-free.
+            Prefetch(
+                "variants",
+                queryset=MachineModel.objects.select_related(
+                    "corporate_entity__manufacturer"
+                ),
+            ),
+            Prefetch(
+                "variant_of__variants",
+                queryset=MachineModel.objects.select_related(
+                    "corporate_entity__manufacturer"
+                ),
+            ),
+            # Reverse lineage lists render as ModelRefs with a maker; select the
+            # manufacturer join here to keep the ref build query-free.
+            Prefetch(
+                "conversions",
+                queryset=MachineModel.objects.select_related(
+                    "corporate_entity__manufacturer"
+                ),
+            ),
+            Prefetch(
+                "remakes",
+                queryset=MachineModel.objects.select_related(
+                    "corporate_entity__manufacturer"
+                ),
+            ),
+            Prefetch(
+                "bootlegs",
+                queryset=MachineModel.objects.select_related(
+                    "corporate_entity__manufacturer"
+                ),
+            ),
             "themes",
             Prefetch(
                 "machinemodelgameplayfeature_set",

--- a/backend/apps/catalog/tests/test_api_models.py
+++ b/backend/apps/catalog/tests/test_api_models.py
@@ -126,6 +126,36 @@ class TestModelsAPI:
         }
         assert year_claims[0]["is_winner"] is True
 
+    def test_lineage_refs_carry_manufacturer(self, client, machine_model, stern_entity):
+        # A bootleg by a different maker copies the original's name, so without a
+        # maker the reader can't tell the two same-named entries apart. The ref
+        # carries the maker for both directions of the link.
+        bootleg = make_machine_model(
+            name="Medieval Madness",
+            slug="medieval-madness-bootleg",
+            corporate_entity=stern_entity,
+            bootleg_of=machine_model,
+        )
+
+        # Reverse: the original's `bootlegs` list carries the copy's maker.
+        original = client.get(f"/api/pages/model/{machine_model.slug}").json()
+        assert original["bootlegs"][0]["manufacturer"]["name"] == "Stern"
+
+        # Forward: the copy's `bootleg_of` carries the original's maker.
+        copy = client.get(f"/api/pages/model/{bootleg.slug}").json()
+        assert copy["bootleg_of"]["manufacturer"]["name"] == "Williams"
+
+        # Variants carry a maker too, so a different-maker variant disambiguates
+        # like any other lineage link rather than being the one that can't.
+        make_machine_model(
+            name="Medieval Madness (bootleg edition)",
+            slug="medieval-madness-variant",
+            corporate_entity=stern_entity,
+            variant_of=machine_model,
+        )
+        original = client.get(f"/api/pages/model/{machine_model.slug}").json()
+        assert original["variants"][0]["manufacturer"]["name"] == "Stern"
+
     def test_get_model_detail_images(self, client, db):
         pm = make_machine_model(
             name="With Image",

--- a/frontend/src/lib/components/pages/record/detail/ModelLineageLinkList.svelte
+++ b/frontend/src/lib/components/pages/record/detail/ModelLineageLinkList.svelte
@@ -1,15 +1,22 @@
 <!-- @component Renders a list of model lineage links (name + year) as a plain `<ul>`. Shared by the mobile model relationships list and the single-model title page; the desktop sidebar renders its own list via `SidebarList`. -->
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import type { ModelLineageLink } from '$lib/entities/model-lineage';
+  import type { ModelLineageLinkView } from '$lib/entities/model-lineage';
 
-  let { links }: { links: ModelLineageLink[] } = $props();
+  let { links }: { links: ModelLineageLinkView[] } = $props();
 </script>
 
 <ul class="lineage-links">
   {#each links as link (link.public_id)}
     <li>
       <a href={resolve('/models/[slug]', { slug: link.public_id })}>{link.name}</a>
+      {#if link.manufacturer}
+        <a
+          class="maker"
+          href={resolve('/manufacturers/[slug]', { slug: link.manufacturer.public_id })}
+          >{link.manufacturer.name}</a
+        >
+      {/if}
       {#if link.year}
         <span class="muted">({link.year})</span>
       {/if}
@@ -31,6 +38,11 @@
 
   .muted {
     color: var(--color-text-muted);
+    font-size: var(--font-size-0);
+  }
+
+  /* Maker link reads as supplementary: link-colored but at the muted size. */
+  .maker {
     font-size: var(--font-size-0);
   }
 </style>

--- a/frontend/src/lib/components/pages/record/detail/ModelLineageSidebarSections.svelte
+++ b/frontend/src/lib/components/pages/record/detail/ModelLineageSidebarSections.svelte
@@ -1,0 +1,44 @@
+<!-- @component Renders a model's model↔model lineage relations as `SidebarSection`s — the desktop sidebar presentation. Shared by the model page and the single-model title page; the mobile presentation is `ModelLineageGroups`. -->
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import SidebarList from '$lib/components/layout/page/sidebar/SidebarList.svelte';
+  import SidebarListItem from '$lib/components/layout/page/sidebar/SidebarListItem.svelte';
+  import SidebarSection from '$lib/components/layout/page/sidebar/SidebarSection.svelte';
+  import { modelLineageSections } from '$lib/entities/model-lineage';
+  import type { ModelDetailSchema } from '$lib/api/schema';
+
+  let { model }: { model: ModelDetailSchema } = $props();
+</script>
+
+{#each modelLineageSections(model) as { relation, links } (relation.key)}
+  <SidebarSection heading={relation.heading} note={relation.note}>
+    <SidebarList>
+      {#each links as link (link.public_id)}
+        <SidebarListItem>
+          <a href={resolve('/models/[slug]', { slug: link.public_id })}>{link.name}</a>
+          {#if link.manufacturer || link.year}
+            <span class="muted">
+              {#if link.manufacturer}<a
+                  class="maker"
+                  href={resolve('/manufacturers/[slug]', { slug: link.manufacturer.public_id })}
+                  >{link.manufacturer.name}</a
+                >{/if}{#if link.manufacturer && link.year}&nbsp;·&nbsp;{/if}{#if link.year}{link.year}{/if}
+            </span>
+          {/if}
+        </SidebarListItem>
+      {/each}
+    </SidebarList>
+  </SidebarSection>
+{/each}
+
+<style>
+  .muted {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-0);
+  }
+
+  /* Maker link reads as supplementary: link-colored but at the muted size. */
+  .maker {
+    font-size: var(--font-size-0);
+  }
+</style>

--- a/frontend/src/lib/entities/model-lineage.test.ts
+++ b/frontend/src/lib/entities/model-lineage.test.ts
@@ -58,6 +58,76 @@ describe('modelLineageSections', () => {
     expect(section.relation.key).toBe('bootlegs');
     expect(section.links.map((l) => l.public_id)).toEqual(['rugby-sidam', 'clone']);
   });
+
+  describe('manufacturer disambiguation', () => {
+    // A bootleg keeps the original's name, so with no maker shown it reads as a
+    // relation to itself. The maker is surfaced only when it differs.
+    const gottlieb = { name: 'D. Gottlieb & Company', public_id: 'gottlieb' };
+    const zaccaria = { name: 'Zaccaria', public_id: 'zaccaria' };
+
+    it('shows the maker when it differs from the subject', () => {
+      const model = makeModelDetail({
+        manufacturer: gottlieb,
+        bootlegs: [
+          { name: 'Jungle Life', public_id: 'jungle-life-zaccaria', manufacturer: zaccaria },
+        ],
+      });
+
+      const [section] = modelLineageSections(model);
+      // Keeps the full ref (name + public_id) so the maker renders as a link.
+      expect(section.links[0].manufacturer).toEqual(zaccaria);
+    });
+
+    it('omits the maker when it matches the subject', () => {
+      const model = makeModelDetail({
+        manufacturer: gottlieb,
+        remakes: [{ name: 'Jungle Life 2', public_id: 'jungle-life-2', manufacturer: gottlieb }],
+      });
+
+      const [section] = modelLineageSections(model);
+      expect(section.links[0].manufacturer).toBeNull();
+    });
+
+    it('shows the maker when the subject has none (still disambiguating)', () => {
+      const model = makeModelDetail({
+        manufacturer: null,
+        bootlegs: [
+          { name: 'Jungle Life', public_id: 'jungle-life-zaccaria', manufacturer: zaccaria },
+        ],
+      });
+
+      const [section] = modelLineageSections(model);
+      expect(section.links[0].manufacturer?.name).toBe('Zaccaria');
+    });
+
+    it('omits the maker when the link has none', () => {
+      const model = makeModelDetail({
+        manufacturer: gottlieb,
+        bootlegs: [{ name: 'Jungle Life', public_id: 'jungle-life-emmepi' }],
+      });
+
+      const [section] = modelLineageSections(model);
+      expect(section.links[0].manufacturer).toBeNull();
+    });
+
+    it('disambiguates variant links too, not only ModelRef relations', () => {
+      const model = makeModelDetail({
+        manufacturer: gottlieb,
+        variants: [
+          {
+            name: 'Jungle Life',
+            public_id: 'jungle-life-alt',
+            variant_features: [],
+            manufacturer: zaccaria,
+          },
+        ],
+      });
+
+      const [section] = modelLineageSections(model);
+      expect(section.relation.key).toBe('variants');
+      expect(section.links[0].manufacturer?.name).toBe('Zaccaria');
+    });
+  });
 });
 
 describe('modelLineageRelation', () => {

--- a/frontend/src/lib/entities/model-lineage.ts
+++ b/frontend/src/lib/entities/model-lineage.ts
@@ -11,10 +11,10 @@
  * the forward set stays in sync with `ENTITY_META`, so a new backend
  * model↔model FK forces a descriptor here rather than silently going unshown.
  */
-import type { ModelDetailSchema, ModelRef } from '$lib/api/schema';
+import type { EntityRef, ModelDetailSchema, ModelRef } from '$lib/api/schema';
 
 /** A related model. Forward-FK and reverse-list targets share this shape. */
-export type ModelLineageLink = Pick<ModelRef, 'name' | 'public_id' | 'year'>;
+export type ModelLineageLink = Pick<ModelRef, 'name' | 'public_id' | 'year' | 'manufacturer'>;
 
 /** Keys on {@link ModelDetailSchema} whose values are model↔model lineage links. */
 export type ModelLineageKey =
@@ -113,10 +113,27 @@ export const MODEL_LINEAGE_RELATIONS: readonly ModelLineageRelation[] = [
   },
 ];
 
+/**
+ * A resolved lineage link ready to render: identity plus the maker to show for
+ * disambiguation (or `null` to omit it).
+ */
+export interface ModelLineageLinkView {
+  name: string;
+  public_id: string;
+  year?: number | null;
+  /**
+   * Manufacturer to show (as a link to its page), or `null` when it matches the
+   * subject's maker or is unknown. Same-named links (a game and the bootlegs
+   * that copied its name) otherwise read as a relation to itself, since no
+   * reader surface shows a maker; a *differing* maker is what disambiguates them.
+   */
+  manufacturer: EntityRef | null;
+}
+
 /** A lineage relation paired with its resolved, non-empty link list. */
 export interface ModelLineageSection {
   relation: ModelLineageRelation;
-  links: ModelLineageLink[];
+  links: ModelLineageLinkView[];
 }
 
 /**
@@ -125,10 +142,23 @@ export interface ModelLineageSection {
  * the "has any lineage" check that gates the mobile Related Models accordion.
  */
 export function modelLineageSections(model: ModelDetailSchema): ModelLineageSection[] {
+  const subjectManufacturer = model.manufacturer?.name ?? null;
   const sections: ModelLineageSection[] = [];
   for (const relation of MODEL_LINEAGE_RELATIONS) {
     const links = relation.resolve(model);
-    if (links.length > 0) sections.push({ relation, links });
+    if (links.length === 0) continue;
+    sections.push({
+      relation,
+      links: links.map((link) => ({
+        name: link.name,
+        public_id: link.public_id,
+        year: link.year,
+        manufacturer:
+          link.manufacturer && link.manufacturer.name !== subjectManufacturer
+            ? link.manufacturer
+            : null,
+      })),
+    });
   }
   return sections;
 }

--- a/frontend/src/routes/models/[slug]/+layout.svelte
+++ b/frontend/src/routes/models/[slug]/+layout.svelte
@@ -9,9 +9,9 @@
   import ExternalLinksSidebarSection from '$lib/components/pages/record/detail/ExternalLinksSidebarSection.svelte';
   import { externalLinks } from '$lib/entities/external-links';
   import { model as modelInfo } from '$lib/entities/model';
-  import { modelLineageSections } from '$lib/entities/model-lineage';
   import { showsProductionStatus } from '$lib/entities/production-status';
   import ModelHierarchy from '$lib/components/pages/record/detail/ModelHierarchy.svelte';
+  import ModelLineageSidebarSections from '$lib/components/pages/record/detail/ModelLineageSidebarSections.svelte';
   import ModelSpecsSidebar from '$lib/components/pages/record/detail/ModelSpecsSidebar.svelte';
   import PageActionBar from '$lib/components/layout/page/PageActionBar.svelte';
   import RecordDetailShell from '$lib/components/pages/record/detail/RecordDetailShell.svelte';
@@ -257,20 +257,7 @@
       </SidebarList>
     </SidebarSection>
 
-    {#each modelLineageSections(model) as { relation, links } (relation.key)}
-      <SidebarSection heading={relation.heading} note={relation.note}>
-        <SidebarList>
-          {#each links as link (link.public_id)}
-            <SidebarListItem>
-              <a href={resolve('/models/[slug]', { slug: link.public_id })}>{link.name}</a>
-              {#if link.year}
-                <span class="muted">{link.year}</span>
-              {/if}
-            </SidebarListItem>
-          {/each}
-        </SidebarList>
-      </SidebarSection>
-    {/each}
+    <ModelLineageSidebarSections {model} />
 
     <ModelHierarchy
       models={model.title_models}
@@ -316,10 +303,3 @@
     {/snippet}
   </SectionEditorHost>
 {/if}
-
-<style>
-  .muted {
-    color: var(--color-text-muted);
-    font-size: var(--font-size-0);
-  }
-</style>

--- a/frontend/src/routes/titles/[slug]/+layout.svelte
+++ b/frontend/src/routes/titles/[slug]/+layout.svelte
@@ -9,15 +9,13 @@
   import ExternalLinksSidebarSection from '$lib/components/pages/record/detail/ExternalLinksSidebarSection.svelte';
   import { externalLinks } from '$lib/entities/external-links';
   import { model as modelInfo } from '$lib/entities/model';
-  import { modelLineageSections } from '$lib/entities/model-lineage';
   import { title as titleInfo } from '$lib/entities/title';
   import ModelHierarchy from '$lib/components/pages/record/detail/ModelHierarchy.svelte';
+  import ModelLineageSidebarSections from '$lib/components/pages/record/detail/ModelLineageSidebarSections.svelte';
   import ModelSpecsSidebar from '$lib/components/pages/record/detail/ModelSpecsSidebar.svelte';
   import PageActionBar from '$lib/components/layout/page/PageActionBar.svelte';
   import RecordDetailShell from '$lib/components/pages/record/detail/RecordDetailShell.svelte';
   import SectionEditorHost from '$lib/components/pages/record/edit/SectionEditorHost.svelte';
-  import SidebarList from '$lib/components/layout/page/sidebar/SidebarList.svelte';
-  import SidebarListItem from '$lib/components/layout/page/sidebar/SidebarListItem.svelte';
   import SidebarSection from '$lib/components/layout/page/sidebar/SidebarSection.svelte';
   import TaxonomyLinkSidebarSection from '$lib/components/pages/record/detail/TaxonomyLinkSidebarSection.svelte';
   import {
@@ -269,20 +267,7 @@
            accordion. On a single-model title every lineage link is inherently
            cross-title, so this fully replaces the page's Related Titles /
            Bootlegs accordions. -->
-      {#each modelLineageSections(md) as { relation, links } (relation.key)}
-        <SidebarSection heading={relation.heading} note={relation.note}>
-          <SidebarList>
-            {#each links as link (link.public_id)}
-              <SidebarListItem>
-                <a href={resolve('/models/[slug]', { slug: link.public_id })}>{link.name}</a>
-                {#if link.year}
-                  <span class="muted">{link.year}</span>
-                {/if}
-              </SidebarListItem>
-            {/each}
-          </SidebarList>
-        </SidebarSection>
-      {/each}
+      <ModelLineageSidebarSections model={md} />
 
       <ExternalLinksSidebarSection
         links={externalSiteLinks}
@@ -480,10 +465,5 @@
 
   dd {
     color: var(--color-text);
-  }
-
-  .muted {
-    color: var(--color-text-muted);
-    font-size: var(--font-size-0);
   }
 </style>


### PR DESCRIPTION
## Summary

Same-named lineage links read as a relation of a game to itself, because no reader surface shows a manufacturer — e.g. Gottlieb's "Jungle Life" lists three bootlegs all named "Jungle Life" (Emmepi, LORI, Zaccaria), two without even a year. This surfaces the related game's maker — as a link to its manufacturer page — but only when it differs from the page's subject, the sole case it disambiguates.

- `ModelRef` and `ModelVariantSchema` now carry a `manufacturer` (resolved via `corporate_entity`) built by a shared `_manufacturer_ref` helper, so every lineage relation — forward FKs, reverse lists, variants and siblings — can disambiguate; none is structurally the one that can't. The detail query select_relates / prefetches `corporate_entity__manufacturer` on those relations so the refs stay query-free.
- `modelLineageSections()` keeps the full manufacturer ref only when it differs from the subject's maker (or the subject has none); same-maker variants/remakes stay uncluttered. Rendered as a link on every lineage surface (mobile list + desktop sidebar).
- Folded the two identical desktop sidebar lineage loops (model page + single-model title page) into a shared `ModelLineageSidebarSections` component.

## Test plan

- [ ] `make test` — backend (`test_lineage_refs_carry_manufacturer` covers both link directions + a variant) and frontend (`model-lineage` differ/matches/subject-null/link-null/variant cases) green
- [ ] `/models/jungle-life`: the three same-named "Jungle Life" bootlegs each show a distinct, clickable maker (Emmepi / LORI / Zaccaria); sidebar reads `Zaccaria · 1973` with spacing
- [ ] A same-maker variant/remake shows no maker (uncluttered)
- [ ] Maker link navigates to `/manufacturers/[slug]`
