### PR TITLE
feat(search): global search includes descriptions

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "backend",
+      "runtimeExecutable": "uv",
+      "runtimeArgs": ["run", "--directory", "backend", "python", "manage.py", "runserver", "127.0.0.1:8000"],
+      "port": 8000
+    },
+    {
+      "name": "frontend",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--dir", "frontend", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/backend/apps/catalog/api/_search_sections.py
+++ b/backend/apps/catalog/api/_search_sections.py
@@ -1,0 +1,89 @@
+"""The description tier for global search (``GET /api/pages/search``).
+
+Global search ranks results in two tiers: name/alias matches first, then rows
+matched only by their long-form ``description``. The description tier is added
+**here, in the section builders only** — deliberately kept out of the shared
+``q`` predicate that the listing pages and the record-creation ``query_count``
+gate reuse, so searching a description can never make the "create this record?"
+prompt disappear.
+
+The tier is model-driven: ``description`` comes from the shared
+:class:`DescribedModel` mixin, so :func:`tiered_search_rows` gates on
+``issubclass(model, DescribedModel)`` — any describable entity in global search
+gets it automatically, a non-describable one is skipped.
+
+Lives in the catalog API layer (not next to the ``fold`` primitives in
+``apps.core.search``) because the capability check imports ``DescribedModel``,
+and ``apps.core.search`` is a core-only leaf that must not import
+``apps.core.models`` (enforced by import-linter).
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from django.db import connection
+from django.db.models import Model, Q, QuerySet
+
+from apps.core.models.mixins import DescribedModel
+from apps.core.search import fold
+
+
+def description_match_q(q: str) -> Q:
+    """Folded substring predicate on :attr:`DescribedModel.description`.
+
+    Postgres de-accents both sides (``UNACCENT(description) ILIKE unaccented``,
+    mirroring the autocomplete engine); SQLite (dev/CI) falls back to plain
+    ``icontains`` — the same dev/prod gap as the rest of search. Matches the raw
+    markdown source of the ``MarkdownField``, not the rendered HTML.
+    """
+    if connection.vendor == "postgresql":
+        return Q(description__unaccent__icontains=fold(q))
+    return Q(description__icontains=q)
+
+
+class TieredRows[ModelT: Model](NamedTuple):
+    """One search section's merged rows plus whether more matches exist.
+
+    ``rows`` is name/alias matches first, then description-only matches — the
+    ranking the global search page renders. ``has_more`` reports "> limit"
+    across **both** tiers combined.
+    """
+
+    rows: list[ModelT]
+    has_more: bool
+
+
+def tiered_search_rows[ModelT: Model](
+    primary: QuerySet[ModelT],
+    ordered_base: QuerySet[ModelT],
+    q: str,
+    *,
+    limit: int = 10,
+) -> TieredRows[ModelT]:
+    """Merge a name/alias tier and a description tier into one capped section.
+
+    *primary* is the entity's existing ``q``-filtered, ordered queryset (the
+    name/alias/etc. matches). *ordered_base* is that **same** base and ordering
+    with **no** ``q`` filter — the description tier is ``ordered_base`` narrowed
+    by :func:`description_match_q` and de-duplicated against *primary*, so both
+    tiers share the entity's canonical sort, annotations and prefetch.
+
+    Fetches ``limit + 1`` to report *has_more* without a second ``count()``. The
+    description tier runs only when the model is a :class:`DescribedModel`
+    (a base-class capability check — any describable entity in global search
+    gets it automatically, a non-describable one is skipped), and only when the
+    name tier hasn't already filled the section.
+    """
+    primary_rows = list(primary[: limit + 1])
+    if len(primary_rows) > limit:
+        return TieredRows(primary_rows[:limit], has_more=True)
+    if not issubclass(ordered_base.model, DescribedModel):
+        return TieredRows(primary_rows, has_more=False)
+    seen = [row.pk for row in primary_rows]
+    fill = limit + 1 - len(primary_rows)
+    description_rows = list(
+        ordered_base.filter(description_match_q(q)).exclude(pk__in=seen)[:fill]
+    )
+    rows = primary_rows + description_rows
+    return TieredRows(rows[:limit], has_more=len(rows) > limit)

--- a/backend/apps/catalog/api/manufacturers.py
+++ b/backend/apps/catalog/api/manufacturers.py
@@ -50,6 +50,7 @@ from ._manufacturer_facets import (
     ordered,
     query_count,
 )
+from ._search_sections import tiered_search_rows
 from ._typing import FacetOptionDict, HasModelCount
 from .helpers import (
     collect_titles,
@@ -445,11 +446,15 @@ def manufacturer_search_section(
     q: str, *, min_rank: int
 ) -> ManufacturerSearchSectionSchema:
     """Top ≤10 manufacturer cards matching ``q``, composing the **ordered** listing
-    queryset + card serializer so results match ``/manufacturers?q=`` exactly. Slices
-    ``[:11]`` to detect ">10" without a second ``count()``."""
-    rows = list(ordered(MfrFilters(q=q))[:11])
-    items = rows[:10]
-    thumbnails = _page_thumbnails([m.pk for m in items], min_rank=min_rank)
+    queryset + card serializer so name matches rank exactly as ``/manufacturers?q=``.
+
+    Manufacturers matched only by their description rank *below* the name/alias tier
+    (:func:`tiered_search_rows`, gated on the shared ``DescribedModel``), and — unlike
+    the name tier — never reach the record-creation ``query_count`` gate. The
+    ``model_count`` annotation rides on ``ordered(...)`` so description-tier rows
+    serialize identically."""
+    result = tiered_search_rows(ordered(MfrFilters(q=q)), ordered(MfrFilters()), q)
+    thumbnails = _page_thumbnails([m.pk for m in result.rows], min_rank=min_rank)
     return ManufacturerSearchSectionSchema(
         items=[
             ManufacturerCardSchema(
@@ -458,9 +463,9 @@ def manufacturer_search_section(
                 model_count=cast(HasModelCount, m).model_count,
                 thumbnail_url=thumbnails.get(m.pk),
             )
-            for m in items
+            for m in result.rows
         ],
-        has_more=len(rows) > 10,
+        has_more=result.has_more,
     )
 
 

--- a/backend/apps/catalog/api/people.py
+++ b/backend/apps/catalog/api/people.py
@@ -60,6 +60,7 @@ from ..engine.entity_api.listing import _apply_list_q, paginated_list_response
 from ..engine.entity_api.own_media import own_media
 from ..engine.query.constants import NameAliasQuery, PageParam
 from ..models import Credit, MachineModel, Person
+from ._search_sections import tiered_search_rows
 from ._typing import HasCreditCount
 from .images import (
     extract_image_urls,
@@ -329,20 +330,25 @@ class PersonSearchSectionSchema(Schema):
 
 def person_search_section(q: str) -> PersonSearchSectionSchema:
     """Top ≤10 person cards matching ``q``, composing the listing queryset + card
-    serializer so results match ``/people?q=`` exactly. Re-applies the explicit
+    serializer so name matches rank exactly as ``/people?q=``. Re-applies the explicit
     ``("-credit_count", "name", "pk")`` total order (``_person_list_qs`` omits the
     ``pk`` tiebreak, so the slice would be nondeterministic on credit-count ties).
-    Slices ``[:11]`` to detect ">10" without a second ``count()``."""
+
+    People matched only by their description rank *below* the name/alias tier
+    (:func:`tiered_search_rows`, gated on the shared ``DescribedModel``)."""
     # Splat a tuple (not literal args) so django-stubs doesn't field-check
     # ``credit_count`` — it's a real annotation from ``_person_list_qs`` that the stub
     # can't see across the ``_apply_list_q`` boundary (same shape ``list_people`` uses).
     ordering = ("-credit_count", "name", "pk")
-    rows = list(_apply_list_q(_person_list_qs(), q).order_by(*ordering)[:11])
-    items = rows[:10]
-    thumbnails = _people_thumbnails([p.pk for p in items])
+    result = tiered_search_rows(
+        _apply_list_q(_person_list_qs(), q).order_by(*ordering),
+        _person_list_qs().order_by(*ordering),
+        q,
+    )
+    thumbnails = _people_thumbnails([p.pk for p in result.rows])
     return PersonSearchSectionSchema(
-        items=[_serialize_person_row(p, thumbnails.get(p.pk)) for p in items],
-        has_more=len(rows) > 10,
+        items=[_serialize_person_row(p, thumbnails.get(p.pk)) for p in result.rows],
+        has_more=result.has_more,
     )
 
 

--- a/backend/apps/catalog/api/titles.py
+++ b/backend/apps/catalog/api/titles.py
@@ -80,6 +80,7 @@ from ..models import (
     MachineModelGameplayFeature,
     Title,
 )
+from ._search_sections import tiered_search_rows
 from ._title_facets import (
     Bounds,
     FacetOption,
@@ -887,15 +888,20 @@ class TitleSearchSectionSchema(Schema):
 
 def title_search_section(q: str, *, min_rank: int) -> TitleSearchSectionSchema:
     """Top ≤10 title cards matching ``q``, composing the **ordered** listing
-    queryset + card serializer so results match ``/titles?q=`` exactly. Slices
-    ``[:11]`` to detect ">10" without a second ``count()``."""
-    rows = list(
-        ordered_titles(TitleFilters(q=q)).prefetch_related(_card_models_prefetch())[:11]
+    queryset + card serializer so name matches rank exactly as ``/titles?q=``.
+
+    Titles matched only by their description rank *below* the name/alias tier
+    (:func:`tiered_search_rows`, gated on the shared ``DescribedModel``), and —
+    unlike the name tier — never reach the record-creation ``query_count`` gate."""
+    prefetch = _card_models_prefetch()
+    result = tiered_search_rows(
+        ordered_titles(TitleFilters(q=q)).prefetch_related(prefetch),
+        ordered_titles(TitleFilters()).prefetch_related(prefetch),
+        q,
     )
-    items = rows[:10]
     return TitleSearchSectionSchema(
-        items=[_serialize_card(t, min_rank=min_rank) for t in items],
-        has_more=len(rows) > 10,
+        items=[_serialize_card(t, min_rank=min_rank) for t in result.rows],
+        has_more=result.has_more,
     )
 
 

--- a/backend/apps/catalog/tests/test_api_search.py
+++ b/backend/apps/catalog/tests/test_api_search.py
@@ -5,6 +5,12 @@ reusing its listing-page ``q`` + card serializer, capped at 10 with a ``has_more
 flag. These tests pin: the ``<3``-char no-work guard, per-section matching + card
 shape, the 10-cap, the diacritic dev/prod split, fixed section order, that a section
 preserves its listing sort, the all-empty case, and a constant-query N+1 guard.
+
+Global search also has a **description tier**: rows matched only by their
+``DescribedModel.description`` rank *below* the name/alias tier, and — unlike the name
+tier — never feed the record-creation ``query_count`` gate. Those tests pin the tier
+surfacing per section, the name-before-description ranking, combined ``has_more``, and
+the gate staying blind to description-only matches.
 """
 
 import pytest
@@ -23,14 +29,16 @@ CARD_KEYS = {
 }
 
 
-def _make_manufacturer(name: str, slug: str, source: Source) -> Manufacturer:
-    mfr = Manufacturer.objects.create(name=name, slug=slug)
+def _make_manufacturer(
+    name: str, slug: str, source: Source, description: str = ""
+) -> Manufacturer:
+    mfr = Manufacturer.objects.create(name=name, slug=slug, description=description)
     make_claim(mfr, "name", name, ingest_source=source)
     return mfr
 
 
-def _make_person(name: str, slug: str, source: Source) -> Person:
-    p = Person.objects.create(name=name, slug=slug)
+def _make_person(name: str, slug: str, source: Source, description: str = "") -> Person:
+    p = Person.objects.create(name=name, slug=slug, description=description)
     make_claim(p, "name", name, ingest_source=source)
     return p
 
@@ -185,3 +193,102 @@ def test_query_count_is_constant_across_result_size(
     large = query_count()
 
     assert small == large
+
+
+# ---------------------------------------------------------------------------
+# Description tier (global search only)
+# ---------------------------------------------------------------------------
+
+
+def test_description_only_match_surfaces_in_each_section(client, db, bootstrap_source):
+    """A row whose ``name`` does NOT contain the term but whose ``description`` does
+    still appears in its section — the ``DescribedModel`` tier, applied uniformly to
+    every describable entity in global search."""
+    Title.objects.create(
+        name="Bright Star",
+        slug="bright-star",
+        description="A cabinet with xylophone art.",
+    )
+    _make_manufacturer(
+        "Acme Corp",
+        "acme-corp",
+        bootstrap_source,
+        description="Builds xylophone machines.",
+    )
+    _make_person(
+        "Jane Doe",
+        "jane-doe",
+        bootstrap_source,
+        description="Designed the xylophone ramp.",
+    )
+
+    data = client.get("/api/pages/search?q=xylophone").json()
+    assert [t["name"] for t in data["titles"]["items"]] == ["Bright Star"]
+    assert [m["name"] for m in data["manufacturers"]["items"]] == ["Acme Corp"]
+    assert [p["name"] for p in data["people"]["items"]] == ["Jane Doe"]
+
+
+def test_name_matches_rank_above_description_matches(client, db, williams_entity):
+    """Tiering: a name match precedes a description-only match even when the
+    description match would otherwise sort first. The name-tier title is older, so a
+    single ``latest_year``-ordered query (tiering broken) would rank the newer
+    description-only title first — this pins the two-tier ordering."""
+    zeta = Title.objects.create(name="Zeta Classic", slug="zeta-classic")
+    make_machine_model(
+        title=zeta, name="Zeta Classic", slug="zeta-classic-m", year=1985
+    )
+    retro = Title.objects.create(
+        name="Retro Blast",
+        slug="retro-blast",
+        description="Includes a zeta bonus mode.",
+    )
+    make_machine_model(title=retro, name="Retro Blast", slug="retro-blast-m", year=2020)
+
+    names = [
+        t["name"]
+        for t in client.get("/api/pages/search?q=zeta").json()["titles"]["items"]
+    ]
+    assert names == ["Zeta Classic", "Retro Blast"]
+
+
+def test_has_more_counts_name_and_description_combined(client, db, bootstrap_source):
+    """``has_more`` reflects both tiers: a section under 11 name matches but over 11
+    combined (name + description) still reports more."""
+    for i in range(6):
+        _make_manufacturer(f"Combo {i}", f"combo-name-{i}", bootstrap_source)
+    for i in range(6):
+        _make_manufacturer(
+            f"Filler {i}",
+            f"combo-desc-{i}",
+            bootstrap_source,
+            description="a combo maker",
+        )
+
+    section = client.get("/api/pages/search?q=combo").json()["manufacturers"]
+    assert len(section["items"]) == 10
+    assert section["has_more"] is True
+    # Name-tier rows come first; a description-only row fills a remaining slot.
+    names = [m["name"] for m in section["items"]]
+    assert names[:6] == [f"Combo {i}" for i in range(6)]
+    assert any(n.startswith("Filler") for n in names)
+
+
+def test_description_match_does_not_feed_the_create_gate(client, db, bootstrap_source):
+    """The core constraint: a description-only match is surfaced by global search but
+    must NOT count toward the listing endpoints' ``query_count`` — otherwise the
+    "create this record?" prompt would wrongly vanish for a name that is still free."""
+    Title.objects.create(
+        name="Blank Slate", slug="blank-slate", description="mentions a widget"
+    )
+    _make_manufacturer(
+        "Empty Co", "empty-co", bootstrap_source, description="assembles a widget"
+    )
+
+    # Global search DOES surface them (description tier)…
+    search = client.get("/api/pages/search?q=widget").json()
+    assert [t["name"] for t in search["titles"]["items"]] == ["Blank Slate"]
+    assert [m["name"] for m in search["manufacturers"]["items"]] == ["Empty Co"]
+
+    # …but the record-creation gate stays blind, so the prompt still fires.
+    assert client.get("/api/pages/titles?q=widget").json()["query_count"] == 0
+    assert client.get("/api/pages/manufacturers?q=widget").json()["query_count"] == 0


### PR DESCRIPTION
## What

Global search (`GET /api/pages/search`) now also surfaces records whose **description** contains the query, across all three sections (titles, manufacturers, people). Description matches are ranked as a **second tier, below** name/alias matches.

## Why

Previously global search matched only name + aliases/abbreviations (and, for titles/mfrs, the first-model manufacturer / corporate-entity / location). Users couldn't find a record by text that only appears in its description.

## The key constraint

The three search sections share their `q` predicate with the **record-creation gate** — the `query_count` on `/api/pages/titles` & `/api/pages/manufacturers` that powers the "you can only create a record if search returns nothing" prompt. Adding `description` to that shared predicate would let a description match suppress the create prompt for a name that's actually free.

So descriptions are layered in **only inside the global-search section builders**, never in the shared `q` predicate. A dedicated test pins this asymmetry: a description-only match is surfaced by global search but leaves `query_count` at `0`.

## Model-driven

`description` comes from the shared `DescribedModel` mixin, so `tiered_search_rows` gates the description tier on `issubclass(model, DescribedModel)` — a base-class capability check, not per-type branching. Any describable entity added to global search gets description search automatically; a non-describable one is skipped.

## Behavior notes

- **Tiering:** name/alias matches always precede description-only matches; within each tier the entity's canonical sort holds.
- **`has_more`:** counts combined name + description matches. Known, accepted caveat — the section's "see all" link goes to the listing page, which is a record-specific search and won't show description-only matches.
- **Diacritics:** description matching folds accents on Postgres (`UNACCENT(description) ILIKE …`) and falls back to plain `icontains` on SQLite (dev/CI) — the same documented dev/prod gap as the rest of search. Matches the raw markdown source of the `MarkdownField`.

## Changes

- **New** `backend/apps/catalog/api/_search_sections.py` — `description_match_q` + generic, fully-typed `tiered_search_rows` / `TieredRows`. Lives in the catalog API layer (not next to the `fold` primitives in `apps.core.search`) because the capability check imports `DescribedModel`, which the core-only `apps.core.search` leaf may not import (enforced by import-linter).
- `title_search_section`, `manufacturer_search_section`, `person_search_section` each delegate to the tier helper. The name-tier querysets are unchanged.
- Untouched by design: the shared `q` predicate and the `query_count` create gate.

## Tests

Added to `test_api_search.py`: description-only surfacing per section, name-before-description ranking (the description-only row is deliberately newer so a broken single-query impl would fail), combined `has_more`, and the create-gate guard.

## Verification

- `pytest apps/catalog/tests/test_api_search.py` and the titles/manufacturers facet + `query_count` suites — 122 passed.
- `make mypy` — clean (596 files).
- ruff + import-linter (29 contracts) pass via pre-commit.
- No frontend/codegen changes — the response schema (`items` + `has_more`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JebzK4RgUmmNn9mZZNdyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019JebzK4RgUmmNn9mZZNdyZ)_